### PR TITLE
fix(ui): replace generic loading indicators with page-specific messages

### DIFF
--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -449,7 +449,14 @@ const Environments = () => {
     }
   };
 
-  if (isEnvironmentsFetching && !environmentsData) {
+  if (
+    CAN(
+      Keys.WorkspaceManagementViewEnvironment.id,
+      Keys.WorkspaceManagementViewEnvironment.function,
+    ) &&
+    isEnvironmentsFetching &&
+    !environmentsData
+  ) {
     return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Environments..." />;
   }
 

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -449,7 +449,7 @@ const Environments = () => {
     }
   };
 
-  if (!orgId || isEnvironmentsFetching) {
+  if (isEnvironmentsFetching && !environmentsData) {
     return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Environments..." />;
   }
 

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -51,6 +51,7 @@ import CAN from '@/utils/can';
 import DefaultError from '../general/error-404/index';
 import { useSelector } from 'react-redux';
 import { updateProgress } from '@/store/slices/mesheryUi';
+import LoadingScreen from '../shared/LoadingState/LoadingComponent';
 
 const ACTION_TYPES = {
   CREATE: 'create',
@@ -92,6 +93,7 @@ const Environments = () => {
     data: environmentsData,
     isError: isEnvironmentsError,
     error: environmentsError,
+    isFetching: isEnvironmentsFetching,
   } = useGetEnvironmentsQuery(
     {
       search: search,
@@ -446,6 +448,10 @@ const Environments = () => {
       );
     }
   };
+
+  if (!orgId || isEnvironmentsFetching) {
+    return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Environments..." />;
+  }
 
   return (
     <NoSsr>

--- a/ui/components/settings/MesherySettings.test.tsx
+++ b/ui/components/settings/MesherySettings.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const routerState = {
@@ -17,52 +17,56 @@ vi.mock('next/link', () => ({
   default: ({ children, href }: any) => <a href={href}>{children}</a>,
 }));
 
-vi.mock('@sistent/sistent', () => ({
-  NoSsr: ({ children }: any) => <>{children}</>,
-  CustomTooltip: ({ children, title, value }: any) => (
-    <span data-tooltip-title={String(title)} data-tooltip-value={String(value)}>
-      {children}
-    </span>
-  ),
-  AppBar: ({ children }: any) => <div>{children}</div>,
-  Typography: ({ children, sx, color, variant, ...rest }: any) => (
-    <span data-variant={variant} {...rest}>
-      {children}
-    </span>
-  ),
-  Tabs: ({ children, value, onChange }: any) => (
-    <div data-testid="tabs" data-value={value} onClick={(e) => onChange?.(e, 'mock-tab')}>
-      {children}
-    </div>
-  ),
-  Tab: ({ label, value, disabled }: any) => (
-    <button data-testid={`tab-${value}`} disabled={disabled}>
-      {label}
-    </button>
-  ),
-  Paper: ({ children, ...rest }: any) => <div {...rest}>{children}</div>,
-  Grid2: ({ children }: any) => <div>{children}</div>,
-  LeftArrowIcon: () => <svg />,
-  PollIcon: () => <svg />,
-  DatabaseIcon: () => <svg />,
-  MendeleyIcon: () => <svg />,
-  FileIcon: () => <svg />,
-  SettingsIcon: () => <svg />,
-  useTheme: () => ({
-    palette: {
-      icon: { default: 'icon' },
-      primary: { main: 'primary' },
+vi.mock('@sistent/sistent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sistent/sistent')>();
+  return {
+    ...actual,
+    NoSsr: ({ children }: any) => <>{children}</>,
+    CustomTooltip: ({ children, title, value }: any) => (
+      <span data-tooltip-title={String(title)} data-tooltip-value={String(value)}>
+        {children}
+      </span>
+    ),
+    AppBar: ({ children }: any) => <div>{children}</div>,
+    Typography: ({ children, sx, color, variant, ...rest }: any) => (
+      <span data-variant={variant} {...rest}>
+        {children}
+      </span>
+    ),
+    Tabs: ({ children, value, onChange }: any) => (
+      <div data-testid="tabs" data-value={value} onClick={(e) => onChange?.(e, 'mock-tab')}>
+        {children}
+      </div>
+    ),
+    Tab: ({ label, value, disabled }: any) => (
+      <button data-testid={`tab-${value}`} disabled={disabled}>
+        {label}
+      </button>
+    ),
+    Paper: ({ children, ...rest }: any) => <div {...rest}>{children}</div>,
+    Grid2: ({ children }: any) => <div>{children}</div>,
+    LeftArrowIcon: () => <svg />,
+    PollIcon: () => <svg />,
+    DatabaseIcon: () => <svg />,
+    MendeleyIcon: () => <svg />,
+    FileIcon: () => <svg />,
+    SettingsIcon: () => <svg />,
+    useTheme: () => ({
+      palette: {
+        icon: { default: 'icon' },
+        primary: { main: 'primary' },
+      },
+      spacing: (n: number) => n,
+    }),
+    styled: (Component: any) => () => {
+      const StyledComponent = ({ children, ...rest }: any) =>
+        typeof Component === 'string'
+          ? React.createElement(Component, rest, children)
+          : React.createElement(Component, rest, children);
+      return StyledComponent;
     },
-    spacing: (n: number) => n,
-  }),
-  styled: (Component: any) => () => {
-    const StyledComponent = ({ children, ...rest }: any) =>
-      typeof Component === 'string'
-        ? React.createElement(Component, rest, children)
-        : React.createElement(Component, rest, children);
-    return StyledComponent;
-  },
-}));
+  };
+});
 
 vi.mock('../dashboard/charts/DashboardMeshModelGraph', () => ({
   default: () => <div data-testid="dashboard-graph" />,
@@ -166,10 +170,10 @@ describe('MesherySettings', () => {
     };
   });
 
-  it('renders the main settings tab bar with the 5 settings categories', () => {
+  it('renders the main settings tab bar with the 5 settings categories', async () => {
     render(<MesherySettings />);
 
-    expect(screen.getByTestId('tab-Overview')).toBeInTheDocument();
+    expect(await screen.findByTestId('tab-Overview')).toBeInTheDocument();
     expect(screen.getByTestId('tab-Adapters')).toBeInTheDocument();
     expect(screen.getByTestId('tab-Registry')).toBeInTheDocument();
     expect(screen.getByTestId('tab-Controllers')).toBeInTheDocument();
@@ -177,22 +181,22 @@ describe('MesherySettings', () => {
     expect(screen.queryByTestId('tab-Metrics')).not.toBeInTheDocument();
   });
 
-  it('renders the controllers configuration tab when selected', () => {
+  it('renders the controllers configuration tab when selected', async () => {
     routerState.query = { settingsCategory: 'Controllers' };
     render(<MesherySettings />);
-    expect(screen.getByTestId('controllers-config')).toBeInTheDocument();
+    expect(await screen.findByTestId('controllers-config')).toBeInTheDocument();
   });
 
-  it('renders the Overview tab content (dashboard graph) by default', () => {
+  it('renders the Overview tab content (dashboard graph) by default', async () => {
     render(<MesherySettings />);
-    expect(screen.getByTestId('dashboard-graph')).toBeInTheDocument();
+    expect(await screen.findByTestId('dashboard-graph')).toBeInTheDocument();
     expect(screen.getByTestId('config-charts')).toBeInTheDocument();
     expect(screen.getByTestId('connection-charts')).toBeInTheDocument();
   });
 
-  it('returns null when MesherySystemViewSettings permission is denied', () => {
+  it('returns null when MesherySystemViewSettings permission is denied', async () => {
     canMockReturn = false;
     const { container } = render(<MesherySettings />);
-    expect(container.textContent).toBe('');
+    await waitFor(() => expect(container.textContent).toBe(''));
   });
 });

--- a/ui/components/settings/MesherySettings.tsx
+++ b/ui/components/settings/MesherySettings.tsx
@@ -39,6 +39,7 @@ import MesheryConfigurationChart from '../dashboard/charts/MesheryConfigurationC
 import ConnectionStatsChart from '../dashboard/charts/ConnectionCharts';
 import { useSelector } from 'react-redux';
 import { useGetProviderCapabilitiesQuery } from '@/rtk-query/user';
+import LoadingScreen from '../shared/LoadingState/LoadingComponent';
 
 const StyledPaper = styled(Paper)(() => ({
   flexGrow: 1,
@@ -120,7 +121,8 @@ const MesherySettings = () => {
   const theme = useTheme();
   const { k8sConfig } = useSelector((state) => state.ui);
   const { meshAdapters } = useSelector((state) => state.adapter);
-  const { data: providerCapabilities } = useGetProviderCapabilitiesQuery();
+  const { data: providerCapabilities, isLoading: isCapabilitiesLoading } =
+    useGetProviderCapabilitiesQuery();
   const [state, setState] = useState({
     meshAdapters,
     tabVal: selectedSettingsCategory || OVERVIEW,
@@ -130,6 +132,7 @@ const MesherySettings = () => {
     registrantCount: 0,
     isMeshConfigured: k8sConfig.clusterConfigured,
   });
+  const [isCountsLoading, setIsCountsLoading] = useState(true);
 
   const systemResetPromptRef = useRef<{ show: (_args: any) => Promise<string> } | null>(null);
 
@@ -155,6 +158,8 @@ const MesherySettings = () => {
         }));
       } catch (error) {
         console.error(error);
+      } finally {
+        setIsCountsLoading(false);
       }
     };
     fetchData();
@@ -198,6 +203,11 @@ const MesherySettings = () => {
       </div>
     );
   }
+
+  if (isCapabilitiesLoading || isCountsLoading) {
+    return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Meshery Settings..." />;
+  }
+
   return (
     <>
       {CAN(Keys.MesherySystemViewSettings.id, Keys.MesherySystemViewSettings.function) ? (

--- a/ui/components/settings/MesherySettings.tsx
+++ b/ui/components/settings/MesherySettings.tsx
@@ -204,7 +204,10 @@ const MesherySettings = () => {
     );
   }
 
-  if (isCapabilitiesLoading || isCountsLoading) {
+  if (
+    CAN(Keys.MesherySystemViewSettings.id, Keys.MesherySystemViewSettings.function) &&
+    (isCapabilitiesLoading || isCountsLoading)
+  ) {
     return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Meshery Settings..." />;
   }
 

--- a/ui/components/telemetry/dashboards/index.tsx
+++ b/ui/components/telemetry/dashboards/index.tsx
@@ -4,7 +4,6 @@ import {
   AddIcon,
   Box,
   Button,
-  CircularProgress,
   Drawer,
   InsertChartIcon,
   Typography,
@@ -25,6 +24,7 @@ import { DEFAULT_RANGE, resolveWindow } from '../common/time';
 import BoardLibrary from './BoardLibrary';
 import BoardView from './BoardView';
 import type { PinnedBoard } from './types';
+import LoadingScreen from '../../shared/LoadingState/LoadingComponent';
 
 const Toolbar = styled(Box)(({ theme }) => ({
   position: 'sticky',
@@ -134,9 +134,7 @@ const TelemetryDashboards: React.FC = () => {
 
   if (connectionsLoading) {
     return (
-      <Centered>
-        <CircularProgress />
-      </Centered>
+      <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Telemetry Dashboards..." />
     );
   }
 

--- a/ui/components/user-preferences/index.test.tsx
+++ b/ui/components/user-preferences/index.test.tsx
@@ -25,43 +25,47 @@ let capabilitiesReturn: any = {
   isSuccess: false,
 };
 
-vi.mock('@sistent/sistent', () => ({
-  Tab: ({ label, ...rest }: any) => <button {...rest}>{label}</button>,
-  Tabs: ({ children, value, onChange }: any) => (
-    <div data-testid="tabs" data-value={value} onClick={(e) => onChange?.(e, 0)}>
-      {children}
-    </div>
-  ),
-  Typography: ({ children, ...rest }: any) => <span {...rest}>{children}</span>,
-  Grid2: ({ children }: any) => <div>{children}</div>,
-  FormGroup: ({ children }: any) => <div>{children}</div>,
-  FormControlLabel: ({ label, control }: any) => (
-    <label>
-      {control}
-      {label}
-    </label>
-  ),
-  Switch: ({ checked, onChange, ...rest }: any) => (
-    <input
-      type="checkbox"
-      checked={!!checked}
-      onChange={onChange}
-      data-testid={rest['data-cy'] || 'switch'}
-    />
-  ),
-  IconButton: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
-  CardContent: ({ children }: any) => <div>{children}</div>,
-  CardHeader: ({ children }: any) => <div>{children}</div>,
-  CustomTooltip: ({ children }: any) => <>{children}</>,
-  NoSsr: ({ children }: any) => <>{children}</>,
-  TachometerIcon: () => <svg />,
-  SettingsCellIcon: () => <svg />,
-  SettingsRemoteIcon: () => <svg />,
-  useTheme: () => ({
-    palette: { icon: { default: 'icon' }, mode: 'light' },
-  }),
-  ErrorBoundary: ({ children }: any) => <>{children}</>,
-}));
+vi.mock('@sistent/sistent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sistent/sistent')>();
+  return {
+    ...actual,
+    Tab: ({ label, ...rest }: any) => <button {...rest}>{label}</button>,
+    Tabs: ({ children, value, onChange }: any) => (
+      <div data-testid="tabs" data-value={value} onClick={(e) => onChange?.(e, 0)}>
+        {children}
+      </div>
+    ),
+    Typography: ({ children, ...rest }: any) => <span {...rest}>{children}</span>,
+    Grid2: ({ children }: any) => <div>{children}</div>,
+    FormGroup: ({ children }: any) => <div>{children}</div>,
+    FormControlLabel: ({ label, control }: any) => (
+      <label>
+        {control}
+        {label}
+      </label>
+    ),
+    Switch: ({ checked, onChange, ...rest }: any) => (
+      <input
+        type="checkbox"
+        checked={!!checked}
+        onChange={onChange}
+        data-testid={rest['data-cy'] || 'switch'}
+      />
+    ),
+    IconButton: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+    CardContent: ({ children }: any) => <div>{children}</div>,
+    CardHeader: ({ children }: any) => <div>{children}</div>,
+    CustomTooltip: ({ children }: any) => <>{children}</>,
+    NoSsr: ({ children }: any) => <>{children}</>,
+    TachometerIcon: () => <svg />,
+    SettingsCellIcon: () => <svg />,
+    SettingsRemoteIcon: () => <svg />,
+    useTheme: () => ({
+      palette: { icon: { default: 'icon' }, mode: 'light' },
+    }),
+    ErrorBoundary: ({ children }: any) => <>{children}</>,
+  };
+});
 
 vi.mock('../../assets/icons/CopyIcon', () => ({
   default: () => <svg />,

--- a/ui/components/user-preferences/index.tsx
+++ b/ui/components/user-preferences/index.tsx
@@ -56,6 +56,7 @@ import { ThemeTogglerCore } from '@/themes/hooks';
 import { SecondaryTab, SecondaryTabs } from '../dashboard/style';
 import { useDispatch, useSelector } from 'react-redux';
 import { toggleCatalogContent, updateProgress } from '@/store/slices/mesheryUi';
+import LoadingScreen from '../shared/LoadingState/LoadingComponent';
 
 interface ThemeTogglerProps {
   handleUpdateUserPref: (_theme: string) => void;
@@ -143,10 +144,14 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
     isSuccess: isUserDataFetched,
     isError: isUserDataError,
     error: userDataError,
+    isLoading: isUserPrefLoading,
   } = useGetUserPrefQuery();
 
-  const { data: capabilitiesData, isSuccess: isCapabilitiesDataFetched } =
-    useGetProviderCapabilitiesQuery();
+  const {
+    data: capabilitiesData,
+    isSuccess: isCapabilitiesDataFetched,
+    isLoading: isCapabilitiesLoading,
+  } = useGetProviderCapabilitiesQuery();
 
   const [updateUserPref] = useUpdateUserPrefMutation();
   const [updateUserPrefWithContext] = useUpdateUserPrefWithContextMutation();
@@ -529,6 +534,11 @@ const UserPreference: React.FC<UserPreferenceProps> = (props) => {
     const updates = _.set(_.cloneDeep(userData), key, value);
     updateUserPrefWithContext(updates);
   };
+
+  if (isUserPrefLoading || isCapabilitiesLoading) {
+    return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading User Preferences..." />;
+  }
+
   return (
     <>
       <NoSsr>

--- a/ui/components/workspaces/index.tsx
+++ b/ui/components/workspaces/index.tsx
@@ -389,7 +389,7 @@ const Workspaces = ({ onSelectWorkspace }) => {
 
   const [columnVisibility, setColumnVisibility] = useState({});
 
-  if (!organization?.id || isWorkspacesFetching) {
+  if (isWorkspacesFetching && !workspacesData) {
     return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Workspaces..." />;
   }
 

--- a/ui/components/workspaces/index.tsx
+++ b/ui/components/workspaces/index.tsx
@@ -53,6 +53,7 @@ import { updateProgress } from '@/store/slices/mesheryUi';
 import { useContext } from 'react';
 import { WorkspaceModalContext } from '@/utils/context/WorkspaceModalContextProvider';
 import { useEffect } from 'react';
+import LoadingScreen from '../shared/LoadingState/LoadingComponent';
 
 export const WORKSPACE_ACTION_TYPES = {
   CREATE: 'create',
@@ -173,7 +174,7 @@ const Workspaces = ({ onSelectWorkspace }) => {
   const bulkDeleteRef = useRef(null);
   const { notify } = useNotification();
 
-  const { data: workspacesData } = useGetWorkspacesQuery(
+  const { data: workspacesData, isFetching: isWorkspacesFetching } = useGetWorkspacesQuery(
     {
       page: page,
       pagesize: pageSize,
@@ -387,6 +388,10 @@ const Workspaces = ({ onSelectWorkspace }) => {
   };
 
   const [columnVisibility, setColumnVisibility] = useState({});
+
+  if (!organization?.id || isWorkspacesFetching) {
+    return <LoadingScreen animatedIcon="AnimatedMeshery" message="Loading Workspaces..." />;
+  }
 
   return (
     <NoSsr>


### PR DESCRIPTION
**Notes for Reviewers**
Replaces bare/generic loading indicators (`CircularProgress` with no context, or pages with no loading state at all) with the existing `LoadingScreen` component, giving each page a contextual message while its data loads — matching the pattern already used on Connections, Credentials, Patterns, and Filters.

- This PR fixes #20512 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
