### PR TITLE
[Server] Log human-readable summary in SaveConnection debug line

### DIFF
--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -4495,7 +4495,8 @@ func (l *RemoteProvider) SaveConnection(conn *connections.ConnectionPayload, tok
 		if err != nil {
 			return nil, ErrUnmarshal(err, "Connection \"%s\" of type \"%s\" with status \"%s\" from the remote provider")
 		}
-		l.Log.Debug("connections, ", connectionPage)
+		l.Log.Debugf("RemoteProvider::SaveConnection: parsed %d connection(s) (page=%d, pageSize=%d, totalCount=%d)",
+			len(connectionPage.Connections), connectionPage.Page, connectionPage.PageSize, connectionPage.TotalCount)
 		// On POST request to Remote Provider API, the response always contains single entry/connection.
 		if len(connectionPage.Connections) > 0 {
 			return connectionPage.Connections[0], nil


### PR DESCRIPTION
## Summary
- `RemoteProvider.SaveConnection`'s debug log formatted the parsed `*ConnectionPage` with `%v`, printing raw pointer addresses for the `Connections` slice (e.g. `[0x34f516a72640]`) and `<nil>` for the unset `StatusSummary` field instead of anything actionable.
- Replaced it with a formatted summary (connection count, page, pageSize, totalCount) so the debug log is human-readable. The raw JSON response is already logged one line above via `bdr`, so this line only needs to confirm the unmarshal succeeded with sane pagination values.

## Test plan
- [x] `make golangci` locally on the changed file