### PR TITLE
[UI] refine expand button spacing and collapsed hover styling

### DIFF
--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -140,10 +140,23 @@ export const ExpandMore = ({ isExpanded, hasChildren, theme, isDrawerCollapsed, 
     aria-expanded={!!isExpanded}
     aria-label={isExpanded ? 'Collapse' : 'Expand'}
     style={{
-      padding: 0,
-      display: hasChildren ? 'inline-block' : 'none',
+      padding: isDrawerCollapsed ? '2px' : '6px',
+      display: hasChildren ? 'inline-flex' : 'none',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minWidth: 'auto',
+      minHeight: 'auto',
+      borderRadius: '50%',
+      marginLeft: 'auto',
       position: isDrawerCollapsed ? 'absolute' : 'relative',
-      right: isDrawerCollapsed ? '5px' : 'auto',
+      right: isDrawerCollapsed ? '2px' : 'auto',
+      // Remove background when collapsed
+      ...(isDrawerCollapsed && {
+        backgroundColor: 'transparent',
+        '&:hover': {
+          backgroundColor: 'transparent',
+        },
+      }),
     }}
     {...props}
   >


### PR DESCRIPTION
**Notes for Reviewers**
## PR content:

This PR refines the styling of the expand/collapse button in the general navigator component.
- It adjust the padding of the expand/collapsed button so that its background appears correctly when it is hovered on and when the sidebar is on DrawerNotCollapse mode
- The button now avoids showing a hover background when the drawer is collapsed, improving the collapsed-state appearance.
- Its positioning has been adjusted to sit further to the right with a clearer gap from the logo/image area, making the layout feel cleaner and more intentional.

### Before

https://github.com/user-attachments/assets/5241b899-3c2e-4fdc-bb81-f06a986d20d8

### After

https://github.com/user-attachments/assets/d2181840-8c14-49fd-8e4b-69862188a28e


- This PR fixes #20734

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
