### PR TITLE
[UI] Fix performance page sizing issues, modal closing, and align environment card flip actions

### DIFF
--- a/ui/components/environments/environment-card.test.tsx
+++ b/ui/components/environments/environment-card.test.tsx
@@ -15,17 +15,40 @@ vi.mock('@/utils/can', () => ({
   default: (...args: unknown[]) => can(...args),
 }));
 
-vi.mock('@sistent/sistent', () => ({
-  DeleteIcon: () => <svg data-testid="delete-icon" />,
-  EditIcon: () => <svg data-testid="edit-icon" />,
-  Grid2: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  SyncAltIcon: () => <svg data-testid="sync-icon" />,
-  useTheme: () => ({
-    palette: {
-      background: { neutral: { default: 'neutral' } },
-    },
-  }),
-}));
+vi.mock('@sistent/sistent', () => {
+  const styled = (Component: any) => () => {
+    const StyledComponent = ({ children, ...props }: any) => (
+      <Component {...props}>{children}</Component>
+    );
+    StyledComponent.displayName = 'StyledSistentMock';
+    return StyledComponent;
+  };
+
+  return {
+    DeleteIcon: () => <svg data-testid="delete-icon" />,
+    EditIcon: () => <svg data-testid="edit-icon" />,
+    Grid2: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    SyncAltIcon: () => <svg data-testid="sync-icon" />,
+    IconButton: ({ children, onClick, disabled, ...props }: any) => (
+      <button data-testid="sistent-icon-button" onClick={onClick} disabled={disabled} {...props}>
+        {children}
+      </button>
+    ),
+    CustomTooltip: ({ children, title }: any) => (
+      <div data-testid="custom-tooltip" title={title}>
+        {children}
+      </div>
+    ),
+    Typography: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    useTheme: () => ({
+      palette: {
+        background: { neutral: { default: 'neutral' } },
+        icon: { secondary: 'secondary' },
+      },
+    }),
+    styled,
+  };
+});
 
 vi.mock('../lifecycle/general', () => ({
   FlipCard: ({ frontComponents, backComponents, disableFlip }: any) => (

--- a/ui/components/environments/environment-card.tsx
+++ b/ui/components/environments/environment-card.tsx
@@ -3,11 +3,19 @@ import { FlipCard } from '../lifecycle/general';
 import { useGetEnvironmentConnectionsQuery } from '../../rtk-query/environments';
 import CAN from '@/utils/can';
 import { Keys } from '@meshery/schemas/permissions';
-import { DeleteIcon, EditIcon, Grid2, SyncAltIcon, useTheme } from '@sistent/sistent';
+import {
+  DeleteIcon,
+  EditIcon,
+  Grid2,
+  SyncAltIcon,
+  useTheme,
+  IconButton,
+  CustomTooltip,
+} from '@sistent/sistent';
+import { iconMedium } from '../../css/icons.styles';
 
 import {
   Name,
-  IconButton,
   CardWrapper,
   DateLabel,
   DescriptionLabel,
@@ -225,32 +233,44 @@ const EnvironmentCard = ({
                   justifyContent: 'flex-end',
                 }}
               >
-                <IconButton
-                  onClick={onEdit}
-                  disabled={
-                    selectedEnvironments?.filter((id) => id == environmentDetails.id).length === 1
-                      ? true
-                      : !CAN(
-                          Keys.WorkspaceManagementEditEnvironment.id,
-                          Keys.WorkspaceManagementEditEnvironment.function,
-                        )
-                  }
-                >
-                  <EditIcon fill="white" style={{ margin: '0 2px' }} />
-                </IconButton>
-                <IconButton
-                  onClick={onDelete}
-                  disabled={
-                    selectedEnvironments?.filter((id) => id == environmentDetails.id).length === 1
-                      ? true
-                      : !CAN(
-                          Keys.WorkspaceManagementDeleteEnvironment.id,
-                          Keys.WorkspaceManagementDeleteEnvironment.function,
-                        )
-                  }
-                >
-                  <DeleteIcon fill="white" style={{ margin: '0 2px' }} />
-                </IconButton>
+                <CustomTooltip title="Edit">
+                  <IconButton
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      onEdit(ev);
+                    }}
+                    sx={{ color: 'white' }}
+                    disabled={
+                      selectedEnvironments?.filter((id) => id == environmentDetails.id).length === 1
+                        ? true
+                        : !CAN(
+                            Keys.WorkspaceManagementEditEnvironment.id,
+                            Keys.WorkspaceManagementEditEnvironment.function,
+                          )
+                    }
+                  >
+                    <EditIcon style={{ ...iconMedium, margin: '0 2px' }} />
+                  </IconButton>
+                </CustomTooltip>
+                <CustomTooltip title="Delete">
+                  <IconButton
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      onDelete(ev);
+                    }}
+                    sx={{ color: 'white' }}
+                    disabled={
+                      selectedEnvironments?.filter((id) => id == environmentDetails.id).length === 1
+                        ? true
+                        : !CAN(
+                            Keys.WorkspaceManagementDeleteEnvironment.id,
+                            Keys.WorkspaceManagementDeleteEnvironment.function,
+                          )
+                    }
+                  >
+                    <DeleteIcon style={{ ...iconMedium, margin: '0 2px' }} />
+                  </IconButton>
+                </CustomTooltip>
               </Grid2>
             </Grid2>
             <Grid2 sx={{ display: 'flex', flexDirection: 'row', color: 'white' }}>

--- a/ui/components/performance/PerformanceProfiles.tsx
+++ b/ui/components/performance/PerformanceProfiles.tsx
@@ -280,7 +280,6 @@ function PerformanceProfile({ handleDelete }) {
               <CustomTooltip title="Edit">
                 <div>
                   <IconButton
-                    style={iconMedium}
                     onClick={(ev) => {
                       ev.stopPropagation();
                       setSelectedProfile(testProfiles[tableMeta.rowIndex]);
@@ -306,7 +305,6 @@ function PerformanceProfile({ handleDelete }) {
               <CustomTooltip title="Run test">
                 <div>
                   <IconButton
-                    style={iconMedium}
                     onClick={(ev) => {
                       ev.stopPropagation();
                       setSelectedProfile({ ...testProfiles[tableMeta.rowIndex], runTest: true });

--- a/ui/components/performance/PerformanceResults.tsx
+++ b/ui/components/performance/PerformanceResults.tsx
@@ -251,11 +251,7 @@ function generateColumnsForDisplay(
         customBodyRender: function CustomBody(_, tableMeta) {
           return (
             <>
-              <IconButton
-                style={iconMedium}
-                aria-label="Share"
-                onClick={(e) => handleSocialExpandClick(e, tableMeta)}
-              >
+              <IconButton aria-label="Share" onClick={(e) => handleSocialExpandClick(e, tableMeta)}>
                 <ReplyIcon
                   style={{
                     transform: 'scaleX(-1)',

--- a/ui/components/shared/Modal/GenericModal.test.tsx
+++ b/ui/components/shared/Modal/GenericModal.test.tsx
@@ -36,6 +36,12 @@ vi.mock('@sistent/sistent', () => {
         {children}
       </div>
     ),
+    IconButton: ({ children, onClick }: any) => (
+      <button data-testid="close-button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+    CloseIcon: () => <span data-testid="close-icon">X</span>,
     styled,
   };
 });
@@ -87,5 +93,16 @@ describe('GenericModal', () => {
     render(<GenericModal open={true} Content={<span>Body</span>} handleClose={vi.fn()} />);
 
     expect(screen.getByTestId('modal')).toHaveAttribute('data-max-width', 'lg');
+  });
+
+  it('renders the close button and calls handleClose when clicked', () => {
+    const handleClose = vi.fn();
+    render(<GenericModal open={true} Content={<span>Body</span>} handleClose={handleClose} />);
+
+    const closeBtn = screen.getByTestId('close-button');
+    expect(closeBtn).toBeInTheDocument();
+
+    closeBtn.click();
+    expect(handleClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/components/shared/Modal/GenericModal.tsx
+++ b/ui/components/shared/Modal/GenericModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Backdrop, Box, styled, Fade } from '@sistent/sistent';
+import { Modal, Backdrop, Box, styled, Fade, IconButton, CloseIcon } from '@sistent/sistent';
 
 const StyledModal = styled(Modal)({
   display: 'flex',
@@ -17,6 +17,7 @@ export default function GenericModal({ open, Content, handleClose, container }) 
     <StyledModal
       open={open}
       onClose={handleClose}
+      closeModal={handleClose}
       closeAfterTransition
       slots={{ backdrop: Backdrop }}
       slotProps={{ backdrop: { timeout: 200 } }}
@@ -24,7 +25,24 @@ export default function GenericModal({ open, Content, handleClose, container }) 
       maxWidth="lg"
     >
       <StyledFade in={open}>
-        <Box sx={{ outline: 'none', width: '100%' }}>{Content}</Box>
+        <Box sx={{ outline: 'none', width: '100%', position: 'relative' }}>
+          <IconButton
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClose();
+            }}
+            sx={{
+              position: 'absolute',
+              top: 12,
+              right: 12,
+              color: (theme) => theme.palette.text.secondary,
+              zIndex: 1300,
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+          {Content}
+        </Box>
       </StyledFade>
     </StyledModal>
   );


### PR DESCRIPTION
## Description

This PR addresses several UI fixes and alignment improvements on the Performance and Environments pages:

1. **Performance Profiles Actions Sizing**: 
   - Fixed an issue where the Edit and Run Test icons in the Actions column of the Performance Profiles table were rendering too small (squeezed by default padding on `IconButton`). Removed `style={iconMedium}` from the outer `IconButton` containers.
2. **Performance Results Share Icon Sizing**:
   - Fixed an issue where the Share Results curving arrow icon in the results table was too small. Removed the outer `IconButton` container's size constraint to allow the icon to render at its proper scale.
3. **Chart Modal Closing**:
   - Supported `closeModal` prop on Sistent's `Modal` component in `GenericModal.tsx` to fix modal closing on backdrop clicks.
   - Added a visible Close icon button (`CloseIcon`) in the top-right corner of the modal for direct closing.
4. **Environment Card Flipside Actions Alignment**:
   - Aligned the Edit/Delete actions on the backside of the Environment card to match the Performance card design.
   - Replaced the custom HTML `<button>` with Sistent's `IconButton`, added tooltips, and wrapped them in `CustomTooltip`.
   - Prevented accidental card-flip behavior on edit/delete button clicks by adding `ev.stopPropagation()`.
   - Configured `color: 'white'` to maintain visibility against the dark background gradient of the environment card flipside.
   
 #### Before 
 

https://github.com/user-attachments/assets/38cb4dfc-e6ef-4da3-9188-602c30eef968


 
 
 #### After 
 

https://github.com/user-attachments/assets/dc825ec3-7682-4ee9-bf4d-36ed334d6e1f


 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
