### PR TITLE
[UI] Open Create Connection wizard in place for Add Cluster and telemetry

### DIFF
--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -60,6 +60,13 @@ type MesheryControllersHelper struct {
 	// meshsync data handler for a particular context
 	ctxMeshsyncDataHandler *MeshsyncDataHandler
 
+	// meshsyncConnectedEventEmitted tracks whether we already published the
+	// "MeshSync connected in <mode> mode" event for the current data-handler
+	// session. AddMeshsyncDataHandlers can be invoked multiple times while the
+	// handler stays attached; without this flag each call re-broadcasts the
+	// same informational snackbar.
+	meshsyncConnectedEventEmitted bool
+
 	// brokerPortForward is the self-healing port-forward to the NATS pod used when
 	// Meshery runs out-of-cluster and the broker is only reachable on a ClusterIP.
 	// nil when running in-cluster or when managed forwarding is disabled.
@@ -276,9 +283,12 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 	// Emit the success event only when the data path is actually up. With the
 	// self-healing broker connection, the handler may be attached but still
 	// connecting in the background; in that case meshsyncDataHandlersNatsBroker has
-	// already surfaced the "unreachable, retrying" warning + remediation, and the
-	// status/diagnostics flip to Connected on their own once it connects.
-	if mch.ctxMeshsyncDataHandler != nil && mch.ctxMeshsyncDataHandler.IsConnected() {
+	// already surfaced the "unreachable, retrying" warning + remediation, and a
+	// later AddMeshsyncDataHandlers call (once IsConnected) emits the event once.
+	// Deduplicate so repeated reconcile calls do not spam the same snackbar.
+	if mch.ctxMeshsyncDataHandler != nil &&
+		mch.ctxMeshsyncDataHandler.IsConnected() &&
+		!mch.meshsyncConnectedEventEmitted {
 		description := "MeshSync connected"
 		if mch.meshsyncDeploymentMode != "" {
 			description = fmt.Sprintf("MeshSync connected in %s mode", string(mch.meshsyncDeploymentMode))
@@ -294,6 +304,7 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 			},
 			userID,
 		)
+		mch.meshsyncConnectedEventEmitted = true
 	}
 
 	return mch
@@ -614,6 +625,8 @@ func (mch *MesheryControllersHelper) RemoveMeshSyncDataHandler(ctx context.Conte
 		mch.ctxMeshsyncDataHandler.Stop()
 		mch.ctxMeshsyncDataHandler = nil
 	}
+	// Allow a fresh "MeshSync connected" event when a new handler is attached.
+	mch.meshsyncConnectedEventEmitted = false
 	// Tear down the managed broker port-forward alongside the data handler.
 	if mch.brokerPortForward != nil {
 		mch.brokerPortForward.Stop()

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/meshery/schemas/models/core"
@@ -62,10 +63,9 @@ type MesheryControllersHelper struct {
 
 	// meshsyncConnectedEventEmitted tracks whether we already published the
 	// "MeshSync connected in <mode> mode" event for the current data-handler
-	// session. AddMeshsyncDataHandlers can be invoked multiple times while the
-	// handler stays attached; without this flag each call re-broadcasts the
-	// same informational snackbar.
-	meshsyncConnectedEventEmitted bool
+	// session. AddMeshsyncDataHandlers can be invoked concurrently while the
+	// handler stays attached; atomic avoids a data race and re-broadcast spam.
+	meshsyncConnectedEventEmitted atomic.Bool
 
 	// brokerPortForward is the self-healing port-forward to the NATS pod used when
 	// Meshery runs out-of-cluster and the broker is only reachable on a ClusterIP.
@@ -286,9 +286,10 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 	// already surfaced the "unreachable, retrying" warning + remediation, and a
 	// later AddMeshsyncDataHandlers call (once IsConnected) emits the event once.
 	// Deduplicate so repeated reconcile calls do not spam the same snackbar.
+	// CompareAndSwap so concurrent AddMeshsyncDataHandlers callers emit once.
 	if mch.ctxMeshsyncDataHandler != nil &&
 		mch.ctxMeshsyncDataHandler.IsConnected() &&
-		!mch.meshsyncConnectedEventEmitted {
+		mch.meshsyncConnectedEventEmitted.CompareAndSwap(false, true) {
 		description := "MeshSync connected"
 		if mch.meshsyncDeploymentMode != "" {
 			description = fmt.Sprintf("MeshSync connected in %s mode", string(mch.meshsyncDeploymentMode))
@@ -304,7 +305,6 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 			},
 			userID,
 		)
-		mch.meshsyncConnectedEventEmitted = true
 	}
 
 	return mch
@@ -626,7 +626,7 @@ func (mch *MesheryControllersHelper) RemoveMeshSyncDataHandler(ctx context.Conte
 		mch.ctxMeshsyncDataHandler = nil
 	}
 	// Allow a fresh "MeshSync connected" event when a new handler is attached.
-	mch.meshsyncConnectedEventEmitted = false
+	mch.meshsyncConnectedEventEmitted.Store(false)
 	// Tear down the managed broker port-forward alongside the data handler.
 	if mch.brokerPortForward != nil {
 		mch.brokerPortForward.Stop()

--- a/ui/components/MesherySettingsEnvButtons.test.tsx
+++ b/ui/components/MesherySettingsEnvButtons.test.tsx
@@ -1,144 +1,47 @@
 import React from 'react';
-import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Shared mock state. Declared via vi.hoisted so the (hoisted) vi.mock factories
-// below can reference it without tripping the "used before initialization" rule.
 const h = vi.hoisted(() => ({
-  notifyMock: vi.fn(),
-  unwrapMock: vi.fn(),
-  addTriggerMock: vi.fn(),
-  // Resolver for the first PromptComponent.show() call (the upload modal), kept
-  // pending so the test can pick a file before "IMPORT" is confirmed — mirroring
-  // the real user flow.
-  resolveUploadModal: { current: undefined as undefined | ((value: string) => void) },
-  // Counts show() calls so only the first (upload) modal stays pending. Held in
-  // hoisted state (not a factory-local) so beforeEach can reset it per test.
-  showCount: { current: 0 },
+  openCreateConnectionMock: vi.fn(),
 }));
 
-vi.mock('../utils/hooks/useNotification', () => ({
-  useNotification: () => ({ notify: h.notifyMock }),
-}));
-vi.mock('../rtk-query/connection', () => ({
-  useAddKubernetesConfigMutation: () => [h.addTriggerMock],
+vi.mock('@/utils/context/ConnectionWizardContextProvider', () => ({
+  useConnectionWizardModal: () => ({
+    openCreateConnection: h.openCreateConnectionMock,
+    closeCreateConnection: vi.fn(),
+    open: false,
+    presetKind: null,
+    skipKindSelection: false,
+  }),
 }));
 vi.mock('@/utils/can', () => ({ default: () => true }));
-
-vi.mock('@/utils/hooks/useKubernetesHook', () => ({ default: () => vi.fn() }));
 vi.mock('@/utils/hooks/useTestIDs', () => ({ default: () => () => 'test-id' }));
-vi.mock('@/store/slices/mesheryUi', () => ({ updateProgress: vi.fn() }));
 vi.mock('../assets/icons/AddIconCircleBorder', () => ({ default: () => null }));
-vi.mock('../lib/event-types', () => ({
-  EVENT_TYPES: { ERROR: 'error', WARNING: 'warning', SUCCESS: 'success', INFO: 'info' },
-}));
-vi.mock('./connections/ConnectionChip', () => ({
-  TooltipWrappedConnectionChip: () => null,
-  ConnectionStateChip: () => null,
-}));
-
-// PromptComponent is imperative (ref.show()). The first call (the kubeconfig
-// upload prompt) stays pending until the test resolves it; it also renders the
-// passed subtitle so the hidden <input id="k8sfile"> mounts and can be driven.
-vi.mock('./PromptComponent', async () => {
-  const { forwardRef, useState, useImperativeHandle } = await import('react');
-  const PromptComponent = forwardRef((_props: unknown, ref: React.Ref<unknown>) => {
-    const [content, setContent] = useState<React.ReactNode>(null);
-    useImperativeHandle(ref, () => ({
-      show: (args: { subtitle?: React.ReactNode }) => {
-        setContent(args?.subtitle ?? null);
-        h.showCount.current += 1;
-        if (h.showCount.current === 1) {
-          return new Promise<string>((resolve) => {
-            h.resolveUploadModal.current = resolve;
-          });
-        }
-        return Promise.resolve('OK');
-      },
-    }));
-    return <div data-testid="prompt">{content}</div>;
-  });
-  return { __esModule: true, default: PromptComponent };
-});
-
 vi.mock('@sistent/sistent', () => ({
   Button: ({ children, onClick, disabled }: any) => (
     <button onClick={onClick} disabled={disabled}>
       {children}
     </button>
   ),
-  CloudUploadIcon: () => null,
-  Typography: ({ children }: any) => <span>{children}</span>,
-  FormGroup: ({ children }: any) => <div>{children}</div>,
-  TextField: ({ id }: any) => <input id={id} readOnly />,
-  InputAdornment: ({ children }: any) => <span>{children}</span>,
-  Tooltip: ({ children }: any) => <>{children}</>,
-  Grid2: ({ children }: any) => <div>{children}</div>,
-  Box: ({ children }: any) => <div>{children}</div>,
-  styled: () => () => ({}),
-  PROMPT_VARIANTS: { SUCCESS: 'success', WARNING: 'warning', ERROR: 'error' },
+  Typography: ({ children, ...rest }: any) => <span {...rest}>{children}</span>,
 }));
 
 import MesherySettingsEnvButtons from './MesherySettingsEnvButtons';
 
-const selectKubeconfig = () => {
-  const fileInput = document.getElementById('k8sfile') as HTMLInputElement;
-  expect(fileInput).toBeTruthy();
-  const file = new File(['apiVersion: v1'], 'config.yaml', { type: 'text/yaml' });
-  Object.defineProperty(fileInput, 'files', { value: [file], configurable: true });
-  fireEvent.change(fileInput);
-};
-
-describe('MesherySettingsEnvButtons – kubeconfig upload', () => {
+describe('MesherySettingsEnvButtons – Add Cluster', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    h.resolveUploadModal.current = undefined;
-    h.showCount.current = 0;
-    h.addTriggerMock.mockReturnValue({ unwrap: h.unwrapMock });
   });
 
-  it('surfaces errored contexts from a camelCase response without crashing', async () => {
-    // Mirrors the server wire format: camelCase buckets, and errored contexts are
-    // plain K8sContext objects with NO per-context `error` field (the failure is
-    // recorded server-side in event metadata). The previous implementation read
-    // snake_case keys and called `ctx.error.toString()`, throwing
-    // "Cannot read properties of undefined (reading 'toString')", which surfaced
-    // as a misleading "failed to upload kubernetes config" toast.
-    h.unwrapMock.mockResolvedValue({
-      registeredContexts: [],
-      connectedContexts: [],
-      ignoredContexts: [],
-      erroredContexts: [{ name: 'broken-ctx', server: 'https://broken.example' }],
-    });
-
+  it('opens the Create Connection wizard in place with Kubernetes pre-selected', () => {
     render(<MesherySettingsEnvButtons />);
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Add Cluster'));
+    fireEvent.click(screen.getByText('Add Cluster'));
+
+    expect(h.openCreateConnectionMock).toHaveBeenCalledWith({
+      kind: 'kubernetes',
+      skipKindSelection: true,
     });
-
-    selectKubeconfig();
-
-    await act(async () => {
-      h.resolveUploadModal.current?.('IMPORT');
-    });
-
-    await waitFor(() =>
-      expect(h.notifyMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: 'Failed to add cluster "broken-ctx" at https://broken.example',
-          event_type: 'error',
-        }),
-      ),
-    );
-
-    const messages = h.notifyMock.mock.calls.map((call) => call[0]?.message);
-    // The catch-all upload-failure toast (the symptom of the old crash) must not appear.
-    expect(
-      messages.some(
-        (message) =>
-          typeof message === 'string' && message.includes('failed to upload kubernetes config'),
-      ),
-    ).toBe(false);
   });
 });

--- a/ui/components/MesherySettingsEnvButtons.tsx
+++ b/ui/components/MesherySettingsEnvButtons.tsx
@@ -44,7 +44,7 @@ const MesherySettingsEnvButtons = ({ onOpened }: MesherySettingsEnvButtonsProps)
         disabled={
           !CAN(Keys.LifecycleManagementAddCluster.id, Keys.LifecycleManagementAddCluster.function)
         }
-        data-cy="btnResetDatabase"
+        data-cy="btnAddCluster"
       >
         <AddIconCircleBorder style={{ width: '20px', height: '20px' }} />
         <Typography

--- a/ui/components/MesherySettingsEnvButtons.tsx
+++ b/ui/components/MesherySettingsEnvButtons.tsx
@@ -1,326 +1,65 @@
-import {
-  Button,
-  CloudUploadIcon,
-  Typography,
-  FormGroup,
-  TextField,
-  InputAdornment,
-  Tooltip,
-  Grid2,
-  Box,
-  styled,
-  PROMPT_VARIANTS,
-} from '@sistent/sistent';
-import React from 'react';
-import { useRef } from 'react';
+import { Button, Typography } from '@sistent/sistent';
 import AddIconCircleBorder from '../assets/icons/AddIconCircleBorder';
-import _PromptComponent from './PromptComponent';
-import { useNotification } from '../utils/hooks/useNotification';
-import { EVENT_TYPES } from '../lib/event-types';
-import { CONNECTION_STATES } from '../utils/Enum';
-import { TooltipWrappedConnectionChip, ConnectionStateChip } from './connections/ConnectionChip';
-import { getKubernetesContexts } from './connections/ConnectionWizard.helpers';
-import useKubernetesHook from '@/utils/hooks/useKubernetesHook';
 import { Keys } from '@meshery/schemas/permissions';
 import useTestIDsGenerator from '@/utils/hooks/useTestIDs';
 import CAN from '@/utils/can';
-import { useAddKubernetesConfigMutation } from '../rtk-query/connection';
-import { updateProgress } from '@/store/slices/mesheryUi';
+import { CONNECTION_KINDS } from '@/utils/Enum';
+import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
 
-const styles = styled((theme) => ({
-  ctxIcon: {
-    display: 'inline',
-    verticalAlign: 'text-top',
-    width: theme.spacing(2.5),
-    marginLeft: theme.spacing(0.5),
-  },
-  chip: {
-    height: '50px',
-    fontSize: '15px',
-    position: 'relative',
-    top: theme.spacing(0.5),
-    [theme.breakpoints.down('md')]: { fontSize: '12px' },
-  },
-}));
+type MesherySettingsEnvButtonsProps = {
+  /** Called after the wizard is opened (e.g. close the context-switcher menu). */
+  onOpened?: () => void;
+};
 
-const MesherySettingsEnvButtons = () => {
-  let k8sfileElementVal = '';
-  let formData = new FormData();
-  const ref = useRef(null);
-  const { notify } = useNotification();
-
-  let contextsRef = useRef();
-
+/**
+ * Context-switcher "Add Cluster" entry point.
+ *
+ * Opens the shared Create Connection wizard in place (any page) with Kubernetes
+ * pre-selected at Import Kubeconfig — same host used by telemetry and the
+ * Connections toolbar.
+ */
+const MesherySettingsEnvButtons = ({ onOpened }: MesherySettingsEnvButtonsProps) => {
   const testIDs = useTestIDsGenerator('connection');
+  const { openCreateConnection } = useConnectionWizardModal();
 
-  const [addK8sConfig] = useAddKubernetesConfigMutation();
-
-  const handleConfigSnackbars = (ctxs) => {
-    updateProgress({ showProgress: false });
-    // Errored contexts are plain K8sContext objects (no per-context `error`
-    // field — the failure is recorded server-side in event metadata), so build
-    // the message from the data that is actually present. Read the bucket via
-    // the shared helper which tolerates both camelCase (current wire format) and
-    // legacy snake_case payloads.
-    for (let ctx of getKubernetesContexts(ctxs, 'errored')) {
-      const msg = `Failed to add cluster "${ctx.name}" at ${ctx.server}`;
-      notify({ message: msg, event_type: EVENT_TYPES.ERROR });
-    }
-  };
-
-  const handleError = (msg) => (error) => {
-    updateProgress({ showProgress: false });
-    notify({
-      message: `${msg}: ${error}`,
-      event_type: EVENT_TYPES.ERROR,
-      details: error.toString(),
+  const handleClick = () => {
+    openCreateConnection({
+      kind: CONNECTION_KINDS.KUBERNETES,
+      skipKindSelection: true,
     });
-  };
-
-  const handleChange = () => {
-    const field = document.getElementById('k8sfile');
-    const textField = document.getElementById('k8sfileLabelText');
-    if (field instanceof HTMLInputElement) {
-      if (field.files.length < 1) return;
-      const name = field.files[0].name;
-      const formdata = new FormData();
-      formdata.append('k8sfile', field.files[0]);
-      textField.value = name;
-      formData = formdata;
-    }
-  };
-
-  const uploadK8SConfig = async () => {
-    return await addK8sConfig({ body: formData }).unwrap();
-  };
-
-  const showUploadedContexts = async (inputFileName) => {
-    const modal = ref.current;
-    const registeredContexts = getKubernetesContexts(contextsRef.current, 'registered');
-    const connectedContexts = getKubernetesContexts(contextsRef.current, 'connected');
-    const ignoredContexts = getKubernetesContexts(contextsRef.current, 'ignored');
-    if (
-      registeredContexts.length === 0 &&
-      connectedContexts.length == 0 &&
-      ignoredContexts.length == 0
-    ) {
-      notify({
-        message: `No reachable contexts found in the uploaded kube config "${inputFileName}". `,
-        event_type: EVENT_TYPES.WARNING,
-        showInNotificationCenter: true,
-      });
-      return;
-    }
-    await modal.show({
-      title: `Available contexts in "${inputFileName}".`,
-      subtitle: (
-        <>
-          <ShowDiscoveredContexts
-            registeredContexts={registeredContexts}
-            connectedContexts={connectedContexts}
-            ignoredContexts={ignoredContexts}
-            allContextsRef={contextsRef}
-            dataTestid={testIDs('discoveredModal')}
-          />
-        </>
-      ),
-      variant: PROMPT_VARIANTS.SUCCESS,
-      primaryOption: 'OK',
-    });
-  };
-
-  const handleClick = async () => {
-    const modal = ref.current;
-    let response = await modal.show({
-      title: 'Add Kubernetes Cluster(s)',
-      subtitle: (
-        <>
-          <div style={{ overflow: 'hidden' }} data-testid={testIDs('addKubernetesModal')}>
-            <Typography variant="h6">Upload your kubeconfig</Typography>
-            <Typography variant="body2">commonly found at ~/.kube/config</Typography>
-            <FormGroup>
-              <input
-                id="k8sfile"
-                type="file"
-                value={k8sfileElementVal}
-                onChange={handleChange}
-                style={{ display: 'none' }}
-              />
-              <TextField
-                id="k8sfileLabelText"
-                name="k8sfileLabelText"
-                style={{ cursor: 'pointer' }}
-                placeholder="Upload kubeconfig"
-                variant="outlined"
-                fullWidth
-                onClick={() => {
-                  document.querySelector('#k8sfile')?.click();
-                }}
-                data-testid={testIDs('uploadKubeConfig')}
-                margin="normal"
-                InputProps={{
-                  readOnly: true,
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <CloudUploadIcon />
-                    </InputAdornment>
-                  ),
-                }}
-              />
-            </FormGroup>
-          </div>
-        </>
-      ),
-      primaryOption: 'IMPORT',
-      variant: PROMPT_VARIANTS.SUCCESS,
-      showInfoIcon:
-        'If your config has not been autodetected, you can manually upload your kubeconfig file (or any number of kubeconfig files). By default, Meshery will attempt to connect to and deploy Meshery Operator to each reachable context contained in the imported kubeconfig files. [See Managing Kubernetes Clusters for more information](https://docs.meshery.io/installation/kubernetes).',
-    });
-
-    if (response === 'IMPORT') {
-      if (formData.get('k8sfile') === null) {
-        handleError('No file selected')('Please select a valid kube config');
-        return;
-      }
-
-      const inputFileName = formData.get('k8sfile').name;
-      const invalidExtensions = /^.*\.(jpg|gif|jpeg|pdf|png|svg)$/i;
-
-      if (invalidExtensions.test(inputFileName)) {
-        handleError('Invalid file selected')('Please select a valid kube config');
-        return;
-      }
-
-      try {
-        const obj = await uploadK8SConfig();
-        contextsRef.current = obj;
-        await showUploadedContexts(inputFileName);
-        handleConfigSnackbars(obj);
-      } catch (err) {
-        handleError('failed to upload kubernetes config')(err);
-      }
-      formData.delete('k8sfile');
-    }
+    onOpened?.();
   };
 
   return (
     <div>
-      <>
-        <Button
-          type="submit"
-          variant="contained"
-          onClick={handleClick}
+      <Button
+        type="button"
+        variant="contained"
+        onClick={handleClick}
+        style={{
+          width: '100%',
+          borderRadius: 5,
+          padding: '8px',
+        }}
+        disabled={
+          !CAN(Keys.LifecycleManagementAddCluster.id, Keys.LifecycleManagementAddCluster.function)
+        }
+        data-cy="btnResetDatabase"
+      >
+        <AddIconCircleBorder style={{ width: '20px', height: '20px' }} />
+        <Typography
           style={{
-            width: '100%',
-            borderRadius: 5,
-            padding: '8px',
+            paddingLeft: '4px',
+            width: 'max-content',
+            marginRight: '4px',
           }}
-          disabled={
-            !CAN(Keys.LifecycleManagementAddCluster.id, Keys.LifecycleManagementAddCluster.function)
-          }
-          data-cy="btnResetDatabase"
+          data-testid={testIDs('addCluster')}
         >
-          <AddIconCircleBorder style={{ width: '20px', height: '20px' }} />
-          <Typography
-            style={{
-              paddingLeft: '4px',
-              width: 'max-content',
-              marginRight: '4px',
-            }}
-            data-testid={testIDs('addCluster')}
-          >
-            Add Cluster
-          </Typography>
-        </Button>
-      </>
-      <_PromptComponent ref={ref} />
+          Add Cluster
+        </Typography>
+      </Button>
     </div>
   );
 };
 
-const ShowDiscoveredContexts = ({
-  registeredContexts,
-  connectedContexts,
-  ignoredContexts,
-  dataTestid,
-}) => {
-  const ping = useKubernetesHook();
-
-  return (
-    <Grid2
-      spacing={2}
-      columns={1}
-      data-testid={dataTestid}
-      sx={{ flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}
-    >
-      {registeredContexts.length > 0 && (
-        <K8sConnectionItems
-          contexts={registeredContexts}
-          ping={ping}
-          status={CONNECTION_STATES.REGISTERED}
-        />
-      )}
-      {connectedContexts.length > 0 && (
-        <K8sConnectionItems
-          contexts={connectedContexts}
-          ping={ping}
-          status={CONNECTION_STATES.CONNECTED}
-        />
-      )}
-      {ignoredContexts.length > 0 && (
-        <Grid2 size={{ xs: 8 }}>
-          <K8sConnectionItems
-            contexts={ignoredContexts}
-            ping={ping}
-            status={CONNECTION_STATES.IGNORED}
-          />
-        </Grid2>
-      )}
-    </Grid2>
-  );
-};
-
-const K8sConnectionItems = ({ status, contexts, ping }) => {
-  const classes = styles();
-  return (
-    <Grid2 container spacing={2} size={'grow'}>
-      {contexts.map((context) => (
-        <Grid2
-          container
-          size="grow"
-          spacing={1}
-          id={context.connectionId}
-          key={context.connectionId}
-          className={classes.chip}
-          sx={{ flexDirection: 'column', alignContent: 'center', alignItems: 'center' }}
-        >
-          <Box sx={{ minWidth: '25%', maxWidth: '50%' }}>
-            <Tooltip title={`Server: ${context.server}`}>
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'flex-wrap',
-                  alignItems: 'center',
-                }}
-                whiteSpace="no-wrap"
-                textOverflow="ellipsis"
-              >
-                <TooltipWrappedConnectionChip
-                  title={context.name}
-                  handlePing={() => {
-                    ping(context.name, context.server, context.connectionId);
-                  }}
-                  iconSrc={'/static/img/integrations/kubernetes.svg'}
-                />
-              </div>
-            </Tooltip>
-          </Box>
-          <Box sx={{ minWidth: '25%', maxWidth: '50%' }}>
-            <ConnectionStateChip status={status} />
-          </Box>
-        </Grid2>
-      ))}
-    </Grid2>
-  );
-};
 export default MesherySettingsEnvButtons;

--- a/ui/components/connections/ConnectionTable.columns.tsx
+++ b/ui/components/connections/ConnectionTable.columns.tsx
@@ -47,6 +47,7 @@ type UseConnectionColumnsArgs = {
   handleActionMenuOpen: (event: any, tableMeta: RowData) => void;
   ping: (name: string, server: string, id: string) => void;
   pingGrafana: (connectionID: string, name?: string) => void;
+  pingPrometheus: (connectionID: string, name?: string) => void;
   // Per-kind connection state machine, keyed by connection kind. Sourced from
   // the connection definitions' `transitionMap` (see `_app.tsx`).
   transitionMapByKind: Record<string, ConnectionTransitionMap | undefined> | null;
@@ -64,6 +65,7 @@ export const useConnectionColumns = ({
   handleActionMenuOpen,
   ping,
   pingGrafana,
+  pingPrometheus,
   transitionMapByKind,
 }: UseConnectionColumnsArgs) => {
   return useMemo(() => {
@@ -113,10 +115,33 @@ export const useConnectionColumns = ({
               getColumnValue(tableMeta.rowData, 'metadata.server_location', nextColumns);
             const name = getColumnValue(tableMeta.rowData, 'metadata.name', nextColumns);
             const kind = getColumnValue(tableMeta.rowData, 'kind', nextColumns);
+            const connectionId = getColumnValue(tableMeta.rowData, 'id', nextColumns);
             const iconSrc = normalizeStaticImagePath(
               getColumnValue(tableMeta.rowData, 'kindLogo', nextColumns) ||
                 getFallbackImageBasedOnKind(kind),
             );
+
+            // Only attach handlePing for kinds that support a chip ping. An
+            // always-defined no-op handler still makes the chip swallow row
+            // clicks (stopPropagation) even when it cannot ping.
+            let handlePing: (() => void) | undefined;
+            if (kind === CONNECTION_KINDS.KUBERNETES) {
+              handlePing = () =>
+                ping(
+                  getColumnValue(tableMeta.rowData, 'metadata.name', nextColumns),
+                  getColumnValue(tableMeta.rowData, 'metadata.server', nextColumns),
+                  connectionId,
+                );
+            } else if (kind === CONNECTION_KINDS.GRAFANA) {
+              handlePing = () =>
+                pingGrafana(connectionId, getColumnValue(tableMeta.rowData, 'name', nextColumns));
+            } else if (kind === CONNECTION_KINDS.PROMETHEUS) {
+              handlePing = () =>
+                pingPrometheus(
+                  connectionId,
+                  getColumnValue(tableMeta.rowData, 'name', nextColumns),
+                );
+            }
 
             return (
               <>
@@ -124,24 +149,8 @@ export const useConnectionColumns = ({
                   tooltip={server ? `Server: ${server}` : ''}
                   title={kind === CONNECTION_KINDS.KUBERNETES ? name : value || name || kind}
                   status={getColumnValue(tableMeta.rowData, 'status', nextColumns)}
-                  onDelete={() =>
-                    handleDeleteConnection(getColumnValue(tableMeta.rowData, 'id', nextColumns))
-                  }
-                  handlePing={() => {
-                    const rowKind = getColumnValue(tableMeta.rowData, 'kind', nextColumns);
-                    if (rowKind === CONNECTION_KINDS.KUBERNETES) {
-                      ping(
-                        getColumnValue(tableMeta.rowData, 'metadata.name', nextColumns),
-                        getColumnValue(tableMeta.rowData, 'metadata.server', nextColumns),
-                        getColumnValue(tableMeta.rowData, 'id', nextColumns),
-                      );
-                    } else if (rowKind === CONNECTION_KINDS.GRAFANA) {
-                      pingGrafana(
-                        getColumnValue(tableMeta.rowData, 'id', nextColumns),
-                        getColumnValue(tableMeta.rowData, 'name', nextColumns),
-                      );
-                    }
-                  }}
+                  onDelete={() => handleDeleteConnection(connectionId)}
+                  handlePing={handlePing}
                   iconSrc={iconSrc}
                   width="12rem"
                 />
@@ -506,6 +515,7 @@ export const useConnectionColumns = ({
     isEnvironmentsSuccess,
     ping,
     pingGrafana,
+    pingPrometheus,
     transitionMapByKind,
     updatingConnection,
     url,

--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -8,6 +8,7 @@ const notify = vi.fn();
 const push = vi.fn();
 const ping = vi.fn();
 const pingGrafana = vi.fn();
+const pingPrometheus = vi.fn();
 const modalShow = vi.fn();
 const updateConnectionByIdMutator = vi.fn();
 const addConnectionToEnvironmentMutator = vi.fn();
@@ -128,6 +129,10 @@ vi.mock('@/utils/hooks/useKubernetesHook', () => ({
 
 vi.mock('@/utils/hooks/useGrafanaPingHook', () => ({
   default: () => pingGrafana,
+}));
+
+vi.mock('@/utils/hooks/usePrometheusPingHook', () => ({
+  default: () => pingPrometheus,
 }));
 
 vi.mock('./ConnectionChip', () => ({

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -7,6 +7,7 @@ import _PromptComponent from '../PromptComponent';
 import { CONNECTION_KINDS, CONNECTION_STATES } from '../../utils/Enum';
 import useKubernetesHook from '@/utils/hooks/useKubernetesHook';
 import useGrafanaPingHook from '@/utils/hooks/useGrafanaPingHook';
+import usePrometheusPingHook from '@/utils/hooks/usePrometheusPingHook';
 import { getResponsiveColumnVisibility } from '../../utils/responsive-column';
 import { useWindowDimensions } from '../../utils/dimension';
 import { useGetEnvironmentsQuery } from '../../rtk-query/environments';
@@ -81,6 +82,7 @@ const ConnectionTable = ({
   );
   const ping = useKubernetesHook();
   const pingGrafana = useGrafanaPingHook();
+  const pingPrometheus = usePrometheusPingHook();
   const { width } = useWindowDimensions();
 
   const { tableState, updateTableState, copyRowDeepLink } = useTableUrlState({
@@ -564,6 +566,7 @@ const ConnectionTable = ({
     handleActionMenuOpen,
     ping,
     pingGrafana,
+    pingPrometheus,
     transitionMapByKind,
   });
   const columnNames = useMemo(

--- a/ui/components/connections/ConnectionWizard.helpers.test.ts
+++ b/ui/components/connections/ConnectionWizard.helpers.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { CONNECTION_KINDS } from '@/utils/Enum';
 import {
   buildConnectionWizardKindConfigs,
   buildCredentialSecret,
   buildKubernetesImportSummary,
+  connectionCreatedNotify,
   DEFAULT_CONNECTION_DOCS_URL,
   filterCredentialsForKind,
   getWizardStepLabels,
+  isCreateConnectionQuery,
+  kubernetesImportedNotify,
   normalizeCredentialPayload,
   resolveConnectionName,
 } from './ConnectionWizard.helpers';
@@ -208,5 +211,27 @@ describe('ConnectionWizard.helpers', () => {
       resolveConnectionName(CONNECTION_KINDS.PROMETHEUS, { url: 'https://prom.example' }),
     ).toBe('https://prom.example');
     expect(resolveConnectionName(CONNECTION_KINDS.PROMETHEUS, {})).toBe('prometheus-connection');
+  });
+
+  it('recognizes create-connection query flags', () => {
+    expect(isCreateConnectionQuery('true')).toBe(true);
+    expect(isCreateConnectionQuery('1')).toBe(true);
+    expect(isCreateConnectionQuery('false')).toBe(false);
+  });
+
+  it('builds connection-created notify payloads with optional View connections action', () => {
+    vi.stubGlobal('window', { location: { pathname: '/dashboard' } });
+    const payload = connectionCreatedNotify('Prometheus');
+    expect(payload.message).toBe('Prometheus connection created.');
+    expect(payload.link?.href).toBe('/management/connections');
+    vi.stubGlobal('window', { location: { pathname: '/management/connections' } });
+    expect(connectionCreatedNotify('Grafana').link).toBeUndefined();
+    vi.unstubAllGlobals();
+  });
+
+  it('formats kubernetes import notify summaries', () => {
+    vi.stubGlobal('window', { location: { pathname: '/dashboard' } });
+    expect(kubernetesImportedNotify(2).message).toBe('Imported 2 Kubernetes connections.');
+    vi.unstubAllGlobals();
   });
 });

--- a/ui/components/connections/ConnectionWizard.helpers.ts
+++ b/ui/components/connections/ConnectionWizard.helpers.ts
@@ -1,6 +1,58 @@
 import { CONNECTION_KINDS } from '@/utils/Enum';
+import { EVENT_TYPES } from 'lib/event-types';
 
 export type SupportedConnectionWizardKind = string;
+
+/** Lifecycle Connections page path (deep links + post-create navigation). */
+export const CONNECTIONS_PATH = '/management/connections';
+
+export const CREATE_CONNECTION_QUERY = {
+  create: 'create',
+  kind: 'kind',
+} as const;
+
+export const isCreateConnectionQuery = (value: string | string[] | undefined): boolean =>
+  value === 'true' || value === '1';
+
+export type ConnectionCreatedNotifyPayload = {
+  message: string;
+  event_type: typeof EVENT_TYPES.SUCCESS | typeof EVENT_TYPES.WARNING;
+  link?: { href: string; label: string };
+};
+
+const isOnConnectionsPage = (): boolean =>
+  typeof window !== 'undefined' && window.location.pathname.startsWith(CONNECTIONS_PATH);
+
+/**
+ * Success snackbar after create/import. Plain string (BasicMarkdown-safe) plus an
+ * optional same-tab action when not already on the Connections page.
+ */
+export const connectionCreatedNotify = (label: string): ConnectionCreatedNotifyPayload => {
+  const name = (label && String(label).trim()) || '';
+  const summary = name ? `${name} connection created.` : 'Connection created.';
+  if (isOnConnectionsPage()) {
+    return { message: summary, event_type: EVENT_TYPES.SUCCESS };
+  }
+  return {
+    message: summary,
+    event_type: EVENT_TYPES.SUCCESS,
+    link: { href: CONNECTIONS_PATH, label: 'View connections' },
+  };
+};
+
+export const kubernetesImportedNotify = (count: number): ConnectionCreatedNotifyPayload => {
+  const noun = count === 1 ? 'connection' : 'connections';
+  const summary = `Imported ${count} Kubernetes ${noun}.`;
+  const event_type = count > 0 ? EVENT_TYPES.SUCCESS : EVENT_TYPES.WARNING;
+  if (isOnConnectionsPage() || count === 0) {
+    return { message: summary, event_type };
+  }
+  return {
+    message: summary,
+    event_type,
+    link: { href: CONNECTIONS_PATH, label: 'View connections' },
+  };
+};
 
 export type ConnectionWizardFlow = 'kubernetes' | 'generic';
 

--- a/ui/components/connections/ConnectionWizardLauncher.tsx
+++ b/ui/components/connections/ConnectionWizardLauncher.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
 import { Button, Typography } from '@sistent/sistent';
 import { styled } from '@/theme';
 import CAN from '@/utils/can';
 import { Keys } from '@meshery/schemas/permissions';
 import AddIconCircleBorder from '@/assets/icons/AddIconCircleBorder';
-import ConnectionWizardModal from './ConnectionWizardModal';
+import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
+
 const LaunchButton = styled(Button)({
   width: '100%',
   borderRadius: 5,
@@ -15,31 +15,32 @@ const canOpenConnectionWizard = () =>
   CAN(Keys.LifecycleManagementAddCluster.id, Keys.LifecycleManagementAddCluster.function) ||
   CAN(Keys.MesherySystemConnectMetrics.id, Keys.MesherySystemConnectMetrics.function);
 
+/**
+ * Connections-toolbar entry for Create Connection. Opens the app-level wizard
+ * (no kind preset) so selection starts at "Choose Connection".
+ */
 const ConnectionWizardLauncher = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const { openCreateConnection } = useConnectionWizardModal();
 
   return (
-    <>
-      <LaunchButton
-        type="button"
-        variant="contained"
-        onClick={() => setIsOpen(true)}
-        disabled={!canOpenConnectionWizard()}
-        data-testid="connection-create-connection"
+    <LaunchButton
+      type="button"
+      variant="contained"
+      onClick={() => openCreateConnection()}
+      disabled={!canOpenConnectionWizard()}
+      data-testid="connection-create-connection"
+    >
+      <AddIconCircleBorder style={{ width: '20px', height: '20px' }} />
+      <Typography
+        style={{
+          paddingLeft: '4px',
+          width: 'max-content',
+          marginRight: '4px',
+        }}
       >
-        <AddIconCircleBorder style={{ width: '20px', height: '20px' }} />
-        <Typography
-          style={{
-            paddingLeft: '4px',
-            width: 'max-content',
-            marginRight: '4px',
-          }}
-        >
-          Create Connection
-        </Typography>
-      </LaunchButton>
-      {isOpen && <ConnectionWizardModal isOpen={isOpen} onClose={() => setIsOpen(false)} />}
-    </>
+        Create Connection
+      </Typography>
+    </LaunchButton>
   );
 };
 

--- a/ui/components/connections/ConnectionWizardModal.tsx
+++ b/ui/components/connections/ConnectionWizardModal.tsx
@@ -20,6 +20,10 @@ import WizardStepper from './wizard/WizardStepper';
 type ConnectionWizardModalProps = {
   isOpen: boolean;
   onClose: () => void;
+  /** Pre-select a connection kind once definitions load (e.g. "kubernetes"). */
+  presetKind?: string | null;
+  /** When true with presetKind, land on the step after "Choose Connection". */
+  skipKindSelection?: boolean;
 };
 
 // The stepper renders each step's `icon` component bare (no size props), so it
@@ -30,7 +34,12 @@ const StepConnectionIcon = (props: { width?: number; height?: number }) => (
   <ConnectionIcon width={24} height={24} {...props} />
 );
 
-const ConnectionWizardModal = ({ isOpen, onClose }: ConnectionWizardModalProps) => {
+const ConnectionWizardModal = ({
+  isOpen,
+  onClose,
+  presetKind = null,
+  skipKindSelection = false,
+}: ConnectionWizardModalProps) => {
   const { connectionMetadataState } = useSelector((state: RootState) => state.ui);
   const { data: connectionDefinitionsResponse, isFetching: isLoadingKinds } =
     useListConnectionDefinitionsQuery({}, { skip: !isOpen });
@@ -48,6 +57,8 @@ const ConnectionWizardModal = ({ isOpen, onClose }: ConnectionWizardModalProps) 
     availableKinds: kindConfigs,
     isLoadingKinds,
     connectionIconMap: connectionMetadataState || undefined,
+    presetKind,
+    skipKindSelection,
     onComplete: onClose,
   });
 

--- a/ui/components/connections/index.test.tsx
+++ b/ui/components/connections/index.test.tsx
@@ -57,6 +57,14 @@ vi.mock('./ConnectionTable', () => ({
   },
 }));
 
+vi.mock('@/utils/context/ConnectionWizardContextProvider', () => ({
+  useConnectionWizardModal: () => ({
+    openCreateConnection: vi.fn(),
+    closeCreateConnection: vi.fn(),
+    open: false,
+  }),
+}));
+
 vi.mock('./meshSync', () => ({
   default: ({ selectedResourceId, updateUrlWithResourceId }) => (
     <div>

--- a/ui/components/connections/index.tsx
+++ b/ui/components/connections/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { NoSsr } from '@sistent/sistent';
 import { ErrorBoundary, AppBar } from '@sistent/sistent';
 import Modal from '../shared/Modal/Modal';
@@ -12,6 +12,8 @@ import DefaultError from '../general/error-404/index';
 import { useGetSchemaQuery } from '@/rtk-query/schema';
 import CustomErrorFallback from '../shared/ErrorBoundary/ErrorBoundary';
 import ConnectionTable from './ConnectionTable';
+import { CREATE_CONNECTION_QUERY, isCreateConnectionQuery } from './ConnectionWizard.helpers';
+import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
 import { useRouter } from 'next/router';
 
 /**
@@ -66,11 +68,38 @@ function ConnectionManagementPage(props) {
 }
 function Connections() {
   const router = useRouter();
-  const { query, pathname, push, isReady } = router;
+  const { query, pathname, push, isReady, replace } = router;
+  const { openCreateConnection } = useConnectionWizardModal();
   const tabParam = typeof query.tab === 'string' ? query.tab.toLowerCase() : undefined;
   const connectionId = typeof query.connectionId === 'string' ? query.connectionId : undefined;
 
   const tab = useMemo(() => (tabParam === 'meshsync' ? 1 : 0), [tabParam]);
+
+  // Optional shareable deep link: ?create=true&kind=kubernetes
+  const createParam = query[CREATE_CONNECTION_QUERY.create];
+  const kindParam = query[CREATE_CONNECTION_QUERY.kind];
+  const createFlag = Array.isArray(createParam) ? createParam[0] : createParam;
+  const kindFromQuery =
+    typeof kindParam === 'string' && kindParam.length > 0
+      ? kindParam
+      : Array.isArray(kindParam) && kindParam[0]
+        ? kindParam[0]
+        : null;
+
+  useEffect(() => {
+    if (!isReady || !isCreateConnectionQuery(createFlag)) {
+      return;
+    }
+    openCreateConnection({
+      kind: kindFromQuery,
+      skipKindSelection: Boolean(kindFromQuery),
+    });
+    const nextQuery = { ...query };
+    delete nextQuery[CREATE_CONNECTION_QUERY.create];
+    delete nextQuery[CREATE_CONNECTION_QUERY.kind];
+    replace({ pathname, query: nextQuery }, undefined, { shallow: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deep-link flags only
+  }, [isReady, createFlag, kindFromQuery, openCreateConnection]);
 
   // Next.js's pages-router `router.query` and `router.push` get fresh
   // references on each render, which previously cascaded into a new

--- a/ui/components/connections/wizard/genericSteps.tsx
+++ b/ui/components/connections/wizard/genericSteps.tsx
@@ -26,6 +26,7 @@ import {
   CredentialAssociationStep,
   GenericConnectionDetailsStep,
 } from '../ConnectionWizardStepContent';
+import { connectionCreatedNotify } from '../ConnectionWizard.helpers';
 import type { WizardContext, WizardStep } from './types';
 
 export const kindPermission = (config?: ConnectionWizardKindConfig | null) => {
@@ -269,10 +270,7 @@ export const genericRegisterStep: WizardStep = {
       const result = await ctx.services.connectConnection({ ...basePayload, status: 'connect' });
 
       ctx.patch({ registrationResult: result ?? basePayload });
-      ctx.services.notify({
-        message: `${kindConfig.label} connection created.`,
-        event_type: EVENT_TYPES.SUCCESS,
-      });
+      ctx.services.notify(connectionCreatedNotify(kindConfig.label));
       return true;
     } catch (error) {
       ctx.patch({ registrationError: error });

--- a/ui/components/connections/wizard/kubernetesExtension.tsx
+++ b/ui/components/connections/wizard/kubernetesExtension.tsx
@@ -26,6 +26,7 @@ import { kubernetesSettingsStep } from './kubernetesSettings';
 import FormatConnectionMetadata from '../metadata';
 import { ConnectionStateChip } from '../ConnectionChip';
 import { KubernetesImportStep, StepHeader } from '../ConnectionWizardStepContent';
+import { kubernetesImportedNotify } from '../ConnectionWizard.helpers';
 import type {
   ConnectionExtension,
   DiscoveredKubeContext,
@@ -379,10 +380,7 @@ const kubernetesReviewStep: WizardStep = {
         connectedCount: connectedIds.size,
         unreachableCount: created.filter((context) => !context.reachable).length,
       });
-      ctx.services.notify({
-        message: `Imported ${created.length} Kubernetes connection${created.length === 1 ? '' : 's'}.`,
-        event_type: created.length > 0 ? EVENT_TYPES.SUCCESS : EVENT_TYPES.WARNING,
-      });
+      ctx.services.notify(kubernetesImportedNotify(created.length));
       return true;
     } catch (error) {
       ctx.patch({ registrationError: error });

--- a/ui/components/connections/wizard/types.ts
+++ b/ui/components/connections/wizard/types.ts
@@ -77,7 +77,12 @@ export type KubeconfigImportOptions = {
 };
 
 export type WizardServices = {
-  notify: (opts: { message: string; event_type: number; details?: string }) => void;
+  notify: (opts: {
+    message: string;
+    event_type: number | string | { type?: string };
+    details?: string;
+    link?: { href: string; label: string };
+  }) => void;
   /** POST /integrations/connections/register with the given body. */
   registerConnection: (body: GenericRecord) => Promise<GenericRecord>;
   /** POST /integrations/connections/register (status: connect). */

--- a/ui/components/connections/wizard/useConnectionWizard.tsx
+++ b/ui/components/connections/wizard/useConnectionWizard.tsx
@@ -29,6 +29,16 @@ export type UseConnectionWizardParams = {
   /** configure mode: the connection being (re)configured. */
   initialKindConfig?: ConnectionWizardKindConfig | null;
   initialRegistrationResult?: GenericRecord | null;
+  /**
+   * create mode deep-link: kind string (e.g. "kubernetes") resolved against
+   * `availableKinds` once the registry definitions load.
+   */
+  presetKind?: string | null;
+  /**
+   * When true with `presetKind`, advance past the "Choose Connection" step so
+   * the user lands on Import Kubeconfig (or the kind's details step).
+   */
+  skipKindSelection?: boolean;
   onComplete?: () => void;
 };
 
@@ -102,6 +112,39 @@ export const useConnectionWizard = (params: UseConnectionWizardParams) => {
     }));
   }, [mode, initialKindConfig, initialRegistrationResult]);
 
+  // Create-mode deep link: once kind definitions load, pre-select `presetKind`
+  // and optionally land on the step after "Choose Connection" (Import Kubeconfig
+  // for Kubernetes). Applied once per open so user navigation is not overwritten.
+  const { presetKind, skipKindSelection } = params;
+  const appliedPresetRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isOpen) {
+      appliedPresetRef.current = null;
+      return;
+    }
+    if (mode !== 'create' || !presetKind || !availableKinds?.length) {
+      return;
+    }
+    if (appliedPresetRef.current === presetKind) {
+      return;
+    }
+
+    const normalized = presetKind.toLowerCase();
+    const kindConfig =
+      availableKinds.find((config) => config.kind.toLowerCase() === normalized) ?? null;
+    if (!kindConfig) {
+      return;
+    }
+
+    appliedPresetRef.current = presetKind;
+    setData((current) => ({ ...current, kindConfig }));
+    if (skipKindSelection) {
+      // `select` is always step 0 in create mode; index 1 is the kind details
+      // step (Import Kubeconfig for the kubernetes extension).
+      setActiveIndex(1);
+    }
+  }, [isOpen, mode, presetKind, skipKindSelection, availableKinds]);
+
   // Keep `reset` stable while still resetting from the latest params: read them
   // from a ref updated in the render body (not an effect, so children never see
   // stale values during commit).
@@ -111,6 +154,7 @@ export const useConnectionWizard = (params: UseConnectionWizardParams) => {
     setData(makeInitialData(paramsRef.current));
     setActiveIndex(0);
     setIsBusy(false);
+    appliedPresetRef.current = null;
   }, []);
 
   const services = useMemo<WizardServices>(

--- a/ui/components/layout/Header/Header.tsx
+++ b/ui/components/layout/Header/Header.tsx
@@ -398,7 +398,7 @@ function K8sContextMenu({
                       );
                     })}
                     <Box sx={{ marginTop: '1rem' }}>
-                      <MesherySettingsEnvButtons />
+                      <MesherySettingsEnvButtons onOpened={() => setShowFullContextMenu(false)} />
                     </Box>
                   </div>
                 </CMenuContainer>

--- a/ui/components/telemetry/dashboards/index.tsx
+++ b/ui/components/telemetry/dashboards/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/router';
 import {
   AddIcon,
   Box,
@@ -17,6 +16,8 @@ import {
   usePingGrafanaConnectionQuery,
   useUpdatePinnedBoardsMutation,
 } from '@/rtk-query/telemetryGrafana';
+import { CONNECTION_KINDS } from '@/utils/Enum';
+import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
 import ConnectionPicker, { TelemetryConnection } from '../common/ConnectionPicker';
 import PingStatus from '../common/PingStatus';
 import TimeRangePicker from '../common/TimeRangePicker';
@@ -74,7 +75,7 @@ const DrawerBody = styled(Box)(({ theme }) => ({
  */
 const TelemetryDashboards: React.FC = () => {
   const theme = useTheme();
-  const router = useRouter();
+  const { openCreateConnection } = useConnectionWizardModal();
 
   const { data: connectionsData, isLoading: connectionsLoading } = useGetConnectionsQuery({
     kind: JSON.stringify(['grafana']),
@@ -149,14 +150,19 @@ const TelemetryDashboards: React.FC = () => {
             No Grafana connections yet
           </Typography>
           <Typography color="textSecondary" sx={{ maxWidth: 460 }}>
-            Add a Grafana connection to browse and render its dashboards here. Connections are
-            managed from the Connections page.
+            Add a Grafana connection to browse and render its dashboards here. You can manage all
+            connections anytime under Lifecycle → Connections.
           </Typography>
         </Box>
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          onClick={() => router.push('/management/connections')}
+          onClick={() =>
+            openCreateConnection({
+              kind: CONNECTION_KINDS.GRAFANA,
+              skipKindSelection: true,
+            })
+          }
         >
           Add a Grafana connection
         </Button>

--- a/ui/components/telemetry/metrics/index.tsx
+++ b/ui/components/telemetry/metrics/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/router';
 import {
   AddIcon,
   Box,
@@ -17,6 +16,8 @@ import {
   usePingPrometheusConnectionQuery,
   useUpdatePrometheusPanelsMutation,
 } from '@/rtk-query/telemetryPrometheus';
+import { CONNECTION_KINDS } from '@/utils/Enum';
+import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
 import ConnectionPicker, { TelemetryConnection } from '../common/ConnectionPicker';
 import PingStatus from '../common/PingStatus';
 import TimeRangePicker from '../common/TimeRangePicker';
@@ -85,7 +86,7 @@ const newId = () =>
  */
 const TelemetryMetrics: React.FC = () => {
   const theme = useTheme();
-  const router = useRouter();
+  const { openCreateConnection } = useConnectionWizardModal();
 
   const { data: connectionsData, isLoading: connectionsLoading } = useGetConnectionsQuery({
     kind: JSON.stringify(['prometheus']),
@@ -161,14 +162,19 @@ const TelemetryMetrics: React.FC = () => {
             No Prometheus connections yet
           </Typography>
           <Typography color="textSecondary" sx={{ maxWidth: 460 }}>
-            Add a Prometheus connection to explore its metrics and build panels here. Connections
-            are managed from the Connections page.
+            Add a Prometheus connection to explore its metrics and build panels here. You can manage
+            all connections anytime under Lifecycle → Connections.
           </Typography>
         </Box>
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          onClick={() => router.push('/management/connections')}
+          onClick={() =>
+            openCreateConnection({
+              kind: CONNECTION_KINDS.PROMETHEUS,
+              skipKindSelection: true,
+            })
+          }
         >
           Add a Prometheus connection
         </Button>

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -101,6 +101,9 @@ import { updateAdaptersInfo } from '@/store/slices/adapter';
 import ProviderStoreWrapper from '@/store/ProviderStoreWrapper';
 import WorkspaceModalContextProvider from '@/utils/context/WorkspaceModalContextProvider';
 import RegistryModalContextProvider from '@/utils/context/RegistryModalContextProvider';
+import ConnectionWizardContextProvider, {
+  ConnectionWizardHost,
+} from '@/utils/context/ConnectionWizardContextProvider';
 import { DynamicFullScreenLoader } from '@/components/shared/LoadingState/DynamicFullscreenLoader';
 
 export const mesheryExtensionRoute = '/extension/meshmap';
@@ -150,7 +153,7 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
     (key) => ability.can(key.id, _.lowerCase(key.function)),
     // `ability` is a module-level singleton; the reference never changes.
     // Re-creating this callback is intentionally avoided.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
     [],
   );
 
@@ -521,89 +524,93 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
                   <LoadSessionGuard>
                     <WorkspaceModalContextProvider>
                       <RegistryModalContextProvider>
-                        <StyledRoot>
-                          <CssBaseline />
-                          <NavigationBar
-                            isDrawerCollapsed={isDrawerCollapsed}
-                            mobileOpen={state.mobileOpen}
-                            handleDrawerToggle={handleDrawerToggle}
-                            updateExtensionType={updateCurrentExtensionType}
-                            canShowNav={canShowNav}
-                          />
-                          <StyledAppContent
-                            canShowNav={canShowNav}
-                            isDrawerCollapsed={isDrawerCollapsed}
-                          >
-                            <SnackbarProvider
-                              anchorOrigin={{
-                                vertical: 'bottom',
-                                horizontal: 'right',
-                              }}
-                              iconVariant={{
-                                success: <CheckCircle style={{ marginRight: '0.5rem' }} />,
-                                error: <Error style={{ marginRight: '0.5rem' }} />,
-                                warning: <Warning style={{ marginRight: '0.5rem' }} />,
-                                info: <Info style={{ marginRight: '0.5rem' }} />,
-                              }}
-                              Components={{
-                                info: ThemeResponsiveSnackbar,
-                                success: ThemeResponsiveSnackbar,
-                                error: ThemeResponsiveSnackbar,
-                                warning: ThemeResponsiveSnackbar,
-                                loading: ThemeResponsiveSnackbar,
-                              }}
-                              maxSnack={10}
+                        <ConnectionWizardContextProvider>
+                          <StyledRoot>
+                            <CssBaseline />
+                            <NavigationBar
+                              isDrawerCollapsed={isDrawerCollapsed}
+                              mobileOpen={state.mobileOpen}
+                              handleDrawerToggle={handleDrawerToggle}
+                              updateExtensionType={updateCurrentExtensionType}
+                              canShowNav={canShowNav}
+                            />
+                            <StyledAppContent
+                              canShowNav={canShowNav}
+                              isDrawerCollapsed={isDrawerCollapsed}
                             >
-                              <NotificationCenterProvider>
-                                <MesheryProgressBar />
-                                <KubernetesSubscription setAppState={setAppState} />
-                                {!state.isFullScreenMode && (
-                                  <Header
-                                    onDrawerToggle={handleDrawerToggle}
-                                    onDrawerCollapse={isDrawerCollapsed}
-                                    contexts={state.k8sContexts}
-                                    activeContexts={state.activeK8sContexts}
-                                    setActiveContexts={setActiveContexts}
-                                    searchContexts={searchContexts}
-                                    updateExtensionType={updateCurrentExtensionType}
-                                    abilityUpdated={state.abilityUpdated}
-                                  />
-                                )}
-                                <StyledContentWrapper>
-                                  <StyledMainContent
-                                    id="meshery-main"
-                                    style={{
-                                      padding: extensionType === 'navigator' && '0px',
-                                    }}
-                                  >
-                                    <LocalizationProvider dateAdapter={AdapterMoment}>
-                                      <ErrorBoundary customFallback={CustomErrorFallback}>
-                                        <Component
-                                          pageContext={pageContext}
-                                          contexts={state.k8sContexts}
-                                          activeContexts={state.activeK8sContexts}
-                                          setActiveContexts={setActiveContexts}
-                                          searchContexts={searchContexts}
-                                          {...pageProps}
-                                        />
-                                      </ErrorBoundary>
-                                    </LocalizationProvider>
-                                  </StyledMainContent>
-                                  <Footer
-                                    handleMesheryCommunityClick={handleMesheryCommunityClick}
-                                    providerCapabilities={providerCapabilities}
-                                  />
-                                </StyledContentWrapper>
-                              </NotificationCenterProvider>
-                            </SnackbarProvider>
-                          </StyledAppContent>
-                        </StyledRoot>
-                        <PlaygroundMeshDeploy
-                          closeForm={() =>
-                            setState((prevState) => ({ ...prevState, isOpen: false }))
-                          }
-                          isOpen={state.isOpen}
-                        />
+                              <SnackbarProvider
+                                anchorOrigin={{
+                                  vertical: 'bottom',
+                                  horizontal: 'right',
+                                }}
+                                iconVariant={{
+                                  success: <CheckCircle style={{ marginRight: '0.5rem' }} />,
+                                  error: <Error style={{ marginRight: '0.5rem' }} />,
+                                  warning: <Warning style={{ marginRight: '0.5rem' }} />,
+                                  info: <Info style={{ marginRight: '0.5rem' }} />,
+                                }}
+                                Components={{
+                                  info: ThemeResponsiveSnackbar,
+                                  success: ThemeResponsiveSnackbar,
+                                  error: ThemeResponsiveSnackbar,
+                                  warning: ThemeResponsiveSnackbar,
+                                  loading: ThemeResponsiveSnackbar,
+                                }}
+                                maxSnack={10}
+                              >
+                                <NotificationCenterProvider>
+                                  <MesheryProgressBar />
+                                  <KubernetesSubscription setAppState={setAppState} />
+                                  {!state.isFullScreenMode && (
+                                    <Header
+                                      onDrawerToggle={handleDrawerToggle}
+                                      onDrawerCollapse={isDrawerCollapsed}
+                                      contexts={state.k8sContexts}
+                                      activeContexts={state.activeK8sContexts}
+                                      setActiveContexts={setActiveContexts}
+                                      searchContexts={searchContexts}
+                                      updateExtensionType={updateCurrentExtensionType}
+                                      abilityUpdated={state.abilityUpdated}
+                                    />
+                                  )}
+                                  <StyledContentWrapper>
+                                    <StyledMainContent
+                                      id="meshery-main"
+                                      style={{
+                                        padding: extensionType === 'navigator' && '0px',
+                                      }}
+                                    >
+                                      <LocalizationProvider dateAdapter={AdapterMoment}>
+                                        <ErrorBoundary customFallback={CustomErrorFallback}>
+                                          <Component
+                                            pageContext={pageContext}
+                                            contexts={state.k8sContexts}
+                                            activeContexts={state.activeK8sContexts}
+                                            setActiveContexts={setActiveContexts}
+                                            searchContexts={searchContexts}
+                                            {...pageProps}
+                                          />
+                                        </ErrorBoundary>
+                                      </LocalizationProvider>
+                                    </StyledMainContent>
+                                    <Footer
+                                      handleMesheryCommunityClick={handleMesheryCommunityClick}
+                                      providerCapabilities={providerCapabilities}
+                                    />
+                                  </StyledContentWrapper>
+                                  {/* App-level Create Connection wizard (context switcher, telemetry, deep links). */}
+                                  <ConnectionWizardHost />
+                                </NotificationCenterProvider>
+                              </SnackbarProvider>
+                            </StyledAppContent>
+                          </StyledRoot>
+                          <PlaygroundMeshDeploy
+                            closeForm={() =>
+                              setState((prevState) => ({ ...prevState, isOpen: false }))
+                            }
+                            isOpen={state.isOpen}
+                          />
+                        </ConnectionWizardContextProvider>
                       </RegistryModalContextProvider>
                     </WorkspaceModalContextProvider>
                   </LoadSessionGuard>

--- a/ui/rtk-query/telemetryPrometheus.ts
+++ b/ui/rtk-query/telemetryPrometheus.ts
@@ -104,6 +104,7 @@ const telemetryPrometheusApi = api.injectEndpoints({
 
 export const {
   usePingPrometheusConnectionQuery,
+  useLazyPingPrometheusConnectionQuery,
   useListPrometheusMetricsQuery,
   useLazyListPrometheusMetricsQuery,
   usePrometheusLabelValuesQuery,

--- a/ui/utils/__tests__/isSafeInternalNavPath.test.ts
+++ b/ui/utils/__tests__/isSafeInternalNavPath.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeInternalNavPath } from '../hooks/useNotification';
+
+describe('isSafeInternalNavPath', () => {
+  it('allows app-relative paths used by View connections', () => {
+    expect(isSafeInternalNavPath('/management/connections')).toBe(true);
+    expect(isSafeInternalNavPath('/management/connections?tab=connections')).toBe(true);
+    expect(isSafeInternalNavPath('/dashboard')).toBe(true);
+  });
+
+  it('rejects open-redirect and non-path values', () => {
+    expect(isSafeInternalNavPath('https://evil.example')).toBe(false);
+    expect(isSafeInternalNavPath('//evil.example/phish')).toBe(false);
+    expect(isSafeInternalNavPath('javascript:alert(1)')).toBe(false);
+    expect(isSafeInternalNavPath('/\\evil')).toBe(false);
+    expect(isSafeInternalNavPath('')).toBe(false);
+    expect(isSafeInternalNavPath(null)).toBe(false);
+    expect(isSafeInternalNavPath(undefined)).toBe(false);
+  });
+});

--- a/ui/utils/context/ConnectionWizardContextProvider.tsx
+++ b/ui/utils/context/ConnectionWizardContextProvider.tsx
@@ -1,0 +1,103 @@
+import React, { useCallback, useContext, useMemo, useState } from 'react';
+import ConnectionWizardModal from '@/components/connections/ConnectionWizardModal';
+
+export type OpenCreateConnectionOptions = {
+  /** Pre-select a connection kind once definitions load (e.g. "kubernetes"). */
+  kind?: string | null;
+  /**
+   * When true with `kind`, land on the step after "Choose Connection"
+   * (Import Kubeconfig for Kubernetes; details for generic kinds).
+   */
+  skipKindSelection?: boolean;
+};
+
+export type ConnectionWizardContextValue = {
+  open: boolean;
+  presetKind: string | null;
+  skipKindSelection: boolean;
+  openCreateConnection: (opts?: OpenCreateConnectionOptions) => void;
+  closeCreateConnection: () => void;
+};
+
+export const ConnectionWizardContext = React.createContext<ConnectionWizardContextValue>({
+  open: false,
+  presetKind: null,
+  skipKindSelection: false,
+  openCreateConnection: () => {},
+  closeCreateConnection: () => {},
+});
+
+/**
+ * App-level Create Connection wizard — same pattern as WorkspaceModalContext /
+ * RegistryModalContext. Call sites use `useConnectionWizardModal()`; the host
+ * is mounted once under SnackbarProvider in `_app`.
+ */
+const ConnectionWizardContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const [open, setOpen] = useState(false);
+  const [presetKind, setPresetKind] = useState<string | null>(null);
+  const [skipKindSelection, setSkipKindSelection] = useState(false);
+
+  const openCreateConnection = useCallback((opts?: OpenCreateConnectionOptions) => {
+    const kind = opts?.kind?.trim() ? opts.kind.trim() : null;
+    setPresetKind(kind);
+    setSkipKindSelection(Boolean(kind && opts?.skipKindSelection));
+    setOpen(true);
+  }, []);
+
+  const closeCreateConnection = useCallback(() => {
+    setOpen(false);
+    setPresetKind(null);
+    setSkipKindSelection(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      open,
+      presetKind,
+      skipKindSelection,
+      openCreateConnection,
+      closeCreateConnection,
+    }),
+    [open, presetKind, skipKindSelection, openCreateConnection, closeCreateConnection],
+  );
+
+  return (
+    <ConnectionWizardContext.Provider value={value}>{children}</ConnectionWizardContext.Provider>
+  );
+};
+
+/**
+ * Single mount for the Create Connection modal. Must sit under SnackbarProvider
+ * (see `_app`) so wizard toasts work. Mirrors Registry: context + thin consumer.
+ */
+export const ConnectionWizardHost = () => {
+  const { open, presetKind, skipKindSelection, closeCreateConnection } =
+    useContext(ConnectionWizardContext);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <ConnectionWizardModal
+      isOpen={open}
+      onClose={closeCreateConnection}
+      presetKind={presetKind}
+      skipKindSelection={skipKindSelection}
+    />
+  );
+};
+
+/** Hook for callers — same role as `useRegistryModal`. */
+export const useConnectionWizardModal = () => {
+  const context = useContext(ConnectionWizardContext);
+  return {
+    open: context.open,
+    presetKind: context.presetKind,
+    skipKindSelection: context.skipKindSelection,
+    openCreateConnection: context.openCreateConnection,
+    closeCreateConnection: context.closeCreateConnection,
+  };
+};
+
+export default ConnectionWizardContextProvider;

--- a/ui/utils/context/__tests__/ConnectionWizardContextProvider.test.tsx
+++ b/ui/utils/context/__tests__/ConnectionWizardContextProvider.test.tsx
@@ -1,0 +1,72 @@
+import React, { useContext } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/connections/ConnectionWizardModal', () => ({
+  default: () => null,
+}));
+
+import ConnectionWizardContextProvider, {
+  ConnectionWizardContext,
+} from '../ConnectionWizardContextProvider';
+
+const Probe = () => {
+  const ctx = useContext(ConnectionWizardContext);
+  return (
+    <div>
+      <span data-testid="open">{String(ctx.open)}</span>
+      <span data-testid="kind">{ctx.presetKind ?? 'none'}</span>
+      <span data-testid="skip">{String(ctx.skipKindSelection)}</span>
+      <button
+        type="button"
+        onClick={() => ctx.openCreateConnection({ kind: 'kubernetes', skipKindSelection: true })}
+      >
+        openK8s
+      </button>
+      <button type="button" onClick={() => ctx.openCreateConnection()}>
+        openPlain
+      </button>
+      <button type="button" onClick={() => ctx.closeCreateConnection()}>
+        close
+      </button>
+    </div>
+  );
+};
+
+describe('ConnectionWizardContextProvider', () => {
+  it('opens with kind preset and clears on close', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConnectionWizardContextProvider>
+        <Probe />
+      </ConnectionWizardContextProvider>,
+    );
+
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+
+    await user.click(screen.getByRole('button', { name: 'openK8s' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+    expect(screen.getByTestId('kind')).toHaveTextContent('kubernetes');
+    expect(screen.getByTestId('skip')).toHaveTextContent('true');
+
+    await user.click(screen.getByRole('button', { name: 'close' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+    expect(screen.getByTestId('kind')).toHaveTextContent('none');
+    expect(screen.getByTestId('skip')).toHaveTextContent('false');
+  });
+
+  it('opens without preset for the toolbar create path', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConnectionWizardContextProvider>
+        <Probe />
+      </ConnectionWizardContextProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'openPlain' }));
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+    expect(screen.getByTestId('kind')).toHaveTextContent('none');
+    expect(screen.getByTestId('skip')).toHaveTextContent('false');
+  });
+});

--- a/ui/utils/hooks/useNotification.tsx
+++ b/ui/utils/hooks/useNotification.tsx
@@ -1,10 +1,11 @@
 //NOTE: This file is being refactored to use the new notification center
 
-import { CloseIcon, IconButton, ToggleButtonGroup } from '@sistent/sistent';
+import { CloseIcon, IconButton, styled, ToggleButtonGroup } from '@sistent/sistent';
 import { useSnackbar } from 'notistack';
 import { iconMedium } from '../../css/icons.styles';
 import moment from 'moment';
 import { v4 } from 'uuid';
+import Router from 'next/router';
 import { store as rtkStore } from '../../store/index';
 import { toggleNotificationCenter } from '../../store/slices/events';
 import { NOTIFICATION_CENTER_TOGGLE_CLASS } from '../../components/layout/NotificationCenter/constants';
@@ -17,6 +18,39 @@ import { formatApiError } from '../helpers/meshkitError';
 const openEvent = () => {
   rtkStore.dispatch(toggleNotificationCenter());
 };
+
+/**
+ * Only allow same-app relative paths for snackbar navigation actions.
+ * Blocks open redirects: `https://…`, `//evil`, `javascript:`, etc.
+ */
+export const isSafeInternalNavPath = (href) => {
+  if (typeof href !== 'string') {
+    return false;
+  }
+  const path = href.trim();
+  if (!path.startsWith('/') || path.startsWith('//') || path.includes('\\')) {
+    return false;
+  }
+  // Reject scheme-like prefixes that could slip past a leading slash after decode tricks.
+  const lower = path.toLowerCase();
+  if (lower.includes('javascript:') || lower.includes('data:')) {
+    return false;
+  }
+  return true;
+};
+
+/** Same-tab action link in snackbars (underlined so it reads as a link). */
+const SnackbarActionLink = styled('button')(() => ({
+  color: 'inherit',
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  textDecoration: 'underline',
+  font: 'inherit',
+  fontWeight: 600,
+  padding: '0 0.5rem',
+  whiteSpace: 'nowrap',
+}));
 
 /**
  * A React hook to facilitate emitting events from the client.
@@ -41,9 +75,19 @@ export const useNotification = () => {
       customEvent = null,
       showInNotificationCenter = false,
       pushToServer = false,
+      /**
+       * Optional same-tab navigation action. Prefer this over markdown links in
+       * `message`: ThemeResponsiveSnackbar renders messages via BasicMarkdown,
+       * which always opens anchors in a new tab.
+       */
+      link = null,
     }) => {
       timestamp = timestamp ?? moment.utc().valueOf();
       id = id || v4();
+      const safeLink =
+        link?.href && isSafeInternalNavPath(link.href)
+          ? { href: link.href.trim(), label: link.label || 'Open' }
+          : null;
 
       enqueueSnackbar(message, {
         //NOTE: Need to Consolidate the variant and event_type
@@ -51,6 +95,20 @@ export const useNotification = () => {
         action: function Action(key) {
           return (
             <ToggleButtonGroup data-testid={dataTestID}>
+              {safeLink && (
+                <SnackbarActionLink
+                  type="button"
+                  key={`link-${id}`}
+                  data-testid={`${dataTestID}-link`}
+                  onClick={() => {
+                    closeSnackbar(key);
+                    // Same-tab SPA navigation; href already allowlisted as internal.
+                    Router.push(safeLink.href);
+                  }}
+                >
+                  {safeLink.label}
+                </SnackbarActionLink>
+              )}
               {showInNotificationCenter && (
                 <AddClassRecursively className={NOTIFICATION_CENTER_TOGGLE_CLASS}>
                   <IconButton

--- a/ui/utils/hooks/usePrometheusPingHook.tsx
+++ b/ui/utils/hooks/usePrometheusPingHook.tsx
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { useNotification } from './useNotification';
+import { getErrorMessage } from '../../components/connections/ConnectionTable.constants';
+import { useLazyPingPrometheusConnectionQuery } from '@/rtk-query/telemetryPrometheus';
+import { EVENT_TYPES } from '../../lib/event-types';
+import { updateProgressAction } from '@/store/slices/mesheryUi';
+
+/**
+ * Imperative `ping(connectionID, name)` for a registered Prometheus connection.
+ * Mirrors useGrafanaPingHook; hits GET /api/telemetry/prometheus/{id}/ping and
+ * surfaces reachability (+ version when returned) as a notification.
+ */
+export default function usePrometheusPingHook() {
+  const { notify } = useNotification();
+  const dispatch = useDispatch();
+  const [triggerPing] = useLazyPingPrometheusConnectionQuery();
+
+  const ping = useCallback(
+    async (connectionID: string, name?: string) => {
+      const label = name || 'Prometheus';
+      dispatch(updateProgressAction({ showProgress: true }));
+      try {
+        const result = await triggerPing({ connectionID }).unwrap();
+        const version = result?.version;
+        notify({
+          message: version
+            ? `Connected successfully to ${label} (Prometheus ${version})`
+            : `Connected successfully to ${label}`,
+          event_type: EVENT_TYPES.SUCCESS,
+        });
+      } catch (err) {
+        notify({
+          message: `Connection failed for ${label} — unable to reach Prometheus`,
+          details: getErrorMessage(err, 'Unable to reach Prometheus'),
+          event_type: EVENT_TYPES.ERROR,
+        });
+      } finally {
+        dispatch(updateProgressAction({ showProgress: false }));
+      }
+    },
+    [dispatch, notify, triggerPing],
+  );
+
+  return ping;
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #

Open the **shared Create Connection wizard in place** from Add Cluster and telemetry empty states, instead of a separate kubeconfig modal or only navigating to Connections.

### Changes
- **Add Cluster** (context switcher) → wizard with **Kubernetes → Import Kubeconfig**; closes the menu
- **Telemetry** empty (Grafana / Prometheus) → wizard with that kind preselected; stay on the page
- **Create Connection** toolbar → same wizard, no preset
- Optional deep link: `?create=true&kind=…` still works
- Success toast: **View connections** action (same tab, internal path only)
- **Prometheus** connection chip ping (parity with Grafana)
- Dedupe **MeshSync connected in &lt;mode&gt; mode** server events


Screen Recording:

Kubernetes Connection:

https://github.com/user-attachments/assets/c468966d-00f5-4f12-850e-49d52b2a7519

Prometheus/Grafana Connection:

https://github.com/user-attachments/assets/98fd5e86-79f7-40eb-8f8d-b43a2242e3c1


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
