### PR TITLE
[Server] Resolve unreachable K8s connections to NOT_FOUND instead of REGISTERED

### DIFF
--- a/server/machines/kubernetes/machine.go
+++ b/server/machines/kubernetes/machine.go
@@ -35,6 +35,10 @@ func Registered() machines.State {
 		Events: machines.Events{
 			machines.Connect: machines.CONNECTED,
 			machines.Ignore:  machines.IGNORED,
+			// RegisterAction redirects here to NOTFOUND when the cluster ping
+			// fails; without this edge the redirect is dropped and the
+			// connection is wrongly left/persisted as REGISTERED.
+			machines.NotFound: machines.NOTFOUND,
 		},
 		Action: &RegisterAction{},
 	}

--- a/server/machines/kubernetes/machine_registered_test.go
+++ b/server/machines/kubernetes/machine_registered_test.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/meshery/meshery/server/machines"
+)
+
+// TestRegisteredStateRoutesNotFound guards the fix for #20642: RegisterAction
+// redirects the machine to NOTFOUND when the cluster ping fails, so the
+// REGISTERED state must declare that edge. Without it the redirect is dropped
+// and an unreachable cluster is wrongly persisted as REGISTERED.
+func TestRegisteredStateRoutesNotFound(t *testing.T) {
+	st := Registered()
+
+	if got, ok := st.Events[machines.NotFound]; !ok || got != machines.NOTFOUND {
+		t.Fatalf("Registered must route NotFound -> NOTFOUND; got %q present=%v", got, ok)
+	}
+
+	// Existing edges must remain intact.
+	if st.Events[machines.Connect] != machines.CONNECTED {
+		t.Errorf("Registered lost its Connect -> CONNECTED edge")
+	}
+	if st.Events[machines.Ignore] != machines.IGNORED {
+		t.Errorf("Registered lost its Ignore -> IGNORED edge")
+	}
+}

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -138,12 +138,19 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	defer sm.mx.Unlock()
 	var event *events.Event
 	var err error
+	// Set when the transition loop aborts on an invalid transition (e.g. an
+	// action redirects to an event the current state has no edge for). In that
+	// case the machine may have advanced into an intermediate state it was only
+	// passing through, so the status update below is skipped to avoid persisting
+	// a partially-transitioned state.
+	partialTransition := false
 	for eventType != NoOp {
 		nextState, err := sm.getNextState(eventType)
 		if err != nil {
 			sm.Log.Error(err)
 			event = defaultEvent.WithMetadata(map[string]interface{}{"error": err}).Build()
 			sm.Log.Debug(defaultEvent.WithMetadata(map[string]interface{}{"error": err}).Build())
+			partialTransition = true
 			break
 		}
 
@@ -155,6 +162,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 			sm.Log.Error(err)
 			event = defaultEvent.WithMetadata(map[string]interface{}{"error": ErrInvalidTransition(sm.CurrentState, nextState)}).Build()
 			sm.Log.Debug(event)
+			partialTransition = true
 			break
 		}
 
@@ -198,7 +206,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		sm.CurrentState = nextState
 	}
 
-	if sm.Provider != nil && eventType != Exit {
+	if sm.Provider != nil && eventType != Exit && !partialTransition {
 		token, _ := ctx.Value(models.TokenCtxKey).(string)
 		connection, _, err := sm.Provider.GetConnectionByID(token, sm.ID)
 

--- a/server/machines/send_event_test.go
+++ b/server/machines/send_event_test.go
@@ -1,0 +1,146 @@
+package machines
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/meshkit/models/events"
+	"github.com/meshery/schemas/models/core"
+)
+
+// redirectAction mimics the real kubernetes RegisterAction: its Execute returns
+// a redirect event (and optionally an error), asking the engine to move the
+// machine on to another state.
+type redirectAction struct {
+	redirect EventType
+	err      error
+}
+
+func (a *redirectAction) ExecuteOnEntry(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+func (a *redirectAction) Execute(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return a.redirect, nil, a.err
+}
+func (a *redirectAction) ExecuteOnExit(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+
+// terminalAction ends a transition (always NoOp).
+type terminalAction struct{}
+
+func (a *terminalAction) ExecuteOnEntry(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+func (a *terminalAction) Execute(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+func (a *terminalAction) ExecuteOnExit(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+
+// fakeProvider records the status persisted via UpdateConnectionById. Only the
+// two methods SendEvent calls are implemented; the rest are inherited from the
+// embedded (nil) interface and are never invoked on these paths.
+type fakeProvider struct {
+	models.Provider
+	updateCalled  bool
+	updatedStatus connections.ConnectionStatus
+}
+
+func (f *fakeProvider) GetConnectionByID(string, core.Uuid) (*connections.Connection, int, error) {
+	return &connections.Connection{Kind: "test"}, 200, nil
+}
+func (f *fakeProvider) UpdateConnectionById(_ string, conn *connections.ConnectionPayload, _ string) (*connections.Connection, error) {
+	f.updateCalled = true
+	f.updatedStatus = conn.Status
+	return &connections.Connection{ID: conn.ID, Kind: conn.Kind}, nil
+}
+
+func testCtx() context.Context {
+	sysID := core.Uuid(uuid.Must(uuid.NewV4()))
+	ctx := context.WithValue(context.Background(), models.UserCtxKey, &models.User{ID: core.Uuid(uuid.Must(uuid.NewV4()))})
+	return context.WithValue(ctx, models.SystemIDKey, &sysID)
+}
+
+func newTestLogger(t *testing.T) logger.Handler {
+	t.Helper()
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	return log
+}
+
+const (
+	stateStart StateType = "start"
+	stateMid   StateType = "mid"
+	stateFinal StateType = "final"
+
+	eventGo       EventType = "go"
+	eventFallback EventType = "fallback"
+)
+
+// TestSendEvent_FollowsRedirectToDefinedEdge covers the fix for #20642: when an
+// action redirects (as RegisterAction does to NOTFOUND on ping failure) and the
+// current state declares that edge, the machine must follow it and persist the
+// resolved final state — not stall in the intermediate state.
+func TestSendEvent_FollowsRedirectToDefinedEdge(t *testing.T) {
+	provider := &fakeProvider{}
+	sm := &StateMachine{
+		ID:           core.Uuid(uuid.Must(uuid.NewV4())),
+		Name:         "test",
+		CurrentState: stateStart,
+		Log:          newTestLogger(t),
+		Provider:     provider,
+		States: States{
+			stateStart: {Events: Events{eventGo: stateMid}},
+			// mid redirects onward to final, and declares the edge for it.
+			stateMid:   {Events: Events{eventFallback: stateFinal}, Action: &redirectAction{redirect: eventFallback, err: errors.New("ping failed")}},
+			stateFinal: {Events: Events{}, Action: &terminalAction{}},
+		},
+	}
+
+	if _, err := sm.SendEvent(testCtx(), eventGo, nil); err != nil {
+		t.Fatalf("SendEvent returned error: %v", err)
+	}
+	if sm.CurrentState != stateFinal {
+		t.Fatalf("machine state = %q, want %q (redirect not followed)", sm.CurrentState, stateFinal)
+	}
+	if !provider.updateCalled || provider.updatedStatus != connections.ConnectionStatus(stateFinal) {
+		t.Fatalf("persisted status = %q (called=%v), want %q", provider.updatedStatus, provider.updateCalled, stateFinal)
+	}
+}
+
+// TestSendEvent_DoesNotPersistPartialTransition covers the second half of
+// #20642: when an action redirects to an event the current state has no edge
+// for, the transition is invalid and the machine must NOT persist the
+// intermediate state it was passing through.
+func TestSendEvent_DoesNotPersistPartialTransition(t *testing.T) {
+	provider := &fakeProvider{}
+	sm := &StateMachine{
+		ID:           core.Uuid(uuid.Must(uuid.NewV4())),
+		Name:         "test",
+		CurrentState: stateStart,
+		Log:          newTestLogger(t),
+		Provider:     provider,
+		States: States{
+			stateStart: {Events: Events{eventGo: stateMid}},
+			// mid redirects to fallback but declares NO edge for it -> invalid.
+			stateMid: {Events: Events{}, Action: &redirectAction{redirect: eventFallback}},
+		},
+	}
+
+	event, _ := sm.SendEvent(testCtx(), eventGo, nil)
+	if provider.updateCalled {
+		t.Fatalf("status was persisted (%q) on an invalid transition; expected no persistence", provider.updatedStatus)
+	}
+	if event == nil || event.Severity != events.Error {
+		t.Fatalf("expected an error-severity event on an invalid transition, got %#v", event)
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20642

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
