### PR TITLE
feat(ui): improve environment assignment discoverability

### DIFF
--- a/ui/components/connections/ConnectionTable.columns.tsx
+++ b/ui/components/connections/ConnectionTable.columns.tsx
@@ -225,6 +225,9 @@ export const useConnectionColumns = ({
                         options={environmentOptions}
                         value={cleanedEnvs}
                         placeholder={`Select or create an environment`}
+                        noOptionsMessage={() =>
+                          'No matching environments. Type to create a new one.'
+                        }
                         isSelectAll={true}
                         menuPlacement={'bottom'}
                         disabled={

--- a/ui/components/connections/ConnectionTable.columns.tsx
+++ b/ui/components/connections/ConnectionTable.columns.tsx
@@ -224,7 +224,7 @@ export const useConnectionColumns = ({
                         }
                         options={environmentOptions}
                         value={cleanedEnvs}
-                        placeholder={`Assigned Environments`}
+                        placeholder={`Select or create an environment`}
                         isSelectAll={true}
                         menuPlacement={'bottom'}
                         disabled={

--- a/ui/components/multi-select-wrapper.tsx
+++ b/ui/components/multi-select-wrapper.tsx
@@ -199,6 +199,7 @@ const MultiSelectWrapper = (props) => {
         ...props.components,
       }}
       filterOption={customFilterOption}
+      noOptionsMessage={() => 'No matching environments. Type to create a new one.'}
       menuPlacement={props.menuPlacement ?? 'auto'}
       styles={customStyles}
       theme={(selectTheme) => ({

--- a/ui/components/multi-select-wrapper.tsx
+++ b/ui/components/multi-select-wrapper.tsx
@@ -199,7 +199,9 @@ const MultiSelectWrapper = (props) => {
         ...props.components,
       }}
       filterOption={customFilterOption}
-      noOptionsMessage={() => 'No matching environments. Type to create a new one.'}
+      noOptionsMessage={
+        props.noOptionsMessage ?? (() => 'No matching environments. Type to create a new one.')
+      }
       menuPlacement={props.menuPlacement ?? 'auto'}
       styles={customStyles}
       theme={(selectTheme) => ({

--- a/ui/components/multi-select-wrapper.tsx
+++ b/ui/components/multi-select-wrapper.tsx
@@ -199,9 +199,7 @@ const MultiSelectWrapper = (props) => {
         ...props.components,
       }}
       filterOption={customFilterOption}
-      noOptionsMessage={
-        props.noOptionsMessage ?? (() => 'No matching environments. Type to create a new one.')
-      }
+      noOptionsMessage={props.noOptionsMessage}
       menuPlacement={props.menuPlacement ?? 'auto'}
       styles={customStyles}
       theme={(selectTheme) => ({

--- a/ui/components/select-wrappers.test.tsx
+++ b/ui/components/select-wrappers.test.tsx
@@ -24,6 +24,21 @@ describe('select wrappers', () => {
     capturedSelectProps = [];
   });
 
+  it('passes a custom noOptionsMessage to CreatableSelect', () => {
+    const customMessage = () => 'Custom empty state';
+
+    render(
+      <MultiSelectWrapper
+        onChange={vi.fn()}
+        options={[]}
+        value={[]}
+        noOptionsMessage={customMessage}
+      />,
+    );
+
+    expect(capturedSelectProps.at(-1).noOptionsMessage).toBe(customMessage);
+  });
+
   it('renders ReactSelectWrapper option content without a menu context error', () => {
     render(
       <ReactSelectWrapper


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20761
- This PR improves the discoverability of assigning and creating environments from the Connections table.

### Changes made:
- Updated the placeholder from `Assigned Environments` to `Select or create an environment` to clearly communicate the supported interaction.
- Replaced the default empty-state message `No options` with `No matching environments. Type to create a new one.` to guide users when no matching environment exists.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

### Screenshots

#### Before
<img width="1157" height="689" alt="Screenshot 2026-07-18 at 2 44 10 PM" src="https://github.com/user-attachments/assets/0713235c-dec0-4257-9aa7-54287d1aa0bb" />
<img width="1079" height="686" alt="Screenshot 2026-07-18 at 2 44 32 PM" src="https://github.com/user-attachments/assets/3542db12-7e12-4367-807d-454485b2e3b0" />

### After
<img width="1163" height="686" alt="Screenshot 2026-07-18 at 2 45 32 PM" src="https://github.com/user-attachments/assets/99db9c56-dbc5-4715-aaae-cf462911a438" />
<img width="1509" height="903" alt="Screenshot 2026-07-18 at 2 47 45 PM" src="https://github.com/user-attachments/assets/b996397c-f896-4697-bab7-8d58ea2eab72" />

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
