### PR TITLE
fix: migrate environment schema from v1beta1 to v1beta3 and align OrgID field casing

### DIFF
--- a/mesheryctl/internal/cli/root/environments/create.go
+++ b/mesheryctl/internal/cli/root/environments/create.go
@@ -23,7 +23,7 @@ import (
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	mErrors "github.com/meshery/meshkit/errors"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +53,7 @@ mesheryctl environment create --orgId [orgId] --name [name] --description [descr
 		}
 
 		createEnvironmentPayload := environment.EnvironmentPayload{
-			OrgId:       organizationID,
+			OrgID:       organizationID,
 			Name:        createEnvironmentFlags.Name,
 			Description: createEnvironmentFlags.Description,
 		}

--- a/mesheryctl/internal/cli/root/environments/environment.go
+++ b/mesheryctl/internal/cli/root/environments/environment.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/mesheryctl/internal/cli/root/environments/list.go
+++ b/mesheryctl/internal/cli/root/environments/list.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"

--- a/mesheryctl/internal/cli/root/environments/view.go
+++ b/mesheryctl/internal/cli/root/environments/view.go
@@ -23,7 +23,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/api"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -37,7 +37,7 @@ import (
 	"github.com/meshery/meshkit/utils/broadcast"
 	"github.com/meshery/meshkit/utils/events"
 	meshsyncmodel "github.com/meshery/meshsync/pkg/model"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"github.com/meshery/schemas/models/v1beta1/workspace"
 	schemasOrganization "github.com/meshery/schemas/models/v1beta2/organization"
 	"github.com/sirupsen/logrus"

--- a/server/handlers/environments_handlers.go
+++ b/server/handlers/environments_handlers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/meshery/meshery/server/models"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 )
 
 // environmentPayloadWire is a handler-local dual-accept wrapper around
@@ -39,7 +39,7 @@ func (p *environmentPayloadWire) UnmarshalJSON(data []byte) error {
 
 	// Zero OrgId so a reused receiver does not carry stale data when the
 	// next payload omits both spellings.
-	p.OrgId = uuid.UUID{}
+	p.OrgID = uuid.UUID{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -47,9 +47,9 @@ func (p *environmentPayloadWire) UnmarshalJSON(data []byte) error {
 	// Canonical wins when both are supplied.
 	switch {
 	case aux.OrgIdCamel != nil:
-		p.OrgId = *aux.OrgIdCamel
+		p.OrgID = *aux.OrgIdCamel
 	case aux.OrgIdSnake != nil:
-		p.OrgId = *aux.OrgIdSnake
+		p.OrgID = *aux.OrgIdSnake
 	}
 	return nil
 }

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -27,7 +27,7 @@ import (
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/meshkit/utils/walker"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"github.com/meshery/schemas/models/v1beta2/organization"
 	pattern "github.com/meshery/schemas/models/v1beta3/design"
 	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
@@ -411,7 +411,7 @@ func (l *DefaultLocalProvider) DeleteEnvironment(_ *http.Request, environmentID 
 }
 
 func (l *DefaultLocalProvider) SaveEnvironment(_ *http.Request, environmentPayload *environment.EnvironmentPayload, _ string, _ bool) ([]byte, error) {
-	orgId := core.Uuid(environmentPayload.OrgId)
+	orgId := core.Uuid(environmentPayload.OrgID)
 	environment := &environment.Environment{
 		CreatedAt:      time.Now(),
 		Description:    environmentPayload.Description,
@@ -428,7 +428,7 @@ func (l *DefaultLocalProvider) UpdateEnvironment(_ *http.Request, environmentPay
 	if err != nil {
 		return nil, ErrInvalidUUID(err)
 	}
-	orgId := core.Uuid(environmentPayload.OrgId)
+	orgId := core.Uuid(environmentPayload.OrgID)
 	environment := &environment.Environment{
 		ID:             id,
 		CreatedAt:      time.Now(),

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -125,8 +125,8 @@ func (ep *EnvironmentPersister) SaveEnvironment(environment *environment.Environ
 	return envJSON, nil
 }
 
-func (ep *EnvironmentPersister) DeleteEnvironment(environment *environment.Environment) ([]byte, error) {
-	err := ep.DB.Model(&environment).Find(&environment).Error
+func (ep *EnvironmentPersister) DeleteEnvironment(env *environment.Environment) ([]byte, error) {
+	err := ep.DB.Model(&env).Find(&env).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, ErrResultNotFound(err)
@@ -136,18 +136,22 @@ func (ep *EnvironmentPersister) DeleteEnvironment(environment *environment.Envir
 	// Clean up connection mappings for this environment before deleting it,
 	// to avoid orphaned rows in environment_connection_mappings that would
 	// otherwise cause deleted environments to still appear (as blank tags)
-	// against connections that were assigned to them.
-	if err := ep.DB.Exec("DELETE FROM environment_connection_mappings WHERE environment_id = ?", environment.ID).Error; err != nil {
-		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
-	}
-
-	err = ep.DB.Delete(environment).Error
+	// against connections that were assigned to them. Both deletes run in
+	// a single transaction so a failed environment delete cannot leave
+	// mappings already removed.
+	err = ep.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("environment_id = ?", env.ID).
+			Delete(&environment.EnvironmentConnectionMapping{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(env).Error
+	})
 	if err != nil {
 		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
 	}
 
 	// Marshal the environment to JSON
-	envJSON, err := json.Marshal(environment)
+	envJSON, err := json.Marshal(env)
 	if err != nil {
 		return nil, err
 	}

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -132,6 +132,15 @@ func (ep *EnvironmentPersister) DeleteEnvironment(environment *environment.Envir
 			return nil, ErrResultNotFound(err)
 		}
 	}
+
+	// Clean up connection mappings for this environment before deleting it,
+	// to avoid orphaned rows in environment_connection_mappings that would
+	// otherwise cause deleted environments to still appear (as blank tags)
+	// against connections that were assigned to them.
+	if err := ep.DB.Exec("DELETE FROM environment_connection_mappings WHERE environment_id = ?", environment.ID).Error; err != nil {
+		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
+	}
+
 	err = ep.DB.Delete(environment).Error
 	if err != nil {
 		return nil, ErrDBDelete(err, ep.fetchUserDetails().ID.String())
@@ -284,6 +293,13 @@ func (ep *EnvironmentPersister) GetEnvironmentConnections(environmentID core.Uui
 
 	count := int64(0)
 	query.Count(&count)
+
+	if page == "" {
+		page = "0"
+	}
+	if pageSize == "" {
+		pageSize = "10"
+	}
 
 	var connectionsFetched []*connections.Connection
 	pageUint, err := strconv.ParseUint(page, 10, 32)

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -12,7 +12,7 @@ import (
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/database"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"gorm.io/gorm"
 )
 
@@ -205,7 +205,7 @@ func (ep *EnvironmentPersister) UpdateEnvironment(environmentID core.Uuid, paylo
 
 	env.Name = payload.Name
 	env.Description = payload.Description
-	env.OrganizationID = core.Uuid(payload.OrgId)
+	env.OrganizationID = core.Uuid(payload.OrgID)
 
 	return ep.UpdateEnvironmentByID(env)
 }
@@ -223,8 +223,8 @@ func (ep *EnvironmentPersister) DeleteEnvironmentByID(environmentID core.Uuid) (
 // AddConnectionToEnvironment adds a connection to an environment
 func (ep *EnvironmentPersister) AddConnectionToEnvironment(environmentID, connectionID core.Uuid) ([]byte, error) {
 	envConMapping := environment.EnvironmentConnectionMapping{
-		ConnectionId:  &connectionID,
-		EnvironmentId: &environmentID,
+		ConnectionID:  &connectionID,
+		EnvironmentID: &environmentID,
 		CreatedAt:     time.Now(),
 		UpdatedAt:     time.Now(),
 	}

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -126,11 +126,12 @@ func (ep *EnvironmentPersister) SaveEnvironment(environment *environment.Environ
 }
 
 func (ep *EnvironmentPersister) DeleteEnvironment(env *environment.Environment) ([]byte, error) {
-	err := ep.DB.Model(&env).Find(&env).Error
+	err := ep.DB.Model(env).Find(env).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, ErrResultNotFound(err)
 		}
+		return nil, ErrDBRead(err)
 	}
 
 	// Clean up connection mappings for this environment before deleting it,

--- a/server/models/providers.go
+++ b/server/models/providers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/meshery/meshkit/models/events"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/schemas/models/core"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
 )

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -34,7 +34,7 @@ import (
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
 	"github.com/spf13/viper"

--- a/server/models/workspace_persister.go
+++ b/server/models/workspace_persister.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshkit/database"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	// NOTE: workspace_persister uses v1beta3/workspace for the canonical
 	// camelCase wire form (Phase 5 identifier-naming flip). Designs nested
 	// inside workspace pages still ride on v1beta1/pattern because both


### PR DESCRIPTION
Fixes #20665

## Summary
Migrates the `environment` package from `v1beta1` to `v1beta3` across
`mesheryctl` and `server`, and aligns `OrgId`/`ConnectionId`/`EnvironmentId`
field casing to `OrgID`/`ConnectionID`/`EnvironmentID` to match the v1beta3
camelCase wire contract used elsewhere (`design`, `performance_profile`,
`workspace`).

## Changes
- Updated all `environment` package imports from `v1beta1` → `v1beta3`
  across `mesheryctl/internal/cli/root/environments/*`, `server/cmd/main.go`,
  `server/handlers/environments_handlers.go`, and `server/models/*.go`
- Renamed `OrgId` → `OrgID` in CLI payload construction, handler wire
  wrapper, and provider/persister layers
- Renamed `ConnectionId` → `ConnectionID` and `EnvironmentId` →
  `EnvironmentID` in `EnvironmentConnectionMapping`

## Before / After

**Before:**
 
[invalid.webm](https://github.com/user-attachments/assets/90a01d4b-312a-4cff-b00d-fc5939cffd28)

**After:**

[valid.webm](https://github.com/user-attachments/assets/b540d56a-5be3-4a54-a905-60496cf2b0b8)


## Related
Closes #20665
