### PR TITLE
fix(ui): use CheckCircleIcon for Notification Center success severity

### DIFF
--- a/ui/components/layout/NotificationCenter/constants.test.tsx
+++ b/ui/components/layout/NotificationCenter/constants.test.tsx
@@ -63,7 +63,7 @@ describe('NotificationCenter constants', () => {
     expect(SEVERITY_STYLE[SEVERITY.ERROR].darkColor).toBe(notificationColors.error.dark);
     expect(SEVERITY_STYLE[SEVERITY.WARNING].color).toBe(notificationColors.warning.main);
     expect(SEVERITY_STYLE[SEVERITY.SUCCESS].color).toBe(notificationColors.success.main);
-    
+
     expect(SEVERITY_STYLE[SEVERITY.SUCCESS].icon).toBe(CheckCircleIcon);
     expect(SEVERITY_STYLE[SEVERITY.INFO].icon).toBe(InfoIcon);
 

--- a/ui/components/layout/NotificationCenter/constants.test.tsx
+++ b/ui/components/layout/NotificationCenter/constants.test.tsx
@@ -31,7 +31,7 @@ import {
   eventDetailFormatterKey,
   getStatusStyle,
 } from './constants';
-import { notificationColors } from '@sistent/sistent';
+import { CheckCircleIcon, InfoIcon, notificationColors } from '@sistent/sistent';
 
 describe('NotificationCenter constants', () => {
   it('defines severity levels', () => {
@@ -63,6 +63,10 @@ describe('NotificationCenter constants', () => {
     expect(SEVERITY_STYLE[SEVERITY.ERROR].darkColor).toBe(notificationColors.error.dark);
     expect(SEVERITY_STYLE[SEVERITY.WARNING].color).toBe(notificationColors.warning.main);
     expect(SEVERITY_STYLE[SEVERITY.SUCCESS].color).toBe(notificationColors.success.main);
+    
+    expect(SEVERITY_STYLE[SEVERITY.SUCCESS].icon).toBe(CheckCircleIcon);
+    expect(SEVERITY_STYLE[SEVERITY.INFO].icon).toBe(InfoIcon);
+
     Object.values(SEVERITY_STYLE).forEach((style) => {
       expect(style.icon).toBeDefined();
     });

--- a/ui/components/layout/NotificationCenter/constants.test.tsx
+++ b/ui/components/layout/NotificationCenter/constants.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@sistent/sistent', () => ({
   InfoIcon: () => null,
+  CheckCircleIcon: () => null,
   notificationColors: {
     info: { main: '#info' },
     error: { main: '#error', dark: '#error_dark' },

--- a/ui/components/layout/NotificationCenter/constants.tsx
+++ b/ui/components/layout/NotificationCenter/constants.tsx
@@ -1,7 +1,7 @@
 import AlertIcon from '../../../assets/icons/AlertIcon';
 import ErrorIcon from '../../../assets/icons/ErrorIcon';
 import ReadIcon from '../../../assets/icons/ReadIcon';
-import { InfoIcon, notificationColors } from '@sistent/sistent';
+import { CheckCircleIcon, InfoIcon, notificationColors } from '@sistent/sistent';
 import type { Theme } from '@sistent/sistent';
 
 export const SEVERITY = {
@@ -54,7 +54,7 @@ export const SEVERITY_STYLE = {
     darkColor: notificationColors.warning.main,
   },
   [SEVERITY.SUCCESS]: {
-    icon: InfoIcon,
+    icon: CheckCircleIcon,
     color: notificationColors.success.main,
     darkColor: notificationColors.success.main,
   },

--- a/ui/components/layout/NotificationCenter/metadata.test.tsx
+++ b/ui/components/layout/NotificationCenter/metadata.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@sistent/sistent', () => ({
   }),
   DownloadIcon: () => <svg data-testid="download-icon" />,
   InfoIcon: () => <svg data-testid="info-icon" />,
+  CheckCircleIcon: () => <svg data-testid="check-circle-icon" />,
   createTheme: () => ({ breakpoints: { up: () => '', down: () => '' } }),
   notificationColors: {
     info: { main: '#info' },

--- a/ui/components/layout/NotificationCenter/notificationCenter.style.test.tsx
+++ b/ui/components/layout/NotificationCenter/notificationCenter.style.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@sistent/sistent', () => {
     IconButton: ({ children, ...props }: any) => <button {...props}>{children}</button>,
     Typography: ({ children, ...props }: any) => <span {...props}>{children}</span>,
     InfoIcon: () => null,
+    CheckCircleIcon: () => null,
     createTheme: () => ({ breakpoints: { up: () => '', down: () => '' } }),
     notificationColors: {
       info: { main: '#info' },


### PR DESCRIPTION
## Summary

This PR updates the Notification Center to use `CheckCircleIcon` for `SEVERITY.SUCCESS` instead of `InfoIcon`.

Previously, both informational and success notifications displayed the same icon, making them visually indistinguishable. Using a dedicated success icon improves visual consistency and makes notification types easier to recognize at a glance.

This change also aligns the Notification Center with the existing snackbar implementation, which already uses `CheckCircleIcon` for success states.

## Changes

- Replace `InfoIcon` with `CheckCircleIcon` for `SEVERITY.SUCCESS` in the Notification Center.
- No functional behavior was changed; this is a UI consistency improvement.

## Testing

- Verified the icon mapping for `SEVERITY.SUCCESS`.
- Ran ESLint:
  ```bash
  npx eslint components/layout/NotificationCenter/constants.tsx
  ```
- Formatted the file using Prettier.

Fixes #20769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Success notifications now display a check-circle icon, improving visual distinction from informational notifications.

* **Tests**
  * Expanded notification coverage to verify the correct icons are shown for success and informational messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->