### PR TITLE
[UI] Fix Publish to Catalog validation failure and RJSF multi-select crash

### DIFF
--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -47,20 +47,30 @@ export default function CustomSelectWidget({
   const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;
   const xRjsfGridArea = schema?.['x-rjsf-grid-area']; // check if the field is used in different modal (e.g. publish)
 
-  multiple = typeof multiple === 'undefined' ? false : !!multiple;
-  const emptyValue = multiple ? [] : '';
+  // RJSF may sometimes pass multiple=false or undefined even for array enums.
+  // We force it to true if the schema type is array or it has items.
+  const isMultiple =
+    multiple || schema?.type === 'array' || schema?.items !== undefined || options?.multiple;
+
+  const emptyValue = isMultiple ? [] : '';
   const isEmpty =
     typeof value === 'undefined' ||
-    (multiple && value.length < 1) ||
-    (!multiple && value === emptyValue);
+    (isMultiple && value.length < 1) ||
+    (!isMultiple && value === emptyValue);
 
-  const _onChange = ({ target: { value } }) =>
-    onChange(enumOptionsValueForIndex(value, enumOptions, optEmptyVal));
+  const _onChange = ({ target: { value } }) => {
+    let safeValue = value;
+    if (isMultiple && typeof value === 'string') {
+      safeValue = value.split(',').filter(Boolean);
+    }
+    const nextValue = enumOptionsValueForIndex(safeValue, enumOptions, optEmptyVal);
+    onChange(isMultiple && !Array.isArray(nextValue) ? (nextValue ? [nextValue] : []) : nextValue);
+  };
   const _onBlur = ({ target: { value } }) =>
     onBlur(id, enumOptionsValueForIndex(value, enumOptions, optEmptyVal));
   const _onFocus = ({ target: { value } }) =>
     onFocus(id, enumOptionsValueForIndex(value, enumOptions, optEmptyVal));
-  const selectedIndexes = enumOptionsIndexForValue(value, enumOptions, multiple);
+  const selectedIndexes = enumOptionsIndexForValue(value, enumOptions, isMultiple);
   const theme = useTheme();
 
   const labelContent = labelValue(label, hideLabel || !label, false);
@@ -136,13 +146,13 @@ export default function CustomSelectWidget({
         SelectProps={{
           ...textFieldProps.SelectProps,
           renderValue: (selected) => {
-            if (multiple && Array.isArray(selected)) {
+            if (isMultiple && Array.isArray(selected)) {
               return selected.map((i) => safeDisplayValue(enumOptions?.[i]?.label)).join(', ');
             }
             const idx = selected as number;
             return safeDisplayValue(enumOptions?.[idx]?.label);
           },
-          multiple,
+          multiple: isMultiple,
           MenuProps: {
             anchorOrigin: {
               vertical: 'bottom',
@@ -167,7 +177,7 @@ export default function CustomSelectWidget({
             const disabled = Array.isArray(enumDisabled) && enumDisabled?.indexOf(value) !== -1;
             return (
               <MenuItem key={i} value={String(i)} disabled={disabled}>
-                {multiple && <Checkbox checked={selectedIndexes?.indexOf(String(i)) !== -1} />}
+                {isMultiple && <Checkbox checked={selectedIndexes?.indexOf(String(i)) !== -1} />}
                 <ListItemText primary={safeDisplayValue(label)} />
               </MenuItem>
             );

--- a/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
+++ b/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
@@ -283,7 +283,17 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
 
   useEffect(() => {
     if (publishSchema) {
-      const newUiSchema = { ...publishSchema.uiSchema };
+      const newUiSchema = {
+        ...publishSchema.uiSchema,
+        // Force a multi-select dropdown for the compatibility/Technology field.
+        // RJSF v5 auto-selects CheckboxesWidget when schema has uniqueItems:true + items.enum,
+        // which causes formData.compatibility to be submitted as a string instead of an array.
+        // Explicitly setting 'ui:widget': 'select' restores multi-select array behaviour.
+        compatibility: {
+          ...(publishSchema.uiSchema?.compatibility || {}),
+          'ui:widget': 'select',
+        },
+      };
 
       if (isReadOnly) {
         newUiSchema['ui:readonly'] = true;
@@ -454,6 +464,18 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
                     liveValidate={false}
                     formRef={formRef}
                     hideTitle={true}
+                    transformErrors={(errors) => {
+                      return errors?.map((error) => {
+                        if (
+                          error.property === '.compatibility' ||
+                          (error.name === 'required' &&
+                            error.params?.missingProperty === 'compatibility')
+                        ) {
+                          error.message = 'Please select at least one technology.';
+                        }
+                        return error;
+                      });
+                    }}
                   />
                 </Grid>
               </Grid>


### PR DESCRIPTION
**Description**

This PR fixes a bug in the "Publish to Catalog" flow where users were unable to successfully publish a design due to a persistent schema validation error (`'Technology' must be array`) on the Technology dropdown, accompanied by a silent crash in the console (`e?.map is not a function`).

**Before**

https://github.com/user-attachments/assets/80bec678-357e-4d6b-a871-aeac27b1b248

**After**

<img width="732" height="643" alt="Screenshot 2026-07-18 at 11 16 41 PM" src="https://github.com/user-attachments/assets/2df6c149-a157-4cae-b181-7195fca9dca7" />

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
