### PR TITLE
fix(docs): update broken tutorial links in archived v0.9 docs

### DIFF
--- a/docs/static/v0.9/categories/tutorials/index.html
+++ b/docs/static/v0.9/categories/tutorials/index.html
@@ -850,13 +850,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       
         
         <article class="card article-teaser article-type-guides">
-          <h3><a href="/v0.9/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/">Deploy AWS EC2 Instances with Meshery</a></h3>
+          <h3><a href="/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/">Deploy AWS EC2 Instances with Meshery</a></h3>
           <nav class="td-breadcrumbs">
   <ol class="breadcrumb">
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/aws/">AWS</a></li>
   <li class="breadcrumb-item">
@@ -876,13 +876,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       
         
         <article class="card article-teaser article-type-guides">
-          <h3><a href="/v0.9/guides/tutorials/azure/deploy-azure-resources-with-meshery/">Deploy Azure resources with Meshery</a></h3>
+          <h3><a href="/guides/tutorials/azure/deploy-azure-resources-with-meshery/">Deploy Azure resources with Meshery</a></h3>
           <nav class="td-breadcrumbs">
   <ol class="breadcrumb">
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/azure/">Azure</a></li>
   <li class="breadcrumb-item">
@@ -902,13 +902,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       
         
         <article class="card article-teaser article-type-guides">
-          <h3><a href="/v0.9/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/">Deploy Azure Storage Account with Meshery</a></h3>
+          <h3><a href="/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/">Deploy Azure Storage Account with Meshery</a></h3>
           <nav class="td-breadcrumbs">
   <ol class="breadcrumb">
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/azure/">Azure</a></li>
   <li class="breadcrumb-item">
@@ -934,7 +934,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -960,7 +960,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -986,7 +986,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -1006,13 +1006,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       
         
         <article class="card article-teaser article-type-guides">
-          <h3><a href="/v0.9/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/">Embedding a Meshery Design in a WordPress Post</a></h3>
+          <h3><a href="/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/">Embedding a Meshery Design in a WordPress Post</a></h3>
           <nav class="td-breadcrumbs">
   <ol class="breadcrumb">
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/wordpress/">Wordpress</a></li>
   <li class="breadcrumb-item">
@@ -1038,7 +1038,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -1064,7 +1064,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -1090,7 +1090,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -1116,7 +1116,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -1142,7 +1142,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
@@ -1162,13 +1162,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       
         
         <article class="card article-teaser article-type-guides">
-          <h3><a href="/v0.9/guides/tutorials/artifacthub/publish-to-artifacthub/">Publishing Meshery Designs to ArtifactHub</a></h3>
+          <h3><a href="/guides/tutorials/artifacthub/publish-to-artifacthub/">Publishing Meshery Designs to ArtifactHub</a></h3>
           <nav class="td-breadcrumbs">
   <ol class="breadcrumb">
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/artifacthub/">Artifacthub</a></li>
   <li class="breadcrumb-item">
@@ -1188,7 +1188,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       
         
         <article class="card article-teaser article-type-guides">
-          <h3><a href="/v0.9/guides/tutorials/">Tutorials</a></h3>
+          <h3><a href="/guides/tutorials/">Tutorials</a></h3>
           <nav class="td-breadcrumbs">
   <ol class="breadcrumb">
   <li class="breadcrumb-item">
@@ -1216,7 +1216,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/">Guides</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
+    <a href="/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
     <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">

--- a/docs/static/v0.9/categories/tutorials/index.html
+++ b/docs/static/v0.9/categories/tutorials/index.html
@@ -858,7 +858,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/aws/">AWS</a></li>
+    <a href="/guides/tutorials/aws/">AWS</a></li>
   <li class="breadcrumb-item">
     Deploy AWS EC2 Instances with Meshery</li>
   </ol>
@@ -884,7 +884,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/azure/">Azure</a></li>
+    <a href="/guides/tutorials/azure/">Azure</a></li>
   <li class="breadcrumb-item">
     Deploy Azure resources with Meshery</li>
   </ol>
@@ -910,7 +910,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/azure/">Azure</a></li>
+    <a href="/guides/tutorials/azure/">Azure</a></li>
   <li class="breadcrumb-item">
     Deploy Azure Storage Account with Meshery</li>
   </ol>
@@ -936,7 +936,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Deploying Apache Cassandra with a StatefulSet in Meshery Playground</li>
   </ol>
@@ -962,7 +962,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Deploying PHP Guestbook application with Redis in Meshery</li>
   </ol>
@@ -988,7 +988,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Deploying WordPress and MySQL with Persistent Volumes with Meshery</li>
   </ol>
@@ -1014,7 +1014,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/wordpress/">Wordpress</a></li>
+    <a href="/guides/tutorials/wordpress/">Wordpress</a></li>
   <li class="breadcrumb-item">
     Embedding a Meshery Design in a WordPress Post</li>
   </ol>
@@ -1040,7 +1040,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Exploring Kubernetes CronJobs</li>
   </ol>
@@ -1066,7 +1066,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Exploring Kubernetes Deployments with Meshery</li>
   </ol>
@@ -1092,7 +1092,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Exploring Kubernetes Pods with Meshery</li>
   </ol>
@@ -1118,7 +1118,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Exploring Kubernetes Services with Meshery</li>
   </ol>
@@ -1144,7 +1144,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Kubernetes Request Flow – A Visual Guide</li>
   </ol>
@@ -1170,7 +1170,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/artifacthub/">Artifacthub</a></li>
+    <a href="/guides/tutorials/artifacthub/">Artifacthub</a></li>
   <li class="breadcrumb-item">
     Publishing Meshery Designs to ArtifactHub</li>
   </ol>
@@ -1218,7 +1218,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <li class="breadcrumb-item">
     <a href="/v0.9/guides/tutorials/">Tutorials</a></li>
   <li class="breadcrumb-item">
-    <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li>
+    <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li>
   <li class="breadcrumb-item">
     Understanding Kubernetes ConfigMaps and Secrets with Meshery</li>
   </ol>

--- a/docs/static/v0.9/concepts/logical/designs/index.html
+++ b/docs/static/v0.9/concepts/logical/designs/index.html
@@ -1054,7 +1054,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a href="/guides/tutorials/aws/">AWS</a></li><li>
       <a href="/guides/tutorials/azure/">Azure</a></li><li>
       <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li><li>
-      <a href="/v0.9/guides/tutorials/">Tutorials</a><span> - Explore the tutorials to learn how to use Meshery for collaboratively managing infrastructure.</span></li><li>
+      <a href="/guides/tutorials/">Tutorials</a><span> - Explore the tutorials to learn how to use Meshery for collaboratively managing infrastructure.</span></li><li>
       <a href="/guides/tutorials/wordpress/">Wordpress</a></li>
   </ul>
 </details>

--- a/docs/static/v0.9/concepts/logical/designs/index.html
+++ b/docs/static/v0.9/concepts/logical/designs/index.html
@@ -1050,12 +1050,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </summary>
   <ul class="section-title">
     <li>
-      <a href="/v0.9/guides/tutorials/artifacthub/">Artifacthub</a></li><li>
-      <a href="/v0.9/guides/tutorials/aws/">AWS</a></li><li>
-      <a href="/v0.9/guides/tutorials/azure/">Azure</a></li><li>
-      <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li><li>
+      <a href="/guides/tutorials/artifacthub/">Artifacthub</a></li><li>
+      <a href="/guides/tutorials/aws/">AWS</a></li><li>
+      <a href="/guides/tutorials/azure/">Azure</a></li><li>
+      <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li><li>
       <a href="/v0.9/guides/tutorials/">Tutorials</a><span> - Explore the tutorials to learn how to use Meshery for collaboratively managing infrastructure.</span></li><li>
-      <a href="/v0.9/guides/tutorials/wordpress/">Wordpress</a></li>
+      <a href="/guides/tutorials/wordpress/">Wordpress</a></li>
   </ul>
 </details>
 <p>Try the <a href="/v0.9/installation/playground/">Meshery Playground</a> for a hands-on experience with Meshery Designs.</p>

--- a/docs/static/v0.9/guides/index.html
+++ b/docs/static/v0.9/guides/index.html
@@ -893,7 +893,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   
     
       <li style="list-style-type: disc; margin: 2px 0;">
-        <a href="/v0.9/guides/tutorials/">Tutorials</a>
+        <a href="/guides/tutorials/">Tutorials</a>
 
         
           - Explore the tutorials to learn how to use Meshery for collaboratively managing infrastructure.

--- a/docs/static/v0.9/index.html
+++ b/docs/static/v0.9/index.html
@@ -917,7 +917,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <details>
       <summary>
         <p style="display:inline">
-          <a href="/v0.9/guides/tutorials/" class="text-black">🧑‍🔬 Tutorials</a>
+          <a href="/guides/tutorials/" class="text-black">🧑‍🔬 Tutorials</a>
         </p>
       </summary>
       <ul class="section-title">
@@ -926,7 +926,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <a href="/guides/tutorials/aws/">AWS</a></li><li>
           <a href="/guides/tutorials/azure/">Azure</a></li><li>
           <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li><li>
-          <a href="/v0.9/guides/tutorials/">Tutorials</a><span> - Explore the tutorials to learn how to use Meshery for collaboratively managing infrastructure.</span></li><li>
+          <a href="/guides/tutorials/">Tutorials</a><span> - Explore the tutorials to learn how to use Meshery for collaboratively managing infrastructure.</span></li><li>
           <a href="/guides/tutorials/wordpress/">Wordpress</a></li>
       </ul>
     </details>

--- a/docs/static/v0.9/index.html
+++ b/docs/static/v0.9/index.html
@@ -922,12 +922,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </summary>
       <ul class="section-title">
         <li>
-          <a href="/v0.9/guides/tutorials/artifacthub/">Artifacthub</a></li><li>
-          <a href="/v0.9/guides/tutorials/aws/">AWS</a></li><li>
-          <a href="/v0.9/guides/tutorials/azure/">Azure</a></li><li>
-          <a href="/v0.9/guides/tutorials/kubernetes/">Kubernetes</a></li><li>
+          <a href="/guides/tutorials/artifacthub/">Artifacthub</a></li><li>
+          <a href="/guides/tutorials/aws/">AWS</a></li><li>
+          <a href="/guides/tutorials/azure/">Azure</a></li><li>
+          <a href="/guides/tutorials/kubernetes/">Kubernetes</a></li><li>
           <a href="/v0.9/guides/tutorials/">Tutorials</a><span> - Explore the tutorials to learn how to use Meshery for collaboratively managing infrastructure.</span></li><li>
-          <a href="/v0.9/guides/tutorials/wordpress/">Wordpress</a></li>
+          <a href="/guides/tutorials/wordpress/">Wordpress</a></li>
       </ul>
     </details>
     <details>

--- a/docs/static/v0.9/installation/quick-start/index.html
+++ b/docs/static/v0.9/installation/quick-start/index.html
@@ -6678,7 +6678,7 @@ If you have deployed Meshery in-cluster, Meshery Server will automatically conne
       <ul style="list-style-type: circle;">
       
     
-    <li><a href="/v0.9/guides/tutorials/artifacthub/publish-to-artifacthub/">Publishing Meshery Designs to ArtifactHub</a></li>
+    <li><a href="/guides/tutorials/artifacthub/publish-to-artifacthub/">Publishing Meshery Designs to ArtifactHub</a></li>
   
     
       </ul>
@@ -6686,7 +6686,7 @@ If you have deployed Meshery in-cluster, Meshery Server will automatically conne
       <ul style="list-style-type: circle;">
       
     
-    <li><a href="/v0.9/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/">Deploy AWS EC2 Instances with Meshery</a></li>
+    <li><a href="/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/">Deploy AWS EC2 Instances with Meshery</a></li>
   
     
       </ul>
@@ -6694,10 +6694,10 @@ If you have deployed Meshery in-cluster, Meshery Server will automatically conne
       <ul style="list-style-type: circle;">
       
     
-    <li><a href="/v0.9/guides/tutorials/azure/deploy-azure-resources-with-meshery/">Deploy Azure resources with Meshery</a></li>
+    <li><a href="/guides/tutorials/azure/deploy-azure-resources-with-meshery/">Deploy Azure resources with Meshery</a></li>
   
     
-    <li><a href="/v0.9/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/">Deploy Azure Storage Account with Meshery</a></li>
+    <li><a href="/guides/tutorials/azure/deploy-azure-storage-account-with-meshery/">Deploy Azure Storage Account with Meshery</a></li>
   
     
       </ul>
@@ -6737,7 +6737,7 @@ If you have deployed Meshery in-cluster, Meshery Server will automatically conne
       <ul style="list-style-type: circle;">
       
     
-    <li><a href="/v0.9/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/">Embedding a Meshery Design in a WordPress Post</a></li>
+    <li><a href="/guides/tutorials/wordpress/embedding-meshery-design-in-wordpress/">Embedding a Meshery Design in a WordPress Post</a></li>
   
   </ul>
 </div>


### PR DESCRIPTION
## Description

This PR updates broken tutorial category links in the archived v0.9 documentation.

The archived pages referenced tutorial category URLs under `/v0.9/guides/tutorials/{category}/`, but those archived destinations are no longer available. This PR updates those links to point to the corresponding current tutorial category pages under `/guides/tutorials/{category}/`.

### Changes
- Updated Artifacthub tutorial category link
- Updated AWS tutorial category link
- Updated Azure tutorial category link
- Updated Kubernetes tutorial category link
- Updated WordPress tutorial category link

### Verification
- Verified that the archived category destinations are unavailable.
- Verified that the corresponding current tutorial category pages exist.
- Limited the changes to the affected `href` values only.

Fixes #20781