### PR TITLE
[UI] Bump @meshery/schemas to v1.3.33

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.3.32",
+        "@meshery/schemas": "^1.3.33",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.2",
@@ -2068,9 +2068,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.32",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.32.tgz",
-      "integrity": "sha512-b1RCsiArTi6ILArF4i7vpzO/JKgtYaJk1Od7sL7bD5gKm1jqG1o8FaszGxSHHs/eysc0xY0KP9D5FvbUITWvpg==",
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.33.tgz",
+      "integrity": "sha512-aD9qAG1aNOZJp2tBNF4g+saMk5d9O73Q+fyN9KiTqtOQRVVbT24vohSzp3+sYaoDKAbI0zydsiJzrKIttC1VEg==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.3.32",
+    "@meshery/schemas": "^1.3.33",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.2",


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #

Bumps `@meshery/schemas` in `ui/package.json` from `^1.3.32` to `^1.3.33` (npm-side companion to the Go-side bump in #19633).

**What changed in v1.3.33** (verified against the schemas repo, commits `dcbdbd4`..`e690ddb`):
- Import Design's `name` field no longer forces a hardcoded RJSF `default: "Untitled Design"` - it's now just a `ui:placeholder`, so users can actually clear/edit the field (meshery/schemas#1059).
- Permissions data refreshed from the canonical Google Sheet (`permissions.csv`/`permissions.go`/`permissions.ts`).

**Consumption**: checked for direct consumers of both changes in this repo -
- The Import Design form (`ui/components/designs/ImportDesignModal.tsx`) renders `@sistent/sistent`'s own `importDesignSchema`/`importDesignUiSchema`, not `@meshery/schemas`'s `DesignImportRjsfSchemaV1Beta3` directly, so this repo doesn't pick up that fix through this bump (that flows through Sistent's own dependency on schemas instead).
- No `server/` or `ui/` code imports the schemas-generated permissions constants directly.

So this is a version-only bump with no required code changes.

**Verified**: `npm install`-generated `package-lock.json` diff is scoped to the `@meshery/schemas` entry only; full `vitest run` suite passes (2603 passed, 18 skipped, 0 failed); eslint/prettier clean.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.