### PR TITLE
[UI] Fix premature success and missing error notifications in Environments

### DIFF
--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -51,7 +51,7 @@ import {
 import { Keys } from '@meshery/schemas/permissions';
 import CAN from '@/utils/can';
 import DefaultError from '../general/error-404/index';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { updateProgress } from '@/store/slices/mesheryUi';
 
 const ACTION_TYPES = {
@@ -62,7 +62,6 @@ const ACTION_TYPES = {
 const Environments = () => {
   const theme = useTheme();
   const { organization } = useSelector((state) => state.ui);
-  const dispatch = useDispatch();
   const [environmentModal, setEnvironmentModal] = useState({
     open: false,
     schema: {},
@@ -179,7 +178,7 @@ const Environments = () => {
 
   function handleError(action) {
     return (error: unknown) => {
-      dispatch(updateProgress({ showProgress: false }));
+      updateProgress({ showProgress: false });
       const { message } = formatApiError(error, action);
       notify({
         message,
@@ -190,7 +189,7 @@ const Environments = () => {
   }
 
   const handleSuccess = (msg) => {
-    dispatch(updateProgress({ showProgress: false }));
+    updateProgress({ showProgress: false });
     notify({
       message: msg,
       event_type: EVENT_TYPES.SUCCESS,

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -18,6 +18,7 @@ import EnvironmentIcon from '../../assets/icons/Environment';
 import { EVENT_TYPES } from '../../lib/event-types';
 import { useNotification } from '../../utils/hooks/useNotification';
 import { formatApiError } from '../../utils/helpers/meshkitError';
+import { getErrorMessage } from '../connections/ConnectionTable.constants';
 import { RJSFModalWrapper } from '../shared/Modal/Modal';
 import _PromptComponent from '../PromptComponent';
 import { EmptyState } from '../lifecycle/general';
@@ -50,7 +51,7 @@ import {
 import { Keys } from '@meshery/schemas/permissions';
 import CAN from '@/utils/can';
 import DefaultError from '../general/error-404/index';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { updateProgress } from '@/store/slices/mesheryUi';
 
 const ACTION_TYPES = {
@@ -61,6 +62,7 @@ const ACTION_TYPES = {
 const Environments = () => {
   const theme = useTheme();
   const { organization } = useSelector((state) => state.ui);
+  const dispatch = useDispatch();
   const [environmentModal, setEnvironmentModal] = useState({
     open: false,
     schema: {},
@@ -176,19 +178,19 @@ const Environments = () => {
   ]);
 
   function handleError(action) {
-    return (error) => {
-      updateProgress({ showProgress: false });
+    return (error: unknown) => {
+      dispatch(updateProgress({ showProgress: false }));
       const { message } = formatApiError(error, action);
       notify({
         message,
         event_type: EVENT_TYPES.ERROR,
-        details: error?.toString(),
+        details: getErrorMessage(error),
       });
     };
   }
 
   const handleSuccess = (msg) => {
-    updateProgress({ showProgress: false });
+    dispatch(updateProgress({ showProgress: false }));
     notify({
       message: msg,
       event_type: EVENT_TYPES.SUCCESS,

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -17,6 +17,7 @@ import EnvironmentCard from './environment-card';
 import EnvironmentIcon from '../../assets/icons/Environment';
 import { EVENT_TYPES } from '../../lib/event-types';
 import { useNotification } from '../../utils/hooks/useNotification';
+import { formatApiError } from '../../utils/helpers/meshkitError';
 import { RJSFModalWrapper } from '../shared/Modal/Modal';
 import _PromptComponent from '../PromptComponent';
 import { EmptyState } from '../lifecycle/general';
@@ -157,15 +158,13 @@ const Environments = () => {
 
   useEffect(() => {
     if (isEnvironmentsError) {
-      handleError(`Environments Fetching Error: ${environmentsError?.data}`);
+      handleError('Environments Fetching Error')(environmentsError);
     }
     if (isEnvironmentConnectionsError) {
-      handleError(
-        `Connections of a Environment fetching Error: ${environmentConnectionsError?.data}`,
-      );
+      handleError('Connections of a Environment fetching Error')(environmentConnectionsError);
     }
     if (isConnectionsError) {
-      handleError(`Connections fetching Error: ${connectionsError?.data}`);
+      handleError('Connections fetching Error')(connectionsError);
     }
   }, [
     isEnvironmentsError,
@@ -179,10 +178,11 @@ const Environments = () => {
   function handleError(action) {
     return (error) => {
       updateProgress({ showProgress: false });
+      const { message } = formatApiError(error, action);
       notify({
-        message: `${action.error_msg}: ${error}`,
+        message,
         event_type: EVENT_TYPES.ERROR,
-        details: error.toString(),
+        details: error?.toString(),
       });
     };
   }
@@ -279,8 +279,8 @@ const Environments = () => {
       },
     })
       .unwrap()
-      .then(handleSuccess(`Environment "${name}" created `))
-      .catch((error) => handleError(`Environment Create Error: ${error?.data}`));
+      .then(() => handleSuccess(`Environment "${name}" created `))
+      .catch(handleError('Environment Create Error'));
     handleEnvironmentModalClose();
   };
 
@@ -294,8 +294,8 @@ const Environments = () => {
       },
     })
       .unwrap()
-      .then(handleSuccess(`Environment "${name}" updated`))
-      .catch((error) => handleError(`Environment Update Error: ${error?.data}`));
+      .then(() => handleSuccess(`Environment "${name}" updated`))
+      .catch(handleError('Environment Update Error'));
     handleEnvironmentModalClose();
   };
 
@@ -320,8 +320,8 @@ const Environments = () => {
       environmentId: id,
     })
       .unwrap()
-      .then(handleSuccess(`Environment deleted`))
-      .catch((error) => handleError(`Environment Delete Error: ${error?.data}`));
+      .then(() => handleSuccess(`Environment deleted`))
+      .catch(handleError('Environment Delete Error'));
   };
 
   const deleteEnvironmentModalContent = (environment) => (

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -158,7 +158,7 @@ const Environments = () => {
 
   useEffect(() => {
     if (isEnvironmentsError) {
-      handleError('Environments Fetching Error')(environmentsError);
+      handleError('Environments Fetch Error')(environmentsError);
     }
     if (isEnvironmentConnectionsError) {
       handleError('Connections of a Environment fetching Error')(environmentConnectionsError);

--- a/ui/utils/helpers/__tests__/meshkitError.test.ts
+++ b/ui/utils/helpers/__tests__/meshkitError.test.ts
@@ -115,4 +115,19 @@ describe('formatApiError', () => {
     const result = formatApiError(undefined);
     expect(result.message).toBe('An unexpected error occurred');
   });
+
+  it('prefers fallbackTitle over the generic browser message on FETCH_ERROR (offline)', () => {
+    const networkError = { status: 'FETCH_ERROR', error: 'TypeError: Failed to fetch' };
+    expect(formatApiError(networkError, 'Environment Create Error').message).toBe(
+      'Environment Create Error',
+    );
+    expect(formatApiError(networkError, 'Environments Fetch Error').message).toBe(
+      'Environments Fetch Error',
+    );
+  });
+
+  it('falls back to the generic browser message on FETCH_ERROR when no title is supplied', () => {
+    const networkError = { status: 'FETCH_ERROR', error: 'TypeError: Failed to fetch' };
+    expect(formatApiError(networkError).message).toBe('TypeError: Failed to fetch');
+  });
 });

--- a/ui/utils/helpers/meshkitError.ts
+++ b/ui/utils/helpers/meshkitError.ts
@@ -122,6 +122,17 @@ export const formatApiError = (error: unknown, fallbackTitle?: string): Formatte
     };
   }
 
-  const fallback = extractFallbackMessage(error) ?? fallbackTitle ?? 'An unexpected error occurred';
+  // Network-level failures (offline, timeout) carry a generic browser message
+  // (e.g. "TypeError: Failed to fetch") that is identical across every failed
+  // request, so it can't distinguish "create" from "fetch" errors. Prefer the
+  // operation-specific fallbackTitle in that case.
+  const status = (error as Record<string, unknown> | null | undefined)?.status;
+  const isNetworkError = status === 'FETCH_ERROR' || status === 'TIMEOUT_ERROR';
+
+  const fallback =
+    (isNetworkError ? fallbackTitle : undefined) ??
+    extractFallbackMessage(error) ??
+    fallbackTitle ??
+    'An unexpected error occurred';
   return { message: fallback };
 };

--- a/ui/utils/helpers/meshkitError.ts
+++ b/ui/utils/helpers/meshkitError.ts
@@ -126,7 +126,8 @@ export const formatApiError = (error: unknown, fallbackTitle?: string): Formatte
   // (e.g. "TypeError: Failed to fetch") that is identical across every failed
   // request, so it can't distinguish "create" from "fetch" errors. Prefer the
   // operation-specific fallbackTitle in that case.
-  const status = (error as Record<string, unknown> | null | undefined)?.status;
+  const status =
+    error && typeof error === 'object' ? (error as Record<string, unknown>).status : undefined;
   const isNetworkError = status === 'FETCH_ERROR' || status === 'TIMEOUT_ERROR';
 
   const fallback =


### PR DESCRIPTION
## Description

This PR fixes incorrect notification handling in the Environments UI.

### Changes
- Show success notifications only after create, update, and delete requests complete successfully.
- Fix error handling so failed requests correctly display error notifications.
- Fix the environment fetch error path to correctly invoke the error handler.
- Ensure notifications accurately reflect the outcome of environment operations.

### Testing
- [x] Verified success notifications appear only after successful API responses.
- [x] Verified failed requests display error notifications using Chrome DevTools Offline mode.

### Demo


https://github.com/user-attachments/assets/21bf5afb-d15d-40c9-838b-b837705a8013



**Notes for Reviewers**

- This PR fixes #20670

**Signed commits**
- [x] Yes, I signed my commits.