### PR TITLE
[UI] Migrate Catalog table toolbar to Sistent DataTableToolbar

### DIFF
--- a/ui/components/designs/patterns/MesheryPatterns.styled.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.styled.tsx
@@ -1,29 +1,8 @@
-import { Box, DialogTitle, Typography, styled } from '@sistent/sistent';
+import { DialogTitle, Typography, styled } from '@sistent/sistent';
 import { AddCircleOutlined as AddIcon } from '@/assets/icons';
-
-export const ViewSwitchButton = styled(Box)(() => ({
-  justifySelf: 'flex-end',
-}));
-
-export const CreateButton = styled(Box)(() => ({
-  display: 'flex',
-  justifyContent: 'flex-start',
-  alignItems: 'center',
-  whiteSpace: 'nowrap',
-}));
 
 export const AddIconStyled = styled(AddIcon)(() => ({
   paddingRight: '.35rem',
-}));
-
-export const SearchWrapper = styled(Box)(() => ({
-  justifySelf: 'flex-end',
-  marginLeft: 'auto',
-  paddingLeft: '1rem',
-  display: 'flex',
-  '@media (max-width: 965px)': {
-    width: 'max-content',
-  },
 }));
 
 export const BtnText = styled('span')(() => ({

--- a/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
+++ b/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import { CustomColumnVisibilityControl, SearchBar, UniversalFilter } from '@sistent/sistent';
+import {
+  CustomColumnVisibilityControl,
+  SearchBar,
+  UniversalFilter,
+  DataTableToolbar,
+} from '@sistent/sistent';
 import { Publish as PublishIcon } from '@/assets/icons';
 import ViewSwitch from '../../ViewSwitch';
 import CAN from '@/utils/can';
 import { Keys } from '@meshery/schemas/permissions';
 import TooltipButton from '@/utils/TooltipButton';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
-import {
-  ViewSwitchButton,
-  CreateButton,
-  AddIconStyled,
-  SearchWrapper,
-  BtnText,
-} from './MesheryPatterns.styled';
+import { AddIconStyled, BtnText } from './MesheryPatterns.styled';
 
 /**
  * Header toolbar for the Designs page.
@@ -43,110 +41,94 @@ function MesheryPatternsToolbar({
   setColumnVisibility,
 }) {
   return (
-    <ToolWrapper>
-      {width < 600 && isSearchExpanded ? null : (
-        <CreateButton style={{ display: 'flex' }}>
-          {!selectedPattern.show && (patterns.length >= 0 || viewType === 'table') && (
-            <div>
-              {disableCreateImportDesignButton ? null : (
-                <div style={{ display: 'flex', order: '1' }}>
-                  <TooltipButton
-                    title="Create Design"
-                    data-testid="meshery-patterns-create-design-btn"
-                    aria-label="Add Pattern"
-                    variant="contained"
-                    color="primary"
-                    size="large"
-                    // @ts-ignore
-                    onClick={() => router.push('designs/configurator')}
-                    style={{ display: 'flex', marginRight: '2rem' }}
-                    disabled={
-                      !CAN(
-                        Keys.CatalogManagementCreateNewDesign.id,
-                        Keys.CatalogManagementCreateNewDesign.function,
-                      )
-                    }
-                  >
-                    <AddIconStyled />
-                    <BtnText> Create Design </BtnText>
-                  </TooltipButton>
-                  <TooltipButton
-                    title="Import Design"
-                    data-testid="meshery-patterns-import-design-btn"
-                    aria-label="Add Pattern"
-                    variant="contained"
-                    color="primary"
-                    size="large"
-                    // @ts-ignore
-                    onClick={handleUploadImport}
-                    style={{ display: 'flex', marginRight: '2rem', marginLeft: '-0.6rem' }}
-                    disabled={
-                      !CAN(
-                        Keys.CatalogManagementImportDesign.id,
-                        Keys.CatalogManagementImportDesign.function,
-                      )
-                    }
-                  >
-                    <AddIconStyled>
-                      <PublishIcon />
-                    </AddIconStyled>
-                    <BtnText> Import Design </BtnText>
-                  </TooltipButton>
-                </div>
-              )}
-            </div>
-          )}
-          {!selectedPattern.show && (
-            <div style={{ display: 'flex' }}>
-              {/* <StyledCatalogFilter>
-              <CatalogFilter
-                catalogVisibility={catalogVisibility}
-                handleCatalogVisibility={handleCatalogVisibility}
-                classes={classes}
-              />
-              </StyledCatalogFilter>*/}
-            </div>
-          )}
-        </CreateButton>
-      )}
-      <SearchWrapper style={{ display: 'flex' }}>
-        <>
-          <SearchBar
-            onSearch={(value) => {
-              setSearch(value);
-            }}
-            expanded={isSearchExpanded}
-            setExpanded={setIsSearchExpanded}
-            placeholder={`Search ${pageTitle.toLowerCase()}...`}
-            data-testid="meshery-patterns-search-bar"
+    <DataTableToolbar
+      primaryActions={
+        width < 600 && isSearchExpanded ? null : !selectedPattern.show &&
+          (patterns.length >= 0 || viewType === 'table') &&
+          !disableCreateImportDesignButton ? (
+          <div style={{ display: 'flex' }}>
+            <TooltipButton
+              title="Create Design"
+              data-testid="meshery-patterns-create-design-btn"
+              aria-label="Add Pattern"
+              variant="contained"
+              color="primary"
+              size="large"
+              // @ts-ignore
+              onClick={() => router.push('designs/configurator')}
+              style={{ display: 'flex', marginRight: '2rem' }}
+              disabled={
+                !CAN(
+                  Keys.CatalogManagementCreateNewDesign.id,
+                  Keys.CatalogManagementCreateNewDesign.function,
+                )
+              }
+            >
+              <AddIconStyled />
+              <BtnText> Create Design </BtnText>
+            </TooltipButton>
+            <TooltipButton
+              title="Import Design"
+              data-testid="meshery-patterns-import-design-btn"
+              aria-label="Add Pattern"
+              variant="contained"
+              color="primary"
+              size="large"
+              // @ts-ignore
+              onClick={handleUploadImport}
+              style={{ display: 'flex', marginRight: '2rem', marginLeft: '-0.6rem' }}
+              disabled={
+                !CAN(
+                  Keys.CatalogManagementImportDesign.id,
+                  Keys.CatalogManagementImportDesign.function,
+                )
+              }
+            >
+              <AddIconStyled>
+                <PublishIcon />
+              </AddIconStyled>
+              <BtnText> Import Design </BtnText>
+            </TooltipButton>
+          </div>
+        ) : null
+      }
+      search={
+        <SearchBar
+          onSearch={(value) => {
+            setSearch(value);
+          }}
+          expanded={isSearchExpanded}
+          setExpanded={setIsSearchExpanded}
+          placeholder={`Search ${pageTitle.toLowerCase()}...`}
+          data-testid="meshery-patterns-search-bar"
+        />
+      }
+      filter={
+        !disableUniversalFilter ? (
+          <UniversalFilter
+            id="ref"
+            filters={filter}
+            selectedFilters={selectedFilters}
+            setSelectedFilters={setSelectedFilters}
+            handleApplyFilter={handleApplyFilter}
+            data-testid="meshery-patterns-universal-filter"
           />
-          {disableUniversalFilter ? null : (
-            <UniversalFilter
-              id="ref"
-              filters={filter}
-              selectedFilters={selectedFilters}
-              setSelectedFilters={setSelectedFilters}
-              handleApplyFilter={handleApplyFilter}
-              data-testid="meshery-patterns-universal-filter"
-            />
-          )}
-          {viewType === 'table' && (
-            <CustomColumnVisibilityControl
-              data-testid="meshery-patterns-column-visibility-control"
-              id="ref"
-              columns={columns}
-              customToolsProps={{ columnVisibility, setColumnVisibility }}
-            />
-          )}
-        </>
-
-        {!selectedPattern.show && (
-          <ViewSwitchButton>
-            <ViewSwitch view={viewType} changeView={setViewType} />
-          </ViewSwitchButton>
-        )}
-      </SearchWrapper>
-    </ToolWrapper>
+        ) : null
+      }
+      columnVisibility={
+        viewType === 'table' ? (
+          <CustomColumnVisibilityControl
+            data-testid="meshery-patterns-column-visibility-control"
+            id="ref"
+            columns={columns}
+            customToolsProps={{ columnVisibility, setColumnVisibility }}
+          />
+        ) : null
+      }
+      viewSwitch={
+        !selectedPattern.show ? <ViewSwitch view={viewType} changeView={setViewType} /> : null
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## Description
This PR resolves #20659 by migrating the `MesheryPatternsToolbar` (used by the Catalog and Designs pages) to use Sistent's `DataTableToolbar`, replacing the custom toolbar layout with the standardized component.

### Changes
- Replaced the custom toolbar layout with `DataTableToolbar`.
- Mapped existing controls to:
  - `primaryActions`
  - `search`
  - `filter`
  - `columnVisibility`
  - `viewSwitch`
- Removed redundant layout-specific styled components that are no longer needed.
- Preserved existing callbacks, permission checks, and business logic.

### Notes
- The existing mobile responsive condition (`width < 600 && isSearchExpanded`) has been intentionally preserved to maintain the current behavior while migrating the layout. This can be revisited in a future cleanup if it becomes redundant.

Fixes #20659
