### PR TITLE
[Server] Secure file handlers against directory traversal vulnerabilities

### DIFF
--- a/server/handlers/common_handlers.go
+++ b/server/handlers/common_handlers.go
@@ -9,9 +9,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/meshery/meshery/server/core"
 	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/utils"
 )
 
 // LoginHandler redirects user for auth or issues session
@@ -63,6 +65,34 @@ func (h *Handler) TokenHandler(w http.ResponseWriter, r *http.Request, p models.
 	p.TokenHandler(w, r, fromMiddleWare)
 }
 
+// isSafePath checks if the target file path resides inside the Meshery home directory (~/.meshery)
+func isSafePath(filePath string) (bool, error) {
+	// Get the absolute path of the requested file
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return false, err
+	}
+
+	// Get the absolute path of the Meshery home directory
+	homeDir := utils.GetHome()
+	mesheryHome, err := filepath.Abs(filepath.Join(homeDir, ".meshery"))
+	if err != nil {
+		return false, err
+	}
+
+	// Ensure the path starts with the allowed mesheryHome directory prefix
+	// Clean both paths to handle different OS path separators consistently
+	cleanAbsPath := filepath.Clean(absPath)
+	cleanMesheryHome := filepath.Clean(mesheryHome)
+
+	// Since Clean on Windows might produce C:\Users\..., let's do a case-insensitive prefix check on Windows
+	// or case-sensitive on Unix systems
+	if strings.HasPrefix(strings.ToLower(cleanAbsPath), strings.ToLower(cleanMesheryHome)+string(os.PathSeparator)) || strings.EqualFold(cleanAbsPath, cleanMesheryHome) {
+		return true, nil
+	}
+	return false, nil
+}
+
 // ViewHandler handles viewing the file content.
 func (h *Handler) ViewHandler(responseWriter http.ResponseWriter, request *http.Request) {
 	filePath, err := url.QueryUnescape(request.URL.Query().Get("file"))
@@ -71,6 +101,13 @@ func (h *Handler) ViewHandler(responseWriter http.ResponseWriter, request *http.
 		writeMeshkitError(responseWriter, ErrInvalidFileRequest(err), http.StatusBadRequest)
 		return
 	}
+
+	safe, err := isSafePath(filePath)
+	if err != nil || !safe {
+		writeMeshkitError(responseWriter, ErrPathTraversal(filePath), http.StatusBadRequest)
+		return
+	}
+
 	file, err := os.Open(filePath)
 	if err != nil {
 		writeMeshkitError(responseWriter, ErrReadFileContent(err, filePath), http.StatusInternalServerError)
@@ -100,6 +137,12 @@ func (h *Handler) DownloadHandler(responseWriter http.ResponseWriter, request *h
 	filePath, err := url.QueryUnescape(request.URL.Query().Get("file"))
 	if err != nil {
 		writeMeshkitError(responseWriter, ErrInvalidFileRequest(err), http.StatusBadRequest)
+		return
+	}
+
+	safe, err := isSafePath(filePath)
+	if err != nil || !safe {
+		writeMeshkitError(responseWriter, ErrPathTraversal(filePath), http.StatusBadRequest)
 		return
 	}
 

--- a/server/handlers/common_handlers_test.go
+++ b/server/handlers/common_handlers_test.go
@@ -1,0 +1,152 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/utils"
+)
+
+func TestViewHandler_SafePath(t *testing.T) {
+	// Create a temporary file inside the allowed directory (~/.meshery)
+	homeDir := utils.GetHome()
+	mesheryDir := filepath.Join(homeDir, ".meshery")
+	
+	// Ensure directory exists for testing
+	if err := os.MkdirAll(mesheryDir, 0o755); err != nil {
+		t.Fatalf("failed to create .meshery directory: %v", err)
+	}
+
+	tmpFile, err := os.CreateTemp(mesheryDir, "safe-file-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create safe temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	expectedContent := "safe logs or files content"
+	if _, err := tmpFile.WriteString(expectedContent); err != nil {
+		t.Fatalf("failed to write to safe temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+
+	// Construct request with the filepath of the safe file
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileView?file="+url.QueryEscape(tmpFile.Name()), nil)
+	rec := httptest.NewRecorder()
+
+	h.ViewHandler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200 OK, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	if string(body) != expectedContent {
+		t.Errorf("expected content %q, got %q", expectedContent, string(body))
+	}
+}
+
+func TestViewHandler_PathTraversalBlocked(t *testing.T) {
+	// Create a temporary file outside the allowed directory
+	tmpFile, err := os.CreateTemp("", "unsafe-file-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create unsafe temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+
+	// Request access to the file located outside of ~/.meshery
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileView?file="+url.QueryEscape(tmpFile.Name()), nil)
+	rec := httptest.NewRecorder()
+
+	h.ViewHandler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	// Should be blocked and return 400 Bad Request
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400 Bad Request for path traversal attempt, got %d", resp.StatusCode)
+	}
+}
+
+func TestDownloadHandler_SafePath(t *testing.T) {
+	homeDir := utils.GetHome()
+	mesheryDir := filepath.Join(homeDir, ".meshery")
+
+	if err := os.MkdirAll(mesheryDir, 0o755); err != nil {
+		t.Fatalf("failed to create .meshery directory: %v", err)
+	}
+
+	tmpFile, err := os.CreateTemp(mesheryDir, "safe-download-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create safe download file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	expectedContent := "safe downloadable logs content"
+	if _, err := tmpFile.WriteString(expectedContent); err != nil {
+		t.Fatalf("failed to write to safe download file: %v", err)
+	}
+	tmpFile.Close()
+
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileDownload?file="+url.QueryEscape(tmpFile.Name()), nil)
+	rec := httptest.NewRecorder()
+
+	h.DownloadHandler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200 OK, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	if string(body) != expectedContent {
+		t.Errorf("expected content %q, got %q", expectedContent, string(body))
+	}
+}
+
+func TestDownloadHandler_PathTraversalBlocked(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "unsafe-download-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create unsafe download file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/system/fileDownload?file="+url.QueryEscape(tmpFile.Name()), nil)
+	rec := httptest.NewRecorder()
+
+	h.DownloadHandler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400 Bad Request for path traversal attempt, got %d", resp.StatusCode)
+	}
+}

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -794,6 +794,9 @@ func ErrServeSchema(err error) error {
 func ErrInvalidFileRequest(err error) error {
 	return errors.New(ErrInvalidFileRequestCode, errors.Alert, []string{"Invalid file request"}, []string{err.Error()}, []string{"The provided file query parameter could not be decoded"}, []string{"Ensure the file parameter is a properly URL-encoded path"})
 }
+func ErrPathTraversal(file string) error {
+	return errors.New(ErrInvalidFileRequestCode, errors.Alert, []string{"Path traversal detected", file}, []string{"Access denied to files outside Meshery home directory"}, []string{"The requested file path points outside the allowed directory"}, []string{"Request files only within the allowed Meshery directory (~/.meshery)"})
+}
 func ErrReadFileContent(err error, file string) error {
 	return errors.New(ErrReadFileContentCode, errors.Alert, []string{"Failed to read file content", file}, []string{err.Error()}, []string{"The file could not be opened or streamed to the response"}, []string{"Verify the file exists and the server has permission to read it"})
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20678

### Context
A path traversal vulnerability was identified in `/api/system/fileView` and `/api/system/fileDownload`. The handlers `ViewHandler` and `DownloadHandler` unescaped the user-controlled `file` query parameter and opened it directly using `os.Open` without validating if the requested path resided in a safe location.

### Verification
Ran the unit tests successfully:
```bash
go test -v -run="TestViewHandler_SafePath|TestViewHandler_PathTraversalBlocked|TestDownloadHandler_SafePath|TestDownloadHandler_PathTraversalBlocked" ./server/handlers
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.