### PR TITLE
[server] Sanitize order parameter in GetUserCredentials

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -1601,6 +1601,7 @@ func (l *DefaultLocalProvider) GetUserCredentials(_ *http.Request, userID string
 		result = result.Where("(lower(name) like ?)", like)
 	}
 
+	order = SanitizeOrderInput(order, []string{"created_at", "updated_at", "name"})
 	result = result.Order(order)
 
 	var count int64

--- a/server/models/default_local_provider_test.go
+++ b/server/models/default_local_provider_test.go
@@ -75,27 +75,31 @@ func TestGetUserCredentialsRejectsUnsanitizedOrderInput(t *testing.T) {
 		}
 	}
 
-	// "foobar" is not a real column. Pre-fix, this string was handed straight to
-	// gorm's Order(), which built `ORDER BY foobar asc` and the query failed with
-	// a driver-level "no such column" error -- proof the raw input reached SQL
-	// construction unsanitized. Post-fix, SanitizeOrderInput rejects it outright
-	// and Order() becomes a no-op, so the query must still succeed.
-	page, err := provider.GetUserCredentials(nil, userID.String(), 0, 10, "", "foobar asc")
-	if err != nil {
-		t.Fatalf("unsanitized order value reached the query and caused an error: %v", err)
-	}
-	if page.TotalCount != 2 {
-		t.Errorf("got TotalCount=%d, want 2", page.TotalCount)
-	}
+	t.Run("rejects unsanitized order input", func(t *testing.T) {
+		// "foobar" is not a real column. Pre-fix, this string was handed straight to
+		// gorm's Order(), which built `ORDER BY foobar asc` and the query failed with
+		// a driver-level "no such column" error -- proof the raw input reached SQL
+		// construction unsanitized. Post-fix, SanitizeOrderInput rejects it outright
+		// and Order() becomes a no-op, so the query must still succeed.
+		page, err := provider.GetUserCredentials(nil, userID.String(), 0, 10, "", "foobar asc")
+		if err != nil {
+			t.Fatalf("unsanitized order value reached the query and caused an error: %v", err)
+		}
+		if page.TotalCount != 2 {
+			t.Errorf("got TotalCount=%d, want 2", page.TotalCount)
+		}
+	})
 
-	// A legitimate, allowlisted order value must still work after sanitization.
-	page, err = provider.GetUserCredentials(nil, userID.String(), 0, 10, "", "name asc")
-	if err != nil {
-		t.Fatalf("unexpected error with legitimate order value: %v", err)
-	}
-	if len(page.Credentials) != 2 || page.Credentials[0].Name != "a-cred" || page.Credentials[1].Name != "b-cred" {
-		t.Fatalf("got order %v, want [a-cred b-cred]", credentialNames(page.Credentials))
-	}
+	t.Run("accepts legitimate order input", func(t *testing.T) {
+		// A legitimate, allowlisted order value must still work after sanitization.
+		page, err := provider.GetUserCredentials(nil, userID.String(), 0, 10, "", "name asc")
+		if err != nil {
+			t.Fatalf("unexpected error with legitimate order value: %v", err)
+		}
+		if len(page.Credentials) != 2 || page.Credentials[0].Name != "a-cred" || page.Credentials[1].Name != "b-cred" {
+			t.Fatalf("got order %v, want [a-cred b-cred]", credentialNames(page.Credentials))
+		}
+	})
 }
 
 func credentialNames(creds []Credential) []string {

--- a/server/models/default_local_provider_test.go
+++ b/server/models/default_local_provider_test.go
@@ -53,6 +53,59 @@ func TestSaveUserCredentialReturnsPopulatedCredential(t *testing.T) {
 	}
 }
 
+// TestGetUserCredentialsRejectsUnsanitizedOrderInput verifies that GetUserCredentials
+// no longer passes the caller-supplied "order" query parameter straight into gorm's
+// Order(), which treats a plain string as raw, unescaped SQL. Without sanitization,
+// arbitrary attacker-controlled text (e.g. "foobar asc", or a crafted SQL injection
+// payload) reaches the database driver directly -- an unpatched sibling of the
+// SQL injection vulnerabilities already fixed elsewhere (CVE-2024-35181, CVE-2024-35182)
+// via models.SanitizeOrderInput, which this endpoint had been missed by.
+func TestGetUserCredentialsRejectsUnsanitizedOrderInput(t *testing.T) {
+	provider := newTestProviderWithCredentialDB(t)
+
+	userID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate user id: %v", err)
+	}
+
+	for _, name := range []string{"b-cred", "a-cred"} {
+		cred := &Credential{Name: name, Type: "token", UserId: userID}
+		if _, err := provider.SaveUserCredential("tok", cred); err != nil {
+			t.Fatalf("failed to seed credential %q: %v", name, err)
+		}
+	}
+
+	// "foobar" is not a real column. Pre-fix, this string was handed straight to
+	// gorm's Order(), which built `ORDER BY foobar asc` and the query failed with
+	// a driver-level "no such column" error -- proof the raw input reached SQL
+	// construction unsanitized. Post-fix, SanitizeOrderInput rejects it outright
+	// and Order() becomes a no-op, so the query must still succeed.
+	page, err := provider.GetUserCredentials(nil, userID.String(), 0, 10, "", "foobar asc")
+	if err != nil {
+		t.Fatalf("unsanitized order value reached the query and caused an error: %v", err)
+	}
+	if page.TotalCount != 2 {
+		t.Errorf("got TotalCount=%d, want 2", page.TotalCount)
+	}
+
+	// A legitimate, allowlisted order value must still work after sanitization.
+	page, err = provider.GetUserCredentials(nil, userID.String(), 0, 10, "", "name asc")
+	if err != nil {
+		t.Fatalf("unexpected error with legitimate order value: %v", err)
+	}
+	if len(page.Credentials) != 2 || page.Credentials[0].Name != "a-cred" || page.Credentials[1].Name != "b-cred" {
+		t.Fatalf("got order %v, want [a-cred b-cred]", credentialNames(page.Credentials))
+	}
+}
+
+func credentialNames(creds []Credential) []string {
+	names := make([]string, len(creds))
+	for i, c := range creds {
+		names[i] = c.Name
+	}
+	return names
+}
+
 // TestEventsPersisterPersistEventAcceptsStructValue verifies that PersistEvent
 // successfully writes events when called with a struct value (the shape
 // callers pass via `PersistSystemEvent(*event)`). The function previously


### PR DESCRIPTION
## Summary

`GetUserCredentials` (`server/models/default_local_provider.go`) passed the
caller-supplied `order` query parameter from `GET /api/integrations/credentials?order=...`
directly into gorm's `Order()`, which treats a plain string as raw,
unescaped SQL (`clause.Column{Raw: true}`).

This is the same defect as the SQL injection vulnerabilities already
fixed via `SanitizeOrderInput`'s column allowlist:

- CVE-2023-46575 / GHSA-9jjc-grg5-67gj
- CVE-2024-29031 / GHSA-652r-q29p-m25h
- CVE-2024-35181 / GHSA-9f24-jrv4-f8g5
- CVE-2024-35182 / GHSA-h7cm-jvpp-69xf

Every other persister was routed through `SanitizeOrderInput` when those
were patched; `GetUserCredentials` was missed and remained unpatched
on `master` while auditing issue #14739. Found during a fix-verification
pass on that issue - see [comment](https://github.com/meshery/meshery/issues/14739#issuecomment-4995993518).

## Fix

Apply the same `SanitizeOrderInput` allowlist (`created_at`, `updated_at`,
`name`) used by every sibling persister in this file, so an
unrecognized/malicious `order` value is dropped rather than reaching the
query builder.

## Test plan

- [x] Added `TestGetUserCredentialsRejectsUnsanitizedOrderInput` in
      `server/models/default_local_provider_test.go`. Confirmed it **fails**
      against the pre-fix code (driver returns `no such column: foobar` from
      the raw `ORDER BY foobar asc` built from the unsanitized input) and
      **passes** with the fix.
- [x] `go test ./server/models/...` - all passing
- [x] `golangci-lint run --config=.github/.golangci.yml ./server/models/...` -
      no new issues introduced (2 pre-existing, unrelated `errcheck` findings
      in `telemetry/grafana` and `telemetry/prometheus`)
- [x] `gofmt -l` - clean

Flagging for security review per this repo's guardrails on auth/security-sensitive changes.