### PR TITLE
Fix for Missing error check

### DIFF
--- a/mesheryctl/internal/cli/root/adapter/adapter.go
+++ b/mesheryctl/internal/cli/root/adapter/adapter.go
@@ -272,10 +272,11 @@ func waitForValidateResponse(mctlCfg *config.MesheryCtlConfig, query string) (st
 	method := "GET"
 	client := &http.Client{}
 	req, err := utils.NewRequest(method, path, nil)
-	req.Header.Add("Accept", "text/event-stream")
 	if err != nil {
 		return "", ErrCreatingDeployResponseRequest(err)
 	}
+	req.Header.Add("Accept", "text/event-stream")
+
 
 	res, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
To fix this safely without changing behavior, check `err` immediately after `utils.NewRequest(...)` and only then use `req`. Specifically in `mesheryctl/internal/cli/root/adapter/adapter.go`, inside `waitForValidateResponse`, move `req.Header.Add("Accept", "text/event-stream")` to after the existing `if err != nil { ... }` block.

This preserves existing functionality (still sets the SSE `Accept` header) while guaranteeing `req` is non-nil when dereferenced. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._