### PR TITLE
[Docs] Correct meshery.io/blog link at security-vulnerabilities page

### DIFF
--- a/docs/content/en/project/security-vulnerabilities.md
+++ b/docs/content/en/project/security-vulnerabilities.md
@@ -70,7 +70,7 @@ branches.
 - Meshery team ensures all necessary binaries are promptly built and published.
 
 - Once the binaries are available, an announcement is sent out on the following channels:
-  - The [Meshery blog](https://meshery.io/blog/)
+  - The [Meshery blog](https://meshery.io/blog)
   - The [Meshery X feed](https://x.com/mesheryio)
   - The [#announcements](https://mesheryio.slack.com/archives/CSF3PSZT9) channel on community [Slack](https://slack.meshery.io/)
 


### PR DESCRIPTION
Removed trailing slash from the Meshery blog URL on the security-vulnerabilities page. The URL https://meshery.io/blog/ (with trailing slash) causes a redirect issue, while https://meshery.io/blog (without trailing slash) works correctly.

Fixes #20544

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
