### PR TITLE
[UI] Point Enum.ts status constants at their meshery/schemas source of truth

### DIFF
--- a/ui/utils/Enum.ts
+++ b/ui/utils/Enum.ts
@@ -45,6 +45,11 @@ export const REGISTRY_ITEM_STATES_TO_TRANSITION_MAP = {
   [REGISTRY_ITEM_STATES.IGNORED]: 'Ignore',
 };
 
+// Mirrors the ConnectionStatusValue enum in meshery/schemas
+// (schemas/constructs/v1beta1/connection/api.yml), which is the source of
+// truth for these wire values. TODO: type-check this object's values against
+// the schemas-exported `v1beta1.ConnectionStatusValue` TS type once
+// @meshery/schemas publishes it (it isn't in the published package yet).
 export const CONNECTION_STATES = {
   DISCOVERED: 'discovered',
   REGISTERED: 'registered',
@@ -62,7 +67,16 @@ export const CONTROLLERS = {
   MESHSYNC: 'MESHSYNC',
 };
 
-// Fetch from GraphQL/REST API remove this
+// DEPLOYED..CONNECTED mirror the ControllerStatusValue enum newly formalized
+// in meshery/schemas (schemas/constructs/v1beta1/system/api.yml,
+// meshery/schemas#1064), itself mirroring the MesheryControllerStatus
+// GraphQL enum (server/internal/graphql/schema/schema.graphql) - these are
+// real wire values, including the published UNKOWN spelling. DISABLED and
+// UNKNOWN (correct spelling) below are UI-only sentinel states with no wire
+// equivalent (see ui/utils/hooks/useKubernetesHook.tsx) and do not belong in
+// the schema. TODO: once @meshery/schemas publishes the new enum, type-check
+// the wire-backed subset here against the schemas-exported
+// `v1beta1.ControllerStatusValue` TS type.
 export const CONTROLLER_STATES = {
   DEPLOYED: 'DEPLOYED',
   NOTDEPLOYED: 'NOTDEPLOYED',


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

Follow-up to an audit prompted by #20686: `ui/utils/Enum.ts`'s `CONNECTION_STATES` and `CONTROLLER_STATES` are hand-rolled locally with no reference to `meshery/schemas`, which is supposed to be the authoritative source of truth for these wire values (AGENTS.md).

- `CONNECTION_STATES` already exactly duplicates the `ConnectionStatusValue` enum in `meshery/schemas` (`schemas/constructs/v1beta1/connection/api.yml`).
- `CONTROLLER_STATES` had no schema-side equivalent - `meshery/schemas` now defines a matching `ControllerStatusValue` enum (meshery/schemas#1066), mirroring the existing `MesheryControllerStatus` GraphQL enum (`server/internal/graphql/schema/schema.graphql`). Two of the ten `CONTROLLER_STATES` entries (`DISABLED`, `UNKNOWN`) are UI-only sentinel states with no wire equivalent (see `ui/utils/hooks/useKubernetesHook.tsx`) and correctly stay out of the schema.

This PR only replaces the stale `// Fetch from GraphQL/REST API remove this` comment with accurate ones pointing at the schemas constructs and documents which values are wire-backed vs. UI-only. **No behavior change** - the actual type-check-against-schemas swap (deriving these constants' types from `@meshery/schemas`) is tracked as follow-up work (#20714), since the currently published `@meshery/schemas` package doesn't yet export the new type (it isn't released), and committing a temporary `file:../schemas` local link isn't appropriate for a merge-ready PR per AGENTS.md's release-coupling workflow.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
