### PR TITLE
[CI] Add Self-paced Contributor Trainings link to playground issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/playground.md
+++ b/.github/ISSUE_TEMPLATE/playground.md
@@ -19,3 +19,4 @@ assignees: ''
    - Meshery documentation [site](https://docs.meshery.io/) and [source](https://github.com/meshery/meshery/tree/master/docs)
 - 🎨 Wireframes and designs for Meshery UI in [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)


### PR DESCRIPTION
**Description**

This PR fixes #20766

**Notes for Reviewers**

Audited all 14 templates in `.github/ISSUE_TEMPLATE/` — 13 already include the `📺 Self-paced Contributor Trainings` link. `playground.md` was the only template missing it. This PR adds the line specified in the issue's implementation and this is consistent with the other 13 templates

Before (master): https://github.com/meshery/meshery/blob/master/.github/ISSUE_TEMPLATE/playground.md
After (this branch): https://github.com/Sathwik-parimi-07/meshery/blob/fix/gh-20766-playground-training-link/.github/ISSUE_TEMPLATE/playground.md

**Signed commits**

- [x] Yes, I signed my commits.