### PR TITLE
[Server] Fix nil pointer crash in MeshSync auto-registration

### DIFF
--- a/server/machines/helpers/auto_register.go
+++ b/server/machines/helpers/auto_register.go
@@ -176,8 +176,6 @@ func (arh *AutoRegistrationHelper) getConnectionDefinitions(connType string) []c
 // The asserted pointer is checked for nil because a typed nil pointer in an entity.Entity passes
 // the type assertion with ok == true.
 func toConnectionDefinitions(connectionEntities []entity.Entity) []component.ComponentDefinition {
-	connectionDefs := make([]component.ComponentDefinition, 0, len(connectionEntities))
-	for _, connectionEntity := range connectionEntities {
 		def, ok := connectionEntity.(*component.ComponentDefinition)
 		if !ok || def == nil || def.Model == nil {
 			continue

--- a/server/machines/helpers/auto_register.go
+++ b/server/machines/helpers/auto_register.go
@@ -173,11 +173,13 @@ func (arh *AutoRegistrationHelper) getConnectionDefinitions(connType string) []c
 // toConnectionDefinitions returns the entities that are usable as connection definitions.
 // Entities that are not ComponentDefinitions, and definitions without a Model, are skipped:
 // getConnectionPayload dereferences Model, so a definition without one cannot yield a connection.
+// The asserted pointer is checked for nil because a typed nil pointer in an entity.Entity passes
+// the type assertion with ok == true.
 func toConnectionDefinitions(connectionEntities []entity.Entity) []component.ComponentDefinition {
 	connectionDefs := make([]component.ComponentDefinition, 0, len(connectionEntities))
 	for _, connectionEntity := range connectionEntities {
 		def, ok := connectionEntity.(*component.ComponentDefinition)
-		if !ok || def.Model == nil {
+		if !ok || def == nil || def.Model == nil {
 			continue
 		}
 		connectionDefs = append(connectionDefs, *def)

--- a/server/machines/helpers/auto_register.go
+++ b/server/machines/helpers/auto_register.go
@@ -18,6 +18,7 @@ import (
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
+	"github.com/meshery/meshkit/models/meshmodel/entity"
 	regv1beta1 "github.com/meshery/meshkit/models/meshmodel/registry/v1beta1"
 	"github.com/meshery/meshkit/utils"
 	"github.com/meshery/schemas/models/v1beta3/component"
@@ -166,12 +167,20 @@ func (arh *AutoRegistrationHelper) getConnectionDefinitions(connType string) []c
 	}
 
 	connectionEntities, _, _, _ := connectionCompFilter.Get(arh.dbHandler)
-	connectionDefs := make([]component.ComponentDefinition, len(connectionEntities))
+	return toConnectionDefinitions(connectionEntities)
+}
+
+// toConnectionDefinitions returns the entities that are usable as connection definitions.
+// Entities that are not ComponentDefinitions, and definitions without a Model, are skipped:
+// getConnectionPayload dereferences Model, so a definition without one cannot yield a connection.
+func toConnectionDefinitions(connectionEntities []entity.Entity) []component.ComponentDefinition {
+	connectionDefs := make([]component.ComponentDefinition, 0, len(connectionEntities))
 	for _, connectionEntity := range connectionEntities {
 		def, ok := connectionEntity.(*component.ComponentDefinition)
-		if ok {
-			connectionDefs = append(connectionDefs, *def)
+		if !ok || def.Model == nil {
+			continue
 		}
+		connectionDefs = append(connectionDefs, *def)
 	}
 	return connectionDefs
 }

--- a/server/machines/helpers/auto_register_test.go
+++ b/server/machines/helpers/auto_register_test.go
@@ -1,0 +1,85 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/meshkit/models/meshmodel/entity"
+	"github.com/meshery/schemas/models/core"
+	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta3/component"
+)
+
+// nonComponentEntity is an entity.Entity that is not a *component.ComponentDefinition.
+type nonComponentEntity struct{}
+
+func (nonComponentEntity) Type() entity.EntityType        { return entity.EntityType("non-component") }
+func (nonComponentEntity) GetEntityDetail() string        { return "non-component" }
+func (nonComponentEntity) GenerateID() (core.Uuid, error) { return core.Uuid{}, nil }
+func (nonComponentEntity) GetID() core.Uuid               { return core.Uuid{} }
+func (nonComponentEntity) Create(_ *database.Handler, _ core.Uuid) (core.Uuid, error) {
+	return core.Uuid{}, nil
+}
+
+func connectionDef(name string) *component.ComponentDefinition {
+	return &component.ComponentDefinition{
+		DisplayName: core.InputString(name),
+		Model:       &modelv1beta1.ModelDefinition{},
+	}
+}
+
+func TestToConnectionDefinitions(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Entities []entity.Entity
+		WantLen  int
+	}{
+		{
+			Name:     "given no entities when converting then no definitions are returned",
+			Entities: nil,
+			WantLen:  0,
+		},
+		{
+			Name: "given only connection definitions when converting then no phantom entries are returned",
+			Entities: []entity.Entity{
+				connectionDef("grafana"),
+				connectionDef("prometheus"),
+			},
+			WantLen: 2,
+		},
+		{
+			Name: "given a non component entity when converting then it is skipped",
+			Entities: []entity.Entity{
+				connectionDef("grafana"),
+				nonComponentEntity{},
+			},
+			WantLen: 1,
+		},
+		{
+			Name: "given a definition without a model when converting then it is skipped",
+			Entities: []entity.Entity{
+				connectionDef("grafana"),
+				&component.ComponentDefinition{},
+			},
+			WantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			got := toConnectionDefinitions(tt.Entities)
+
+			if len(got) != tt.WantLen {
+				t.Fatalf("got %d connection definitions, want %d", len(got), tt.WantLen)
+			}
+
+			// getConnectionPayload dereferences Model, so any definition returned here with a
+			// nil Model is the server crash reported in #20729.
+			for i, def := range got {
+				if def.Model == nil {
+					t.Errorf("connection definition at index %d has a nil Model, getConnectionPayload would panic on it", i)
+				}
+			}
+		})
+	}
+}

--- a/server/machines/helpers/auto_register_test.go
+++ b/server/machines/helpers/auto_register_test.go
@@ -63,6 +63,16 @@ func TestToConnectionDefinitions(t *testing.T) {
 			},
 			WantLen: 1,
 		},
+		{
+			Name: "given a nil definition when converting then it is skipped",
+			Entities: []entity.Entity{
+				connectionDef("grafana"),
+				// A typed nil pointer in an entity.Entity passes the type assertion with
+				// ok == true, so the asserted pointer itself has to be checked for nil.
+				(*component.ComponentDefinition)(nil),
+			},
+			WantLen: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20729

`getConnectionDefinitions` in `server/machines/helpers/auto_register.go` pre-sized its result with `make([]component.ComponentDefinition, len(connectionEntities))` and then **appended** to it. So it returned `len(connectionEntities)` zero value `ComponentDefinition`s followed by the real ones:

```go
connectionDefs := make([]component.ComponentDefinition, len(connectionEntities))
for _, connectionEntity := range connectionEntities {
    def, ok := connectionEntity.(*component.ComponentDefinition)
    if ok {
        connectionDefs = append(connectionDefs, *def)
    }
}
```

`Model` is a pointer and is nil on those phantom entries. `processRegistration` ranges over the whole result and passes each one to `getConnectionPayload`, which dereferences `connectionDef.Model.SubCategory` and `connectionDef.Model.Category.Name`. That is the nil pointer dereference. It happens inside the detached goroutine at `auto_register.go:65`, which has no recover, so it takes the whole server down whenever MeshSync discovers a Grafana or Prometheus service.

**what changed**

- Pulled the conversion out into `toConnectionDefinitions` so it can be unit tested without a database handler.
- Allocated with `make(..., 0, len(...))` so the capacity hint stays but no phantom entries are produced.
- Skipped definitions whose `Model` is nil. `getConnectionPayload` cannot build a connection payload without a `Model`, so a malformed definition is now ignored rather than being able to crash the server.

**before**

2 connection entities in, 4 definitions out (2 zero value ones first), and `getConnectionPayload` panics on the first:

```
runtime error: invalid memory address or nil pointer dereference
  in getConnectionPayload -> processRegistration
```

**after**

2 connection entities in, 2 definitions out, all with a non nil `Model`.

**tests**

Added `TestToConnectionDefinitions` covering the phantom entries, a non `ComponentDefinition` entity, and a definition with no `Model`. Each case also asserts every returned definition has a non nil `Model`, since that is exactly what `getConnectionPayload` dereferences.

It fails before the change:

```
--- FAIL: TestToConnectionDefinitions/given_only_connection_definitions_when_converting_then_no_phantom_entries_are_returned
    auto_register_test.go:73: got 4 connection definitions, want 2
```

and passes after:

```
go test -run TestToConnectionDefinitions ./machines/helpers/
ok  	github.com/meshery/meshery/server/machines/helpers	7.630s
```

`gofmt` is clean on both files. No API or schema surface is touched, so no `meshery/schemas` change is needed.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
