### PR TITLE
[Server] Surface real connection failures from state machine SendEvent

### DIFF
--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1444
+  "next_error_code": 1445
 }

--- a/server/machines/error.go
+++ b/server/machines/error.go
@@ -12,6 +12,7 @@ const (
 	ErrInititalizeK8sMachineCode  = "meshery-server-1216"
 	ErrAssetMachineCtxCode        = "meshery-server-1217"
 	ErrInvalidTypeCode            = "meshery-server-1218"
+	ErrConnectionNotFoundCode     = "meshery-server-1444"
 )
 
 func ErrInvalidTransition(from, to StateType) error {
@@ -32,4 +33,8 @@ func ErrAssertMachineCtx(err error) error {
 
 func ErrInvalidType(err error) error {
 	return errors.New(ErrInvalidTypeCode, errors.Alert, []string{"Provided connection id is invalid"}, []string{err.Error()}, []string{"Provided ID is not a valid uuid."}, []string{"Hard delete and reinitialise the connection process."})
+}
+
+func ErrConnectionNotFound(id string) error {
+	return errors.New(ErrConnectionNotFoundCode, errors.Alert, []string{fmt.Sprintf("No connection found with id \"%s\" while updating its status.", id)}, []string{"The provider returned no connection for the given id without reporting an error."}, []string{"The connection may have been deleted, or the persisted record is missing."}, []string{"Reinitialise the connection, or verify the connection id exists in the provider."})
 }

--- a/server/machines/kubernetes/register.go
+++ b/server/machines/kubernetes/register.go
@@ -37,7 +37,11 @@ func (ra *RegisterAction) Execute(ctx context.Context, machineCtx interface{}, d
 	err = machinectx.K8sContext.PingTest()
 
 	if err != nil {
-		eventBuilder.WithDescription(fmt.Sprintf("Unable to ping kubernetes context %s at %s", machinectx.K8sContext.Name, machinectx.K8sContext.Server)).WithMetadata(map[string]interface{}{"error": err})
+		// Mark the ping/reachability failure as an Error so it is findable under
+		// the notification center's Error filter, matching the sibling
+		// ConnectAction and DiscoverAction failure events. Without this the event
+		// lands with an empty severity and is effectively invisible to users.
+		eventBuilder.WithSeverity(events.Error).WithDescription(fmt.Sprintf("Unable to ping kubernetes context %s at %s", machinectx.K8sContext.Name, machinectx.K8sContext.Server)).WithMetadata(map[string]interface{}{"error": err})
 		machinectx.log.Error(err)
 		return machines.NotFound, eventBuilder.Build(), err
 	}

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -137,7 +137,25 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	sm.mx.Lock()
 	defer sm.mx.Unlock()
 	var event *events.Event
-	var err error
+
+	// actionErr and actionErrEvent capture the FIRST genuine action failure: the
+	// non-nil error returned by a state's entry/execute action, together with the
+	// Error event that action built. A failing action may return a non-NoOp
+	// "recovery" event (e.g. NotFound) instead of NoOp, so the loop does not
+	// early-return; it transitions onward and the recovery state's
+	// exit/entry/execute actions then reassign "event" (frequently to nil). That
+	// previously masked the original failure and made SendEvent return an
+	// Informational "success" with a nil error, so every caller that gates on
+	// "if err != nil" persisted/published nothing for real connection failures.
+	// Capturing here — and returning it after the status update — makes the
+	// failure reach callers.
+	//
+	// NOTE: the loop-scoped "err" below is declared with ":=" inside the
+	// for-block and shadows any function-scope err, so it MUST NOT be relied upon
+	// for the terminal return. The captured values are the source of truth.
+	var actionErr error
+	var actionErrEvent *events.Event
+
 	for eventType != NoOp {
 		nextState, err := sm.getNextState(eventType)
 		if err != nil {
@@ -176,6 +194,10 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 			if err != nil {
 				sm.Log.Error(err)
 				sm.Log.Debug(event)
+				if actionErr == nil {
+					actionErr = err
+					actionErrEvent = event
+				}
 				if eventType == NoOp {
 					return event, err
 				}
@@ -186,6 +208,10 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 				if err != nil {
 					sm.Log.Error(err)
 					sm.Log.Debug(event)
+					if actionErr == nil {
+						actionErr = err
+						actionErrEvent = event
+					}
 					if eventType == NoOp {
 						return event, err
 					}
@@ -198,6 +224,16 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		sm.CurrentState = nextState
 	}
 
+	// statusChanged tracks whether this send actually moves the persisted
+	// connection status. K8sFSMMiddleware re-runs discovery on EVERY request for
+	// each connected context, so once failures propagate to callers a cluster
+	// that stays down would emit a persisted + broadcast Error event on every
+	// request (notification spam). Emitting the failure only on an actual status
+	// transition de-duplicates that noise while still surfacing the first
+	// failure. Defaults to true so paths without a provider (or the Exit event)
+	// still report failures.
+	statusChanged := true
+
 	if sm.Provider != nil && eventType != Exit {
 		token, _ := ctx.Value(models.TokenCtxKey).(string)
 		connection, _, err := sm.Provider.GetConnectionByID(token, sm.ID)
@@ -206,6 +242,11 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 
 			return events.NewEvent().WithDescription(fmt.Sprintf("Failed to retrieve the connection with id %s to update status.", sm.ID)).WithMetadata(map[string]interface{}{"error": err}).FromSystem(*sysID).FromOwner(userUUID).ActedUpon(sm.ID).WithCategory("connection").WithAction("update").Build(), err
 		}
+
+		// Compare the currently persisted status against the state the machine
+		// settled in. Only an actual change should produce a user-facing failure
+		// event (see statusChanged above).
+		statusChanged = connection.Status != connections.ConnectionStatus(sm.CurrentState)
 
 		connectionPayload := &connections.ConnectionPayload{
 			ID:       sm.ID,
@@ -227,6 +268,29 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		sm.Log.Debugf("%s: updated \"status\" for connection with id: %s to \"%s\"", sm.Name, connection.ID, sm.CurrentState)
 	}
 
+	// A genuine action failure occurred earlier in the transition loop. Return
+	// its ORIGINAL Error event together with the non-nil error so callers persist
+	// + broadcast it — this is the core fix for failures previously masked by a
+	// later recovery transition. The connection-status update above has already
+	// run, so the connection has been moved to its recovery state (e.g. NOTFOUND)
+	// regardless of what we return here. Suppress the emit when the persisted
+	// status did not change, so a repeatedly re-discovered down connection does
+	// not spam a notification on every request.
+	if actionErr != nil {
+		if !statusChanged {
+			return nil, nil
+		}
+		// Guarantee a non-nil event on the error return: callers such as the K8s
+		// middleware and addK8SConfig dereference the event (*event) whenever the
+		// error is non-nil. Real actions always build an Error event on failure,
+		// but fall back to a generic Error event so a misbehaving action can never
+		// turn a surfaced failure into a nil-pointer panic.
+		if actionErrEvent == nil {
+			actionErrEvent = defaultEvent.WithMetadata(map[string]interface{}{"error": actionErr}).Build()
+		}
+		return actionErrEvent, actionErr
+	}
+
 	// The action func only emits event when an error occurs.
 	// If "event" is nil, it indicates actions were execeuted successfully, hence send an confirmation that request was processed successsfully.
 	if event == nil {
@@ -236,5 +300,5 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		}).WithSeverity(events.Informational).Build()
 	}
 
-	return event, err
+	return event, nil
 }

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -144,30 +144,43 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// and (b) restrict failure de-duplication to the background Discovery path.
 	originalEventType := eventType
 
-	// actionErr and actionErrEvent capture the FIRST genuine action failure: the
-	// non-nil error returned by a state's entry/execute action, together with the
-	// Error event that action built. A failing action may return a non-NoOp
-	// "recovery" event (e.g. NotFound) instead of NoOp, so the loop does not
-	// early-return; it transitions onward and the recovery state's
-	// exit/entry/execute actions then reassign "event" (frequently to nil). That
-	// previously masked the original failure and made SendEvent return an
-	// Informational "success" with a nil error, so every caller that gates on
-	// "if err != nil" persisted/published nothing for real connection failures.
-	// Capturing here — and returning it after the status update — makes the
-	// failure reach callers.
+	// failureErr and failureEvent capture the FIRST genuine failure inside the
+	// transition loop, together with the Error event built for it. Two sources:
+	//
+	//  1. A state's entry/execute action returning a non-nil error. A failing
+	//     action may return a non-NoOp "recovery" event (e.g. NotFound) instead
+	//     of NoOp, so the loop does not early-return; it transitions onward and
+	//     the recovery state's exit/entry/execute actions then reassign "event"
+	//     (frequently to nil). That previously masked the original failure and
+	//     made SendEvent return an Informational "success" with a nil error, so
+	//     every caller that gates on "if err != nil" persisted/published nothing
+	//     for real connection failures.
+	//  2. A fatal transition error — getNextState finding no edge for the event,
+	//     or the target state missing/having no action. These "break" out of the
+	//     loop; without capture they would likewise fall through to the success
+	//     path and return a nil error, silently dropping the Error event.
+	//
+	// First failure wins: a transition error that follows a captured action
+	// failure (e.g. a recovery event with no edge in the graph) must not replace
+	// the more informative original failure. Capturing here — and returning after
+	// the status update — makes the failure reach callers.
 	//
 	// NOTE: the loop-scoped "err" below is declared with ":=" inside the
 	// for-block and shadows any function-scope err, so it MUST NOT be relied upon
 	// for the terminal return. The captured values are the source of truth.
-	var actionErr error
-	var actionErrEvent *events.Event
+	var failureErr error
+	var failureEvent *events.Event
 
 	for eventType != NoOp {
 		nextState, err := sm.getNextState(eventType)
 		if err != nil {
 			sm.Log.Error(err)
 			event = defaultEvent.WithMetadata(map[string]interface{}{"error": err}).Build()
-			sm.Log.Debug(defaultEvent.WithMetadata(map[string]interface{}{"error": err}).Build())
+			sm.Log.Debug(event)
+			if failureErr == nil {
+				failureErr = err
+				failureEvent = event
+			}
 			break
 		}
 
@@ -176,9 +189,14 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		// next state to transition
 		state, ok := sm.States[nextState]
 		if !ok || state.Action == nil {
+			err = ErrInvalidTransition(sm.CurrentState, nextState)
 			sm.Log.Error(err)
-			event = defaultEvent.WithMetadata(map[string]interface{}{"error": ErrInvalidTransition(sm.CurrentState, nextState)}).Build()
+			event = defaultEvent.WithMetadata(map[string]interface{}{"error": err}).Build()
 			sm.Log.Debug(event)
+			if failureErr == nil {
+				failureErr = err
+				failureEvent = event
+			}
 			break
 		}
 
@@ -200,9 +218,9 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 			if err != nil {
 				sm.Log.Error(err)
 				sm.Log.Debug(event)
-				if actionErr == nil {
-					actionErr = err
-					actionErrEvent = event
+				if failureErr == nil {
+					failureErr = err
+					failureEvent = event
 				}
 				if eventType == NoOp {
 					return event, err
@@ -214,9 +232,9 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 				if err != nil {
 					sm.Log.Error(err)
 					sm.Log.Debug(event)
-					if actionErr == nil {
-						actionErr = err
-						actionErrEvent = event
+					if failureErr == nil {
+						failureErr = err
+						failureEvent = event
 					}
 					if eventType == NoOp {
 						return event, err
@@ -240,6 +258,9 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// still report failures.
 	statusChanged := true
 
+	// originalEventType (not eventType) is compared against Exit here: by the
+	// time the loop finishes, eventType has been overwritten to NoOp, so the
+	// caller's intent is only visible in the captured original.
 	if sm.Provider != nil && originalEventType != Exit {
 		token, _ := ctx.Value(models.TokenCtxKey).(string)
 		connection, _, err := sm.Provider.GetConnectionByID(token, sm.ID)
@@ -282,15 +303,16 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		sm.Log.Debugf("%s: updated \"status\" for connection with id: %s to \"%s\"", sm.Name, connection.ID, sm.CurrentState)
 	}
 
-	// A genuine action failure occurred earlier in the transition loop. Return
-	// its ORIGINAL Error event together with the non-nil error so callers persist
-	// + broadcast it — this is the core fix for failures previously masked by a
-	// later recovery transition. The connection-status update above has already
-	// run, so the connection has been moved to its recovery state (e.g. NOTFOUND)
-	// regardless of what we return here. Suppress the emit when the persisted
-	// status did not change, so a repeatedly re-discovered down connection does
-	// not spam a notification on every request.
-	if actionErr != nil {
+	// A genuine failure (action error or fatal transition error) occurred
+	// earlier in the transition loop. Return its ORIGINAL Error event together
+	// with the non-nil error so callers persist + broadcast it — this is the
+	// core fix for failures previously masked by a later recovery transition.
+	// The connection-status update above has already run, so the connection has
+	// been moved to its recovery state (e.g. NOTFOUND) regardless of what we
+	// return here. Suppress the emit when the persisted status did not change,
+	// so a repeatedly re-discovered down connection does not spam a notification
+	// on every request.
+	if failureErr != nil {
 		// De-duplicate ONLY the background discovery path. K8sFSMMiddleware
 		// re-runs SendEvent(Discovery) on every request, so a cluster that stays
 		// down must not re-emit an Error event once its status is already the
@@ -303,13 +325,16 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		}
 		// Guarantee a non-nil event on the error return: callers such as the K8s
 		// middleware and addK8SConfig dereference the event (*event) whenever the
-		// error is non-nil. Real actions always build an Error event on failure,
-		// but fall back to a generic Error event so a misbehaving action can never
-		// turn a surfaced failure into a nil-pointer panic.
-		if actionErrEvent == nil {
-			actionErrEvent = defaultEvent.WithMetadata(map[string]interface{}{"error": actionErr}).Build()
+		// error is non-nil. Real actions always build an Error event on failure
+		// (and transition errors capture their event above), but fall back to a
+		// dedicated Error event so a misbehaving action can never turn a surfaced
+		// failure into a nil-pointer panic. Built here rather than reusing
+		// defaultEvent, whose "Invalid status change requested" description would
+		// mislead for an action failure.
+		if failureEvent == nil {
+			failureEvent = events.NewEvent().WithDescription(fmt.Sprintf("%s connection action failed.", sm.Name)).ActedUpon(sm.ID).FromOwner(userUUID).FromSystem(*sysID).WithCategory("connection").WithAction("update").WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": failureErr}).Build()
 		}
-		return actionErrEvent, actionErr
+		return failureEvent, failureErr
 	}
 
 	// The action func only emits event when an error occurs.

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -133,10 +133,18 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
 	userUUID := user.ID
 	ctx = context.WithValue(ctx, models.ProviderCtxKey, sm.Provider)
-	defaultEvent := events.NewEvent().WithDescription(fmt.Sprintf("Invalid status change requested to %s for connection type %s.", eventType, sm.Name)).ActedUpon(sm.ID).FromOwner(userUUID).FromSystem(*sysID).WithSeverity(events.Error)
 	sm.mx.Lock()
 	defer sm.mx.Unlock()
 	var event *events.Event
+
+	// invalidTransitionEvent builds the Error event for a fatal transition
+	// error. It must be constructed at the failure site — not once up front —
+	// because eventType is reassigned inside the loop (an action may emit a
+	// follow-up event), and the description has to name the event that actually
+	// failed, not the one the caller originally sent.
+	invalidTransitionEvent := func(failedEventType EventType, err error) *events.Event {
+		return events.NewEvent().WithDescription(fmt.Sprintf("Invalid status change requested to %s for connection type %s.", failedEventType, sm.Name)).ActedUpon(sm.ID).FromOwner(userUUID).FromSystem(*sysID).WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": err}).Build()
+	}
 
 	// eventType is reassigned inside the transition loop (to the recovery event,
 	// then ultimately to NoOp), so capture the caller's original event up front.
@@ -165,9 +173,9 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// the more informative original failure. Capturing here — and returning after
 	// the status update — makes the failure reach callers.
 	//
-	// NOTE: the loop-scoped "err" below is declared with ":=" inside the
-	// for-block and shadows any function-scope err, so it MUST NOT be relied upon
-	// for the terminal return. The captured values are the source of truth.
+	// NOTE: "err" below is declared with ":=" inside the for-block, so it is
+	// scoped to the loop and unavailable after it; the terminal return MUST rely
+	// on the captured values, never on loop state.
 	var failureErr error
 	var failureEvent *events.Event
 
@@ -175,7 +183,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		nextState, err := sm.getNextState(eventType)
 		if err != nil {
 			sm.Log.Error(err)
-			event = defaultEvent.WithMetadata(map[string]interface{}{"error": err}).Build()
+			event = invalidTransitionEvent(eventType, err)
 			sm.Log.Debug(event)
 			if failureErr == nil {
 				failureErr = err
@@ -191,7 +199,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		if !ok || state.Action == nil {
 			err = ErrInvalidTransition(sm.CurrentState, nextState)
 			sm.Log.Error(err)
-			event = defaultEvent.WithMetadata(map[string]interface{}{"error": err}).Build()
+			event = invalidTransitionEvent(eventType, err)
 			sm.Log.Debug(event)
 			if failureErr == nil {
 				failureErr = err
@@ -327,10 +335,8 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 		// middleware and addK8SConfig dereference the event (*event) whenever the
 		// error is non-nil. Real actions always build an Error event on failure
 		// (and transition errors capture their event above), but fall back to a
-		// dedicated Error event so a misbehaving action can never turn a surfaced
-		// failure into a nil-pointer panic. Built here rather than reusing
-		// defaultEvent, whose "Invalid status change requested" description would
-		// mislead for an action failure.
+		// dedicated "connection action failed" Error event so a misbehaving
+		// action can never turn a surfaced failure into a nil-pointer panic.
 		if failureEvent == nil {
 			failureEvent = events.NewEvent().WithDescription(fmt.Sprintf("%s connection action failed.", sm.Name)).ActedUpon(sm.ID).FromOwner(userUUID).FromSystem(*sysID).WithCategory("connection").WithAction("update").WithSeverity(events.Error).WithMetadata(map[string]interface{}{"error": failureErr}).Build()
 		}

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -138,6 +138,12 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	defer sm.mx.Unlock()
 	var event *events.Event
 
+	// eventType is reassigned inside the transition loop (to the recovery event,
+	// then ultimately to NoOp), so capture the caller's original event up front.
+	// It is needed after the loop to (a) skip the status update on an Exit event
+	// and (b) restrict failure de-duplication to the background Discovery path.
+	originalEventType := eventType
+
 	// actionErr and actionErrEvent capture the FIRST genuine action failure: the
 	// non-nil error returned by a state's entry/execute action, together with the
 	// Error event that action built. A failing action may return a non-NoOp
@@ -234,12 +240,20 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// still report failures.
 	statusChanged := true
 
-	if sm.Provider != nil && eventType != Exit {
+	if sm.Provider != nil && originalEventType != Exit {
 		token, _ := ctx.Value(models.TokenCtxKey).(string)
 		connection, _, err := sm.Provider.GetConnectionByID(token, sm.ID)
 
 		if err != nil {
 
+			return events.NewEvent().WithDescription(fmt.Sprintf("Failed to retrieve the connection with id %s to update status.", sm.ID)).WithMetadata(map[string]interface{}{"error": err}).FromSystem(*sysID).FromOwner(userUUID).ActedUpon(sm.ID).WithCategory("connection").WithAction("update").Build(), err
+		}
+
+		// Defensive guard: a provider that reports no error but hands back a nil
+		// connection would panic on the field access below. Treat it as a
+		// retrieval failure so the caller sees an error instead of a crash.
+		if connection == nil {
+			err = ErrConnectionNotFound(sm.ID.String())
 			return events.NewEvent().WithDescription(fmt.Sprintf("Failed to retrieve the connection with id %s to update status.", sm.ID)).WithMetadata(map[string]interface{}{"error": err}).FromSystem(*sysID).FromOwner(userUUID).ActedUpon(sm.ID).WithCategory("connection").WithAction("update").Build(), err
 		}
 
@@ -277,7 +291,14 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// status did not change, so a repeatedly re-discovered down connection does
 	// not spam a notification on every request.
 	if actionErr != nil {
-		if !statusChanged {
+		// De-duplicate ONLY the background discovery path. K8sFSMMiddleware
+		// re-runs SendEvent(Discovery) on every request, so a cluster that stays
+		// down must not re-emit an Error event once its status is already the
+		// recovery state. User-initiated events (Register, Connect, ...) always
+		// propagate their failure — a manual action that fails must be reported
+		// even when the persisted status does not change (e.g. it was already
+		// NOTFOUND/DISCONNECTED), otherwise the request silently "succeeds".
+		if !statusChanged && originalEventType == Discovery {
 			return nil, nil
 		}
 		// Guarantee a non-nil event on the error return: callers such as the K8s

--- a/server/machines/models_test.go
+++ b/server/machines/models_test.go
@@ -310,6 +310,12 @@ func TestSendEvent_TransitionErrorOnDiscoveryDeDuplicated(t *testing.T) {
 	if err == nil || event == nil {
 		t.Fatalf("expected the first transition error to surface (event + error), got event=%v err=%v", event, err)
 	}
+	// The description must name the event that actually failed (the Connect the
+	// action emitted mid-loop), not the Discovery the caller originally sent.
+	wantDesc := "Invalid status change requested to connect for connection type kubernetes."
+	if event.Description != wantDesc {
+		t.Fatalf("expected invalid-transition description %q, got %q", wantDesc, event.Description)
+	}
 	if provider.lastUpdateTo != connections.DISCOVERED {
 		t.Fatalf("expected connection status persisted as %q, got %q", connections.DISCOVERED, provider.lastUpdateTo)
 	}

--- a/server/machines/models_test.go
+++ b/server/machines/models_test.go
@@ -1,0 +1,265 @@
+package machines
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/meshkit/models/events"
+	"github.com/meshery/schemas/models/core"
+)
+
+// stubAction is a configurable machines.Action used to exercise SendEvent's
+// transition loop without any real connection side effects. ExecuteOnEntry and
+// ExecuteOnExit always succeed with a nil event (mirroring the real k8s actions,
+// which only emit events on failure); Execute returns whatever the test wires
+// up so we can simulate both success and a failing action that hands back a
+// non-NoOp recovery event.
+type stubAction struct {
+	execNext  EventType
+	execEvent *events.Event
+	execErr   error
+}
+
+func (a *stubAction) ExecuteOnEntry(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+
+func (a *stubAction) Execute(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return a.execNext, a.execEvent, a.execErr
+}
+
+func (a *stubAction) ExecuteOnExit(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+
+// fakeProvider is a partial models.Provider implementation: it embeds the
+// interface (so the type satisfies models.Provider) but only implements the two
+// methods SendEvent calls on the status-update path. Any other method would
+// panic on the nil embedded interface, which keeps the test honest about what
+// SendEvent actually touches.
+type fakeProvider struct {
+	models.Provider
+
+	// status is the currently "persisted" connection status. UpdateConnectionById
+	// mutates it so a second SendEvent observes the state left by the first,
+	// exercising the de-duplication gate.
+	status connections.ConnectionStatus
+
+	getErr    error
+	updateErr error
+
+	updateCalls  int
+	lastUpdateTo connections.ConnectionStatus
+}
+
+func (f *fakeProvider) GetConnectionByID(_ string, connectionID core.Uuid) (*connections.Connection, int, error) {
+	if f.getErr != nil {
+		return nil, http.StatusInternalServerError, f.getErr
+	}
+	return &connections.Connection{
+		ID:     connectionID,
+		Kind:   "kubernetes",
+		Status: f.status,
+	}, http.StatusOK, nil
+}
+
+func (f *fakeProvider) UpdateConnectionById(_ string, conn *connections.ConnectionPayload, _ string) (*connections.Connection, error) {
+	f.updateCalls++
+	f.lastUpdateTo = conn.Status
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	f.status = conn.Status
+	return &connections.Connection{
+		ID:     conn.ID,
+		Kind:   conn.Kind,
+		Status: conn.Status,
+	}, nil
+}
+
+// newTestMachine builds a minimal three-state machine:
+//
+//	initialized --Discovery--> discovered --NotFound--> not found
+//
+// The discovered state's action is supplied by the test so it can succeed or
+// fail. The "not found" recovery state uses a no-op action that returns a nil
+// event, which is exactly the overwrite that used to mask the original failure.
+func newTestMachine(t *testing.T, provider models.Provider, discoveredAction Action) *StateMachine {
+	t.Helper()
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to build test logger: %v", err)
+	}
+	connectionID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate connection UUID: %v", err)
+	}
+	return &StateMachine{
+		ID:            core.Uuid(connectionID),
+		Name:          "kubernetes",
+		InitialState:  InitialState,
+		CurrentState:  InitialState,
+		PreviousState: DefaultState,
+		Log:           log,
+		Provider:      provider,
+		States: States{
+			InitialState: State{
+				Events: Events{Discovery: DISCOVERED},
+				Action: nil,
+			},
+			DISCOVERED: State{
+				Events: Events{NotFound: NOTFOUND, Register: REGISTERED},
+				Action: discoveredAction,
+			},
+			NOTFOUND: State{
+				Events: Events{Discovery: DISCOVERED, Delete: DELETED},
+				Action: &stubAction{execNext: NoOp},
+			},
+		},
+	}
+}
+
+func newTestContext(t *testing.T) context.Context {
+	t.Helper()
+	userID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate user UUID: %v", err)
+	}
+	sysID := core.Uuid(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000000"))
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, models.UserCtxKey, &models.User{ID: core.Uuid(userID)})
+	ctx = context.WithValue(ctx, models.SystemIDKey, &sysID)
+	ctx = context.WithValue(ctx, models.TokenCtxKey, "test-token")
+	return ctx
+}
+
+// TestSendEvent_SuccessReturnsInformationalEvent covers case (a): a clean
+// transition returns a nil error and an Informational confirmation event, and
+// the connection status is persisted to the state the machine settled in.
+func TestSendEvent_SuccessReturnsInformationalEvent(t *testing.T) {
+	provider := &fakeProvider{status: connections.CONNECTED}
+	// A discovered action that returns NoOp with no error is a success: the loop
+	// settles in the DISCOVERED state.
+	sm := newTestMachine(t, provider, &stubAction{execNext: NoOp})
+	ctx := newTestContext(t)
+
+	event, err := sm.SendEvent(ctx, Discovery, nil)
+	if err != nil {
+		t.Fatalf("expected nil error on a successful transition, got %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected a confirmation event on success, got nil")
+	}
+	if event.Severity != events.Informational {
+		t.Fatalf("expected Informational severity on success, got %q", event.Severity)
+	}
+	if sm.CurrentState != DISCOVERED {
+		t.Fatalf("expected machine to settle in %q, got %q", DISCOVERED, sm.CurrentState)
+	}
+	if provider.lastUpdateTo != connections.ConnectionStatus(DISCOVERED) {
+		t.Fatalf("expected connection status persisted as %q, got %q", DISCOVERED, provider.lastUpdateTo)
+	}
+}
+
+// TestSendEvent_FailureReturnsOriginalErrorEvent covers cases (b) and (c): an
+// action that fails with a NotFound recovery transition must return the
+// ORIGINAL Error event and the non-nil error (not the Informational fallback
+// nor a nil error), and the connection status must still be updated to the
+// recovery state (NOTFOUND).
+func TestSendEvent_FailureReturnsOriginalErrorEvent(t *testing.T) {
+	provider := &fakeProvider{status: connections.DISCOVERED}
+
+	failErr := errors.New("unable to ping kubernetes context")
+	failEvent := events.NewEvent().
+		WithSeverity(events.Error).
+		WithCategory("connection").
+		WithAction("register").
+		WithDescription("Unable to ping kubernetes context test at https://127.0.0.1:1").
+		Build()
+
+	// The discovered action fails and asks the machine to recover into NOTFOUND,
+	// exactly like DiscoverAction.Execute / RegisterAction.Execute do on a
+	// reachability failure.
+	sm := newTestMachine(t, provider, &stubAction{
+		execNext:  NotFound,
+		execEvent: failEvent,
+		execErr:   failErr,
+	})
+	ctx := newTestContext(t)
+
+	event, err := sm.SendEvent(ctx, Discovery, nil)
+
+	// (b) the non-nil error must propagate.
+	if err == nil {
+		t.Fatal("expected a non-nil error for a failing action, got nil — the failure was silently swallowed")
+	}
+	if !errors.Is(err, failErr) {
+		t.Fatalf("expected the original action error to propagate, got %v", err)
+	}
+
+	// (b) the ORIGINAL Error event must be returned, not the Informational
+	// fallback and not the nil event produced by the NotFound recovery action.
+	if event == nil {
+		t.Fatal("expected the original Error event, got nil")
+	}
+	if event != failEvent {
+		t.Fatalf("expected the original Error event to be returned; got a different event %#v", event)
+	}
+	if event.Severity != events.Error {
+		t.Fatalf("expected Error severity on the failure event, got %q", event.Severity)
+	}
+
+	// (c) the connection status must still be moved to the recovery state.
+	if sm.CurrentState != NOTFOUND {
+		t.Fatalf("expected machine to settle in %q, got %q", NOTFOUND, sm.CurrentState)
+	}
+	if provider.updateCalls == 0 {
+		t.Fatal("expected the connection status to be updated even on failure")
+	}
+	if provider.lastUpdateTo != connections.NOTFOUND {
+		t.Fatalf("expected connection status updated to %q, got %q", connections.NOTFOUND, provider.lastUpdateTo)
+	}
+}
+
+// TestSendEvent_DeDuplicatesRepeatFailure guards the middleware anti-spam gate:
+// K8sFSMMiddleware re-runs discovery on every request, so a cluster that stays
+// down must not emit a fresh Error event each time. The first failure surfaces
+// (status transitions into NOTFOUND); the second, with no status change, is
+// suppressed (nil event, nil error) so callers persist/publish nothing.
+func TestSendEvent_DeDuplicatesRepeatFailure(t *testing.T) {
+	provider := &fakeProvider{status: connections.DISCOVERED}
+
+	failErr := errors.New("unable to ping kubernetes context")
+	failEvent := events.NewEvent().WithSeverity(events.Error).WithDescription("down").Build()
+
+	sm := newTestMachine(t, provider, &stubAction{
+		execNext:  NotFound,
+		execEvent: failEvent,
+		execErr:   failErr,
+	})
+	ctx := newTestContext(t)
+
+	// First re-discovery: status changes DISCOVERED -> NOTFOUND, failure surfaces.
+	sm.ResetState()
+	event, err := sm.SendEvent(ctx, Discovery, nil)
+	if err == nil || event == nil {
+		t.Fatalf("expected the first failure to surface (event + error), got event=%v err=%v", event, err)
+	}
+
+	// Second re-discovery of the still-down cluster: status is already NOTFOUND,
+	// so nothing new should be emitted.
+	sm.ResetState()
+	event, err = sm.SendEvent(ctx, Discovery, nil)
+	if err != nil {
+		t.Fatalf("expected repeat failure with no status change to be suppressed, got error %v", err)
+	}
+	if event != nil {
+		t.Fatalf("expected no event on a suppressed repeat failure, got %#v", event)
+	}
+}

--- a/server/machines/models_test.go
+++ b/server/machines/models_test.go
@@ -264,6 +264,68 @@ func TestSendEvent_DeDuplicatesRepeatFailure(t *testing.T) {
 	}
 }
 
+// TestSendEvent_InvalidTransitionPropagatesError covers the fatal
+// transition-error path: a user-initiated event with no edge from the current
+// state breaks out of the loop with an "Invalid status change requested" Error
+// event, which must reach the caller with a non-nil error instead of falling
+// through to the success path (which would return the event with a nil error
+// and silently drop it).
+func TestSendEvent_InvalidTransitionPropagatesError(t *testing.T) {
+	provider := &fakeProvider{status: connections.CONNECTED}
+	sm := newTestMachine(t, provider, &stubAction{execNext: NoOp})
+	ctx := newTestContext(t)
+
+	// InitialState only has a Discovery edge in the test machine, so a
+	// user-initiated Register is an invalid transition on the first iteration.
+	event, err := sm.SendEvent(ctx, Register, nil)
+	if err == nil {
+		t.Fatal("expected a non-nil error for an invalid transition, got nil — the transition error was silently swallowed")
+	}
+	if event == nil {
+		t.Fatal("expected the invalid-transition Error event, got nil")
+	}
+	if event.Severity != events.Error {
+		t.Fatalf("expected Error severity on the invalid-transition event, got %q", event.Severity)
+	}
+}
+
+// TestSendEvent_TransitionErrorOnDiscoveryDeDuplicated guards the anti-spam
+// gate for transition errors on the background Discovery path: a mid-loop
+// transition error (a successful action emitting an event with no edge from the
+// settled state) surfaces the first time the persisted status changes, and is
+// suppressed on a repeat run with no status change — same contract as repeated
+// action failures.
+func TestSendEvent_TransitionErrorOnDiscoveryDeDuplicated(t *testing.T) {
+	provider := &fakeProvider{status: connections.CONNECTED}
+
+	// The discovered action succeeds but emits Connect, which has no edge from
+	// DISCOVERED in the test machine, forcing a mid-loop transition error.
+	sm := newTestMachine(t, provider, &stubAction{execNext: Connect})
+	ctx := newTestContext(t)
+
+	// First discovery: status changes CONNECTED -> DISCOVERED, so the transition
+	// error surfaces.
+	sm.ResetState()
+	event, err := sm.SendEvent(ctx, Discovery, nil)
+	if err == nil || event == nil {
+		t.Fatalf("expected the first transition error to surface (event + error), got event=%v err=%v", event, err)
+	}
+	if provider.lastUpdateTo != connections.DISCOVERED {
+		t.Fatalf("expected connection status persisted as %q, got %q", connections.DISCOVERED, provider.lastUpdateTo)
+	}
+
+	// Repeat discovery settles in the same state with no status change: the
+	// same transition error must be suppressed to avoid per-request spam.
+	sm.ResetState()
+	event, err = sm.SendEvent(ctx, Discovery, nil)
+	if err != nil {
+		t.Fatalf("expected repeat transition error with no status change to be suppressed, got error %v", err)
+	}
+	if event != nil {
+		t.Fatalf("expected no event on a suppressed repeat transition error, got %#v", event)
+	}
+}
+
 // TestSendEvent_UserInitiatedFailureAlwaysPropagates guards the boundary of the
 // de-duplication gate: suppression is restricted to the background Discovery
 // path. A user-initiated event (here Connect) whose action fails must surface

--- a/server/machines/models_test.go
+++ b/server/machines/models_test.go
@@ -131,7 +131,7 @@ func newTestContext(t *testing.T) context.Context {
 	if err != nil {
 		t.Fatalf("failed to generate user UUID: %v", err)
 	}
-	sysID := core.Uuid(uuid.FromStringOrNil("00000000-0000-0000-0000-000000000000"))
+	sysID := core.Uuid(uuid.Nil)
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, models.UserCtxKey, &models.User{ID: core.Uuid(userID)})
 	ctx = context.WithValue(ctx, models.SystemIDKey, &sysID)
@@ -261,5 +261,65 @@ func TestSendEvent_DeDuplicatesRepeatFailure(t *testing.T) {
 	}
 	if event != nil {
 		t.Fatalf("expected no event on a suppressed repeat failure, got %#v", event)
+	}
+}
+
+// TestSendEvent_UserInitiatedFailureAlwaysPropagates guards the boundary of the
+// de-duplication gate: suppression is restricted to the background Discovery
+// path. A user-initiated event (here Connect) whose action fails must surface
+// its Error event + error even when the persisted status does not change, so a
+// manual action never silently "succeeds" when it actually failed.
+func TestSendEvent_UserInitiatedFailureAlwaysPropagates(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to build test logger: %v", err)
+	}
+	connectionID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate connection UUID: %v", err)
+	}
+
+	// The connection is ALREADY persisted as NOTFOUND, so the failing Connect
+	// below settles back in NOTFOUND with no status change.
+	provider := &fakeProvider{status: connections.NOTFOUND}
+
+	failErr := errors.New("connection unreachable")
+	failEvent := events.NewEvent().WithSeverity(events.Error).WithDescription("connect failed").Build()
+
+	sm := &StateMachine{
+		ID:            core.Uuid(connectionID),
+		Name:          "kubernetes",
+		InitialState:  InitialState,
+		CurrentState:  InitialState,
+		PreviousState: DefaultState,
+		Log:           log,
+		Provider:      provider,
+		States: States{
+			InitialState: State{
+				Events: Events{Connect: CONNECTED},
+				Action: nil,
+			},
+			CONNECTED: State{
+				Events: Events{NotFound: NOTFOUND, Disconnect: DISCONNECTED},
+				Action: &stubAction{execNext: NotFound, execEvent: failEvent, execErr: failErr},
+			},
+			NOTFOUND: State{
+				Events: Events{Discovery: DISCOVERED, Delete: DELETED},
+				Action: &stubAction{execNext: NoOp},
+			},
+		},
+	}
+	ctx := newTestContext(t)
+
+	// A user-initiated Connect that fails, with the connection already NOTFOUND.
+	event, err := sm.SendEvent(ctx, Connect, nil)
+	if err == nil {
+		t.Fatal("expected a user-initiated failure to propagate even with no status change, got nil error")
+	}
+	if !errors.Is(err, failErr) {
+		t.Fatalf("expected the original action error, got %v", err)
+	}
+	if event != failEvent {
+		t.Fatalf("expected the original Error event, got %#v", event)
 	}
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20725
- Recreates #20751 (closed), carrying its changes and review follow-ups forward unchanged.

`server/machines/models.go` `StateMachine.SendEvent` silently swallowed genuine connection failures. This is the deeper, shared root cause behind #20725 (failed Kubernetes connection notifications not findable), which was previously worked around at the receipt layer in `server/handlers/k8sconfig_handler.go`. **This is core connection state-machine infrastructure shared by ALL connection types - requesting human review.**

**Defects fixed**

1. **Variable shadowing.** The loop's `nextState, err := sm.getNextState(...)` declared a new block-scoped `err` that shadowed the function-scope one. The in-loop action assignments (`_, event, err =` / `eventType, event, err =`) all wrote the shadowed copy, so the terminal `return event, err` returned the function-scope `err`, which was **always nil**.

2. **Failure event overwrite.** When a failing action returned a non-NoOp recovery event (e.g. `machines.NotFound`), the loop did **not** early-return (that only happens on `NoOp`). It kept transitioning into the recovery state, whose `ExecuteOnExit`/`ExecuteOnEntry`/`Execute` reassigned `event` (`NotFoundAction` returns a nil event), losing the original Error event. The terminal fallback then replaced the nil event with an Informational "connection changed to `<state>`" event.

Net effect: a ping/reachability failure returned `(Informational event, nil error)`, so every caller that gates on `if err != nil { persist; publish }` - `k8sconfig_handler.go` `addK8SConfig`, `connections_handlers.go` `ProcessConnectionRegistration`, and both `middlewares.go` `K8sFSMMiddleware` sites - **persisted/published nothing** for real failures.

**Fix**

- `SendEvent` now captures the **first** genuine action failure (its Error event + non-nil error) in function-scoped variables that survive later transitions, and returns them at the end - **after** the connection-status update still runs, so the connection is still moved to its recovery state (e.g. `NOTFOUND`).
- Defends against a nil-deref: guarantees a non-nil event on the error return, since two callers dereference `*event` when `err != nil`.
- `kubernetes/register.go` `RegisterAction` now sets `events.Error` severity on its ping-failure event (its siblings `ConnectAction`/`DiscoverAction` already do), so the event is findable under the notification center's Error filter.

**Notification-spam mitigation (required side-effect handling)**

`K8sFSMMiddleware` runs `SendEvent(ctx, machines.Discovery, nil)` on **every** request for each connected k8s context. Once failures propagate, a down cluster would otherwise emit a persisted + broadcast Error event on every request. To prevent this, `SendEvent` emits the failure only on an **actual persisted-status transition**: it compares the persisted `connection.Status` (from `GetConnectionByID`) against the state the machine settled in, and suppresses a repeat failure that produces no status change. Per review on #20751, this de-duplication is restricted to the background Discovery path - user-initiated events (Register, Connect, ...) always propagate their failure.

**Known limitation (out of scope, noted for reviewers):** a `RegisterAction` ping-failure returns `NotFound`, but the `REGISTERED` state has no `NotFound` edge in the graph, so such a connection settles in `REGISTERED` rather than `NOTFOUND`. The Error event is now surfaced regardless; adding the graph edge would be a separate, broader behavior change.

**Tests**

Adds `server/machines/models_test.go` (the package had no `*_test.go` for `SendEvent`):
- success returns a nil error + Informational event, with status persisted to the settled state;
- a failing action with a `NotFound` recovery transition returns the **original** Error event + non-nil error, and the connection is still moved to `NOTFOUND`;
- a repeat failure with no status change is de-duplicated (nil event, nil error);
- a user-initiated (non-Discovery) failure always propagates even with no status change.

`go test ./machines/...`, `go vet ./machines/...`, and `gofmt` all clean.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
