### PR TITLE
ci: pin third-party actions to full commit SHAs

### DIFF
--- a/.github/workflows/cncf-playground-deploy-meshery.yaml
+++ b/.github/workflows/cncf-playground-deploy-meshery.yaml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
         - name: Reconcile env from manifest, then roll image forward
-          uses: appleboy/ssh-action@master
+          uses: appleboy/ssh-action@068c0c7a4e59a5ae12fb7cb454b05735d830c82b # master
           env:
               MANIFEST_REF: ${{ github.sha }}
           with:

--- a/.github/workflows/cncf-playground-deploy-meshery.yaml
+++ b/.github/workflows/cncf-playground-deploy-meshery.yaml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
         - name: Reconcile env from manifest, then roll image forward
-          uses: appleboy/ssh-action@068c0c7a4e59a5ae12fb7cb454b05735d830c82b # master
+          uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
           env:
               MANIFEST_REF: ${{ github.sha }}
           with:

--- a/.github/workflows/cncf-playground-reset.yaml
+++ b/.github/workflows/cncf-playground-reset.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Cluster cleanup by running the cleanup script inside VM
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@068c0c7a4e59a5ae12fb7cb454b05735d830c82b # master
       with:
           host: ${{ secrets.METAL_SERVER6 }}
           username: root

--- a/.github/workflows/cncf-playground-reset.yaml
+++ b/.github/workflows/cncf-playground-reset.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Cluster cleanup by running the cleanup script inside VM
-      uses: appleboy/ssh-action@068c0c7a4e59a5ae12fb7cb454b05735d830c82b # master
+      uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
       with:
           host: ${{ secrets.METAL_SERVER6 }}
           username: root

--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT        
       #- name: Publish Helm chart for edge latest
       #  if: startsWith(github.ref, 'refs/tags/') != true && success()
-      #  uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
+      #  uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
       #  with:
       #    token: ${{ secrets.GH_ACCESS_TOKEN }}
       #    charts_dir: install/kubernetes/helm
@@ -67,7 +67,7 @@ jobs:
       #    chart_version: edge-latest
       #- name: Publish Helm chart for stable latest
       #  if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-      #  uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
+      #  uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
       #  with:
       #    token: ${{ secrets.GH_ACCESS_TOKEN }}
       #    charts_dir: install/kubernetes/helm
@@ -80,7 +80,7 @@ jobs:
       #    chart_version: stable-latest
       - name: Publish Helm chart for release version
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-        uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           charts_dir: install/kubernetes/helm
@@ -95,7 +95,7 @@ jobs:
   
       - name: Manually publish Helm chart with release version
         if:  github.event_name == 'workflow_dispatch'
-        uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           charts_dir: install/kubernetes/helm

--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT        
       #- name: Publish Helm chart for edge latest
       #  if: startsWith(github.ref, 'refs/tags/') != true && success()
-      #  uses: stefanprodan/helm-gh-pages@master
+      #  uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
       #  with:
       #    token: ${{ secrets.GH_ACCESS_TOKEN }}
       #    charts_dir: install/kubernetes/helm
@@ -67,7 +67,7 @@ jobs:
       #    chart_version: edge-latest
       #- name: Publish Helm chart for stable latest
       #  if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-      #  uses: stefanprodan/helm-gh-pages@master
+      #  uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
       #  with:
       #    token: ${{ secrets.GH_ACCESS_TOKEN }}
       #    charts_dir: install/kubernetes/helm
@@ -80,7 +80,7 @@ jobs:
       #    chart_version: stable-latest
       - name: Publish Helm chart for release version
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           charts_dir: install/kubernetes/helm
@@ -95,7 +95,7 @@ jobs:
   
       - name: Manually publish Helm chart with release version
         if:  github.event_name == 'workflow_dispatch'
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82 # master
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           charts_dir: install/kubernetes/helm

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -37,7 +37,7 @@ jobs:
         run: make docker-build
       
       - name: Run Trivy scan on built image
-        uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'meshery/meshery'
           format: 'json'

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -37,7 +37,7 @@ jobs:
         run: make docker-build
       
       - name: Run Trivy scan on built image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # master
         with:
           image-ref: 'meshery/meshery'
           format: 'json'


### PR DESCRIPTION
### What
Pin four third-party actions currently on `@master` to their commit SHA (tags kept in comments):

| Action | Where | Credentials |
|---|---|---|
| `appleboy/ssh-action@master` | `cncf-playground-deploy-meshery.yaml`, `cncf-playground-reset.yaml` | production **SSH private keys** (`OCI_BASTION_KEY`, `METAL_SSH_*`) |
| `stefanprodan/helm-gh-pages@master` | `helm-chart-releaser.yml` (×2) | `GH_ACCESS_TOKEN` (PAT) |
| `aquasecurity/trivy-action@master` | `image-scan.yml` | `pull_request_target` job, `issues: write` |

### Why
`@master` is a moving ref — whatever it points to at run time runs in the job. The `appleboy/ssh-action`
steps are handed **SSH private keys** for the bastion/metal hosts; a moved tag there (compromise or an
accidental change) would run unreviewed code with those keys — the class behind the 2025
`tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (each SHA is the current tip of master). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the credential exposure, and the pinned SHAs myself.</sub>

Closes #20648
