### PR TITLE
[CI] Fix integration test infrastructure: GIT_VERSION fallback, full clone, Go setup ordering

### DIFF
--- a/.github/workflows/server-integration-tests.yml
+++ b/.github/workflows/server-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
         # inspired by .github/workflows/build-ui-and-server.yml
       - name: Free disk space
         run: |
@@ -35,6 +35,11 @@ jobs:
 
       - name: file system info 00
         run: df -h
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
         # TODO  think about if we could reuse image build from ui-and-server build workflow?
       - name: Build meshery image
@@ -48,11 +53,6 @@ jobs:
 
       - name: file system info 02
         run: df -h
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
 
       - name: Integration tests set up (cluster)
         run: make server-integration-tests-meshsync-setup-cluster

--- a/install/Makefile.core.mk
+++ b/install/Makefile.core.mk
@@ -15,9 +15,9 @@
 #-----------------------------------------------------------------------------
 # Global Variables
 #-----------------------------------------------------------------------------
-GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
-GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
-GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
+GIT_VERSION	:= $(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v0.0.0")
+GIT_COMMITSHA := $(shell git rev-list -1 HEAD)
+GIT_STRIPPED_VERSION := $(patsubst v%,%,$(GIT_VERSION))
 
 # Extension Point for remote provider . Add your provider here.
 # Empty by default so installs do not enforce a specific provider; users see


### PR DESCRIPTION
This PR fixes CI integration test failures caused by shallow clones and missing GIT_VERSION tags.

## Changes

- **install/Makefile.core.mk**: Add silent fallback for GIT_VERSION and GIT_STRIPPED_VERSION when no git tags exist, preventing make failures in CI environments with shallow or tag-less clones.
- **.github/workflows/server-integration-tests.yml**: Set fetch-depth to 0 so the full git history is available for version detection. Move Setup Go step before make docker-build so the Go toolchain is available during the image build.

These fixes are prerequisites for several open PRs that currently bundle these same CI changes.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
