### PR TITLE
fix(ui): improve provider selector UX

### DIFF
--- a/provider-ui/components/Provider.js
+++ b/provider-ui/components/Provider.js
@@ -1039,7 +1039,8 @@ export default function Provider() {
               width={12}
               height={12}
               aria-hidden="true"
-              style={{ verticalAlign: "middle", color: "inherit" }}
+              fill="#fff"
+              style={{ verticalAlign: "middle" }}
             />
           </sup>
         </LearnMore>

--- a/provider-ui/components/Provider.js
+++ b/provider-ui/components/Provider.js
@@ -1033,7 +1033,15 @@ export default function Provider() {
           aria-controls="provider-guidance-dialog"
           data-cy="providers-learn-more"
         >
-          Learn more about providers
+          Learn more about providers&nbsp;
+          <sup style={{ lineHeight: 0 }}>
+            <ExternalLinkIcon
+              width={12}
+              height={12}
+              aria-hidden="true"
+              style={{ verticalAlign: "middle", color: "inherit" }}
+            />
+          </sup>
         </LearnMore>
       )}
       <CustomDialog

--- a/provider-ui/components/Provider.style.js
+++ b/provider-ui/components/Provider.style.js
@@ -52,6 +52,9 @@ export const MenuProviderDisabled = styled(MenuItem)(({ theme }) => ({
   "&.Mui-disabled": {
     cursor: "not-allowed",
     pointerEvents: "auto",
+    "&:hover": {
+      backgroundColor: theme.palette.text.default,
+    },
   },
 }));
 

--- a/provider-ui/components/Provider.style.js
+++ b/provider-ui/components/Provider.style.js
@@ -49,6 +49,10 @@ export const MenuProviderDisabled = styled(MenuItem)(({ theme }) => ({
     fontStyle: "italic",
   },
   textOverflow: "ellipsis",
+  "&.Mui-disabled": {
+    cursor: "not-allowed",
+    pointerEvents: "auto",
+  },
 }));
 
 export const CustomDialog = styled(Dialog)(({ theme }) => ({


### PR DESCRIPTION
Fixes #20731

Adds `cursor: not-allowed` to OFFLINE provider menu items, and a superscript external-link icon next to "Learn more about providers" (matching the existing icon spacing pattern used elsewhere in the file).