### PR TITLE
[Server] Return 400 on malformed JSON in bulk event handlers

### DIFF
--- a/server/handlers/events_streamer.go
+++ b/server/handlers/events_streamer.go
@@ -182,7 +182,12 @@ func (h *Handler) BulkUpdateEventStatus(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	_ = json.Unmarshal(body, &reqBody)
+	if err = json.Unmarshal(body, &reqBody); err != nil {
+		_err := models.ErrUnmarshal(err, "bulk update event status")
+		h.log.Error(_err)
+		writeMeshkitError(w, _err, http.StatusBadRequest)
+		return
+	}
 	err = provider.BulkUpdateEventStatus(token, reqBody.StatusIDs, reqBody.Status)
 	if err != nil {
 		_err := ErrBulkUpdateEvent(err)
@@ -207,7 +212,12 @@ func (h *Handler) BulkDeleteEvent(w http.ResponseWriter, req *http.Request, pref
 		return
 	}
 
-	_ = json.Unmarshal(body, &reqBody)
+	if err = json.Unmarshal(body, &reqBody); err != nil {
+		_err := models.ErrUnmarshal(err, "bulk delete event")
+		h.log.Error(_err)
+		writeMeshkitError(w, _err, http.StatusBadRequest)
+		return
+	}
 	err = provider.BulkDeleteEvent(token, reqBody.IDs)
 	if err != nil {
 		_err := ErrBulkDeleteEvent(err)

--- a/server/handlers/events_streamer_test.go
+++ b/server/handlers/events_streamer_test.go
@@ -3,14 +3,19 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/meshery/meshery/server/meshes"
+	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/logger"
 	_events "github.com/meshery/meshkit/utils/events"
+	"github.com/meshery/schemas/models/core"
 )
 
 const testTimeout = time.Second
@@ -428,5 +433,107 @@ func TestListenForCoreEvents_IgnoresUnexpectedPayloads(t *testing.T) {
 	case <-done:
 	case <-time.After(testTimeout):
 		t.Fatal("edge-case listener did not stop after cancellation")
+	}
+}
+
+type bulkEventSpyProvider struct {
+	*models.DefaultLocalProvider
+	bulkUpdateCalled atomic.Bool
+	bulkDeleteCalled atomic.Bool
+}
+
+func newBulkEventSpyProvider() *bulkEventSpyProvider {
+	base := &models.DefaultLocalProvider{}
+	base.Initialize()
+	return &bulkEventSpyProvider{DefaultLocalProvider: base}
+}
+
+func (s *bulkEventSpyProvider) BulkUpdateEventStatus(_ string, _ []*core.Uuid, _ string) error {
+	s.bulkUpdateCalled.Store(true)
+	return nil
+}
+
+func (s *bulkEventSpyProvider) BulkDeleteEvent(_ string, _ []*core.Uuid) error {
+	s.bulkDeleteCalled.Store(true)
+	return nil
+}
+
+func TestBulkUpdateEventStatus_MalformedJSON(t *testing.T) {
+	h := &Handler{config: &models.HandlerConfig{}, log: newTestLogger(t)}
+	spy := newBulkEventSpyProvider()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/events/bulk", bytes.NewBufferString("not json"))
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.BulkUpdateEventStatus(rec, req, nil, nil, spy)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	if spy.bulkUpdateCalled.Load() {
+		t.Fatal("provider BulkUpdateEventStatus should not be called on malformed JSON")
+	}
+}
+
+func TestBulkUpdateEventStatus_ValidJSON(t *testing.T) {
+	h := &Handler{config: &models.HandlerConfig{}, log: newTestLogger(t)}
+	spy := newBulkEventSpyProvider()
+
+	payload, err := json.Marshal(eventStatusPayload{Status: "read"})
+	if err != nil {
+		t.Fatalf("failed to marshal test payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/events/bulk", bytes.NewReader(payload))
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.BulkUpdateEventStatus(rec, req, nil, nil, spy)
+
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("valid JSON should not return 400, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	if !spy.bulkUpdateCalled.Load() {
+		t.Fatal("provider BulkUpdateEventStatus should be called for valid JSON")
+	}
+}
+
+func TestBulkDeleteEvent_MalformedJSON(t *testing.T) {
+	h := &Handler{config: &models.HandlerConfig{}, log: newTestLogger(t)}
+	spy := newBulkEventSpyProvider()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/events/bulk", bytes.NewBufferString("{bad"))
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.BulkDeleteEvent(rec, req, nil, nil, spy)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	if spy.bulkDeleteCalled.Load() {
+		t.Fatal("provider BulkDeleteEvent should not be called on malformed JSON")
+	}
+}
+
+func TestBulkDeleteEvent_ValidJSON(t *testing.T) {
+	h := &Handler{config: &models.HandlerConfig{}, log: newTestLogger(t)}
+	spy := newBulkEventSpyProvider()
+
+	payload, err := json.Marshal(statusIDs{})
+	if err != nil {
+		t.Fatalf("failed to marshal test payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/events/bulk", bytes.NewReader(payload))
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.BulkDeleteEvent(rec, req, nil, nil, spy)
+
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("valid JSON should not return 400, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	if !spy.bulkDeleteCalled.Load() {
+		t.Fatal("provider BulkDeleteEvent should be called for valid JSON")
 	}
 }


### PR DESCRIPTION
This PR fixes silent data corruption in the bulk event handlers where malformed JSON requests were accepted and forwarded to the provider backend with zero-valued payloads.

## Problem

`BulkUpdateEventStatus` and `BulkDeleteEvent` in `server/handlers/events_streamer.go` discard the `json.Unmarshal` error with `_ =`. If the request body contains invalid JSON, the struct remains zero-valued and the provider is called with empty/nil fields — no error is returned to the caller.

## Fix

Check the `json.Unmarshal` error and return HTTP 400 with a descriptive message, matching the existing error handling pattern already used in the same file for body read failures.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.