### PR TITLE
[Server] Record failed Kubernetes connections as Error notifications

### DIFF
--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -243,10 +243,14 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 
 			// A context flagged unreachable during discovery still registers as a
 			// DISCOVERED connection, but the connection attempt itself did not
-			// succeed. Flag it so the receipt event below is raised to Error
+			// succeed. Override the per-status description set above and raise a
+			// dedicated flag so the receipt event below is raised to Error
 			// severity and stays findable under the notification center's Error
 			// filter, instead of being reported as a successful registration
-			// (issue #20725).
+			// (issue #20725). A dedicated flag is used rather than
+			// metadata["error"] because unreachability is not an error returned by
+			// SaveK8sContext, so k8sEventMetadataHasError would not otherwise catch
+			// it.
 			if !ctx.Reachable {
 				hasUnreachableContext = true
 				metadata["description"] = fmt.Sprintf("Unable to establish connection with context \"%s\" at %s: the Kubernetes API server was unreachable.", ctx.Name, ctx.Server)
@@ -295,13 +299,23 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 	// Error-severity events are retrievable under the notification center's
 	// Error filter, and a receipt kept Informational left failed Kubernetes
 	// connections flashing in transiently and then unfindable (issue #20725).
+	// The three conditions cover disjoint failure modes: a failed SaveK8sContext
+	// (ErroredContexts), a context unreachable at discovery (hasUnreachableContext,
+	// which does not set metadata["error"]), and a context whose client could not
+	// be built (an "error" recorded in its per-context metadata during discovery).
 	if len(saveK8sContextResponse.ErroredContexts) > 0 || hasUnreachableContext || k8sEventMetadataHasError(eventMetadata) {
 		eventBuilder.WithSeverity(events.Error).
 			WithDescription("Failed to establish one or more Kubernetes connections.")
 	}
 
 	event := eventBuilder.WithMetadata(eventMetadata).Build()
-	_ = provider.PersistEvent(*event, token)
+	// This receipt is the durable, filterable record of the import, so log a
+	// persistence failure rather than dropping it silently — a missing
+	// notification would otherwise be untraceable. The live event is still
+	// broadcast below regardless.
+	if perr := provider.PersistEvent(*event, token); perr != nil {
+		h.log.Error(models.ErrPersistEvent(perr))
+	}
 	go h.config.EventBroadcaster.Publish(userID, event)
 
 	if err := json.NewEncoder(w).Encode(saveK8sContextResponse); err != nil {

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -157,6 +157,10 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 	// when new api with param "contexts" will be addopted,
 	// only take into account contexts from that param
 	importedCount := 0
+	// Tracks whether any selected context was unreachable. Such contexts still
+	// register (as DISCOVERED) but the connection attempt did not succeed, so the
+	// receipt event below must be raised to Error severity (issue #20725).
+	hasUnreachableContext := false
 	for _, ctx := range contexts {
 		// Honor an explicit selection: skip contexts the caller did not pick.
 		// Matched against the discovered context ID, before any rename below.
@@ -237,6 +241,17 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 				metadata["description"] = fmt.Sprintf("Connection registered with kubernetes context \"%s\" at %s.", ctx.Name, ctx.Server)
 			}
 
+			// A context flagged unreachable during discovery still registers as a
+			// DISCOVERED connection, but the connection attempt itself did not
+			// succeed. Flag it so the receipt event below is raised to Error
+			// severity and stays findable under the notification center's Error
+			// filter, instead of being reported as a successful registration
+			// (issue #20725).
+			if !ctx.Reachable {
+				hasUnreachableContext = true
+				metadata["description"] = fmt.Sprintf("Unable to establish connection with context \"%s\" at %s: the Kubernetes API server was unreachable.", ctx.Name, ctx.Server)
+			}
+
 			inst, err := mhelpers.InitializeMachineWithContext(
 				machineCtx,
 				req.Context(),
@@ -274,6 +289,17 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 		h.config.K8scontextChannel.PublishContext()
 	}
 
+	// The receipt event below is the durable record of this import that the
+	// notification center persists and later filters on. When one or more
+	// contexts failed to connect it MUST be raised to Error severity: only
+	// Error-severity events are retrievable under the notification center's
+	// Error filter, and a receipt kept Informational left failed Kubernetes
+	// connections flashing in transiently and then unfindable (issue #20725).
+	if len(saveK8sContextResponse.ErroredContexts) > 0 || hasUnreachableContext || k8sEventMetadataHasError(eventMetadata) {
+		eventBuilder.WithSeverity(events.Error).
+			WithDescription("Failed to establish one or more Kubernetes connections.")
+	}
+
 	event := eventBuilder.WithMetadata(eventMetadata).Build()
 	_ = provider.PersistEvent(*event, token)
 	go h.config.EventBroadcaster.Publish(userID, event)
@@ -285,6 +311,24 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 		h.log.Error(models.ErrMarshal(err, "kubeconfig"))
 		return
 	}
+}
+
+// k8sEventMetadataHasError reports whether any per-context entry in a Kubernetes
+// connection receipt's metadata recorded a failure. Each context's outcome is
+// keyed by its name and carries an "error" entry only when that context failed
+// (an unreachable API server, an unbuildable client, or a failed save), so the
+// presence of any such entry means the receipt describes at least one failed
+// connection and the receipt event must be raised to Error severity so it stays
+// findable under the notification center's Error filter (issue #20725).
+func k8sEventMetadataHasError(eventMetadata map[string]interface{}) bool {
+	for _, meta := range eventMetadata {
+		if metaMap, ok := meta.(map[string]interface{}); ok {
+			if _, hasErr := metaMap["error"]; hasErr {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (h *Handler) deleteK8SConfig(_ *models.User, _ *models.Preference, w http.ResponseWriter, _ *http.Request, _ models.Provider) {

--- a/server/handlers/k8sconfig_handler.go
+++ b/server/handlers/k8sconfig_handler.go
@@ -323,7 +323,10 @@ func (h *Handler) addK8SConfig(user *models.User, _ *models.Preference, w http.R
 func k8sEventMetadataHasError(eventMetadata map[string]interface{}) bool {
 	for _, meta := range eventMetadata {
 		if metaMap, ok := meta.(map[string]interface{}); ok {
-			if _, hasErr := metaMap["error"]; hasErr {
+			// Require a non-nil value: a present-but-nil "error" entry (an
+			// explicit nil error or a JSON null) does not indicate a failure and
+			// must not raise the receipt to Error severity.
+			if errVal, hasErr := metaMap["error"]; hasErr && errVal != nil {
 				return true
 			}
 		}

--- a/server/handlers/k8sconfig_handler_test.go
+++ b/server/handlers/k8sconfig_handler_test.go
@@ -28,6 +28,15 @@ func TestK8sEventMetadataHasError(t *testing.T) {
 			want:          false,
 		},
 		{
+			name: "present-but-nil error value reports no error",
+			eventMetadata: map[string]interface{}{
+				"prod": map[string]interface{}{
+					"error": nil,
+				},
+			},
+			want: false,
+		},
+		{
 			name: "only successful contexts report no error",
 			eventMetadata: map[string]interface{}{
 				"prod": map[string]interface{}{

--- a/server/handlers/k8sconfig_handler_test.go
+++ b/server/handlers/k8sconfig_handler_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestK8sEventMetadataHasError guards the decision that raises a Kubernetes
+// connection receipt event to Error severity. A receipt whose per-context
+// metadata records any failure must be reported as Error so it persists in the
+// notification center and stays retrievable under the Error severity filter
+// (issue #20725); a receipt describing only successful connections must remain
+// Informational.
+func TestK8sEventMetadataHasError(t *testing.T) {
+	tests := []struct {
+		name          string
+		eventMetadata map[string]interface{}
+		want          bool
+	}{
+		{
+			name:          "nil metadata reports no error",
+			eventMetadata: nil,
+			want:          false,
+		},
+		{
+			name:          "empty metadata reports no error",
+			eventMetadata: map[string]interface{}{},
+			want:          false,
+		},
+		{
+			name: "only successful contexts report no error",
+			eventMetadata: map[string]interface{}{
+				"prod": map[string]interface{}{
+					"description": "Connection registered with kubernetes context \"prod\".",
+				},
+				"staging": map[string]interface{}{
+					"description": "Connection already exists with Kubernetes context \"staging\".",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "a single failed context reports an error",
+			eventMetadata: map[string]interface{}{
+				"unreachable": map[string]interface{}{
+					"description": "Unable to establish connection with context \"unreachable\".",
+					"error":       errors.New("api server unreachable"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "a failure mixed with successes reports an error",
+			eventMetadata: map[string]interface{}{
+				"prod": map[string]interface{}{
+					"description": "Connection registered with kubernetes context \"prod\".",
+				},
+				"unreachable": map[string]interface{}{
+					"error": errors.New("api server unreachable"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "non-map entries are ignored",
+			eventMetadata: map[string]interface{}{
+				"weird": "not a metadata map",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := k8sEventMetadataHasError(tt.eventMetadata); got != tt.want {
+				t.Errorf("k8sEventMetadataHasError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Notes for Reviewers

Fixes #20725

### Symptom
During onboarding, after several failed Kubernetes connection attempts, error notifications appeared briefly in the notification center and then disappeared within ~3 seconds. They could not be found afterward, even when explicitly filtering by the **Error** severity category.

### Root cause
The notification center is fed by two sources sharing one store: a live SSE stream (`/api/system/events/subscribe`, which only carries *published* events) and a REST list (`/api/system/events`, which reads *persisted* rows and is the source for severity/status filtering). An event that is published but **not persisted as `severity="error"`** therefore flashes in via the live path and then vanishes on the next REST refetch, and can never be surfaced under the Error filter.

`addK8SConfig` (the `POST /api/system/kubernetes` handler behind the connection wizard) persisted a single connection-import "receipt" event that was **always `Informational`**, folding each context's outcome - including failures - into its metadata. So a failed Kubernetes connection was never recorded as an Error-severity row: it merely flashed in transiently and was then unfindable.

### Fix
Raise that receipt event to **Error** severity (with a failure-oriented description) whenever the import produced any failure:

- a context failed to save (`ErroredContexts`),
- a selected context was flagged unreachable during discovery (`!ctx.Reachable`), or
- any per-context metadata recorded an `error` (e.g. an unbuildable client from a malformed kubeconfig).

Successful imports remain `Informational`, so the happy path is unchanged. The failed-connection receipt is now durable, styled as an error, and retrievable under the notification center's Error filter - matching the expected behavior in the issue.

### Testing
- `go test --short ./handlers/` - passes; added `TestK8sEventMetadataHasError` covering the new severity-decision helper (nil/empty/success-only/single-failure/mixed/non-map cases).
- `go build ./...`, `go vet ./handlers/`, `gofmt` - clean.

### Watch for (out of scope - flagged for a follow-up)
There is a deeper sibling defect that this PR deliberately does **not** touch, because a naive fix has a noisy blast radius across every connection type:

- `server/machines/models.go` `StateMachine.SendEvent` silently swallows failures: `err` is shadowed by a `:=` in the transition loop (so it always returns `nil`), and a failing action that routes to the `NotFound` recovery state has its Error event overwritten by `NotFoundAction`, then replaced by an `Informational` "connection changed" fallback. Callers that gate persist/publish on `err != nil` therefore drop real state-machine connection failures.
- `server/machines/kubernetes/register.go` `RegisterAction` builds its failure event without `WithSeverity(events.Error)` (its siblings `connect.go`/`discover.go` set it).

A global fix must also de-dupe the `K8sFSMMiddleware` path, which calls `SendEvent(Discovery)` on every request and would otherwise emit a notification per request while a cluster is down. Tracked separately for dedicated review.
