### PR TITLE
 Added missing `parent` capability to VPC 

### DIFF
--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/components/VPC.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/components/VPC.json
@@ -189,7 +189,7 @@
   "status": "enabled",
   "metadata": {
     "configurationUISchema": "",
-    "genealogy": "",
+    "genealogy": "parent",
     "instanceDetails": null,
     "isAnnotation": false,
     "isNamespaced": true,

--- a/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
+++ b/models/aws-ec2-controller/v1.18.2/v1.0.0/relationships/hierarchical-parent-inventory-lkvsv.json
@@ -30,7 +30,7 @@
         "from": [
           {
             "id": null,
-            "kind": "VPC",
+            "kind": "Subnet",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -48,7 +48,11 @@
             "patch": {
               "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"
@@ -58,7 +62,7 @@
         "to": [
           {
             "id": null,
-            "kind": "Subnet",
+            "kind": "VPC",
             "match": {},
             "match_strategy_matrix": null,
             "model": {
@@ -76,9 +80,7 @@
             "patch": {
               "mutatorRef": [
                 [
-                  "configuration",
-                  "spec",
-                  "vpcID"
+                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"


### PR DESCRIPTION
## Description:
This PR resolves two issue in the `aws-ec2-controller` models where : 

1. dragging an AWS Subnet into an AWS VPC on the Kanvas whiteboard resulted in a rejected grouping (creating a generic white Namespace bounding box) or inverted nesting behavior. 

The root cause was a combination of an inverted hierarchical relationship definition, missing `metadata.genealogy.parent ` value in capabilities. 

2. Fixed the inverted relationship

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
