### PR TITLE
[Server] Fix race condition in RemoteProvider TokenStore cleanup

### DIFF
--- a/server/models/remote_auth.go
+++ b/server/models/remote_auth.go
@@ -42,6 +42,11 @@ const (
 // JWK - a type respresting the JSON web Key
 type JWK map[string]string
 
+// defaultTokenDeletionDelay is the default wait before refreshToken evicts a
+// superseded token from TokenStore when RemoteProvider.TokenDeletionDelay is
+// unset.
+const defaultTokenDeletionDelay = 1 * time.Hour
+
 // SafeClose is a helper function help to close the io
 func SafeClose(co io.Closer, log logger.Handler) {
 	if cerr := co.Close(); cerr != nil {
@@ -126,8 +131,14 @@ func (l *RemoteProvider) refreshToken(tokenString string) (string, error) {
 		return "", fmt.Errorf("failed to refresh token. response missing %q", TokenCookieName)
 	}
 	l.TokenStore[tokenString] = newTokenString
-	time.AfterFunc(1*time.Hour, func() {
+	deletionDelay := l.TokenDeletionDelay
+	if deletionDelay <= 0 {
+		deletionDelay = defaultTokenDeletionDelay
+	}
+	time.AfterFunc(deletionDelay, func() {
 		l.Log.Info("deleting old token string")
+		l.TokenStoreMut.Lock()
+		defer l.TokenStoreMut.Unlock()
 		delete(l.TokenStore, tokenString)
 	})
 	return newTokenString, nil

--- a/server/models/remote_auth_race_test.go
+++ b/server/models/remote_auth_race_test.go
@@ -71,6 +71,7 @@ func TestRemoteProviderRefreshToken_TokenStoreConcurrentEviction(t *testing.T) {
 				default:
 				}
 				_, _ = provider.refreshToken(oldToken)
+				time.Sleep(100 * time.Microsecond)
 			}
 		}()
 	}
@@ -78,4 +79,6 @@ func TestRemoteProviderRefreshToken_TokenStoreConcurrentEviction(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	close(stop)
 	wg.Wait()
+	// Allow any in-flight eviction timers to run before the test exits.
+	time.Sleep(5 * provider.TokenDeletionDelay)
 }

--- a/server/models/remote_auth_race_test.go
+++ b/server/models/remote_auth_race_test.go
@@ -1,0 +1,81 @@
+//go:build race
+
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRemoteProviderRefreshToken_TokenStoreConcurrentEviction guards against a
+// regression of the data race between refreshToken's time.AfterFunc eviction
+// callback (delete(l.TokenStore, ...)) and the lock-protected readers
+// ExtractToken / UpdateToken. All TokenStore access must hold TokenStoreMut.
+//
+// It spins tight loops to widen the race window, so it is gated behind the
+// `race` build tag and only runs under `go test -race`.
+func TestRemoteProviderRefreshToken_TokenStoreConcurrentEviction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/refresh" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"token":"refreshed-token"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	provider := newTestRemoteProvider(t, server.URL)
+	// Per-instance delay; no global state mutation.
+	provider.TokenDeletionDelay = time.Millisecond
+
+	const oldToken = "old-token-string"
+
+	newReaderRequest := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/api/token", nil)
+		req.AddCookie(&http.Cookie{Name: TokenCookieName, Value: oldToken})
+		return req
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := newReaderRequest()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				rec := httptest.NewRecorder()
+				provider.ExtractToken(rec, req)
+			}
+		}()
+	}
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _ = provider.refreshToken(oldToken)
+			}
+		}()
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -75,7 +75,7 @@ type RemoteProvider struct {
 	Keys          []map[string]string
 
 	// TokenDeletionDelay controls how long refreshToken waits before evicting
-	// the superseded token from TokenStore. Zero uses defaultTokenDeletionDelay.
+	// the superseded token from TokenStore. Non-positive uses defaultTokenDeletionDelay.
 	// A field (rather than global state) so tests can shrink it safely.
 	TokenDeletionDelay time.Duration
 

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -74,6 +74,11 @@ type RemoteProvider struct {
 	TokenStoreMut sync.Mutex
 	Keys          []map[string]string
 
+	// TokenDeletionDelay controls how long refreshToken waits before evicting
+	// the superseded token from TokenStore. Zero uses defaultTokenDeletionDelay.
+	// A field (rather than global state) so tests can shrink it safely.
+	TokenDeletionDelay time.Duration
+
 	// mostRecentToken caches the last valid user token observed during the
 	// session so it can be reused at server shutdown to authenticate the
 	// deregistration call (DeleteMesheryConnection) and the subsequent token


### PR DESCRIPTION
**Notes for Reviewers**

- Fixes #20623

## Summary

This PR fixes a race condition in `RemoteProvider.refreshToken()` where the delayed `TokenStore` cleanup callback accessed the shared map without acquiring `TokenStoreMut`.

The callback executes in a separate goroutine and could run concurrently with `refreshToken()`, `UpdateToken()`, or `ExtractToken()`, resulting in a data race and potential `fatal error: concurrent map read and map write`.

## Changes

- Synchronize the delayed `TokenStore` cleanup by acquiring `TokenStoreMut` inside the `time.AfterFunc()` callback.
- Add a `-race` regression test that reproduces the issue using the real production code paths.
- Introduce a configurable `tokenDeletionDelay` (default remains `1*time.Hour`) to make the timer deterministic during testing without changing production behavior.

## Verification

Before the fix:

- `go test -race` consistently reported `WARNING: DATA RACE`.
- The test could terminate with `fatal error: concurrent map read and map write`.

After the fix:

- `go test ./models` passes.
- `go test -race ./models` passes with no race detected.
- `go vet ./models` passes.

### Screenshots

<img width="786" height="146" alt="Screenshot 2026-07-13 at 11 48 52 AM" src="https://github.com/user-attachments/assets/98ecaa40-14ff-466c-aee7-4417c5a307fc" />


---

**Signed commits**
- [x] Yes, I signed my commits.