### PR TITLE
[Server] Fix connected clusters showing no MeshSync data when kubernetesServerId is stale

### DIFF
--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1445
+  "next_error_code": 1446
 }

--- a/server/machines/kubernetes/discover.go
+++ b/server/machines/kubernetes/discover.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
-	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/models/events"
 	"github.com/meshery/schemas/models/core"
 )
@@ -65,8 +63,9 @@ func (da *DiscoverAction) Execute(ctx context.Context, machineCtx interface{}, d
 		// now from the server ID just resolved from the reachable cluster so the
 		// dashboard's cluster_id filter matches the MeshSync data this cluster
 		// streams under its real ID; without this the connection ingests data yet
-		// the dashboard shows none.
-		if rerr := reconcilePersistedServerID(provider, token, k8sContext); rerr != nil {
+		// the dashboard shows none. The reconcile lives in the models layer
+		// alongside the rest of the connection/context persistence logic.
+		if rerr := models.ReconcileK8sContextServerID(provider, token, k8sContext); rerr != nil {
 			machinectx.log.Warn(rerr)
 		}
 	} else if err != nil {
@@ -76,59 +75,6 @@ func (da *DiscoverAction) Execute(ctx context.Context, machineCtx interface{}, d
 	// machinectx.log.Debug("exiting execute func from discovered state", connection)
 
 	return machines.Register, nil, nil
-}
-
-// reconcilePersistedServerID keeps an already-persisted kubernetes connection's
-// metadata.kubernetesServerId in step with the server ID freshly resolved from
-// the reachable cluster (its kube-system namespace UID). It self-heals a
-// connection whose persisted server ID is empty or stale - one registered while
-// its cluster was unreachable, or migrated from a Meshery build that predated
-// storing it - which matters because the dashboard filters MeshSync resources by
-// that persisted ID against each row's cluster_id. A mismatch there leaves a live
-// stream invisible.
-//
-// It is a no-op when the persisted value already matches, so the FSM re-running
-// discovery on every request corrects a broken connection exactly once and adds
-// no write on the steady state.
-func reconcilePersistedServerID(provider models.Provider, token string, k8sContext models.K8sContext) error {
-	if k8sContext.KubernetesServerID == nil || *k8sContext.KubernetesServerID == uuid.Nil {
-		return nil
-	}
-	serverID := k8sContext.KubernetesServerID.String()
-
-	connectionID := uuid.FromStringOrNil(k8sContext.ConnectionID)
-	if connectionID == uuid.Nil {
-		return nil
-	}
-
-	connection, _, err := provider.GetConnectionByID(token, connectionID)
-	if err != nil {
-		return ErrReconcileServerID(err)
-	}
-	if connection == nil {
-		return nil
-	}
-
-	metadata := connection.Metadata
-	if metadata == nil {
-		metadata = map[string]interface{}{}
-	}
-	if persisted, _ := metadata["kubernetesServerId"].(string); persisted == serverID {
-		// Already correct - nothing to write.
-		return nil
-	}
-	metadata["kubernetesServerId"] = serverID
-
-	payload := &connections.ConnectionPayload{
-		ID:       connectionID,
-		Kind:     connection.Kind,
-		MetaData: metadata,
-		Status:   connection.Status,
-	}
-	if _, err := provider.UpdateConnectionById(token, payload, connectionID.String()); err != nil {
-		return ErrReconcileServerID(err)
-	}
-	return nil
 }
 
 func (da *DiscoverAction) ExecuteOnExit(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {

--- a/server/machines/kubernetes/discover.go
+++ b/server/machines/kubernetes/discover.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/models/events"
 	"github.com/meshery/schemas/models/core"
 )
@@ -48,9 +50,25 @@ func (da *DiscoverAction) Execute(ctx context.Context, machineCtx interface{}, d
 	}
 	token, _ := ctx.Value(models.TokenCtxKey).(string)
 
-	_, err = provider.SaveK8sContext(token, machinectx.K8sContext, nil)
+	// Persist the freshly-resolved context (k8sContext, which now carries the
+	// server ID and version assigned above) rather than the machine's original
+	// copy, so a brand-new connection is created with its server ID already set.
+	_, err = provider.SaveK8sContext(token, k8sContext, nil)
 	if errors.Is(err, models.ErrContextAlreadyPersisted) {
 		machinectx.log.Info(fmt.Sprintf("context already persisted (\"%s\" at %s)", k8sContext.Name, k8sContext.Server))
+		// The connection already exists, but its persisted kubernetesServerId can
+		// be empty or stale: a connection first registered while its cluster's API
+		// server was unreachable (or one migrated from an older Meshery that never
+		// stored the server ID) is saved with no server ID, and neither
+		// SaveK8sContext (it early-returns above) nor the FSM status update (it
+		// rewrites the existing metadata verbatim) ever corrects it. Back-fill it
+		// now from the server ID just resolved from the reachable cluster so the
+		// dashboard's cluster_id filter matches the MeshSync data this cluster
+		// streams under its real ID; without this the connection ingests data yet
+		// the dashboard shows none.
+		if rerr := reconcilePersistedServerID(provider, token, k8sContext); rerr != nil {
+			machinectx.log.Warn(rerr)
+		}
 	} else if err != nil {
 		return machines.NoOp, eventBuilder.WithDescription(fmt.Sprintf("Unable to establish connection with context \"%s\" at %s", k8sContext.Name, k8sContext.Server)).WithMetadata(map[string]interface{}{"error": err}).Build(), err
 	}
@@ -58,6 +76,59 @@ func (da *DiscoverAction) Execute(ctx context.Context, machineCtx interface{}, d
 	// machinectx.log.Debug("exiting execute func from discovered state", connection)
 
 	return machines.Register, nil, nil
+}
+
+// reconcilePersistedServerID keeps an already-persisted kubernetes connection's
+// metadata.kubernetesServerId in step with the server ID freshly resolved from
+// the reachable cluster (its kube-system namespace UID). It self-heals a
+// connection whose persisted server ID is empty or stale - one registered while
+// its cluster was unreachable, or migrated from a Meshery build that predated
+// storing it - which matters because the dashboard filters MeshSync resources by
+// that persisted ID against each row's cluster_id. A mismatch there leaves a live
+// stream invisible.
+//
+// It is a no-op when the persisted value already matches, so the FSM re-running
+// discovery on every request corrects a broken connection exactly once and adds
+// no write on the steady state.
+func reconcilePersistedServerID(provider models.Provider, token string, k8sContext models.K8sContext) error {
+	if k8sContext.KubernetesServerID == nil || *k8sContext.KubernetesServerID == uuid.Nil {
+		return nil
+	}
+	serverID := k8sContext.KubernetesServerID.String()
+
+	connectionID := uuid.FromStringOrNil(k8sContext.ConnectionID)
+	if connectionID == uuid.Nil {
+		return nil
+	}
+
+	connection, _, err := provider.GetConnectionByID(token, connectionID)
+	if err != nil {
+		return ErrReconcileServerID(err)
+	}
+	if connection == nil {
+		return nil
+	}
+
+	metadata := connection.Metadata
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	if persisted, _ := metadata["kubernetesServerId"].(string); persisted == serverID {
+		// Already correct - nothing to write.
+		return nil
+	}
+	metadata["kubernetesServerId"] = serverID
+
+	payload := &connections.ConnectionPayload{
+		ID:       connectionID,
+		Kind:     connection.Kind,
+		MetaData: metadata,
+		Status:   connection.Status,
+	}
+	if _, err := provider.UpdateConnectionById(token, payload, connectionID.String()); err != nil {
+		return ErrReconcileServerID(err)
+	}
+	return nil
 }
 
 func (da *DiscoverAction) ExecuteOnExit(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {

--- a/server/machines/kubernetes/discover_test.go
+++ b/server/machines/kubernetes/discover_test.go
@@ -1,0 +1,237 @@
+package kubernetes
+
+import (
+	stderrors "errors"
+	"net/http"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/schemas/models/core"
+)
+
+// reconcileFakeProvider is a partial models.Provider: it embeds the interface so
+// the type satisfies models.Provider, and implements only the two methods
+// reconcilePersistedServerID calls. Any other method would panic on the nil
+// embedded interface, keeping the test honest about what the function touches.
+type reconcileFakeProvider struct {
+	models.Provider
+
+	conn      *connections.Connection
+	getErr    error
+	updateErr error
+
+	getCalls    int
+	updateCalls int
+	lastPayload *connections.ConnectionPayload
+}
+
+func (f *reconcileFakeProvider) GetConnectionByID(_ string, _ core.Uuid) (*connections.Connection, int, error) {
+	f.getCalls++
+	if f.getErr != nil {
+		return nil, http.StatusInternalServerError, f.getErr
+	}
+	if f.conn == nil {
+		return nil, http.StatusNotFound, nil
+	}
+	return f.conn, http.StatusOK, nil
+}
+
+func (f *reconcileFakeProvider) UpdateConnectionById(_ string, conn *connections.ConnectionPayload, _ string) (*connections.Connection, error) {
+	f.updateCalls++
+	f.lastPayload = conn
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	return &connections.Connection{ID: conn.ID, Kind: conn.Kind, Status: conn.Status, Metadata: conn.MetaData}, nil
+}
+
+func newServerID(t *testing.T) (*core.Uuid, string) {
+	t.Helper()
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate server UUID: %v", err)
+	}
+	u := core.Uuid(id)
+	return &u, u.String()
+}
+
+func k8sCtxWith(connID string, serverID *core.Uuid) models.K8sContext {
+	return models.K8sContext{
+		Name:               "ctx",
+		ConnectionID:       connID,
+		KubernetesServerID: serverID,
+	}
+}
+
+// A connection first registered while its cluster was unreachable persists an
+// empty kubernetesServerId. Once the cluster is reachable and discovery resolves
+// the real ID, reconcile must back-fill it so the dashboard's cluster_id filter
+// starts matching the streamed MeshSync rows.
+func TestReconcilePersistedServerID_BackfillsEmpty(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4()).String()
+	serverID, serverIDStr := newServerID(t)
+
+	f := &reconcileFakeProvider{
+		conn: &connections.Connection{
+			ID:       uuid.FromStringOrNil(connID),
+			Kind:     "kubernetes",
+			Status:   connections.CONNECTED,
+			Metadata: core.Map{"kubernetesServerId": "", "name": "ctx"},
+		},
+	}
+
+	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if f.updateCalls != 1 {
+		t.Fatalf("expected exactly 1 update call, got %d", f.updateCalls)
+	}
+	if got, _ := f.lastPayload.MetaData["kubernetesServerId"].(string); got != serverIDStr {
+		t.Fatalf("expected metadata kubernetesServerId %q, got %q", serverIDStr, got)
+	}
+	// Unrelated metadata must be preserved through the update.
+	if name, _ := f.lastPayload.MetaData["name"].(string); name != "ctx" {
+		t.Fatalf("expected unrelated metadata preserved, got name %q", name)
+	}
+	// The reconcile must not change the connection's status.
+	if f.lastPayload.Status != connections.CONNECTED {
+		t.Fatalf("expected status preserved as CONNECTED, got %q", f.lastPayload.Status)
+	}
+}
+
+// The remote provider persists a nil UUID (00000000-...) rather than an empty
+// string for an unassigned server ID; reconcile must treat it as stale too.
+func TestReconcilePersistedServerID_CorrectsNilUUID(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4()).String()
+	serverID, serverIDStr := newServerID(t)
+
+	f := &reconcileFakeProvider{
+		conn: &connections.Connection{
+			ID:       uuid.FromStringOrNil(connID),
+			Kind:     "kubernetes",
+			Status:   connections.CONNECTED,
+			Metadata: core.Map{"kubernetesServerId": uuid.Nil.String()},
+		},
+	}
+
+	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if f.updateCalls != 1 {
+		t.Fatalf("expected exactly 1 update call, got %d", f.updateCalls)
+	}
+	if got, _ := f.lastPayload.MetaData["kubernetesServerId"].(string); got != serverIDStr {
+		t.Fatalf("expected metadata kubernetesServerId %q, got %q", serverIDStr, got)
+	}
+}
+
+// A connection whose persisted server ID already matches must incur no write, so
+// the per-request discovery re-drive costs nothing on the steady state.
+func TestReconcilePersistedServerID_NoopWhenAlreadyCorrect(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4()).String()
+	serverID, serverIDStr := newServerID(t)
+
+	f := &reconcileFakeProvider{
+		conn: &connections.Connection{
+			ID:       uuid.FromStringOrNil(connID),
+			Kind:     "kubernetes",
+			Status:   connections.CONNECTED,
+			Metadata: core.Map{"kubernetesServerId": serverIDStr},
+		},
+	}
+
+	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if f.updateCalls != 0 {
+		t.Fatalf("expected no update call when already correct, got %d", f.updateCalls)
+	}
+}
+
+func TestReconcilePersistedServerID_HandlesNilMetadata(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4()).String()
+	serverID, serverIDStr := newServerID(t)
+
+	f := &reconcileFakeProvider{
+		conn: &connections.Connection{
+			ID:       uuid.FromStringOrNil(connID),
+			Kind:     "kubernetes",
+			Status:   connections.CONNECTED,
+			Metadata: nil,
+		},
+	}
+
+	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if f.updateCalls != 1 {
+		t.Fatalf("expected exactly 1 update call, got %d", f.updateCalls)
+	}
+	if got, _ := f.lastPayload.MetaData["kubernetesServerId"].(string); got != serverIDStr {
+		t.Fatalf("expected metadata kubernetesServerId %q, got %q", serverIDStr, got)
+	}
+}
+
+// Guard the early returns: a missing/nil server id or an invalid connection id
+// must not touch the provider at all (nothing authoritative to sync).
+func TestReconcilePersistedServerID_NoopOnMissingInputs(t *testing.T) {
+	serverID, _ := newServerID(t)
+	nilID := core.Uuid(uuid.Nil)
+
+	cases := []struct {
+		name string
+		ctx  models.K8sContext
+	}{
+		{"nil server id", k8sCtxWith(uuid.Must(uuid.NewV4()).String(), nil)},
+		{"nil-uuid server id", k8sCtxWith(uuid.Must(uuid.NewV4()).String(), &nilID)},
+		{"empty connection id", k8sCtxWith("", serverID)},
+		{"invalid connection id", k8sCtxWith("not-a-uuid", serverID)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &reconcileFakeProvider{}
+			if err := reconcilePersistedServerID(f, "token", tc.ctx); err != nil {
+				t.Fatalf("reconcile returned error: %v", err)
+			}
+			if f.getCalls != 0 || f.updateCalls != 0 {
+				t.Fatalf("expected no provider calls, got get=%d update=%d", f.getCalls, f.updateCalls)
+			}
+		})
+	}
+}
+
+func TestReconcilePersistedServerID_PropagatesGetError(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4()).String()
+	serverID, _ := newServerID(t)
+
+	f := &reconcileFakeProvider{getErr: stderrors.New("boom")}
+	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err == nil {
+		t.Fatal("expected an error when GetConnectionByID fails, got nil")
+	}
+	if f.updateCalls != 0 {
+		t.Fatalf("expected no update call when the read fails, got %d", f.updateCalls)
+	}
+}
+
+func TestReconcilePersistedServerID_PropagatesUpdateError(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4()).String()
+	serverID, _ := newServerID(t)
+
+	f := &reconcileFakeProvider{
+		conn: &connections.Connection{
+			ID:       uuid.FromStringOrNil(connID),
+			Kind:     "kubernetes",
+			Status:   connections.CONNECTED,
+			Metadata: core.Map{"kubernetesServerId": ""},
+		},
+		updateErr: stderrors.New("boom"),
+	}
+	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err == nil {
+		t.Fatal("expected an error when UpdateConnectionById fails, got nil")
+	}
+	if f.updateCalls != 1 {
+		t.Fatalf("expected the update to be attempted once, got %d", f.updateCalls)
+	}
+}

--- a/server/machines/kubernetes/error.go
+++ b/server/machines/kubernetes/error.go
@@ -7,7 +7,6 @@ import (
 var (
 	ErrResyncK8SResourcesCode = "meshery-server-1372"
 	ErrConnectActionCode      = "meshery-server-1373"
-	ErrReconcileServerIDCode  = "meshery-server-1445"
 )
 
 func ErrResyncK8SResources(err error) error {
@@ -16,12 +15,4 @@ func ErrResyncK8SResources(err error) error {
 
 func ErrConnectAction(err error) error {
 	return errors.New(ErrConnectActionCode, errors.Critical, []string{"Error connect action"}, []string{err.Error()}, []string{"Fail to perform connect action for the kubernetes machine"}, []string{"Check if token is passed machine from golang context correctly", "Check if there is connection data stored in database for this kubernetes machine"})
-}
-
-// ErrReconcileServerID wraps a failure to back-fill an already-persisted
-// kubernetes connection's kubernetesServerId with the server ID freshly resolved
-// from the reachable cluster. It is best-effort and non-fatal: the reconcile
-// retries on the next discovery cycle, so it is surfaced at None severity.
-func ErrReconcileServerID(err error) error {
-	return errors.New(ErrReconcileServerIDCode, errors.None, []string{"Failed to reconcile the persisted Kubernetes server ID for the connection"}, []string{err.Error()}, []string{"The connection's persisted kubernetesServerId could not be read from or written to the connection store while syncing it with the live cluster's server ID."}, []string{"Verify the connection still exists and Meshery can reach the provider's connection store. The reconcile is retried automatically on the next discovery cycle."})
 }

--- a/server/machines/kubernetes/error.go
+++ b/server/machines/kubernetes/error.go
@@ -7,6 +7,7 @@ import (
 var (
 	ErrResyncK8SResourcesCode = "meshery-server-1372"
 	ErrConnectActionCode      = "meshery-server-1373"
+	ErrReconcileServerIDCode  = "meshery-server-1445"
 )
 
 func ErrResyncK8SResources(err error) error {
@@ -15,4 +16,12 @@ func ErrResyncK8SResources(err error) error {
 
 func ErrConnectAction(err error) error {
 	return errors.New(ErrConnectActionCode, errors.Critical, []string{"Error connect action"}, []string{err.Error()}, []string{"Fail to perform connect action for the kubernetes machine"}, []string{"Check if token is passed machine from golang context correctly", "Check if there is connection data stored in database for this kubernetes machine"})
+}
+
+// ErrReconcileServerID wraps a failure to back-fill an already-persisted
+// kubernetes connection's kubernetesServerId with the server ID freshly resolved
+// from the reachable cluster. It is best-effort and non-fatal: the reconcile
+// retries on the next discovery cycle, so it is surfaced at None severity.
+func ErrReconcileServerID(err error) error {
+	return errors.New(ErrReconcileServerIDCode, errors.None, []string{"Failed to reconcile the persisted Kubernetes server ID for the connection"}, []string{err.Error()}, []string{"The connection's persisted kubernetesServerId could not be read from or written to the connection store while syncing it with the live cluster's server ID."}, []string{"Verify the connection still exists and Meshery can reach the provider's connection store. The reconcile is retried automatically on the next discovery cycle."})
 }

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -147,6 +147,7 @@ const (
 	ErrMarshallingDesignIntoYAMLCode      = "meshery-server-1135"
 	ErrStatusCodeCode                     = "meshery-server-1368"
 	ErrMeshsyncDataHandlerCode            = "meshery-server-1370"
+	ErrReconcileServerIDCode              = "meshery-server-1445"
 	ErrWorkspaceMissingInputCode          = "meshery-server-1375"
 	ErrMeshsyncEventCode                  = "meshery-server-1379"
 	ErrMeshsyncStoreUpdatesCode           = "meshery-server-1380"
@@ -670,6 +671,14 @@ func ErrMarshallingDesignIntoYAML(err error) error {
 
 func ErrMeshsyncDataHandler(err error) error {
 	return errors.New(ErrMeshsyncDataHandlerCode, errors.Alert, []string{"Error in meshsync data hadler"}, []string{err.Error()}, []string{"not deployed operator", "issue with connection to broker"}, []string{"check that operator is deployed", "check that server can establish connection to broker"})
+}
+
+// ErrReconcileServerID wraps a failure to back-fill an already-persisted
+// kubernetes connection's kubernetesServerId with the server ID freshly resolved
+// from the reachable cluster. It is best-effort and non-fatal: the reconcile
+// retries on the next discovery cycle, so it is surfaced at None severity.
+func ErrReconcileServerID(err error) error {
+	return errors.New(ErrReconcileServerIDCode, errors.None, []string{"Failed to reconcile the persisted Kubernetes server ID for the connection"}, []string{err.Error()}, []string{"The connection's persisted kubernetesServerId could not be read from or written to the connection store while syncing it with the live cluster's server ID."}, []string{"Verify the connection still exists and Meshery can reach the provider's connection store. The reconcile is retried automatically on the next discovery cycle."})
 }
 
 // ErrWorkspaceMissingInput is used by both the list-workspaces handler

--- a/server/models/k8s_context.go
+++ b/server/models/k8s_context.go
@@ -483,6 +483,67 @@ func (kc *K8sContext) AssignServerID(handler *kubernetes.Client) error {
 	return nil
 }
 
+// ReconcileK8sContextServerID keeps an already-persisted kubernetes connection's
+// metadata.kubernetesServerId in step with the server ID freshly resolved from
+// the reachable cluster (its kube-system namespace UID, as assigned by
+// AssignServerID). It self-heals a connection whose persisted server ID is empty
+// or stale - one registered while its cluster was unreachable, or migrated from a
+// Meshery build that predated storing it - which matters because the dashboard
+// filters MeshSync resources by that persisted ID against each row's cluster_id.
+// A mismatch there leaves a live stream invisible.
+//
+// The persisted record it reads is the schemas connection model
+// (connections.Connection = github.com/meshery/schemas/.../v1beta1/connection.Connection).
+// The write goes through the token-string provider API UpdateConnectionById - the
+// same path the connection state machine's own status update uses - which takes
+// the server's ConnectionPayload; there is no token-string, schemas-native
+// connection writer (UpdateConnection is request-scoped, and an FSM action has no
+// *http.Request).
+//
+// It is a no-op when the persisted value already matches, so the FSM re-running
+// discovery on every request corrects a broken connection exactly once and adds
+// no write on the steady state.
+func ReconcileK8sContextServerID(provider Provider, token string, k8sContext K8sContext) error {
+	if k8sContext.KubernetesServerID == nil || *k8sContext.KubernetesServerID == uuid.Nil {
+		return nil
+	}
+	serverID := k8sContext.KubernetesServerID.String()
+
+	connectionID := uuid.FromStringOrNil(k8sContext.ConnectionID)
+	if connectionID == uuid.Nil {
+		return nil
+	}
+
+	connection, _, err := provider.GetConnectionByID(token, connectionID)
+	if err != nil {
+		return ErrReconcileServerID(err)
+	}
+	if connection == nil {
+		return nil
+	}
+
+	metadata := connection.Metadata
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	if persisted, _ := metadata["kubernetesServerId"].(string); persisted == serverID {
+		// Already correct - nothing to write.
+		return nil
+	}
+	metadata["kubernetesServerId"] = serverID
+
+	payload := &connections.ConnectionPayload{
+		ID:       connectionID,
+		Kind:     connection.Kind,
+		MetaData: metadata,
+		Status:   connection.Status,
+	}
+	if _, err := provider.UpdateConnectionById(token, payload, connectionID.String()); err != nil {
+		return ErrReconcileServerID(err)
+	}
+	return nil
+}
+
 // FlushMeshSyncData will flush the meshsync data for the passed kubernetes contextID
 func FlushMeshSyncData(ctx context.Context, k8sContext K8sContext, provider Provider, eventsChan *Broadcast, userID string, mesheryInstanceID *core.Uuid, log logger.Handler) {
 	ctxID := k8sContext.ID

--- a/server/models/k8s_context_reconcile_test.go
+++ b/server/models/k8s_context_reconcile_test.go
@@ -1,4 +1,4 @@
-package kubernetes
+package models
 
 import (
 	stderrors "errors"
@@ -6,17 +6,16 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
-	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/schemas/models/core"
 )
 
-// reconcileFakeProvider is a partial models.Provider: it embeds the interface so
-// the type satisfies models.Provider, and implements only the two methods
-// reconcilePersistedServerID calls. Any other method would panic on the nil
+// reconcileFakeProvider is a partial Provider: it embeds the interface so the
+// type satisfies Provider, and implements only the two methods
+// ReconcileK8sContextServerID calls. Any other method would panic on the nil
 // embedded interface, keeping the test honest about what the function touches.
 type reconcileFakeProvider struct {
-	models.Provider
+	Provider
 
 	conn      *connections.Connection
 	getErr    error
@@ -47,7 +46,7 @@ func (f *reconcileFakeProvider) UpdateConnectionById(_ string, conn *connections
 	return &connections.Connection{ID: conn.ID, Kind: conn.Kind, Status: conn.Status, Metadata: conn.MetaData}, nil
 }
 
-func newServerID(t *testing.T) (*core.Uuid, string) {
+func newReconcileServerID(t *testing.T) (*core.Uuid, string) {
 	t.Helper()
 	id, err := uuid.NewV4()
 	if err != nil {
@@ -57,8 +56,8 @@ func newServerID(t *testing.T) (*core.Uuid, string) {
 	return &u, u.String()
 }
 
-func k8sCtxWith(connID string, serverID *core.Uuid) models.K8sContext {
-	return models.K8sContext{
+func reconcileK8sCtx(connID string, serverID *core.Uuid) K8sContext {
+	return K8sContext{
 		Name:               "ctx",
 		ConnectionID:       connID,
 		KubernetesServerID: serverID,
@@ -67,11 +66,11 @@ func k8sCtxWith(connID string, serverID *core.Uuid) models.K8sContext {
 
 // A connection first registered while its cluster was unreachable persists an
 // empty kubernetesServerId. Once the cluster is reachable and discovery resolves
-// the real ID, reconcile must back-fill it so the dashboard's cluster_id filter
-// starts matching the streamed MeshSync rows.
-func TestReconcilePersistedServerID_BackfillsEmpty(t *testing.T) {
+// the real ID, the reconcile must back-fill it so the dashboard's cluster_id
+// filter starts matching the streamed MeshSync rows.
+func TestReconcileK8sContextServerID_BackfillsEmpty(t *testing.T) {
 	connID := uuid.Must(uuid.NewV4()).String()
-	serverID, serverIDStr := newServerID(t)
+	serverID, serverIDStr := newReconcileServerID(t)
 
 	f := &reconcileFakeProvider{
 		conn: &connections.Connection{
@@ -82,7 +81,7 @@ func TestReconcilePersistedServerID_BackfillsEmpty(t *testing.T) {
 		},
 	}
 
-	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+	if err := ReconcileK8sContextServerID(f, "token", reconcileK8sCtx(connID, serverID)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 	if f.updateCalls != 1 {
@@ -102,10 +101,10 @@ func TestReconcilePersistedServerID_BackfillsEmpty(t *testing.T) {
 }
 
 // The remote provider persists a nil UUID (00000000-...) rather than an empty
-// string for an unassigned server ID; reconcile must treat it as stale too.
-func TestReconcilePersistedServerID_CorrectsNilUUID(t *testing.T) {
+// string for an unassigned server ID; the reconcile must treat it as stale too.
+func TestReconcileK8sContextServerID_CorrectsNilUUID(t *testing.T) {
 	connID := uuid.Must(uuid.NewV4()).String()
-	serverID, serverIDStr := newServerID(t)
+	serverID, serverIDStr := newReconcileServerID(t)
 
 	f := &reconcileFakeProvider{
 		conn: &connections.Connection{
@@ -116,7 +115,7 @@ func TestReconcilePersistedServerID_CorrectsNilUUID(t *testing.T) {
 		},
 	}
 
-	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+	if err := ReconcileK8sContextServerID(f, "token", reconcileK8sCtx(connID, serverID)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 	if f.updateCalls != 1 {
@@ -129,9 +128,9 @@ func TestReconcilePersistedServerID_CorrectsNilUUID(t *testing.T) {
 
 // A connection whose persisted server ID already matches must incur no write, so
 // the per-request discovery re-drive costs nothing on the steady state.
-func TestReconcilePersistedServerID_NoopWhenAlreadyCorrect(t *testing.T) {
+func TestReconcileK8sContextServerID_NoopWhenAlreadyCorrect(t *testing.T) {
 	connID := uuid.Must(uuid.NewV4()).String()
-	serverID, serverIDStr := newServerID(t)
+	serverID, serverIDStr := newReconcileServerID(t)
 
 	f := &reconcileFakeProvider{
 		conn: &connections.Connection{
@@ -142,7 +141,7 @@ func TestReconcilePersistedServerID_NoopWhenAlreadyCorrect(t *testing.T) {
 		},
 	}
 
-	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+	if err := ReconcileK8sContextServerID(f, "token", reconcileK8sCtx(connID, serverID)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 	if f.updateCalls != 0 {
@@ -150,9 +149,9 @@ func TestReconcilePersistedServerID_NoopWhenAlreadyCorrect(t *testing.T) {
 	}
 }
 
-func TestReconcilePersistedServerID_HandlesNilMetadata(t *testing.T) {
+func TestReconcileK8sContextServerID_HandlesNilMetadata(t *testing.T) {
 	connID := uuid.Must(uuid.NewV4()).String()
-	serverID, serverIDStr := newServerID(t)
+	serverID, serverIDStr := newReconcileServerID(t)
 
 	f := &reconcileFakeProvider{
 		conn: &connections.Connection{
@@ -163,7 +162,7 @@ func TestReconcilePersistedServerID_HandlesNilMetadata(t *testing.T) {
 		},
 	}
 
-	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err != nil {
+	if err := ReconcileK8sContextServerID(f, "token", reconcileK8sCtx(connID, serverID)); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 	if f.updateCalls != 1 {
@@ -176,23 +175,23 @@ func TestReconcilePersistedServerID_HandlesNilMetadata(t *testing.T) {
 
 // Guard the early returns: a missing/nil server id or an invalid connection id
 // must not touch the provider at all (nothing authoritative to sync).
-func TestReconcilePersistedServerID_NoopOnMissingInputs(t *testing.T) {
-	serverID, _ := newServerID(t)
+func TestReconcileK8sContextServerID_NoopOnMissingInputs(t *testing.T) {
+	serverID, _ := newReconcileServerID(t)
 	nilID := core.Uuid(uuid.Nil)
 
 	cases := []struct {
 		name string
-		ctx  models.K8sContext
+		ctx  K8sContext
 	}{
-		{"nil server id", k8sCtxWith(uuid.Must(uuid.NewV4()).String(), nil)},
-		{"nil-uuid server id", k8sCtxWith(uuid.Must(uuid.NewV4()).String(), &nilID)},
-		{"empty connection id", k8sCtxWith("", serverID)},
-		{"invalid connection id", k8sCtxWith("not-a-uuid", serverID)},
+		{"nil server id", reconcileK8sCtx(uuid.Must(uuid.NewV4()).String(), nil)},
+		{"nil-uuid server id", reconcileK8sCtx(uuid.Must(uuid.NewV4()).String(), &nilID)},
+		{"empty connection id", reconcileK8sCtx("", serverID)},
+		{"invalid connection id", reconcileK8sCtx("not-a-uuid", serverID)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &reconcileFakeProvider{}
-			if err := reconcilePersistedServerID(f, "token", tc.ctx); err != nil {
+			if err := ReconcileK8sContextServerID(f, "token", tc.ctx); err != nil {
 				t.Fatalf("reconcile returned error: %v", err)
 			}
 			if f.getCalls != 0 || f.updateCalls != 0 {
@@ -202,12 +201,12 @@ func TestReconcilePersistedServerID_NoopOnMissingInputs(t *testing.T) {
 	}
 }
 
-func TestReconcilePersistedServerID_PropagatesGetError(t *testing.T) {
+func TestReconcileK8sContextServerID_PropagatesGetError(t *testing.T) {
 	connID := uuid.Must(uuid.NewV4()).String()
-	serverID, _ := newServerID(t)
+	serverID, _ := newReconcileServerID(t)
 
 	f := &reconcileFakeProvider{getErr: stderrors.New("boom")}
-	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err == nil {
+	if err := ReconcileK8sContextServerID(f, "token", reconcileK8sCtx(connID, serverID)); err == nil {
 		t.Fatal("expected an error when GetConnectionByID fails, got nil")
 	}
 	if f.updateCalls != 0 {
@@ -215,9 +214,9 @@ func TestReconcilePersistedServerID_PropagatesGetError(t *testing.T) {
 	}
 }
 
-func TestReconcilePersistedServerID_PropagatesUpdateError(t *testing.T) {
+func TestReconcileK8sContextServerID_PropagatesUpdateError(t *testing.T) {
 	connID := uuid.Must(uuid.NewV4()).String()
-	serverID, _ := newServerID(t)
+	serverID, _ := newReconcileServerID(t)
 
 	f := &reconcileFakeProvider{
 		conn: &connections.Connection{
@@ -228,7 +227,7 @@ func TestReconcilePersistedServerID_PropagatesUpdateError(t *testing.T) {
 		},
 		updateErr: stderrors.New("boom"),
 	}
-	if err := reconcilePersistedServerID(f, "token", k8sCtxWith(connID, serverID)); err == nil {
+	if err := ReconcileK8sContextServerID(f, "token", reconcileK8sCtx(connID, serverID)); err == nil {
 		t.Fatal("expected an error when UpdateConnectionById fails, got nil")
 	}
 	if f.updateCalls != 1 {

--- a/ui/utils/__tests__/multi-ctx.test.ts
+++ b/ui/utils/__tests__/multi-ctx.test.ts
@@ -56,6 +56,18 @@ describe('getK8sClusterIdsFromCtxId', () => {
   it('skips contexts not found in the config', () => {
     expect(getK8sClusterIdsFromCtxId(['ctx-1', 'missing'], sampleConfig)).toEqual(['srv-1']);
   });
+
+  it('omits configs without a resolved kubernetesServerId under "all"', () => {
+    // A connection registered while its cluster was unreachable has no server id
+    // yet; it must not contribute a junk cluster id to the query.
+    const configWithUnresolved = [
+      { id: 'ctx-1', name: 'minikube', kubernetesServerId: 'srv-1', connectionId: 'conn-1' },
+      { id: 'ctx-2', name: 'pending', kubernetesServerId: undefined, connectionId: 'conn-2' },
+      { id: 'ctx-3', name: 'empty', kubernetesServerId: '', connectionId: 'conn-3' },
+      { id: 'ctx-4', name: 'gke-prod', kubernetesServerId: 'srv-4', connectionId: 'conn-4' },
+    ];
+    expect(getK8sClusterIdsFromCtxId(['all'], configWithUnresolved)).toEqual(['srv-1', 'srv-4']);
+  });
 });
 
 describe('getFirstCtxIdFromSelectedCtxIds', () => {

--- a/ui/utils/multi-ctx.ts
+++ b/ui/utils/multi-ctx.ts
@@ -73,7 +73,12 @@ export const getK8sClusterIdsFromCtxId = (selectedContexts, k8sconfig) => {
   }
 
   if (selectedContexts.includes('all')) {
-    return k8sconfig.map((cfg) => cfg?.kubernetesServerId);
+    // Drop configs without a resolved kubernetesServerId (e.g. a connection
+    // registered while its cluster was unreachable, so no server ID was assigned
+    // yet). Sending an undefined/empty cluster id contributes a junk `clusterId`
+    // query param that matches no MeshSync rows, and matches the truthy filter the
+    // explicit-selection branch below already applies.
+    return k8sconfig.map((cfg) => cfg?.kubernetesServerId).filter(Boolean);
   }
   const clusterIds = [];
   selectedContexts.forEach((context) => {


### PR DESCRIPTION
## Notes for Reviewers

Fixes a case where a Kubernetes connection is **connected and actively streaming MeshSync data**, yet the dashboard shows none of that cluster's resources.

### Symptom
A user has multiple Kubernetes connections. At least one is connected and its cluster is streaming MeshSync data, but the Meshery dashboard (Overview honeycomb + resource tables) renders empty for it.

### Root cause
The dashboard filters MeshSync rows by `cluster_id` - a cluster's `kube-system` namespace UID, stamped on every row by the MeshSync agent. It obtains the id it queries with from each connection's persisted `metadata.kubernetesServerId`:

`connection.metadata.kubernetesServerId` -> `getK8sClusterIdsFromCtxId` -> `?clusterId=...` -> `WHERE cluster_id IN (...)`

When a connection is first persisted **before** its server ID is resolved - registered while its cluster's API server was unreachable, or migrated from an older Meshery that never stored it - `kubernetesServerId` is persisted empty (`""`) or as the nil UUID (`00000000-...`). It is then **never corrected** once the cluster becomes reachable and starts streaming:

- `SaveK8sContext` early-returns `ErrContextAlreadyPersisted` (it does not update an existing connection), and
- the FSM status-update path rewrites the *existing* metadata verbatim (`MetaData: connection.Metadata`).

So rows arrive stamped with the real `cluster_id`, while the dashboard queries `cluster_id IN ('' | 00000000-...)` and matches nothing. The GraphQL -> SSE/REST connection migration surfaced this: the old `subscribeK8sContext` computed `kubernetesServerId` from the live in-memory context; the new path reads it from persisted connection metadata.

### Fix
- **[Server]** `DiscoverAction` now reconciles the persisted `kubernetesServerId` with the id freshly resolved by `AssignServerID` whenever they differ (and persists the freshly-resolved context on first save). This runs on the per-request discovery re-drive, is a **no-op once corrected** (no steady-state write), and **self-heals existing broken connections** on their next reconcile. Wrapped in a MeshKit error (`meshery-server-1445`).
- **[UI]** Hardening: `getK8sClusterIdsFromCtxId`'s `all` branch dropped nothing, so an unresolved connection contributed an `undefined`/empty (junk) `clusterId` param. It now filters to truthy ids, matching the check the explicit-selection branch already applies.

### Watch for
- Two connections pointing at the **same** physical cluster resolve to the same `kube-system` UID (same `cluster_id`); MeshSync rows are keyed only by `cluster_id`, so they remain indistinguishable per-connection by design - unchanged here.
- A separate, already-tracked concurrency issue on the MeshSync data-handler lifecycle (`ctxMeshsyncDataHandler`) is out of scope for this PR (see #20763 / #20794).

### Testing
- `go test ./server/machines/kubernetes/` - added `discover_test.go` covering back-fill of empty and nil-UUID server ids, no-op when already correct, nil metadata, early-return guards, and error propagation.
- `vitest run ui/utils/__tests__/multi-ctx.test.ts` - added a case asserting unresolved server ids are dropped under `all`. All 38 pass.
- `make golangci` / `go vet` clean on the changed package; `eslint` + `prettier` clean on the changed UI files.

**[Signed commits]**
- [x] Yes, I signed my commits.
