### PR TITLE
fix: advance connection wizard on kind selection 

### DIFF
--- a/ui/components/connections/wizard/genericSteps.tsx
+++ b/ui/components/connections/wizard/genericSteps.tsx
@@ -71,6 +71,7 @@ const SelectStepBody = ({ ctx }: { ctx: WizardContext }) => (
         registrationError: null,
         postConfig: {},
       });
+      ctx.advance();
     }}
     canUseKind={kindPermission}
   />

--- a/ui/components/connections/wizard/types.ts
+++ b/ui/components/connections/wizard/types.ts
@@ -108,7 +108,7 @@ export type WizardContext = {
   patchPostConfig: (partial: GenericRecord) => void;
   services: WizardServices;
   formRefs: WizardFormRefs;
-  /* Advance to the next step immediately, bypassing the primary ("Next")*/
+  /** Advance to the next step immediately, bypassing the primary ("Next") button. */
   advance: () => void;
 };
 

--- a/ui/components/connections/wizard/types.ts
+++ b/ui/components/connections/wizard/types.ts
@@ -108,6 +108,8 @@ export type WizardContext = {
   patchPostConfig: (partial: GenericRecord) => void;
   services: WizardServices;
   formRefs: WizardFormRefs;
+  /* Advance to the next step immediately, bypassing the primary ("Next")*/
+  advance: () => void;
 };
 
 export type WizardStep = {

--- a/ui/components/connections/wizard/useConnectionWizard.tsx
+++ b/ui/components/connections/wizard/useConnectionWizard.tsx
@@ -220,7 +220,9 @@ export const useConnectionWizard = (params: UseConnectionWizardParams) => {
     ],
   );
 
-  const ctx: WizardContext = { mode, data, patch, patchPostConfig, services, formRefs };
+  const advance = useCallback(() => setActiveIndex((index) => index + 1), []);
+
+  const ctx: WizardContext = { mode, data, patch, patchPostConfig, services, formRefs, advance };
 
   const steps = buildSteps(data.kindConfig, mode).filter((step) => !step.hidden?.(ctx));
   const safeIndex = steps.length === 0 ? 0 : Math.min(activeIndex, steps.length - 1);

--- a/ui/components/connections/wizard/useConnectionWizard.tsx
+++ b/ui/components/connections/wizard/useConnectionWizard.tsx
@@ -220,7 +220,12 @@ export const useConnectionWizard = (params: UseConnectionWizardParams) => {
     ],
   );
 
-  const advance = useCallback(() => setActiveIndex((index) => index + 1), []);
+  const advancingRef = useRef(false);
+  const advance = useCallback(() => {
+    if (advancingRef.current) return;
+    advancingRef.current = true;
+    setActiveIndex((index) => index + 1);
+  }, []);
 
   const ctx: WizardContext = { mode, data, patch, patchPostConfig, services, formRefs, advance };
 
@@ -228,6 +233,10 @@ export const useConnectionWizard = (params: UseConnectionWizardParams) => {
   const safeIndex = steps.length === 0 ? 0 : Math.min(activeIndex, steps.length - 1);
   const activeStep = steps[safeIndex] ?? null;
   const isLast = safeIndex >= steps.length - 1;
+
+  useEffect(() => {
+    advancingRef.current = false;
+  }, [safeIndex]);
 
   const canProceed = activeStep?.canProceed ? activeStep.canProceed(ctx) : true;
   const canGoBack = safeIndex > 0;


### PR DESCRIPTION

**Notes for Reviewers**

- This PR fixes #20764

Selecting a connection type now advances the wizard immediately; no separate "Next" click is needed.
onSelectKind only fires for a permitted kind, so it's safe to advance right there without extra validation.

**Screenshots**

https://github.com/user-attachments/assets/35967730-993d-4cc9-9f63-f4736e9826bd



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

