### PR TITLE
fix: use Debugf in GraphQL resolver debug log 

### DIFF
--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -46,7 +46,7 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 		r.Log.Info("Undeploying Adapter")
 	}
 
-	r.Log.Debug(fmt.Printf("changing adapter status for %s on port %s to %s \n", adapterName, targetPort, targetStatus))
+	r.Log.Debugf("changing adapter status for %s on port %s to %s", adapterName, targetPort, targetStatus)
 	var err error
 	adapter := models.Adapter{Name: adapterName, Location: fmt.Sprintf("%s:%s", adapterName, targetPort)}
 	var operation string


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20704.
- Replaced the incorrect use of `fmt.Printf` with `Debugf`
- This ensures the message is handled by the logger instead of being printed to stdout

**Testing**

- [x] Code formatted using `gofmt`.
- [x] Verified that the change is limited to the logger usage in `adapter.go`.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug logging for adapter status changes to ensure messages are formatted consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->