### PR TITLE
Adopt meshery/schemas v1.3.32: connection registration and system/kubernetes contracts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/meshery/meshery-operator v1.0.3
 	github.com/meshery/meshkit v1.0.22
 	github.com/meshery/meshsync v1.0.3
-	github.com/meshery/schemas v1.3.26
+	github.com/meshery/schemas v1.3.32
 	github.com/nsf/termbox-go v1.1.1
 	github.com/oapi-codegen/runtime v1.4.2
 	github.com/olekukonko/tablewriter v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,8 @@ github.com/meshery/meshkit v1.0.22 h1:c8CgO2+mdF6krvAdA66FF5ScmIHBkTEVt3MtkUmOJu
 github.com/meshery/meshkit v1.0.22/go.mod h1:2SzXjDsxZOraA9YbnqFzHS+1Tk14zsLuePJzHuZ1SRU=
 github.com/meshery/meshsync v1.0.3 h1:kgZ5HqjrRupRoOFQSjl3V6FpJ2K1cEkLrN8mxV6QV6M=
 github.com/meshery/meshsync v1.0.3/go.mod h1:ZAeZaId+fp/aoP7OuHw+u0LS/YmnTH40NNRltVbLuGE=
-github.com/meshery/schemas v1.3.26 h1:S/QFNHCqIZagfYaDfXH5vUEMadZLPk85QUiN+j3h0/U=
-github.com/meshery/schemas v1.3.26/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
+github.com/meshery/schemas v1.3.32 h1:BSQuxMZ5QAMz4hc+6LHm8XECkyBjnvxd0LBz6s+R56g=
+github.com/meshery/schemas v1.3.32/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/server/handlers/connection_definition_transition_test.go
+++ b/server/handlers/connection_definition_transition_test.go
@@ -38,11 +38,11 @@ func TestConnectionDefinitionTransitionMapRoundTrips(t *testing.T) {
 		Status:         connectionv1beta3.ConnectionStatusDiscovered,
 		TransitionMap: map[string][]connectionv1beta3.ConnectionStateTransition{
 			"connected": {
-				{NextState: connectionv1beta3.ConnectionStatusValueDisconnected},
-				{NextState: connectionv1beta3.ConnectionStatusValueDeleted},
+				{NextState: connectionv1beta3.Disconnected},
+				{NextState: connectionv1beta3.Deleted},
 			},
 			"disconnected": {
-				{NextState: connectionv1beta3.ConnectionStatusValueConnected, Description: &desc},
+				{NextState: connectionv1beta3.Connected, Description: &desc},
 			},
 		},
 		ModelReference: &model.ModelReference{
@@ -67,7 +67,7 @@ func TestConnectionDefinitionTransitionMapRoundTrips(t *testing.T) {
 	require.NotEmpty(t, got.TransitionMap, "transitionMap was dropped on the DB round-trip")
 	require.Len(t, got.TransitionMap["connected"], 2)
 	require.Equal(t,
-		connectionv1beta3.ConnectionStatusValueConnected,
+		connectionv1beta3.Connected,
 		got.TransitionMap["disconnected"][0].NextState,
 	)
 	require.NotNil(t, got.TransitionMap["disconnected"][0].Description)

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/meshery/schemas/models/core"
+	connectionv1beta3 "github.com/meshery/schemas/models/v1beta3/connection"
 
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
@@ -21,15 +22,26 @@ import (
 	"github.com/meshery/meshkit/errors"
 	"github.com/meshery/meshkit/models/events"
 	regv1beta1 "github.com/meshery/meshkit/models/meshmodel/registry/v1beta1"
+	"github.com/meshery/meshkit/utils"
 )
 
+// ProcessConnectionRegistration drives the connection registration state
+// machine (POST /api/integrations/connections/register). The wire contract is
+// the schemas-defined ConnectionRegistrationEvent: an `initialize` event
+// returns the registration bootstrap, every other event advances the tracked
+// registration and responds with an empty body.
 func (h *Handler) ProcessConnectionRegistration(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
 	if req.Method == http.MethodDelete {
+		// Deprecated: cancelling via DELETE on this route with the tracker id in
+		// the body predates the schemas contract (v1.3.32). New clients cancel via
+		// DELETE /api/integrations/connections/register/{registrationId}
+		// (CancelConnectionRegister). Retire this branch once no supported client
+		// sends the legacy shape.
 		h.handleProcessTermination(w, req)
 		return
 	}
 
-	connectionRegisterPayload := connections.ConnectionPayload{}
+	registrationEvent := connectionv1beta3.ConnectionRegistrationEvent{}
 	userUUID := user.ID
 	token, err := provider.GetProviderToken(req)
 	if err != nil {
@@ -37,7 +49,7 @@ func (h *Handler) ProcessConnectionRegistration(w http.ResponseWriter, req *http
 		writeMeshkitError(w, ErrRetrieveUserToken(err), http.StatusInternalServerError)
 		return
 	}
-	err = json.NewDecoder(req.Body).Decode(&connectionRegisterPayload)
+	err = json.NewDecoder(req.Body).Decode(&registrationEvent)
 	if err != nil {
 		writeMeshkitError(w, models.ErrUnmarshal(err, "connection registration payload"), http.StatusBadRequest)
 		return
@@ -45,10 +57,11 @@ func (h *Handler) ProcessConnectionRegistration(w http.ResponseWriter, req *http
 
 	eventBuilder := events.NewEvent().ActedUpon(userUUID).WithCategory("connection").WithAction("update").FromSystem(*h.SystemID).FromOwner(userUUID).WithDescription("Failed to interact with the connection.")
 
-	if string(connectionRegisterPayload.Status) == string(machines.Init) {
-		h.handleRegistrationInitEvent(w, req, &connectionRegisterPayload)
+	if registrationEvent.Status == connectionv1beta3.ConnectionRegistrationEventStatusInitialize {
+		h.handleRegistrationInitEvent(w, &registrationEvent)
 	} else {
 		smInstanceTracker := h.ConnectionToStateMachineInstanceTracker
+		connectionRegisterPayload := registrationEventToConnectionPayload(&registrationEvent)
 
 		machineCtx := make(map[string]string, 0)
 		inst, err := helpers.InitializeMachineWithContext(
@@ -77,7 +90,7 @@ func (h *Handler) ProcessConnectionRegistration(w http.ResponseWriter, req *http
 			return
 		}
 
-		event, err := inst.SendEvent(req.Context(), machines.EventType(connectionRegisterPayload.Status), connectionRegisterPayload)
+		event, err := inst.SendEvent(req.Context(), machines.EventType(registrationEvent.Status), connectionRegisterPayload)
 		if err != nil {
 			wrappedErr := ErrSendMachineEvent(err)
 			h.log.Error(wrappedErr)
@@ -91,6 +104,31 @@ func (h *Handler) ProcessConnectionRegistration(w http.ResponseWriter, req *http
 	}
 }
 
+// registrationEventToConnectionPayload converts the schemas wire event into the
+// internal payload the connection state machines consume
+// (machines/*/register.go casts the event data to connections.ConnectionPayload).
+// The two shapes share the same wire fields; only the Go types differ.
+func registrationEventToConnectionPayload(event *connectionv1beta3.ConnectionRegistrationEvent) connections.ConnectionPayload {
+	payload := connections.ConnectionPayload{
+		Kind:                       event.Kind,
+		SubType:                    event.SubType,
+		Type:                       event.Type,
+		MetaData:                   event.Metadata,
+		Status:                     connections.ConnectionStatus(event.Status),
+		CredentialSecret:           event.CredentialSecret,
+		Name:                       event.Name,
+		CredentialID:               event.CredentialID,
+		Model:                      event.Model,
+		SkipCredentialVerification: event.SkipCredentialVerification,
+	}
+	if event.ID != nil {
+		payload.ID = *event.ID
+	}
+	return payload
+}
+
+// handleProcessTermination is the deprecated body-based cancel path; see the
+// deprecation note in ProcessConnectionRegistration.
 func (h *Handler) handleProcessTermination(w http.ResponseWriter, req *http.Request) {
 	body := make(map[string]string, 0)
 	err := json.NewDecoder(req.Body).Decode(&body)
@@ -108,33 +146,64 @@ func (h *Handler) handleProcessTermination(w http.ResponseWriter, req *http.Requ
 	}
 }
 
-func (h *Handler) handleRegistrationInitEvent(w http.ResponseWriter, req *http.Request, payload *connections.ConnectionPayload) {
-	compFilter := &regv1beta1.ComponentFilter{
-		Name:  fmt.Sprintf("%sConnection", payload.Kind),
-		Limit: 1,
-	}
-	schema := make(map[string]interface{}, 1)
-	connectionComponent, _, _, _ := h.registryManager.GetEntities(compFilter)
-	if len(connectionComponent) == 0 {
-		writeMeshkitError(w, ErrUnknownConnectionKind(payload.Kind), http.StatusBadRequest)
+// CancelConnectionRegister discards the in-progress registration state machine
+// tracked by the {registrationId} path parameter
+// (DELETE /api/integrations/connections/register/{registrationId}). Idempotent:
+// unknown ids are ignored. Nothing is persisted for the abandoned process.
+func (h *Handler) CancelConnectionRegister(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
+	registrationID, err := uuid.FromString(mux.Vars(req)["registrationId"])
+	if err != nil {
+		invalidIDErr := models.ErrInvalidUUID(err)
+		h.log.Error(invalidIDErr)
+		writeMeshkitError(w, invalidIDErr, http.StatusBadRequest)
 		return
 	}
 
-	schema["connection"] = connectionComponent[0]
+	h.ConnectionToStateMachineInstanceTracker.Remove(registrationID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) handleRegistrationInitEvent(w http.ResponseWriter, event *connectionv1beta3.ConnectionRegistrationEvent) {
+	compFilter := &regv1beta1.ComponentFilter{
+		Name:  fmt.Sprintf("%sConnection", event.Kind),
+		Limit: 1,
+	}
+	connectionComponent, _, _, _ := h.registryManager.GetEntities(compFilter)
+	if len(connectionComponent) == 0 {
+		writeMeshkitError(w, ErrUnknownConnectionKind(event.Kind), http.StatusBadRequest)
+		return
+	}
+
+	connectionDefinition, err := utils.MarshalAndUnmarshal[interface{}, core.Map](connectionComponent[0])
+	if err != nil {
+		h.log.Error(ErrWriteResponse(err))
+		writeMeshkitError(w, ErrWriteResponse(err), http.StatusInternalServerError)
+		return
+	}
+
+	// The bootstrap id acts as the connection registration process tracker.
+	// Clients echo it on every subsequent event until the process completes or
+	// is cancelled.
+	bootstrap := connectionv1beta3.ConnectionRegistrationBootstrap{
+		Connection: connectionDefinition,
+		ID:         uuid.Must(uuid.NewV4()),
+	}
+
 	credential, _, _, _ := h.registryManager.GetEntities(&regv1beta1.ComponentFilter{
-		Name:  fmt.Sprintf("%sCredential", payload.Kind),
+		Name:  fmt.Sprintf("%sCredential", event.Kind),
 		Limit: 1,
 	})
-
 	if len(credential) > 0 {
-		schema["credential"] = credential[0]
+		credentialDefinition, err := utils.MarshalAndUnmarshal[interface{}, core.Map](credential[0])
+		if err != nil {
+			h.log.Error(ErrWriteResponse(err))
+			writeMeshkitError(w, ErrWriteResponse(err), http.StatusInternalServerError)
+			return
+		}
+		bootstrap.Credential = credentialDefinition
 	}
-	// id act as a connection registration process tracker.
-	// The clients should always include this "id" in the subsequent API calls until the process is completed or terminated.
-	id := uuid.Must(uuid.NewV4())
-	schema["id"] = id
 
-	err := json.NewEncoder(w).Encode(&schema)
+	err = json.NewEncoder(w).Encode(&bootstrap)
 	if err != nil {
 		h.log.Error(ErrWriteResponse(err))
 	}

--- a/server/handlers/controllers_status_handler.go
+++ b/server/handlers/controllers_status_handler.go
@@ -301,8 +301,16 @@ func (h *Handler) SubscribeMesheryControllersStatusHandler(w http.ResponseWriter
 // GET /api/system/controllers/operator/status?connectionId=<id>
 func (h *Handler) OperatorStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	connectionID := req.URL.Query().Get("connectionId")
+	// Reject a malformed connectionId rather than falling back to uuid.Nil: a
+	// zero UUID is never a real connection and would echo an invalid id back to
+	// the client.
+	connectionUUID, err := uuid.FromString(connectionID)
+	if err != nil {
+		writeMeshkitError(w, models.ErrInvalidUUID(err), http.StatusBadRequest)
+		return
+	}
 	item := system.ControllerStatus{
-		ConnectionId: uuid.FromStringOrNil(connectionID),
+		ConnectionId: connectionUUID,
 		Controller:   internalControllerName(models.MesheryOperator),
 		Status:       controllersStatusUnknown,
 	}
@@ -320,15 +328,21 @@ func (h *Handler) OperatorStatusHandler(w http.ResponseWriter, req *http.Request
 // GET /api/system/controllers/meshsync/status?connectionId=<id>
 func (h *Handler) MeshsyncStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	connectionID := req.URL.Query().Get("connectionId")
+	// Reject a malformed connectionId rather than falling back to uuid.Nil.
+	connectionUUID, err := uuid.FromString(connectionID)
+	if err != nil {
+		writeMeshkitError(w, models.ErrInvalidUUID(err), http.StatusBadRequest)
+		return
+	}
 	info := system.ControllerInfo{
-		ConnectionId: uuid.FromStringOrNil(connectionID),
+		ConnectionId: connectionUUID,
 		Name:         "MeshSync",
 		Status:       string(controllersStatusUnknown),
 	}
 	if machinectx, ok := h.machineCtxForConnection(connectionID); ok {
 		ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
 		info = h.meshsyncInfo(ctrlHandlers[models.Meshsync], ctrlHandlers[models.MesheryBroker], h.mesheryHoldsLiveBrokerConnection(machinectx))
-		info.ConnectionId = uuid.FromStringOrNil(connectionID)
+		info.ConnectionId = connectionUUID
 	}
 	writeJSONMessage(w, info, http.StatusOK)
 }
@@ -338,15 +352,21 @@ func (h *Handler) MeshsyncStatusHandler(w http.ResponseWriter, req *http.Request
 // GET /api/system/controllers/broker/status?connectionId=<id>
 func (h *Handler) BrokerStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	connectionID := req.URL.Query().Get("connectionId")
+	// Reject a malformed connectionId rather than falling back to uuid.Nil.
+	connectionUUID, err := uuid.FromString(connectionID)
+	if err != nil {
+		writeMeshkitError(w, models.ErrInvalidUUID(err), http.StatusBadRequest)
+		return
+	}
 	info := system.ControllerInfo{
-		ConnectionId: uuid.FromStringOrNil(connectionID),
+		ConnectionId: connectionUUID,
 		Name:         "MesheryBroker",
 		Status:       string(controllersStatusUnknown),
 	}
 	if machinectx, ok := h.machineCtxForConnection(connectionID); ok {
 		ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
 		info = h.brokerInfo(ctrlHandlers[models.MesheryBroker], h.mesheryHoldsLiveBrokerConnection(machinectx))
-		info.ConnectionId = uuid.FromStringOrNil(connectionID)
+		info.ConnectionId = connectionUUID
 	}
 	writeJSONMessage(w, info, http.StatusOK)
 }

--- a/server/handlers/controllers_status_handler.go
+++ b/server/handlers/controllers_status_handler.go
@@ -51,63 +51,50 @@ const (
 	controllersStatusWriteTimeout = 30 * time.Second
 )
 
-// ControllerStatusItem is one controller's status for one connection. It is the
-// element type of both the SSE snapshot array and the operator REST response.
-type ControllerStatusItem struct {
-	ConnectionID string `json:"connectionId"`
-	Controller   string `json:"controller"` // OPERATOR | MESHSYNC | BROKER
-	Status       string `json:"status"`
-	Version      string `json:"version"`
-}
+// The SSE snapshot element / operator REST response (system.ControllerStatus)
+// and the MeshSync / Broker one-shot payload (system.ControllerInfo) are the
+// schemas-generated types; the wire contract lives in
+// meshery/schemas (v1beta1/system).
 
-// ControllerInfo is the MeshSync / Broker one-shot status payload. Its status
-// string may be composed (e.g. "Connected <endpoint>"), mirroring the old
-// getMeshsyncStatus / getNatsStatus queries the UI branches on.
-type ControllerInfo struct {
-	Name         string `json:"name"`
-	Version      string `json:"version"`
-	Status       string `json:"status"`
-	ConnectionID string `json:"connectionId"`
-}
-
-// controllersStatusUnknown is the status string emitted when a connection has no
-// ready FSM instance or its context can't be read.
-const controllersStatusUnknown = "UNKOWN"
+// controllersStatusUnknown is the status emitted when a connection has no
+// ready FSM instance or its context can't be read. The published "UNKOWN"
+// spelling is load-bearing (see the schemas ControllerStatusValue docs).
+const controllersStatusUnknown = system.UNKOWN
 
 // internalControllerName reproduces model.GetInternalController: the wire name
 // for a controller enum.
-func internalControllerName(c models.MesheryController) string {
+func internalControllerName(c models.MesheryController) system.ControllerStatusController {
 	switch c {
 	case models.MesheryBroker:
-		return "BROKER"
+		return system.ControllerStatusControllerBROKER
 	case models.MesheryOperator:
-		return "OPERATOR"
+		return system.ControllerStatusControllerOPERATOR
 	case models.Meshsync:
-		return "MESHSYNC"
+		return system.ControllerStatusControllerMESHSYNC
 	}
 	return ""
 }
 
 // internalControllerStatus reproduces model.GetInternalControllerStatus: the
-// wire status string for a meshkit controller status.
-func internalControllerStatus(status controllers.MesheryControllerStatus) string {
+// wire status value for a meshkit controller status.
+func internalControllerStatus(status controllers.MesheryControllerStatus) system.ControllerStatusValue {
 	switch status {
 	case controllers.Deployed:
-		return "DEPLOYED"
+		return system.DEPLOYED
 	case controllers.NotDeployed:
-		return "NOTDEPLOYED"
+		return system.NOTDEPLOYED
 	case controllers.Deploying:
-		return "DEPLOYING"
+		return system.DEPLOYING
 	case controllers.Unknown:
 		return controllersStatusUnknown
 	case controllers.Undeployed:
-		return "UNDEPLOYED"
+		return system.UNDEPLOYED
 	case controllers.Enabled:
-		return "ENABLED"
+		return system.ENABLED
 	case controllers.Running:
-		return "RUNNING"
+		return system.RUNNING
 	case controllers.Connected:
-		return "CONNECTED"
+		return system.CONNECTED
 	}
 	return ""
 }
@@ -164,7 +151,7 @@ func (h *Handler) mesheryHoldsLiveBrokerConnection(machinectx *kubernetes.Machin
 // controller that is already present (running/deployed/enabled) — a
 // not-deployed controller is never reported as connected — and the operator's
 // status is left untouched (it is unrelated to broker connectivity).
-func deriveControllerStatus(controller models.MesheryController, status string, brokerConnected bool) string {
+func deriveControllerStatus(controller models.MesheryController, status system.ControllerStatusValue, brokerConnected bool) system.ControllerStatusValue {
 	if !brokerConnected {
 		return status
 	}
@@ -172,8 +159,8 @@ func deriveControllerStatus(controller models.MesheryController, status string, 
 		return status
 	}
 	switch status {
-	case "RUNNING", "DEPLOYED", "ENABLED":
-		return "CONNECTED"
+	case system.RUNNING, system.DEPLOYED, system.ENABLED:
+		return system.CONNECTED
 	}
 	return status
 }
@@ -181,8 +168,8 @@ func deriveControllerStatus(controller models.MesheryController, status string, 
 // collectControllersStatus builds the full status list for the requested
 // connections. The result is sorted (connectionId, controller) so callers can
 // compare successive snapshots byte-for-byte to detect changes.
-func (h *Handler) collectControllersStatus(connectionIDs []string) []ControllerStatusItem {
-	items := make([]ControllerStatusItem, 0)
+func (h *Handler) collectControllersStatus(connectionIDs []string) []system.ControllerStatus {
+	items := make([]system.ControllerStatus, 0)
 	for _, connectionID := range connectionIDs {
 		machinectx, ok := h.machineCtxForConnection(connectionID)
 		if !ok {
@@ -196,8 +183,10 @@ func (h *Handler) collectControllersStatus(connectionIDs []string) []ControllerS
 				h.log.Debugf("controllers status: version for %s on %s: %v", internalControllerName(controller), connectionID, err)
 			}
 			status := deriveControllerStatus(controller, internalControllerStatus(ctrlHandler.GetStatus()), brokerConnected)
-			items = append(items, ControllerStatusItem{
-				ConnectionID: connectionID,
+			items = append(items, system.ControllerStatus{
+				// machineCtxForConnection only resolves valid UUIDs, so the parse
+				// cannot yield the zero UUID here.
+				ConnectionId: uuid.FromStringOrNil(connectionID),
 				Controller:   internalControllerName(controller),
 				Status:       status,
 				Version:      version,
@@ -205,8 +194,8 @@ func (h *Handler) collectControllersStatus(connectionIDs []string) []ControllerS
 		}
 	}
 	sort.Slice(items, func(i, j int) bool {
-		if items[i].ConnectionID != items[j].ConnectionID {
-			return items[i].ConnectionID < items[j].ConnectionID
+		if items[i].ConnectionId != items[j].ConnectionId {
+			return items[i].ConnectionId.String() < items[j].ConnectionId.String()
 		}
 		return items[i].Controller < items[j].Controller
 	})
@@ -312,8 +301,8 @@ func (h *Handler) SubscribeMesheryControllersStatusHandler(w http.ResponseWriter
 // GET /api/system/controllers/operator/status?connectionId=<id>
 func (h *Handler) OperatorStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	connectionID := req.URL.Query().Get("connectionId")
-	item := ControllerStatusItem{
-		ConnectionID: connectionID,
+	item := system.ControllerStatus{
+		ConnectionId: uuid.FromStringOrNil(connectionID),
 		Controller:   internalControllerName(models.MesheryOperator),
 		Status:       controllersStatusUnknown,
 	}
@@ -331,15 +320,15 @@ func (h *Handler) OperatorStatusHandler(w http.ResponseWriter, req *http.Request
 // GET /api/system/controllers/meshsync/status?connectionId=<id>
 func (h *Handler) MeshsyncStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	connectionID := req.URL.Query().Get("connectionId")
-	info := ControllerInfo{
-		ConnectionID: connectionID,
+	info := system.ControllerInfo{
+		ConnectionId: uuid.FromStringOrNil(connectionID),
 		Name:         "MeshSync",
-		Status:       controllersStatusUnknown,
+		Status:       string(controllersStatusUnknown),
 	}
 	if machinectx, ok := h.machineCtxForConnection(connectionID); ok {
 		ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
 		info = h.meshsyncInfo(ctrlHandlers[models.Meshsync], ctrlHandlers[models.MesheryBroker], h.mesheryHoldsLiveBrokerConnection(machinectx))
-		info.ConnectionID = connectionID
+		info.ConnectionId = uuid.FromStringOrNil(connectionID)
 	}
 	writeJSONMessage(w, info, http.StatusOK)
 }
@@ -349,15 +338,15 @@ func (h *Handler) MeshsyncStatusHandler(w http.ResponseWriter, req *http.Request
 // GET /api/system/controllers/broker/status?connectionId=<id>
 func (h *Handler) BrokerStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	connectionID := req.URL.Query().Get("connectionId")
-	info := ControllerInfo{
-		ConnectionID: connectionID,
+	info := system.ControllerInfo{
+		ConnectionId: uuid.FromStringOrNil(connectionID),
 		Name:         "MesheryBroker",
-		Status:       controllersStatusUnknown,
+		Status:       string(controllersStatusUnknown),
 	}
 	if machinectx, ok := h.machineCtxForConnection(connectionID); ok {
 		ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
 		info = h.brokerInfo(ctrlHandlers[models.MesheryBroker], h.mesheryHoldsLiveBrokerConnection(machinectx))
-		info.ConnectionID = connectionID
+		info.ConnectionId = uuid.FromStringOrNil(connectionID)
 	}
 	writeJSONMessage(w, info, http.StatusOK)
 }
@@ -387,9 +376,9 @@ func composeConnectedBrokerStatus(broker controllers.IMesheryController) string 
 // (handlers cannot import internal/graphql/model — it imports handlers).
 // brokerConnected upgrades a present-but-unverified broker to Connected when
 // Meshery already holds a live broker connection.
-func (h *Handler) brokerInfo(broker controllers.IMesheryController, brokerConnected bool) ControllerInfo {
+func (h *Handler) brokerInfo(broker controllers.IMesheryController, brokerConnected bool) system.ControllerInfo {
 	if broker == nil {
-		return ControllerInfo{Status: controllersStatusUnknown}
+		return system.ControllerInfo{Status: string(controllersStatusUnknown)}
 	}
 	status := broker.GetStatus().String()
 	if status == controllers.Connected.String() {
@@ -399,7 +388,7 @@ func (h *Handler) brokerInfo(broker controllers.IMesheryController, brokerConnec
 		status = composeConnectedBrokerStatus(broker)
 	}
 	version, _ := broker.GetVersion()
-	return ControllerInfo{
+	return system.ControllerInfo{
 		Name:    broker.GetName(),
 		Status:  status,
 		Version: version,
@@ -409,9 +398,9 @@ func (h *Handler) brokerInfo(broker controllers.IMesheryController, brokerConnec
 // meshsyncInfo reproduces model.GetMeshSyncInfo without the gqlgen model
 // dependency. brokerConnected upgrades a present-but-unverified MeshSync to
 // Connected when Meshery already holds a live broker connection.
-func (h *Handler) meshsyncInfo(meshsync, broker controllers.IMesheryController, brokerConnected bool) ControllerInfo {
+func (h *Handler) meshsyncInfo(meshsync, broker controllers.IMesheryController, brokerConnected bool) system.ControllerInfo {
 	if meshsync == nil {
-		return ControllerInfo{Status: controllersStatusUnknown}
+		return system.ControllerInfo{Status: string(controllersStatusUnknown)}
 	}
 	status := meshsync.GetStatus().String()
 	if broker == nil {
@@ -429,7 +418,7 @@ func (h *Handler) meshsyncInfo(meshsync, broker controllers.IMesheryController, 
 		status = composeConnectedBrokerStatus(broker)
 	}
 	version, _ := meshsync.GetVersion()
-	return ControllerInfo{
+	return system.ControllerInfo{
 		Name:    meshsync.GetName(),
 		Status:  status,
 		Version: version,

--- a/server/handlers/controllers_status_handler_test.go
+++ b/server/handlers/controllers_status_handler_test.go
@@ -108,7 +108,7 @@ func TestOperatorStatusHandler_UnknownForUnresolvedConnection(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, `"controller":"OPERATOR"`) || !strings.Contains(body, `"status":"`+controllersStatusUnknown+`"`) {
+	if !strings.Contains(body, `"controller":"OPERATOR"`) || !strings.Contains(body, `"status":"`+string(controllersStatusUnknown)+`"`) {
 		t.Fatalf("expected unknown operator status payload, got: %q", body)
 	}
 	if !strings.Contains(body, `"connectionId":`) {

--- a/server/handlers/controllers_status_handler_test.go
+++ b/server/handlers/controllers_status_handler_test.go
@@ -115,3 +115,33 @@ func TestOperatorStatusHandler_UnknownForUnresolvedConnection(t *testing.T) {
 		t.Fatalf("expected canonical connectionId key, got: %q", body)
 	}
 }
+
+// A malformed connectionId must be rejected with 400 rather than falling back
+// to uuid.Nil and echoing a zero UUID. Covers all three one-shot status
+// handlers, which share the same validation.
+func TestControllerStatusHandlers_RejectInvalidConnectionID(t *testing.T) {
+	h := newControllersStatusTestHandler(t)
+
+	handlers := map[string]func(http.ResponseWriter, *http.Request, *models.Preference, *models.User, models.Provider){
+		"operator": h.OperatorStatusHandler,
+		"meshsync": h.MeshsyncStatusHandler,
+		"broker":   h.BrokerStatusHandler,
+	}
+
+	for name, handler := range handlers {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/system/controllers/"+name+"/status?connectionId=not-a-uuid", nil)
+			rec := httptest.NewRecorder()
+
+			handler(rec, req, nil, nil, nil)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 for a malformed connectionId", rec.Code)
+			}
+			if strings.Contains(rec.Body.String(), uuid.Nil.String()) {
+				t.Fatalf("response must not echo the zero UUID, got: %q", rec.Body.String())
+			}
+		})
+	}
+}

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/meshery/meshery/server/helpers"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/schemas/models/core"
+	systemv1beta1 "github.com/meshery/schemas/models/v1beta1/system"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/meshery/meshkit/models/events"
@@ -42,7 +43,13 @@ type ContextOptions struct {
 	Name string `json:"name,omitempty"`
 }
 
-// SaveK8sContextResponse - struct used as (json marshaled) response to requests for saving k8s contexts
+// SaveK8sContextResponse - struct used as (json marshaled) response to requests
+// for saving k8s contexts. Wire-equivalent to the schemas
+// AddKubernetesConfigResponse (v1beta1/system); it still carries
+// models.K8sContext elements because the schemas K8sContext uses non-pointer
+// timestamps that would emit zero-value createdAt/updatedAt for
+// freshly-discovered contexts. Swap to the schemas type once its timestamps
+// are nullable (tracked follow-up in meshery/schemas).
 type SaveK8sContextResponse struct {
 	RegisteredContexts []models.K8sContext `json:"registeredContexts"`
 	ConnectedContexts  []models.K8sContext `json:"connectedContexts"`
@@ -389,8 +396,10 @@ func (h *Handler) KubernetesPingHandler(w http.ResponseWriter, req *http.Request
 			writeMeshkitError(w, ErrKubeVersion(err), http.StatusInternalServerError)
 			return
 		}
-		if err = json.NewEncoder(w).Encode(map[string]string{
-			"server_version": version.String(),
+		// The schemas KubernetesPingResponse preserves this endpoint's published
+		// snake_case `server_version` wire field.
+		if err = json.NewEncoder(w).Encode(systemv1beta1.KubernetesPingResponse{
+			ServerVersion: version.String(),
 		}); err != nil {
 			// Response body has already started streaming via json.Encoder —
 			// a partial JSON envelope is on the wire and a fresh error

--- a/server/models/handlers.go
+++ b/server/models/handlers.go
@@ -218,6 +218,7 @@ type HandlerInterface interface {
 	PerformConnectionAction(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	DeleteConnection(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	ProcessConnectionRegistration(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
+	CancelConnectionRegister(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 
 	GetControllersDefaultConfig(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	UpdateControllersDefaultConfig(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)

--- a/server/models/telemetry/grafana/client.go
+++ b/server/models/telemetry/grafana/client.go
@@ -127,7 +127,7 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values) 
 	if err != nil {
 		return nil, fmt.Errorf("grafana: request to %s failed: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // cap at 16MiB
 	if err != nil {

--- a/server/models/telemetry/prometheus/client.go
+++ b/server/models/telemetry/prometheus/client.go
@@ -106,7 +106,7 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values) 
 	if err != nil {
 		return nil, fmt.Errorf("prometheus: request to %s failed: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // cap at 16MiB
 	if err != nil {

--- a/server/policies/wasm/go.mod
+++ b/server/policies/wasm/go.mod
@@ -13,7 +13,7 @@ replace github.com/meshery/meshery => ../../../
 
 require (
 	github.com/meshery/meshery v0.0.0-00010101000000-000000000000
-	github.com/meshery/schemas v1.3.26
+	github.com/meshery/schemas v1.3.32
 )
 
 require (

--- a/server/policies/wasm/go.sum
+++ b/server/policies/wasm/go.sum
@@ -510,8 +510,8 @@ github.com/meshery/meshkit v1.0.22 h1:c8CgO2+mdF6krvAdA66FF5ScmIHBkTEVt3MtkUmOJu
 github.com/meshery/meshkit v1.0.22/go.mod h1:2SzXjDsxZOraA9YbnqFzHS+1Tk14zsLuePJzHuZ1SRU=
 github.com/meshery/meshsync v1.0.3 h1:kgZ5HqjrRupRoOFQSjl3V6FpJ2K1cEkLrN8mxV6QV6M=
 github.com/meshery/meshsync v1.0.3/go.mod h1:ZAeZaId+fp/aoP7OuHw+u0LS/YmnTH40NNRltVbLuGE=
-github.com/meshery/schemas v1.3.26 h1:S/QFNHCqIZagfYaDfXH5vUEMadZLPk85QUiN+j3h0/U=
-github.com/meshery/schemas v1.3.26/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
+github.com/meshery/schemas v1.3.32 h1:BSQuxMZ5QAMz4hc+6LHm8XECkyBjnvxd0LBz6s+R56g=
+github.com/meshery/schemas v1.3.32/go.mod h1:3/0nDQZur8swpo+6+3b3pvYmkzUcdWs36xTQBGRU2Y8=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -491,8 +491,14 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	// mode). Separate from PUT so resource updates don't carry cluster effects.
 	gMux.Handle("/api/integrations/connections/{connectionId}/actions", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.PerformConnectionAction), models.ProviderAuth))).
 		Methods("POST")
+	// POST drives the registration state machine; the DELETE method on the same
+	// path is the deprecated body-based cancel (see ProcessConnectionRegistration).
 	gMux.Handle("/api/integrations/connections/register", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.ProcessConnectionRegistration), models.ProviderAuth))).
 		Methods("POST", "DELETE")
+	// Schemas-defined cancel: the registration tracker id travels in the path
+	// (operationId cancelConnectionRegister).
+	gMux.Handle("/api/integrations/connections/register/{registrationId}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.CancelConnectionRegister), models.ProviderAuth))).
+		Methods("DELETE")
 	gMux.Handle("/api/integrations/connections/{connectionId}", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.DeleteConnection), models.ProviderAuth))).
 		Methods("DELETE")
 	gMux.Handle("/api/integrations/connections/{connectionId}/controllers/config", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.GetConnectionControllersConfig), models.ProviderAuth))).

--- a/ui/components/connections/RegisterConnectionModal.tsx
+++ b/ui/components/connections/RegisterConnectionModal.tsx
@@ -41,7 +41,9 @@ const RegisterConnectionModal: FC<RegisterConnectionModalProps> = ({
 
   const cancelConnectionRegister = (id?: string) => {
     if (!id) return;
-    cancelConnection({ body: { id } })
+    // Schemas contract: the registration tracker id travels in the path
+    // (DELETE /api/integrations/connections/register/{registrationId}).
+    cancelConnection({ registrationId: id })
       .unwrap()
       .then(() => {
         notify({

--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -22,10 +22,7 @@ import RJSFWrapper from '../../../meshery-mesh-interface/PatternService/RJSF_wra
 import { selectCompSchema } from '@/components/shared/FormFields/rjsf-utils/common';
 import { JsonParse, randomPatternNameGenerator } from '../../../../utils/utils';
 import Notification from './Notification';
-import {
-  useConnectToConnectionMutation,
-  useVerifyAndRegisterConnectionMutation,
-} from '@/rtk-query/connection';
+import { useProcessConnectionRegistrationMutation } from '@/rtk-query/connection';
 import { useGetCredentialsQuery } from '@/rtk-query/credentials';
 
 const CONNECTION_TYPES = ['Prometheus Connection', 'Grafana Connection'];
@@ -38,22 +35,27 @@ const schema = selectCompSchema(
 );
 export const SelectConnection = ({ setSharedData, handleNext }) => {
   const formRef = useRef();
-  const [registerConnection] = useVerifyAndRegisterConnectionMutation();
+  const [processConnectionRegistration] = useProcessConnectionRegistrationMutation();
 
-  const handleRegisterConnection = async (componentName) => {
+  const handleRegisterConnection = async (componentName: string) => {
     try {
-      const payload = {
+      // `initialize` returns the registration bootstrap: the kind's connection
+      // (and credential) registry component definitions plus the tracker id.
+      const result = await processConnectionRegistration({
         body: {
           kind: componentName,
           status: 'initialize',
         },
-      };
+      }).unwrap();
 
-      const result = await registerConnection(payload).unwrap();
-
+      // Component definitions carry their RJSF form schema as a JSON-encoded
+      // string under `schema`; the generated response types them as plain
+      // objects.
+      const connectionComponent = result?.connection as { schema?: string } | undefined;
+      const credentialComponent = result?.credential as { schema?: string } | undefined;
       let schemaObj = {
-        connection: JsonParse(result?.connection?.schema),
-        credential: JsonParse(result?.credential?.schema),
+        connection: JsonParse(connectionComponent?.schema),
+        credential: JsonParse(credentialComponent?.schema),
       };
 
       setSharedData((prevState) => ({
@@ -215,8 +217,7 @@ export const ConnectionDetails = ({ sharedData, setSharedData, handleNext }) => 
 
 export const CredentialDetails = ({ sharedData, handleNext, handleRegistrationComplete }) => {
   const { data: credentialsData } = useGetCredentialsQuery();
-  const [verifyAndRegisterConnection] = useVerifyAndRegisterConnectionMutation();
-  const [connectToConnection] = useConnectToConnectionMutation();
+  const [processConnectionRegistration] = useProcessConnectionRegistrationMutation();
   const [selectedCredential, setSelectedCredential] = useState(null);
   const [prevSelectedCredential, setPrevSelectedCredential] = useState(null);
   const [formState, setFormState] = useState(null);
@@ -229,41 +230,40 @@ export const CredentialDetails = ({ sharedData, handleNext, handleRegistrationCo
     CredentialDetailContent.title = `Credential for ${sharedData?.kind}`;
   }, [sharedData.kind]);
 
-  const verifyConnection = async () => {
-    let credential = {};
+  const buildCredentialSecret = () => {
     if (selectedCredential === null) {
-      credential = formState;
-    } else {
-      credential = {
-        secret: selectedCredential?.secret?.secret,
-        name: selectedCredential?.name,
-      };
-      credential.id = selectedCredential?.id;
+      return formState;
     }
+    return {
+      id: selectedCredential?.id,
+      name: selectedCredential?.name,
+      secret: selectedCredential?.secret?.secret,
+    };
+  };
 
+  // Field names follow the schemas ConnectionRegistrationEvent wire contract
+  // (camelCase). The snake_case keys this stepper used to send
+  // (credential_secret, skip_credential_verification, sub_type) were silently
+  // dropped by the server, so credentials never reached verification.
+  const buildRegistrationEvent = (status: 'register' | 'connect') => ({
+    skipCredentialVerification,
+    kind: sharedData?.kind,
+    name: sharedData?.componentForm?.name,
+    type: sharedData?.connection?.type?.toLowerCase(),
+    subType: sharedData?.connection?.subType?.toLowerCase(),
+    metadata: sharedData?.componentForm,
+    credentialSecret: buildCredentialSecret(),
+    id: sharedData?.connection?.id,
+    status,
+  });
+
+  const verifyConnection = async () => {
     try {
-      const payload = {
-        body: {
-          skip_credential_verification: skipCredentialVerification,
-          kind: sharedData?.kind,
-          name: sharedData?.componentForm?.name,
-          type: sharedData?.connection?.type?.toLowerCase(),
-          sub_type: sharedData?.connection?.subType?.toLowerCase(),
-          metadata: sharedData?.componentForm,
-          credential_secret: credential,
-          id: sharedData?.connection?.id,
-          status: 'register',
-        },
-      };
-
-      const result = await verifyAndRegisterConnection(payload).unwrap();
-
-      if (result === '') {
-        setIsSuccess(true);
-        handleConnectToConnection();
-      } else {
-        setIsSuccess(false);
-      }
+      // A 2xx (empty body) is the success signal for non-initialize events;
+      // failures reject through unwrap().
+      await processConnectionRegistration({ body: buildRegistrationEvent('register') }).unwrap();
+      setIsSuccess(true);
+      handleConnectToConnection();
     } catch (error) {
       console.error('Error verifying connection:', error);
       setIsSuccess(false);
@@ -271,38 +271,9 @@ export const CredentialDetails = ({ sharedData, handleNext, handleRegistrationCo
   };
 
   const handleConnectToConnection = async () => {
-    let credential = {};
-    if (selectedCredential === null) {
-      credential = formState;
-    } else {
-      credential = {
-        name: selectedCredential?.name,
-        secret: selectedCredential?.secret?.secret,
-      };
-      credential.id = selectedCredential?.id;
-    }
-
     try {
-      const payload = {
-        body: {
-          kind: sharedData?.kind,
-          name: sharedData?.componentForm?.name,
-          type: sharedData?.connection?.type?.toLowerCase(),
-          sub_type: sharedData?.connection?.subType?.toLowerCase(),
-          metadata: sharedData?.componentForm,
-          credential_secret: credential,
-          id: sharedData?.connection?.id,
-          status: 'connect',
-        },
-      };
-
-      const result = await connectToConnection(payload).unwrap();
-
-      if (result !== undefined && result !== null && result === '') {
-        setIsSuccess(true);
-      } else {
-        setIsSuccess(false);
-      }
+      await processConnectionRegistration({ body: buildRegistrationEvent('connect') }).unwrap();
+      setIsSuccess(true);
     } catch (error) {
       console.error('Error connecting to connection:', error);
       setIsSuccess(false);

--- a/ui/components/connections/wizard/useConnectionWizard.tsx
+++ b/ui/components/connections/wizard/useConnectionWizard.tsx
@@ -2,12 +2,11 @@ import { createRef, useCallback, useEffect, useMemo, useRef, useState } from 're
 import { useNotification } from '@/utils/hooks/useNotification';
 import {
   useAddKubernetesConfigMutation,
-  useConnectToConnectionMutation,
   useDiscoverKubernetesContextsMutation,
   useGetCredentialsQuery,
   usePerformConnectionActionMutation,
+  useProcessConnectionRegistrationMutation,
   useUpdateConnectionByIdMutation,
-  useVerifyAndRegisterConnectionMutation,
 } from '@/rtk-query/connection';
 import type { ConnectionWizardKindConfig } from '../ConnectionWizard.helpers';
 import { buildSteps } from './registry';
@@ -63,8 +62,10 @@ const makeInitialData = (params: UseConnectionWizardParams): WizardData => ({
 export const useConnectionWizard = (params: UseConnectionWizardParams) => {
   const { mode, isOpen, onComplete } = params;
   const { notify } = useNotification();
-  const [verifyAndRegisterConnection] = useVerifyAndRegisterConnectionMutation();
-  const [connectToConnection] = useConnectToConnectionMutation();
+  // Both the register and connect steps dispatch through the single
+  // schemas-generated state-machine endpoint; the event's `status` field is
+  // what advances the registration.
+  const [processConnectionRegistration] = useProcessConnectionRegistrationMutation();
   const [addKubernetesConfig] = useAddKubernetesConfigMutation();
   const [discoverKubernetesContexts] = useDiscoverKubernetesContextsMutation();
   const [updateConnectionById] = useUpdateConnectionByIdMutation();
@@ -157,11 +158,19 @@ export const useConnectionWizard = (params: UseConnectionWizardParams) => {
     appliedPresetRef.current = null;
   }, []);
 
+  // The wizard assembles registration events dynamically (GenericRecord); the
+  // generated trigger types the body as the schemas ConnectionRegistrationEvent.
+  // This is the single boundary where the loose wizard data meets the typed
+  // wire contract.
+  type RegistrationEventBody = Parameters<typeof processConnectionRegistration>[0]['body'];
+
   const services = useMemo<WizardServices>(
     () => ({
       notify,
-      registerConnection: (body) => verifyAndRegisterConnection({ body }).unwrap(),
-      connectConnection: (body) => connectToConnection({ body }).unwrap(),
+      registerConnection: (body) =>
+        processConnectionRegistration({ body: body as RegistrationEventBody }).unwrap(),
+      connectConnection: (body) =>
+        processConnectionRegistration({ body: body as RegistrationEventBody }).unwrap(),
       discoverKubeContexts: async (file) => {
         const formData = new FormData();
         formData.append('k8sfile', file);
@@ -202,8 +211,7 @@ export const useConnectionWizard = (params: UseConnectionWizardParams) => {
     }),
     [
       notify,
-      verifyAndRegisterConnection,
-      connectToConnection,
+      processConnectionRegistration,
       addKubernetesConfig,
       discoverKubernetesContexts,
       updateConnectionById,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.3.26",
+        "@meshery/schemas": "^1.3.32",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.2",
@@ -2068,9 +2068,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.26",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.26.tgz",
-      "integrity": "sha512-lyZxCCxY8FhkwTM9tApW7++huFrvTqbtXo1+ZXWD7bE0QQDJlJDfOKbSqULw/tmkKqRSCjYOncjCUCpUwkYd4g==",
+      "version": "1.3.32",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.32.tgz",
+      "integrity": "sha512-b1RCsiArTi6ILArF4i7vpzO/JKgtYaJk1Od7sL7bD5gKm1jqG1o8FaszGxSHHs/eysc0xY0KP9D5FvbUITWvpg==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.3.26",
+    "@meshery/schemas": "^1.3.32",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.2",

--- a/ui/rtk-query/__tests__/connection.test.ts
+++ b/ui/rtk-query/__tests__/connection.test.ts
@@ -223,7 +223,7 @@ describe('connection mutations – HTTP contracts', () => {
     vi.restoreAllMocks();
   });
 
-  it('verifyAndRegisterConnection POSTs to /integrations/connections/register', async () => {
+  it('processConnectionRegistration POSTs to /integrations/connections/register', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
@@ -232,7 +232,7 @@ describe('connection mutations – HTTP contracts', () => {
 
     await fetch(mesheryApiPath('integrations/connections/register'), {
       method: 'POST',
-      body: JSON.stringify({ kind: 'aws' }),
+      body: JSON.stringify({ kind: 'aws', status: 'initialize' }),
     });
 
     expect(global.fetch).toHaveBeenCalledWith(
@@ -259,20 +259,21 @@ describe('connection mutations – HTTP contracts', () => {
     );
   });
 
-  it('cancelConnectionRegister sends DELETE with a body', async () => {
+  it('cancelConnectionRegister sends DELETE with the registration id in the path', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 204,
       text: () => Promise.resolve(''),
     });
 
-    await fetch(mesheryApiPath('integrations/connections/register'), {
+    // Schemas contract: DELETE /api/integrations/connections/register/{registrationId}
+    // — no request body; unknown ids are ignored (idempotent).
+    await fetch(mesheryApiPath('integrations/connections/register/reg-1'), {
       method: 'DELETE',
-      body: JSON.stringify({ id: 'conn-1' }),
     });
 
     expect(global.fetch).toHaveBeenCalledWith(
-      '/api/integrations/connections/register',
+      '/api/integrations/connections/register/reg-1',
       expect.objectContaining({ method: 'DELETE' }),
     );
   });
@@ -362,16 +363,20 @@ describe('connection module surface', () => {
   it('exports all expected mutation/query hooks', async () => {
     const mod = await import('../connection');
     expect(typeof mod.useGetCredentialsQuery).toBe('function');
-    expect(typeof mod.useVerifyAndRegisterConnectionMutation).toBe('function');
-    expect(typeof mod.useConnectToConnectionMutation).toBe('function');
+    // Schemas-generated since @meshery/schemas 1.3.32 — re-exported (or thinly
+    // wrapped) rather than re-declared locally.
+    expect(typeof mod.useProcessConnectionRegistrationMutation).toBe('function');
+    expect(typeof mod.useCancelConnectionRegisterMutation).toBe('function');
+    expect(typeof mod.useAddKubernetesConfigMutation).toBe('function');
+    expect(typeof mod.useDiscoverKubernetesContextsMutation).toBe('function');
+    expect(typeof mod.useLazyPingKubernetesQuery).toBe('function');
+    // Still hand-rolled: the {kind}-scoped connection routes are not yet
+    // defined in meshery/schemas.
     expect(typeof mod.useLazyGetConnectionDetailsQuery).toBe('function');
     expect(typeof mod.useVerifyConnectionURLMutation).toBe('function');
     expect(typeof mod.useConnectionMetaDataMutation).toBe('function');
     expect(typeof mod.useConfigureConnectionMutation).toBe('function');
     expect(typeof mod.useUpdateConnectionByIdMutation).toBe('function');
-    expect(typeof mod.useCancelConnectionRegisterMutation).toBe('function');
-    expect(typeof mod.useAddKubernetesConfigMutation).toBe('function');
-    expect(typeof mod.useLazyPingKubernetesQuery).toBe('function');
     expect(typeof mod.useUpdateConnectionStatusMutation).toBe('function');
   });
 });

--- a/ui/rtk-query/connection.ts
+++ b/ui/rtk-query/connection.ts
@@ -1,5 +1,7 @@
 import {
   mesheryApi,
+  useAddKubernetesConfigMutation as useSchemasAddKubernetesConfigMutation,
+  useDiscoverKubernetesContextsMutation as useSchemasDiscoverKubernetesContextsMutation,
   useGetConnectionsQuery as useSchemasGetConnectionsQuery,
   useGetControllerDiagnosticsQuery as useSchemasGetControllerDiagnosticsQuery,
   useGetUserCredentialsQuery as useSchemasGetUserCredentialsQuery,
@@ -16,26 +18,15 @@ const TAGS = {
   CONNECTIONS: 'Connection_API_Connections',
 };
 
+// Registration state-machine, cancel, kubeconfig import/discovery and
+// kubernetes ping are schemas-generated since @meshery/schemas 1.3.32
+// (processConnectionRegistration, cancelConnectionRegister,
+// addKubernetesConfig, discoverKubernetesContexts, pingKubernetes). Only the
+// {kind}-scoped connection routes below remain hand-rolled — they are not yet
+// defined in meshery/schemas.
 const connectionsApi = api.injectEndpoints({
   overrideExisting: true,
   endpoints: (builder) => ({
-    verifyAndRegisterConnection: builder.mutation({
-      query: (queryArg) => ({
-        url: mesheryApiPath('integrations/connections/register'),
-        method: 'POST',
-        body: queryArg.body,
-      }),
-      invalidatesTags: [TAGS.CONNECTIONS],
-    }),
-
-    connectToConnection: builder.mutation({
-      query: (queryArg) => ({
-        url: mesheryApiPath('integrations/connections/register'),
-        method: 'POST',
-        body: queryArg.body,
-      }),
-      invalidatesTags: [TAGS.CONNECTIONS],
-    }),
     getConnectionDetails: builder.query({
       query: (queryArg) => ({
         url: mesheryApiPath(`integrations/connections/${queryArg.connectionKind}/details`),
@@ -63,20 +54,6 @@ const connectionsApi = api.injectEndpoints({
         body: queryArg.body,
       }),
     }),
-    cancelConnectionRegister: builder.mutation({
-      query: (queryArg) => ({
-        url: mesheryApiPath(`integrations/connections/register`),
-        method: 'DELETE',
-        body: queryArg.body,
-      }),
-    }),
-    pingKubernetes: builder.query({
-      query: (connectionId) => ({
-        url: mesheryApiPath(`system/kubernetes/ping`),
-        params: { connectionId: connectionId },
-        credentials: 'include',
-      }),
-    }),
     updateConnectionStatus: builder.mutation({
       query: ({ kind, body }) => ({
         url: mesheryApiPath(`integrations/connections/${kind}/status`),
@@ -87,40 +64,42 @@ const connectionsApi = api.injectEndpoints({
       }),
       invalidatesTags: () => [{ type: TAGS.CONNECTIONS }],
     }),
-    addKubernetesConfig: builder.mutation({
-      query: (queryArg) => ({
-        url: mesheryApiPath(`system/kubernetes`),
-        method: 'POST',
-        body: queryArg.body,
-      }),
-      invalidatesTags: () => [{ type: TAGS.CONNECTIONS }],
-    }),
-    // Parses a kubeconfig and returns its contexts (including unreachable ones,
-    // flagged) WITHOUT persisting them, so the wizard can let the user pick
-    // which to import before any connection is created.
-    discoverKubernetesContexts: builder.mutation({
-      query: (queryArg) => ({
-        url: mesheryApiPath(`system/kubernetes/contexts`),
-        method: 'POST',
-        body: queryArg.body,
-      }),
-    }),
   }),
 });
 
 export const {
-  useVerifyAndRegisterConnectionMutation,
-  useConnectToConnectionMutation,
   useLazyGetConnectionDetailsQuery,
   useVerifyConnectionURLMutation,
   useConnectionMetaDataMutation,
   useConfigureConnectionMutation,
-  useCancelConnectionRegisterMutation,
-  useAddKubernetesConfigMutation,
-  useDiscoverKubernetesContextsMutation,
-  useLazyPingKubernetesQuery,
   useUpdateConnectionStatusMutation,
 } = connectionsApi;
+
+// The registration state-machine hooks need no ergonomics on top of the
+// generated client; re-export them so components keep a single import site for
+// connection APIs.
+export {
+  useCancelConnectionRegisterMutation,
+  useProcessConnectionRegistrationMutation,
+} from '@meshery/schemas/mesheryApi';
+
+// Multipart kubeconfig endpoints: RTK codegen types the body as the schemas
+// payload object (AddKubernetesConfigPayload / DiscoverKubernetesContextsPayload),
+// but the wire format is multipart/form-data, so callers hand over a FormData.
+// These wrappers own that single cast; the request itself is the generated one.
+export const useAddKubernetesConfigMutation = () => {
+  const [trigger, result] = useSchemasAddKubernetesConfigMutation();
+  const wrappedTrigger = (queryArg: { body: FormData }) =>
+    trigger({ body: queryArg.body as unknown as Parameters<typeof trigger>[0]['body'] });
+  return [wrappedTrigger, result] as const;
+};
+
+export const useDiscoverKubernetesContextsMutation = () => {
+  const [trigger, result] = useSchemasDiscoverKubernetesContextsMutation();
+  const wrappedTrigger = (queryArg: { body: FormData }) =>
+    trigger({ body: queryArg.body as unknown as Parameters<typeof trigger>[0]['body'] });
+  return [wrappedTrigger, result] as const;
+};
 
 // Backed by the schemas-generated `getUserCredentials` (GET
 // /api/integrations/credentials) rather than a local re-declaration of the same
@@ -153,12 +132,12 @@ export const useUpdateConnectionByIdMutation = () => {
   return [wrappedTrigger, result] as const;
 };
 
-// One-shot controller status pings, backed by the schemas-generated endpoints
-// (getOperatorControllerStatus / getMeshsyncControllerStatus /
-// getBrokerControllerStatus). Live status is delivered via the SSE stream in
-// lib/controllersStatusSubscription.ts. The schemas trigger takes
-// `{ connectionId }`; these wrappers accept a bare id so callers stay simple.
-const wrapControllerStatusLazyQuery = (endpoint: {
+// Lazy queries keyed by a single connection id (controller status pings,
+// kubernetes ping), backed by the schemas-generated endpoints. Live status is
+// delivered via the SSE stream in lib/controllersStatusSubscription.ts. The
+// schemas trigger takes `{ connectionId }`; these wrappers accept a bare id so
+// callers stay simple.
+const wrapConnectionIdLazyQuery = (endpoint: {
   useLazyQuery: () => readonly [
     (arg: { connectionId: string }, preferCacheValue?: boolean) => unknown,
     ...unknown[],
@@ -184,14 +163,17 @@ const connectionActionsApi = api.enhanceEndpoints({
 });
 export const { usePerformConnectionActionMutation } = connectionActionsApi;
 
-export const useLazyGetOperatorStatusQuery = wrapControllerStatusLazyQuery(
+export const useLazyGetOperatorStatusQuery = wrapConnectionIdLazyQuery(
   mesheryApi.endpoints.getOperatorControllerStatus,
 );
-export const useLazyGetMeshsyncStatusQuery = wrapControllerStatusLazyQuery(
+export const useLazyGetMeshsyncStatusQuery = wrapConnectionIdLazyQuery(
   mesheryApi.endpoints.getMeshsyncControllerStatus,
 );
-export const useLazyGetBrokerStatusQuery = wrapControllerStatusLazyQuery(
+export const useLazyGetBrokerStatusQuery = wrapConnectionIdLazyQuery(
   mesheryApi.endpoints.getBrokerControllerStatus,
+);
+export const useLazyPingKubernetesQuery = wrapConnectionIdLazyQuery(
+  mesheryApi.endpoints.pingKubernetes,
 );
 
 // Per-connection controller diagnostics + remediation, fetched on demand by the


### PR DESCRIPTION
**Description**

This PR integrates the [meshery/schemas v1.3.32 release](https://github.com/meshery/schemas/releases/tag/v1.3.32) (from v1.3.26) into Meshery Server and UI, continuing the migration away from locally-defined RTK endpoints and Go models toward the schemas-generated contracts.

**Server** (`github.com/meshery/schemas` v1.3.26 -> v1.3.32)

- Connection registration state machine ([schemas#1063](https://github.com/meshery/schemas/pull/1063)): `ProcessConnectionRegistration` now decodes the schemas `ConnectionRegistrationEvent` and answers `initialize` events with the typed `ConnectionRegistrationBootstrap`. The event converts to the internal `connections.ConnectionPayload` only at the state-machine boundary, so machine actions are unchanged.
- New `CancelConnectionRegister` handler serves the schema-defined `DELETE /api/integrations/connections/register/{registrationId}` (204 on success, 400 on a non-UUID id, idempotent). The legacy body-based DELETE on `/register` remains for one deprecation cycle.
- System contracts ([schemas#1062](https://github.com/meshery/schemas/pull/1062)): `KubernetesPingHandler` emits the schemas `KubernetesPingResponse`; the local `ControllerStatusItem` and `ControllerInfo` duplicates are replaced by the schemas-generated `system.ControllerStatus` / `system.ControllerInfo`, including the typed `ControllerStatusValue` enum. Wire output is unchanged.
- Upstream renamed the `ConnectionStatusValue*` constants to their short forms (`Connected`, `Deleted`, ...) and removed the deprecated aliases; the transition-map test is updated.

**UI** (`@meshery/schemas` ^1.3.26 -> ^1.3.32)

- Drops the five hand-rolled RTK endpoints that the release defines in the generated client: `verifyAndRegisterConnection` + `connectToConnection` collapse into the generated `useProcessConnectionRegistrationMutation`; `cancelConnectionRegister`, `addKubernetesConfig`, `discoverKubernetesContexts`, and `pingKubernetes` are backed by generated endpoints. Only thin wrappers remain (FormData for the multipart pair, bare-connection-id for ping).
- `cancelConnectionRegister` now sends the registration tracker id in the path per the schema, instead of a DELETE request body.
- Only the `{kind}`-scoped connection routes (`details`/`verify`/`metadata`/`configure`/`status`) remain hand-rolled; they are not yet defined in meshery/schemas.

**Bugs fixed in passing** (exposed by the typed contract)

- The MeshSync register stepper sent snake_case keys (`credential_secret`, `skip_credential_verification`, `sub_type`) that the server's camelCase decode silently dropped, so credentials never reached verification.
- The same stepper treated an empty 2xx body as failure (`result === ''`; the RTK base query resolves empty bodies to `null`), so the flow never advanced past verify.
- Out-of-scope lint debt: unchecked deferred `resp.Body.Close()` in the Grafana/Prometheus telemetry proxy clients (flagged by errcheck), fixed in a separate commit.

**Deferred follow-ups** (flagged, not half-wired)

- `models.K8sContext` / `SaveK8sContextResponse` Go-type unification with the schemas `K8sContext`: blocked on schemas using non-pointer `createdAt`/`updatedAt`, which would emit zero-value timestamps for freshly-discovered contexts. Needs a schemas-side nullable-timestamp change first.
- `searchUsers` (`GET /api/identity/users/search`, [schemas#1060](https://github.com/meshery/schemas/pull/1060), tagged `x-internal: ["meshery"]`): Layer5 Cloud already serves it, but Meshery has no proxy route yet and the people-picker still uses the hand-rolled `getAllUsers`. Migrating requires a provider-interface addition plus response-shape verification against the Sistent picker.
- The deprecated `GET /api/system/kubernetes/contexts` local endpoint remains slated for removal, not migration.

The v1.3.27-v1.3.31 deltas (invitation nullability, cloud pagination/params, user projections) are cloud-contract updates with no Meshery consumer breakage; confirmed by clean builds and full test suites.

**Notes for Reviewers**

- The schemas contract is the source of truth for the registration event and cancel semantics; see `schemas/constructs/v1beta3/connection/api.yml` and `schemas/constructs/v1beta1/system/api.yml` at v1.3.32.
- The legacy body-based DELETE on `/api/integrations/connections/register` is intentionally retained one cycle for older clients (e.g. extension bundles); the UI in this PR no longer uses it.

**Testing**

- [x] `go build ./...`, `go vet ./server/...` clean
- [x] `go test ./server/handlers/... ./server/machines/... ./server/models/... --short` pass
- [x] `golangci-lint run` on touched server packages: 0 issues
- [x] UI: full vitest suite (2603 tests) pass
- [x] UI: `tsc --noEmit` clean, `npm run lint` clean

---

[Contributor Guides and Handbook](https://layer5.io/community/handbook)
