### PR TITLE
[docs] fix: replace deprecated word-wrap with overflow-wrap in _table.scss

### DIFF
--- a/docs/assets/scss/_table.scss
+++ b/docs/assets/scss/_table.scss
@@ -26,7 +26,7 @@ table td {
   padding: 8px;
   text-align: left;
   max-width: 300px;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 table td img {
   text-align: center;


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #18418

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

## Summary

Replaces the deprecated `word-wrap` CSS property with its standardized replacement `overflow-wrap` in `docs/assets/scss/_table.scss`, as requested in #18418.

## Before / After

```diff
 table td {
   border: 1px solid #dddddd;
   padding: 8px;
   text-align: left;
   max-width: 300px;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
```

I kept this PR scoped to the specific fix requested. The issue also suggested reviewing the `max-width: 300px` constraint separately — happy to follow up in another PR if that's still wanted.