### PR TITLE
feat(model): add AWS VPC core relationship definitions

### DIFF
--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-oascb.json
@@ -1,7 +1,7 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "",
-  "kind": "edge",
+  "kind": "hierarchical",
   "metadata": {
     "description": "",
     "isAnnotation": false,
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "VPC",
+            "kind": "NetworkACL",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -48,7 +48,11 @@
             "patch": {
               "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -58,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "NetworkACL",
+            "kind": "VPC",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -76,9 +80,7 @@
             "patch": {
               "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "vpcID"
+                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"
@@ -92,8 +94,8 @@
       }
     }
   ],
-  "subType": "reference",
+  "subType": "inventory",
   "status": "enabled",
-  "type": "non-binding",
+  "type": "parent",
   "version": "v1.0.0"
 }

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-tauea.json
@@ -1,7 +1,7 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "",
-  "kind": "edge",
+  "kind": "hierarchical",
   "metadata": {
     "description": "",
     "isAnnotation": false,
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "VPC",
+            "kind": "SecurityGroup",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -48,7 +48,11 @@
             "patch": {
               "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -58,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "SecurityGroup",
+            "kind": "VPC",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -76,9 +80,7 @@
             "patch": {
               "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "vpcID"
+                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"
@@ -92,8 +94,8 @@
       }
     }
   ],
-  "subType": "reference",
+  "subType": "inventory",
   "status": "enabled",
-  "type": "non-binding",
+  "type": "parent",
   "version": "v1.0.0"
 }

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-uzanp.json
@@ -1,7 +1,7 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
   "evaluationQuery": "",
-  "kind": "edge",
+  "kind": "hierarchical",
   "metadata": {
     "description": "",
     "isAnnotation": false,
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "VPC",
+            "kind": "VPCEndpoint",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -48,7 +48,11 @@
             "patch": {
               "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -58,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "VPCEndpoint",
+            "kind": "VPC",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -76,9 +80,7 @@
             "patch": {
               "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "vpcID"
+                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"
@@ -92,8 +94,8 @@
       }
     }
   ],
-  "subType": "reference",
+  "subType": "inventory",
   "status": "enabled",
-  "type": "non-binding",
+  "type": "parent",
   "version": "v1.0.0"
 }


### PR DESCRIPTION
This PR completes the visual parenting work for VPC-bound resources in the `aws-ec2-controller` model (v1.18.2). 
it also completes the VPC visual parenting work started in @YASHMAHAKAL  #20645 by correcting the remaining VPC-bound resources (Security Groups, Network ACLs, and VPC Endpoints) in the latest version


While Subnets and Route Tables are already corrected on master, this PR fixes the relationship type and direction for the remaining three resources to ensure they also nest correctly inside the VPC container:
- **SecurityGroup ➔ VPC** (in `hierarchical-parent-inventory-tauea.json`)
- **NetworkACL ➔ VPC** (in `hierarchical-parent-inventory-oascb.json`)
- **VPCEndpoint ➔ VPC** (in `hierarchical-parent-inventory-uzanp.json`)

### Details:
- Changed relationship `kind` to `hierarchical`, `type` to `parent`, and `subType` to `inventory`.
- Corrected the direction (child component mapped in `from`, parent `VPC` mapped in `to`).
- Configured reference resolution by patching `vpcRef.from.name` of the child resource with the parent VPC's local `displayName`.

### Visual Parenting Demo
https://github.com/user-attachments/assets/5de98e4d-fffd-466a-b0b9-f218d7d3c22e



