### PR TITLE
Fix/connections toolbar sistent 20655

### DIFF
--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -40,17 +40,20 @@ vi.mock('@sistent/sistent', () => ({
     search,
     filter,
     columnVisibility,
+    tabs,
   }: {
     primaryActions?: React.ReactNode;
     search?: React.ReactNode;
     filter?: React.ReactNode;
     columnVisibility?: React.ReactNode;
+    tabs?: React.ReactNode;
   }) => (
     <div data-testid="data-table-toolbar">
       {primaryActions}
       {search}
       {filter}
       {columnVisibility}
+      {tabs}
     </div>
   ),
   ResponsiveDataTable: (props) => {
@@ -582,5 +585,21 @@ describe('ConnectionTable', () => {
     rerender(<ConnectionTable />);
 
     expect(dataTableProps.options).toBe(firstOptions);
+  });
+
+  // Regression coverage for the review feedback on PR #20695: the
+  // Connections/MeshSync tab switcher must be passed down through the
+  // toolbar (rendered between the toolbar and the data table), not dropped.
+  it('renders the tabs prop inside the toolbar, ahead of the data table', () => {
+    render(<ConnectionTable tabs={<div data-testid="connection-tabs">tabs</div>} />);
+
+    const toolbar = screen.getByTestId('data-table-toolbar');
+    expect(toolbar).toContainElement(screen.getByTestId('connection-tabs'));
+
+    const positions = screen
+      .getByTestId('connection-tabs')
+      .compareDocumentPosition(screen.getByTestId('responsive-data-table'));
+
+    expect(positions & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -34,6 +34,15 @@ vi.mock('@sistent/sistent', () => ({
   CustomColumnVisibilityControl: () => <div data-testid="column-visibility-control" />,
   SearchBar: () => <div data-testid="search-bar" />,
   UniversalFilter: () => <div data-testid="universal-filter" />,
+
+  DataTableToolbar: ({ primaryActions, search, filter, columnVisibility }: any) => (
+    <div data-testid="data-table-toolbar">
+      {primaryActions}
+      {search}
+      {filter}
+      {columnVisibility}
+    </div>
+  ),
   ResponsiveDataTable: (props) => {
     dataTableProps = props;
     return <div data-testid="responsive-data-table" />;

--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -35,7 +35,17 @@ vi.mock('@sistent/sistent', () => ({
   SearchBar: () => <div data-testid="search-bar" />,
   UniversalFilter: () => <div data-testid="universal-filter" />,
 
-  DataTableToolbar: ({ primaryActions, search, filter, columnVisibility }: any) => (
+  DataTableToolbar: ({
+    primaryActions,
+    search,
+    filter,
+    columnVisibility,
+  }: {
+    primaryActions?: React.ReactNode;
+    search?: React.ReactNode;
+    filter?: React.ReactNode;
+    columnVisibility?: React.ReactNode;
+  }) => (
     <div data-testid="data-table-toolbar">
       {primaryActions}
       {search}

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -58,6 +58,7 @@ const ConnectionTable = ({
   selectedFilter,
   selectedConnectionId,
   updateUrlWithConnectionId,
+  tabs,
 }: ConnectionTableProps) => {
   const {
     organization,
@@ -641,6 +642,7 @@ const ConnectionTable = ({
         columns={columns}
         columnVisibility={columnVisibility}
         setColumnVisibility={setColumnVisibilityByUser}
+        tabs={tabs}
       />
 
       <ResponsiveDataTable

--- a/ui/components/connections/ConnectionTable.types.ts
+++ b/ui/components/connections/ConnectionTable.types.ts
@@ -1,7 +1,10 @@
+import type { ReactNode } from 'react';
+
 export type ConnectionTableProps = {
   selectedFilter?: string;
   selectedConnectionId?: string;
   updateUrlWithConnectionId?: (connectionId: string) => void;
+  tabs?: ReactNode;
 };
 
 export type EnvironmentOption = {

--- a/ui/components/connections/ConnectionTableToolbar.tsx
+++ b/ui/components/connections/ConnectionTableToolbar.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { CustomColumnVisibilityControl, SearchBar, UniversalFilter } from '@sistent/sistent';
+import {
+  CustomColumnVisibilityControl,
+  SearchBar,
+  UniversalFilter,
+  DataTableToolbar,
+} from '@sistent/sistent';
 import { CreateButton } from './styles';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
 import { styled } from '@/theme';
 import ConnectionWizardLauncher from './ConnectionWizardLauncher';
 import { getVisibilityColums } from '../../utils/utils';
@@ -40,11 +44,13 @@ export const ConnectionTableToolbar = ({
   setColumnVisibility,
 }: ConnectionTableToolbarProps) => {
   return (
-    <ToolWrapper style={{ marginBottom: '5px', marginTop: '-30px' }}>
-      <CreateButton>
-        <ConnectionWizardLauncher />
-      </CreateButton>
-      <ToolbarActions>
+    <DataTableToolbar
+      primaryActions={
+        <CreateButton>
+          <ConnectionWizardLauncher />
+        </CreateButton>
+      }
+      search={
         <div data-testid="ConnectionTable-search">
           <SearchBar
             onSearch={onSearch}
@@ -53,7 +59,8 @@ export const ConnectionTableToolbar = ({
             setExpanded={setIsSearchExpanded}
           />
         </div>
-
+      }
+      filter={
         <UniversalFilter
           id="ref"
           filters={filters}
@@ -61,14 +68,18 @@ export const ConnectionTableToolbar = ({
           setSelectedFilters={setSelectedFilters}
           handleApplyFilter={handleApplyFilter}
         />
-
+      }
+      columnVisibility={
         <CustomColumnVisibilityControl
           style={{ zIndex: 1300 }}
           id="ref"
           columns={getVisibilityColums(columns)}
-          customToolsProps={{ columnVisibility, setColumnVisibility }}
+          customToolsProps={{
+            columnVisibility,
+            setColumnVisibility,
+          }}
         />
-      </ToolbarActions>
-    </ToolWrapper>
+      }
+    />
   );
 };

--- a/ui/components/connections/ConnectionTableToolbar.tsx
+++ b/ui/components/connections/ConnectionTableToolbar.tsx
@@ -6,7 +6,6 @@ import {
   DataTableToolbar,
 } from '@sistent/sistent';
 import { CreateButton } from './styles';
-import { styled } from '@/theme';
 import ConnectionWizardLauncher from './ConnectionWizardLauncher';
 import { getVisibilityColums } from '../../utils/utils';
 import type { SelectedFilters } from './ConnectionTable.types';
@@ -23,13 +22,6 @@ type ConnectionTableToolbarProps = {
   columnVisibility: Record<string, boolean | undefined>;
   setColumnVisibility: (visibility: Record<string, boolean | undefined>) => void;
 };
-
-const ToolbarActions = styled('div')(() => ({
-  display: 'flex',
-  borderRadius: '0.5rem 0.5rem 0 0',
-  width: '100%',
-  justifyContent: 'flex-end',
-}));
 
 export const ConnectionTableToolbar = ({
   isSearchExpanded,

--- a/ui/components/connections/ConnectionTableToolbar.tsx
+++ b/ui/components/connections/ConnectionTableToolbar.tsx
@@ -21,6 +21,7 @@ type ConnectionTableToolbarProps = {
   columns: Array<{ name: string; label?: string; options?: { display?: boolean } }>;
   columnVisibility: Record<string, boolean | undefined>;
   setColumnVisibility: (visibility: Record<string, boolean | undefined>) => void;
+  tabs?: React.ReactNode;
 };
 
 export const ConnectionTableToolbar = ({
@@ -34,6 +35,7 @@ export const ConnectionTableToolbar = ({
   columns,
   columnVisibility,
   setColumnVisibility,
+  tabs,
 }: ConnectionTableToolbarProps) => {
   return (
     <DataTableToolbar
@@ -54,7 +56,7 @@ export const ConnectionTableToolbar = ({
       }
       filter={
         <UniversalFilter
-          id="ref"
+          id="connection-table-filter"
           filters={filters}
           selectedFilters={selectedFilters}
           setSelectedFilters={setSelectedFilters}
@@ -64,7 +66,7 @@ export const ConnectionTableToolbar = ({
       columnVisibility={
         <CustomColumnVisibilityControl
           style={{ zIndex: 1300 }}
-          id="ref"
+          id="connection-table-column-visibility"
           columns={getVisibilityColums(columns)}
           customToolsProps={{
             columnVisibility,
@@ -72,6 +74,7 @@ export const ConnectionTableToolbar = ({
           }}
         />
       }
+      tabs={tabs}
     />
   );
 };

--- a/ui/components/connections/index.test.tsx
+++ b/ui/components/connections/index.test.tsx
@@ -44,10 +44,11 @@ vi.mock('./styles', () => ({
 const connectionTableCallbackRefs: Array<unknown> = [];
 
 vi.mock('./ConnectionTable', () => ({
-  default: ({ selectedConnectionId, updateUrlWithConnectionId }) => {
+  default: ({ selectedConnectionId, updateUrlWithConnectionId, tabs }) => {
     connectionTableCallbackRefs.push(updateUrlWithConnectionId);
     return (
       <div>
+        {tabs}
         <div data-testid="connection-table">connection:{selectedConnectionId ?? 'none'}</div>
         <button onClick={() => updateUrlWithConnectionId?.('cluster-2')} type="button">
           Update Connection Id
@@ -58,8 +59,9 @@ vi.mock('./ConnectionTable', () => ({
 }));
 
 vi.mock('./meshSync', () => ({
-  default: ({ selectedResourceId, updateUrlWithResourceId }) => (
+  default: ({ selectedResourceId, updateUrlWithResourceId, tabs }) => (
     <div>
+      {tabs}
       <div data-testid="meshsync-table">resource:{selectedResourceId ?? 'none'}</div>
       <button onClick={() => updateUrlWithResourceId?.('resource-2')} type="button">
         Update Resource Id

--- a/ui/components/connections/index.tsx
+++ b/ui/components/connections/index.tsx
@@ -141,42 +141,47 @@ function Connections() {
     [updateUrlParams],
   );
 
-  if (!isReady) return null;
-
   // Rendered by whichever table is active (ConnectionTable or MeshSyncTable) so
   // the tab switcher stays visible - and functional - on both tabs, between
-  // that table's own toolbar and its data grid.
-  const tabs = (
-    <AppBar position="static" color="default" style={{ marginBottom: '3rem' }}>
-      <ConnectionTabs
-        value={tab}
-        onChange={handleTabChange}
-        indicatorColor="primary"
-        textColor="primary"
-        variant="fullWidth"
-        sx={{
-          height: '10%',
-        }}
-      >
-        <ConnectionTab
-          label={
-            <ConnectionIconText>
-              <span style={{ marginRight: '0.3rem' }}>Connections</span>
-              <ConnectionIcon width="20" height="20" />
-            </ConnectionIconText>
-          }
-        />
-        <ConnectionTab
-          label={
-            <ConnectionIconText>
-              <span style={{ marginRight: '0.3rem' }}>MeshSync</span>
-              <MeshsyncIcon width="20" height="20" />
-            </ConnectionIconText>
-          }
-        />
-      </ConnectionTabs>
-    </AppBar>
+  // that table's own toolbar and its data grid. Memoized so the unstable JSX
+  // identity doesn't cascade into the tables' props on every render (this page
+  // has previously hit React error #185 from exactly this kind of churn).
+  const tabs = useMemo(
+    () => (
+      <AppBar position="static" color="default" style={{ marginBottom: '3rem' }}>
+        <ConnectionTabs
+          value={tab}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="fullWidth"
+          sx={{
+            height: '10%',
+          }}
+        >
+          <ConnectionTab
+            label={
+              <ConnectionIconText>
+                <span style={{ marginRight: '0.3rem' }}>Connections</span>
+                <ConnectionIcon width="20" height="20" />
+              </ConnectionIconText>
+            }
+          />
+          <ConnectionTab
+            label={
+              <ConnectionIconText>
+                <span style={{ marginRight: '0.3rem' }}>MeshSync</span>
+                <MeshsyncIcon width="20" height="20" />
+              </ConnectionIconText>
+            }
+          />
+        </ConnectionTabs>
+      </AppBar>
+    ),
+    [tab, handleTabChange],
   );
+
+  if (!isReady) return null;
 
   return (
     <NoSsr>

--- a/ui/components/connections/index.tsx
+++ b/ui/components/connections/index.tsx
@@ -142,6 +142,42 @@ function Connections() {
   );
 
   if (!isReady) return null;
+
+  // Rendered by whichever table is active (ConnectionTable or MeshSyncTable) so
+  // the tab switcher stays visible - and functional - on both tabs, between
+  // that table's own toolbar and its data grid.
+  const tabs = (
+    <AppBar position="static" color="default" style={{ marginBottom: '3rem' }}>
+      <ConnectionTabs
+        value={tab}
+        onChange={handleTabChange}
+        indicatorColor="primary"
+        textColor="primary"
+        variant="fullWidth"
+        sx={{
+          height: '10%',
+        }}
+      >
+        <ConnectionTab
+          label={
+            <ConnectionIconText>
+              <span style={{ marginRight: '0.3rem' }}>Connections</span>
+              <ConnectionIcon width="20" height="20" />
+            </ConnectionIconText>
+          }
+        />
+        <ConnectionTab
+          label={
+            <ConnectionIconText>
+              <span style={{ marginRight: '0.3rem' }}>MeshSync</span>
+              <MeshsyncIcon width="20" height="20" />
+            </ConnectionIconText>
+          }
+        />
+      </ConnectionTabs>
+    </AppBar>
+  );
+
   return (
     <NoSsr>
       {CAN(
@@ -149,36 +185,6 @@ function Connections() {
         Keys.WorkspaceManagementViewConnections.function,
       ) ? (
         <>
-          <AppBar position="static" color="default" style={{ marginBottom: '3rem' }}>
-            <ConnectionTabs
-              value={tab}
-              onChange={handleTabChange}
-              indicatorColor="primary"
-              textColor="primary"
-              variant="fullWidth"
-              sx={{
-                height: '10%',
-              }}
-            >
-              <ConnectionTab
-                label={
-                  <ConnectionIconText>
-                    <span style={{ marginRight: '0.3rem' }}>Connections</span>
-                    <ConnectionIcon width="20" height="20" />
-                  </ConnectionIconText>
-                }
-              />
-              <ConnectionTab
-                label={
-                  <ConnectionIconText>
-                    <span style={{ marginRight: '0.3rem' }}>MeshSync</span>
-                    <MeshsyncIcon width="20" height="20" />
-                  </ConnectionIconText>
-                }
-              />
-            </ConnectionTabs>
-          </AppBar>
-
           {tab === 0 &&
             CAN(
               Keys.WorkspaceManagementViewConnections.id,
@@ -187,12 +193,14 @@ function Connections() {
               <ConnectionTable
                 selectedConnectionId={connectionId}
                 updateUrlWithConnectionId={updateUrlWithConnectionId}
+                tabs={tabs}
               />
             )}
           {tab === 1 && (
             <MeshSyncTable
               selectedResourceId={connectionId}
               updateUrlWithResourceId={updateUrlWithConnectionId}
+              tabs={tabs}
             />
           )}
         </>

--- a/ui/components/connections/meshSync/index.tsx
+++ b/ui/components/connections/meshSync/index.tsx
@@ -43,7 +43,7 @@ const ACTION_TYPES = {
 };
 
 export default function MeshSyncTable(props) {
-  const { selectedResourceId, updateUrlWithResourceId } = props;
+  const { selectedResourceId, updateUrlWithResourceId, tabs } = props;
   const callbackRef = useRef();
   const [openRegistrationModal, setRegistrationModal] = useState(false);
   const [page, setPage] = useState(0);
@@ -722,6 +722,8 @@ export default function MeshSyncTable(props) {
           />
         </div>
       </ToolWrapper>
+
+      {tabs}
 
       {!meshSyncResources || meshSyncResources.length === 0 ? (
         <MeshSyncEmptyState />


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20655
- Migrates the Connections page toolbar to the reusable `DataTableToolbar` component from Sistent.
- Updates the unit test mocks to support `DataTableToolbar`.

**Screenshots**

**After**
<img width="1512" height="903" alt="Screenshot 2026-07-16 at 11 12 51 AM" src="https://github.com/user-attachments/assets/5d28cc06-2afd-46e8-8c21-bfa733e2d230" />


**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
