### PR TITLE
corrected reference relationship between eks addon and cluster 

### DIFF
--- a/models/aws-eks-controller/v1.16.2/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
+++ b/models/aws-eks-controller/v1.16.2/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
@@ -48,9 +48,7 @@
             "patch": {
               "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "name"
+                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"
@@ -80,7 +78,9 @@
                 [
                   "configuration",
                   "spec",
-                  "clusterName"
+                  "clusterRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/aws-eks-controller/v1.16.2/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
+++ b/models/aws-eks-controller/v1.16.2/v1.0.0/relationships/edge-non-binding-reference-uhqem.json
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "Addon",
+            "kind": "Cluster",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -50,7 +50,7 @@
                 [
                   "configuration",
                   "spec",
-                  "clusterName"
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -60,7 +60,7 @@
         "to": [
           {
             "id": null,
-            "kind": "Cluster",
+            "kind": "Addon",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -78,7 +78,9 @@
             "patch": {
               "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "clusterName"
                 ]
               ],
               "patchStrategy": "replace"


### PR DESCRIPTION
**Notes for Reviewers**

corrected reference relationship between eks addon and cluster 
before, the mutation logic was referencing wrong path's so evaluation engine wasn't evaluating it.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
