### PR TITLE
fix(ui): add pointer/not-allowed cursor to Environment card icon buttons

### DIFF
--- a/ui/components/environments/styles.tsx
+++ b/ui/components/environments/styles.tsx
@@ -239,8 +239,12 @@ export const TextButton = styled('button')({
 
 export const IconButton = styled('button')({
   minWidth: 'fit-content',
+  cursor: 'pointer',
   '&:hover': {
     background: 'transparent',
+  },
+  '&:disabled': {
+    cursor: 'not-allowed',
   },
   padding: 0,
   background: 'none',


### PR DESCRIPTION
Fixes #20699

## Description
Adds `cursor: pointer` to the `IconButton` styled component used for the edit/delete icons on the Environment card, and `cursor: not-allowed` for the disabled state. Previously these used a plain `<button>` with no cursor style, so hovering gave no visual affordance that the icons were clickable.