### PR TITLE
Fix for Missing error check

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -233,12 +233,11 @@ func UpdateAuthDetails(filepath string) error {
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	defer SafeClose(resp.Body)
-
 	if err != nil {
 		err = errors.Wrap(err, "error dispatching there request: ")
 		return err
 	}
+	defer SafeClose(resp.Body)
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
To fix this safely without changing behavior, check `err` immediately after `client.Do(req)` and return on error before touching `resp`. Only after confirming success should the code register `defer SafeClose(resp.Body)`.

Best concrete fix in `mesheryctl/pkg/utils/auth.go`:
- In `UpdateAuthDetails`, move `defer SafeClose(resp.Body)` to after the `if err != nil { ... return err }` block.
- No new imports, methods, or definitions are required.

This preserves existing functionality while removing the nil-dereference risk flagged by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._