### PR TITLE
[UI] Persist Kubernetes context selection across navigation

### DIFF
--- a/ui/components/AppComponents.test.tsx
+++ b/ui/components/AppComponents.test.tsx
@@ -9,10 +9,13 @@ const setAppStateMock = vi.fn();
 // Return value of useGetConnectionsQuery, swapped per test.
 let connectionsResult: { data?: { connections?: unknown[] } } = { data: undefined };
 
+// Redux boots with ['all'] selected; swapped per test to exercise the sync path.
+let reduxSelectedK8sContexts: string[] = ['all'];
+
 vi.mock('react-redux', () => ({
   useDispatch: () => dispatchMock,
   useSelector: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({ ui: { extensionType: '' } }),
+    selector({ ui: { extensionType: '', selectedK8sContexts: reduxSelectedK8sContexts } }),
 }));
 
 // The k8s context list is now driven by the connections REST API
@@ -38,15 +41,6 @@ vi.mock('@/store/slices/mesheryUi', () => ({
     type: 'core/setK8sContexts',
     payload,
   }),
-}));
-
-// Redux boots with ['all'] selected; swapped per test to exercise the sync path.
-let reduxSelectedK8sContexts: string[] = ['all'];
-
-vi.mock('@/store', () => ({
-  store: {
-    getState: () => ({ ui: { selectedK8sContexts: reduxSelectedK8sContexts } }),
-  },
 }));
 
 vi.mock('@sistent/sistent', () => ({
@@ -201,6 +195,40 @@ describe('KubernetesSubscription', () => {
     expect(setAppStateMock).toHaveBeenCalledWith(
       expect.objectContaining({ activeK8sContexts: ['ctx-1', 'ctx-2', 'all'] }),
     );
+    // Storage is resynced to the resolved selection so it does not keep a
+    // stale variant of the same selection.
+    expect(JSON.parse(window.sessionStorage.getItem('selectedK8sContexts') || 'null')).toEqual([
+      'all',
+    ]);
+  });
+
+  it('does not touch the selection or storage while connections are still loading', () => {
+    connectionsResult = { data: undefined };
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify(['ctx-2']));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
+    // The persisted selection survives untouched until data arrives.
+    expect(JSON.parse(window.sessionStorage.getItem('selectedK8sContexts') || 'null')).toEqual([
+      'ctx-2',
+    ]);
+  });
+
+  it('leaves redux and storage untouched when no contexts exist', () => {
+    connectionsResult = { data: { connections: [] } };
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify(['ctx-1']));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    // k8sConfig still syncs (empty), but the selection is not rewritten.
+    expect(dispatchMock.mock.calls.map(([action]) => action)).not.toContainEqual(
+      expect.objectContaining({ type: 'core/setK8sContexts' }),
+    );
+    expect(JSON.parse(window.sessionStorage.getItem('selectedK8sContexts') || 'null')).toEqual([
+      'ctx-1',
+    ]);
   });
 
   it('drops stale ids but keeps the surviving persisted selection', () => {

--- a/ui/components/AppComponents.test.tsx
+++ b/ui/components/AppComponents.test.tsx
@@ -34,6 +34,19 @@ vi.mock('@/store/slices/mesheryUi', () => ({
     type: 'core/updateK8SConfig',
     payload,
   }),
+  setK8sContexts: (payload: Record<string, unknown>) => ({
+    type: 'core/setK8sContexts',
+    payload,
+  }),
+}));
+
+// Redux boots with ['all'] selected; swapped per test to exercise the sync path.
+let reduxSelectedK8sContexts: string[] = ['all'];
+
+vi.mock('@/store', () => ({
+  store: {
+    getState: () => ({ ui: { selectedK8sContexts: reduxSelectedK8sContexts } }),
+  },
 }));
 
 vi.mock('@sistent/sistent', () => ({
@@ -59,28 +72,32 @@ vi.mock('../themes/App.styles', () => ({
   StyledFooterText: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
+const twoConnections = {
+  data: {
+    connections: [
+      {
+        id: 'conn-1',
+        metadata: { id: 'ctx-1', name: 'prod-us', kubernetes_server_id: 's1' },
+      },
+      {
+        id: 'conn-2',
+        metadata: { id: 'ctx-2', name: 'prod-eu' },
+      },
+    ],
+  },
+};
+
 describe('KubernetesSubscription', () => {
   beforeEach(() => {
     dispatchMock.mockReset();
     setAppStateMock.mockReset();
     connectionsResult = { data: undefined };
+    reduxSelectedK8sContexts = ['all'];
+    window.sessionStorage.clear();
   });
 
   it('maps kubernetes connections into contexts and connection config', () => {
-    connectionsResult = {
-      data: {
-        connections: [
-          {
-            id: 'conn-1',
-            metadata: { id: 'ctx-1', name: 'prod-us', kubernetes_server_id: 's1' },
-          },
-          {
-            id: 'conn-2',
-            metadata: { id: 'ctx-2', name: 'prod-eu' },
-          },
-        ],
-      },
-    };
+    connectionsResult = twoConnections;
 
     render(<KubernetesSubscription setAppState={setAppStateMock} />);
 
@@ -117,6 +134,94 @@ describe('KubernetesSubscription', () => {
         type: 'core/updateK8SConfig',
         payload: { k8sConfig: [] },
       }),
+    );
+  });
+
+  it('honors a persisted partial selection instead of force-selecting every context', () => {
+    connectionsResult = twoConnections;
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify(['ctx-2']));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ activeK8sContexts: ['ctx-2'] }),
+    );
+    // Redux boots with ['all'], so the restored selection must be synced.
+    expect(dispatchMock.mock.calls.map(([action]) => action)).toContainEqual(
+      expect.objectContaining({
+        type: 'core/setK8sContexts',
+        payload: { selectedK8sContexts: ['ctx-2'] },
+      }),
+    );
+  });
+
+  it('honors a persisted explicit empty selection', () => {
+    connectionsResult = twoConnections;
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify([]));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ activeK8sContexts: [] }),
+    );
+  });
+
+  it('selects every context when the persisted selection is ["all"]', () => {
+    connectionsResult = twoConnections;
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify(['all']));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ activeK8sContexts: ['ctx-1', 'ctx-2', 'all'] }),
+    );
+    // Redux already holds ['all'] — no redundant sync dispatch.
+    expect(dispatchMock.mock.calls.map(([action]) => action)).not.toContainEqual(
+      expect.objectContaining({ type: 'core/setK8sContexts' }),
+    );
+  });
+
+  it('falls back to selecting all contexts when every persisted id is stale', () => {
+    connectionsResult = twoConnections;
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify(['ctx-gone']));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ activeK8sContexts: ['ctx-1', 'ctx-2', 'all'] }),
+    );
+  });
+
+  it('restores the implicit "all" when the persisted ids cover every context', () => {
+    connectionsResult = twoConnections;
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify(['ctx-1', 'ctx-2']));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ activeK8sContexts: ['ctx-1', 'ctx-2', 'all'] }),
+    );
+  });
+
+  it('drops stale ids but keeps the surviving persisted selection', () => {
+    connectionsResult = twoConnections;
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify(['ctx-1', 'ctx-gone']));
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ activeK8sContexts: ['ctx-1'] }),
+    );
+  });
+
+  it('ignores corrupt persisted values and defaults to all contexts', () => {
+    connectionsResult = twoConnections;
+    window.sessionStorage.setItem('selectedK8sContexts', 'not-json');
+
+    render(<KubernetesSubscription setAppState={setAppStateMock} />);
+
+    expect(setAppStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ activeK8sContexts: ['ctx-1', 'ctx-2', 'all'] }),
     );
   });
 });

--- a/ui/components/AppComponents.tsx
+++ b/ui/components/AppComponents.tsx
@@ -13,8 +13,12 @@ import { StyledDrawer, StyledFooterBody, StyledFooterText } from '../themes/App.
 
 // Order-insensitive equality for context-id selections: ['a','b'] and
 // ['b','a'] are the same selection.
-const isSameSelection = (a: string[], b: string[]) =>
-  a.length === b.length && [...a].sort().every((id, index) => id === [...b].sort()[index]);
+const isSameSelection = (a: string[], b: string[]) => {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((id, index) => id === sortedB[index]);
+};
 
 type FooterProps = {
   providerCapabilities?: { restrictedAccess?: { isMesheryUiRestricted?: boolean } } | null;

--- a/ui/components/AppComponents.tsx
+++ b/ui/components/AppComponents.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { FavoriteIcon, Hidden, Typography, useTheme } from '@sistent/sistent';
 import Navigator from './layout/Navigator/Navigator';
 import CAN from '@/utils/can';
@@ -8,9 +8,13 @@ import { connectionsToK8sContexts } from '@/rtk-query/transforms';
 import { useGetConnectionsQuery } from '@/rtk-query/connection';
 import { CONNECTION_KINDS } from '@/utils/Enum';
 import { setK8sContexts, updateK8SConfig } from '@/store/slices/mesheryUi';
-import { loadSelectedK8sContexts } from '@/utils/multi-ctx';
-import { store } from '@/store';
+import { loadSelectedK8sContexts, persistSelectedK8sContexts } from '@/utils/multi-ctx';
 import { StyledDrawer, StyledFooterBody, StyledFooterText } from '../themes/App.styles';
+
+// Order-insensitive equality for context-id selections: ['a','b'] and
+// ['b','a'] are the same selection.
+const isSameSelection = (a: string[], b: string[]) =>
+  a.length === b.length && [...a].sort().every((id, index) => id === [...b].sort()[index]);
 
 type FooterProps = {
   providerCapabilities?: { restrictedAccess?: { isMesheryUiRestricted?: boolean } } | null;
@@ -84,8 +88,24 @@ export const KubernetesSubscription = ({ setAppState }: { setAppState: SetAppSta
     { skip: !canViewClusters },
   );
 
+  // Read the current selection through a render-synced ref so the effect can
+  // consult the latest value without listing it as a dependency (the effect
+  // dispatches setK8sContexts, so depending on the selection would loop).
+  const selectedK8sContexts = useSelector(
+    (state: { ui: { selectedK8sContexts: string[] } }) => state.ui.selectedK8sContexts,
+  );
+  const selectedK8sContextsRef = useRef(selectedK8sContexts);
+  selectedK8sContextsRef.current = selectedK8sContexts;
+
   useEffect(() => {
     if (!canViewClusters) {
+      return;
+    }
+
+    // Until the connections query resolves there is nothing to reconcile
+    // against - proceeding would treat "still loading" as "no contexts" and
+    // wipe the persisted selection with an empty one.
+    if (!connectionData) {
       return;
     }
 
@@ -120,13 +140,24 @@ export const KubernetesSubscription = ({ setAppState }: { setAppState: SetAppSta
 
     dispatch(updateK8SConfig({ k8sConfig: normalizedK8sContext?.contexts ?? [] }));
 
+    // With no contexts at all there is no selection to reconcile - leave
+    // redux and storage untouched so a cluster added later starts from the
+    // default all-selected view instead of an accidental explicit-empty one.
+    if (availableIds.length === 0) {
+      return;
+    }
+
     // Keep the redux selection (what dashboards, deploys, and queries consume)
     // in step with the restored selection; redux boots with ['all'] and would
-    // otherwise disagree with the header checkboxes after a reload.
+    // otherwise disagree with the header checkboxes after a reload. The thunk
+    // also rewrites sessionStorage, resyncing it after stale ids were dropped.
     const resolvedSelection = activeContexts.includes('all') ? ['all'] : activeContexts;
-    const currentSelection = store.getState().ui.selectedK8sContexts;
-    if (JSON.stringify(currentSelection) !== JSON.stringify(resolvedSelection)) {
+    if (!isSameSelection(selectedK8sContextsRef.current, resolvedSelection)) {
       dispatch(setK8sContexts({ selectedK8sContexts: resolvedSelection }));
+    } else {
+      // Same selection redux-side, but storage may still hold a stale variant
+      // of it (e.g. dropped ids resolved back to the implicit 'all').
+      persistSelectedK8sContexts(resolvedSelection);
     }
   }, [connectionData, canViewClusters, dispatch, setAppState]);
 

--- a/ui/components/AppComponents.tsx
+++ b/ui/components/AppComponents.tsx
@@ -7,7 +7,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { connectionsToK8sContexts } from '@/rtk-query/transforms';
 import { useGetConnectionsQuery } from '@/rtk-query/connection';
 import { CONNECTION_KINDS } from '@/utils/Enum';
-import { updateK8SConfig } from '@/store/slices/mesheryUi';
+import { setK8sContexts, updateK8SConfig } from '@/store/slices/mesheryUi';
+import { loadSelectedK8sContexts } from '@/utils/multi-ctx';
+import { store } from '@/store';
 import { StyledDrawer, StyledFooterBody, StyledFooterText } from '../themes/App.styles';
 
 type FooterProps = {
@@ -88,18 +90,44 @@ export const KubernetesSubscription = ({ setAppState }: { setAppState: SetAppSta
     }
 
     const normalizedK8sContext = connectionsToK8sContexts(connectionData?.connections);
-    const allContexts: string[] = [];
-    if (normalizedK8sContext?.contexts?.length > 0) {
-      normalizedK8sContext.contexts.forEach((ctx: { id: string }) => allContexts.push(ctx.id));
-      allContexts.push('all');
+    const availableIds: string[] = (normalizedK8sContext?.contexts ?? []).map(
+      (ctx: { id: string }) => ctx.id,
+    );
+    const allContexts: string[] = availableIds.length > 0 ? [...availableIds, 'all'] : [];
+
+    // Honor the selection persisted for this browser session instead of
+    // force-selecting every context on each refetch of the connections query
+    // (which previously wiped the user's include/exclude choices on every
+    // navigation-triggered cache refresh).
+    const persisted = loadSelectedK8sContexts();
+    let activeContexts = allContexts;
+    if (persisted !== null && !persisted.includes('all')) {
+      const valid = persisted.filter((id) => availableIds.includes(id));
+      if (valid.length === availableIds.length || (valid.length === 0 && persisted.length > 0)) {
+        // Every context is selected (restore the implicit 'all'), or every
+        // persisted id is stale (contexts were replaced) — default to all.
+        activeContexts = allContexts;
+      } else {
+        // Partial selection — includes the explicit "none selected" case.
+        activeContexts = valid;
+      }
     }
 
     setAppState({
       k8sContexts: normalizedK8sContext,
-      activeK8sContexts: allContexts,
+      activeK8sContexts: activeContexts,
     });
 
     dispatch(updateK8SConfig({ k8sConfig: normalizedK8sContext?.contexts ?? [] }));
+
+    // Keep the redux selection (what dashboards, deploys, and queries consume)
+    // in step with the restored selection; redux boots with ['all'] and would
+    // otherwise disagree with the header checkboxes after a reload.
+    const resolvedSelection = activeContexts.includes('all') ? ['all'] : activeContexts;
+    const currentSelection = store.getState().ui.selectedK8sContexts;
+    if (JSON.stringify(currentSelection) !== JSON.stringify(resolvedSelection)) {
+      dispatch(setK8sContexts({ selectedK8sContexts: resolvedSelection }));
+    }
   }, [connectionData, canViewClusters, dispatch, setAppState]);
 
   return null;

--- a/ui/store/slices/__tests__/mesheryUi.test.ts
+++ b/ui/store/slices/__tests__/mesheryUi.test.ts
@@ -9,7 +9,10 @@ vi.mock('@/utils/eventBus', () => ({
   },
 }));
 
+const persistSelectedK8sContextsMock = vi.fn();
+
 vi.mock('@/utils/multi-ctx', () => ({
+  persistSelectedK8sContexts: (...args: unknown[]) => persistSelectedK8sContextsMock(...args),
   getK8sClusterIdsFromCtxId: vi.fn((selectedContexts, k8sconfig) => {
     if (!selectedContexts || !k8sconfig || selectedContexts.length === 0) return [];
     if (selectedContexts.includes('all')) {
@@ -216,6 +219,13 @@ describe('mesheryUi slice', () => {
         type: 'K8S_CONTEXTS_UPDATED',
         data: { selectedK8sContexts: ['ctx-1'] },
       });
+    });
+
+    it('session-persists the selection (side effect lives in the thunk, not the reducer)', () => {
+      const dispatch = vi.fn();
+      setK8sContexts({ selectedK8sContexts: ['ctx-1', 'ctx-2'] })(dispatch);
+
+      expect(persistSelectedK8sContextsMock).toHaveBeenCalledWith(['ctx-1', 'ctx-2']);
     });
   });
 

--- a/ui/store/slices/mesheryUi.ts
+++ b/ui/store/slices/mesheryUi.ts
@@ -52,7 +52,7 @@ const coreSlice = createSlice({
     setK8sContexts: (state, action) => {
       state.selectedK8sContexts = action.payload.selectedK8sContexts;
       // Note: Side effects (session persistence, event bus publication) are
-      // handled in the setK8sContexts thunk below - reducers stay pure.
+      // handled in the setK8sContexts thunk below; this reducer is side-effect free.
     },
     updateProgress: (state, action) => {
       state.showProgress = action.payload.showProgress;

--- a/ui/store/slices/mesheryUi.ts
+++ b/ui/store/slices/mesheryUi.ts
@@ -51,10 +51,8 @@ const coreSlice = createSlice({
     },
     setK8sContexts: (state, action) => {
       state.selectedK8sContexts = action.payload.selectedK8sContexts;
-      // Session-persist the selection so it survives navigation and reloads
-      // (same inline pattern as setOrganization/setWorkspace below).
-      persistSelectedK8sContexts(action.payload.selectedK8sContexts);
-      // Note: Event bus publication would be handled in the thunk action
+      // Note: Side effects (session persistence, event bus publication) are
+      // handled in the setK8sContexts thunk below - reducers stay pure.
     },
     updateProgress: (state, action) => {
       state.showProgress = action.payload.showProgress;
@@ -117,6 +115,12 @@ export const {
 // Add thunks for async operations or side effects
 export const setK8sContexts = (payload) => (dispatch) => {
   dispatch(setK8sContextsAction(payload));
+
+  // Session-persist the selection so it survives navigation and reloads.
+  // Every selection change in the app flows through this thunk (header
+  // checkboxes, deploy modal, context search), making it the single
+  // persistence funnel while keeping the reducer pure.
+  persistSelectedK8sContexts(payload.selectedK8sContexts);
 
   mesheryEventBus.publish({
     type: 'K8S_CONTEXTS_UPDATED',

--- a/ui/store/slices/mesheryUi.ts
+++ b/ui/store/slices/mesheryUi.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { getK8sClusterIdsFromCtxId } from '@/utils/multi-ctx';
+import { getK8sClusterIdsFromCtxId, persistSelectedK8sContexts } from '@/utils/multi-ctx';
 import { mesheryEventBus } from '@/utils/eventBus';
 import { store } from '..';
 
@@ -51,6 +51,9 @@ const coreSlice = createSlice({
     },
     setK8sContexts: (state, action) => {
       state.selectedK8sContexts = action.payload.selectedK8sContexts;
+      // Session-persist the selection so it survives navigation and reloads
+      // (same inline pattern as setOrganization/setWorkspace below).
+      persistSelectedK8sContexts(action.payload.selectedK8sContexts);
       // Note: Event bus publication would be handled in the thunk action
     },
     updateProgress: (state, action) => {

--- a/ui/utils/__tests__/multi-ctx.test.ts
+++ b/ui/utils/__tests__/multi-ctx.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   ctxUrl,
+  loadSelectedK8sContexts,
+  persistSelectedK8sContexts,
   getK8sClusterIdsFromCtxId,
   getFirstCtxIdFromSelectedCtxIds,
   getK8sConfigIdsFromK8sConfig,
@@ -222,5 +224,44 @@ describe('getControllerPollConnectionIDsFromContextIds', () => {
 
   it('respects the context filter', () => {
     expect(getControllerPollConnectionIDsFromContextIds(['ctx-1'], pollConfig)).toEqual(['conn-1']);
+  });
+});
+
+describe('selected k8s contexts session persistence', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('round-trips a selection through sessionStorage', () => {
+    persistSelectedK8sContexts(['ctx-1', 'ctx-2']);
+    expect(loadSelectedK8sContexts()).toEqual(['ctx-1', 'ctx-2']);
+  });
+
+  it('round-trips the sentinel and empty selections', () => {
+    persistSelectedK8sContexts(['all']);
+    expect(loadSelectedK8sContexts()).toEqual(['all']);
+
+    persistSelectedK8sContexts([]);
+    expect(loadSelectedK8sContexts()).toEqual([]);
+  });
+
+  it('returns null when nothing is persisted', () => {
+    expect(loadSelectedK8sContexts()).toBeNull();
+  });
+
+  it('returns null for corrupt or non-array persisted values', () => {
+    window.sessionStorage.setItem('selectedK8sContexts', 'not-json');
+    expect(loadSelectedK8sContexts()).toBeNull();
+
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify({ ctx: true }));
+    expect(loadSelectedK8sContexts()).toBeNull();
+
+    window.sessionStorage.setItem('selectedK8sContexts', JSON.stringify([1, 2]));
+    expect(loadSelectedK8sContexts()).toBeNull();
+  });
+
+  it('ignores non-array input on persist', () => {
+    persistSelectedK8sContexts('all' as unknown as string[]);
+    expect(loadSelectedK8sContexts()).toBeNull();
   });
 });

--- a/ui/utils/multi-ctx.ts
+++ b/ui/utils/multi-ctx.ts
@@ -1,5 +1,48 @@
 import { CONNECTION_STATES, MESHSYNC_DEPLOYMENT_TYPE } from './Enum';
 
+// sessionStorage key for the user's include/exclude selection of Kubernetes
+// contexts. Session-scoped on purpose: the selection is a view preference, not
+// durable configuration, so it survives navigation and reloads within a
+// browser session without any server round-trip.
+const SELECTED_K8S_CONTEXTS_STORAGE_KEY = 'selectedK8sContexts';
+
+/**
+ * Reads the persisted context selection for this browser session.
+ *
+ * @returns {Array.<string>|null} The persisted selection (may be `[]` when the
+ *   user deselected every context, or `['all']`), or `null` when nothing valid
+ *   is persisted and the caller should fall back to the default selection.
+ */
+export function loadSelectedK8sContexts(): string[] | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(SELECTED_K8S_CONTEXTS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) && parsed.every((id) => typeof id === 'string') ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persists the context selection for this browser session.
+ *
+ * @param {Array.<string>} selectedK8sContexts Context ids, or `['all']`.
+ */
+export function persistSelectedK8sContexts(selectedK8sContexts: string[]): void {
+  if (typeof window === 'undefined' || !Array.isArray(selectedK8sContexts)) return;
+  try {
+    window.sessionStorage.setItem(
+      SELECTED_K8S_CONTEXTS_STORAGE_KEY,
+      JSON.stringify(selectedK8sContexts),
+    );
+  } catch {
+    // Quota exceeded or private browsing — degrade silently; the selection
+    // simply won't survive navigation.
+  }
+}
+
 /**
  * A function to be used by the requests sent for the
  * operations based on multi-context support


### PR DESCRIPTION
## Description

The Kubernetes context switcher behaved in a memory-less way: a user's choice to include or exclude any given cluster from view was forgotten as they navigated page-to-page.

**Symptom** - Unchecking a cluster in the context switcher, then navigating to another page (or triggering any connections-cache refresh), snapped the selection back to all-selected.

**Root cause** - `KubernetesSubscription` (`ui/components/AppComponents.tsx`) unconditionally rebuilt `activeK8sContexts` as *every* context id on each refetch of the kubernetes connections query, overwriting the user's selection. Neither the local selection (`_app.tsx` state) nor the redux selection (`ui.selectedK8sContexts`) was persisted anywhere, so a reload also reset it.

**Fix**
- Persist the selection in `sessionStorage` via the `setK8sContexts` reducer - the single funnel through which every selection change flows (header checkboxes, deploy modal, context search). Follows the existing inline pattern used for `currentOrg`/`currentWorkspace`/`keys`.
- `KubernetesSubscription` now reconciles the persisted selection against the currently available contexts instead of force-selecting everything: stale ids are dropped, a fully-stale or complete selection restores the implicit `all`, and an explicit empty selection is honored.
- The restored selection is synced into redux on boot, which otherwise initializes to `['all']` and would disagree with the header checkboxes after a reload.

Session storage is deliberately favored over additional user-preference API calls: the selection is a per-session view preference, not durable configuration.

**Watch for** - `searchContexts` in `_app.tsx` still replaces the context list with search results (pre-existing quirk, unchanged); the deploy modal's own context checkboxes write through the same redux funnel and therefore now persist too, which is consistent with them mutating the global selection.

## Tests
- `ui/components/AppComponents.test.tsx`: 7 new cases - persisted partial selection honored, explicit empty selection honored, `['all']` sentinel, stale-id fallback, implicit-all restoration, partial stale survival, corrupt-value fallback.
- `ui/utils/__tests__/multi-ctx.test.ts`: round-trip, sentinel/empty, corrupt/non-array guards for the new persistence helpers.
- `npx vitest run` on both files: 46 passed. ESLint and `tsc --noEmit` clean.

## Notes for reviewers
The empty-catch in `persistSelectedK8sContexts` intentionally degrades to non-persistence when storage is unavailable (private browsing/quota), mirroring `useColumnVisibilityPreference`.