### PR TITLE
[Docs] Move code block copy button to the right

### DIFF
--- a/docs/assets/scss/_clipboard.scss
+++ b/docs/assets/scss/_clipboard.scss
@@ -1,11 +1,7 @@
 pre.codeblock-pre {
-  display: inline-flex;
-  justify-content: flex-start;
+  display: block;
   text-align: left;
-  align-items: center;
-  align-content: flex-start;
-  flex-wrap: nowrap;
-  flex-direction: row;
+  position: relative;
   overflow: hidden !important;
   margin: 0;
   font-size: .9rem;
@@ -17,19 +13,20 @@ pre.codeblock-pre {
 }
 .codeblock {
   width: 100%;
-  display: inline-flex;
+  display: block;
   overflow: auto;
-  justify-content: flex-start;
   color: #f8f9fa;
   margin: 0px;
   padding: 0px;
+  position: relative;
 }
 .clipboardjs {
   width: 100%;
-  overflow: auto;
+  display: block;
+  overflow-x: auto;
   font-size: .9rem;
   margin: 0px;
-  padding: 0.5rem 0.75rem;
+  padding: 0.6rem 2.5rem 0.6rem 0.8rem;
   color: #f8f9fa;
   align-items: center;
   white-space: pre;
@@ -55,19 +52,23 @@ pre.codeblock-pre {
   }
 }
 .btn-copy-wrap {
-  align-content: center;
-  z-index: auto;
-  position: relative;
-  text-align: right;
+  position: absolute;
+  top: 0.45rem;
+  right: 0.75rem;
+  z-index: 15;
   display: flex;
   align-items: center;
 }
 .clipbtn {
-  right: 0;
-  margin: 5px;
+  margin: 0;
+  padding: 4px 6px;
   border: 0px;
   background-color: transparent;
   font-size: 1.05rem;
+  line-height: 1;
+  color: #f1f3f5;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.1s ease;
   & i.fa-copy::before {
     color: #f1f3f5;
   }
@@ -77,9 +78,14 @@ pre.codeblock-pre {
 }
 .clipbtn:hover {
   color: #fff;
-  cursor: pointer;
+  opacity: 0.85;
 }
 .clipbtn:active {
-  background-color: #495057;
-  transform: scale(0.75);
+  transform: scale(0.85);
 }
+.clipbtn:focus-visible {
+  outline: 2px solid var(--brand-color-secondary);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+

--- a/docs/assets/scss/_td-content.scss
+++ b/docs/assets/scss/_td-content.scss
@@ -92,8 +92,8 @@
   box-shadow: var(--box-shadow-primary);
   font-size: 16px;
   font-family: "Fira Mono", Consolas, Menlo, Monaco, "Courier New", Courier, monospace;
-  border-radius: 0px;
-  padding: 4rem;
+  border-radius: 4px;
+  padding: 2.5rem 1.25rem 1.25rem 1.25rem;
   position: relative;
   overflow: hidden;
   overflow-x: auto;
@@ -107,6 +107,19 @@
     color: #fff;
   }
 
+  // Gray top header bar matching production
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2rem;
+    background: #3d3d3d;
+    border-radius: 4px 4px 0 0;
+    z-index: 5;
+  }
+
   &::-webkit-scrollbar-thumb {
     background: #868e96;
     // background: #343a40;
@@ -118,18 +131,18 @@
 
 .window-buttons {
   content: "";
-  position: relative;
-  top: -2.8rem;
-  left: 1.5rem;
-  margin-bottom: -2rem;
+  position: absolute;
+  top: 0.55rem;
+  left: 0.75rem;
+  z-index: 10;
   display: inline-block;
   width: 0.85rem;
   height: 0.85rem;
   border-radius: 50%;
   /* A little hack to display the window buttons in one pseudo element. */
   background: #d9515d;
-  -webkit-box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
-  box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
+  -webkit-box-shadow: 20px 0 0 #f4c025, 40px 0 0 #3ec930;
+  box-shadow: 20px 0 0 #f4c025, 40px 0 0 #3ec930;
 }
 
 .clipboardjs::after {

--- a/docs/content/en/installation/docker/docker-extension/index.md
+++ b/docs/content/en/installation/docker/docker-extension/index.md
@@ -65,21 +65,19 @@ Finally, you can also install the Meshery Docker Extension using the Docker CLI.
 {% capture code_content %}docker extension install meshery/docker-extension-meshery{% endcapture %} -->
 <!-- {% include code.html code=code_content %} -->
 
-<pre class="codeblock-pre" style="padding: 0; font-size: 0px;">
-  <div class="codeblock" style="display: block;">
-    <!-- Updated style for clipboardjs -->
-    <div class="clipboardjs" style="padding: 0; height: 0.5rem; overflow: hidden;">
-      <span style="font-size: 0;">docker extension install meshery/docker-extension-meshery</span> 
-    </div>
-    <div class="window-buttons"></div>
-    <div id="termynal2" style="width: 100%; height: 200px; max-width: 100%;" data-termynal="">
-      <span data-ty="input">docker extension install meshery/docker-extension-meshery</span>
-      <span data-ty="progress"></span>
-      <span data-ty="">Successfully installed Meshery</span>
-      <span data-ty="input">mesheryctl system dashboard</span>
-    </div>
+<div class="codeblock" style="display: block; position: relative;">
+  <!-- Updated style for clipboardjs -->
+  <div class="clipboardjs" style="padding: 0; height: 0; margin: 0; overflow: hidden; font-size: 0; line-height: 0;">
+    <span style="font-size: 0;">docker extension install meshery/docker-extension-meshery</span> 
   </div>
-</pre>
+  <div class="window-buttons"></div>
+  <div id="termynal2" style="width: 100%; max-width: 100%;" data-termynal="">
+    <span data-ty="input">docker extension install meshery/docker-extension-meshery</span>
+    <span data-ty="progress"></span>
+    <span data-ty="">Successfully installed Meshery</span>
+    <span data-ty="input">mesheryctl system dashboard</span>
+  </div>
+</div>
 
 It runs as a set of one or more containers inside your Docker Desktop virtual machine.
 

--- a/docs/content/en/installation/quick-start/index.md
+++ b/docs/content/en/installation/quick-start/index.md
@@ -16,17 +16,15 @@ This quick start guide enables you to download, install, and run Meshery in a si
 
 If you are on a macOS or Linux system, you can download, install, and run both `mesheryctl` and Meshery Server by executing the following command.
 
-<!-- <pre class="codeblock-pre" style="padding: 0; font-size:0px;">
-<div class="codeblock" style="display: block;">
-  <div class="clipboardjs" style="visibility:hidden;padding: 0;">
+<!-- <div class="codeblock" style="display: block; position: relative;">
+  <div class="clipboardjs" style="visibility:hidden;padding: 0; height: 0; margin: 0; overflow: hidden; font-size: 0; line-height: 0;">
     <span style="visibility:hidden">curl -L https://meshery.io/install | PLATFORM=kubernetes bash -</span>
   </div>
   <div class="window-buttons"></div>
   <div id="termynal0" style="width:fit-content;min-height:content-fit;" data-termynal="">
     <span data-ty="input">curl -L https://meshery.io/install | PLATFORM=kubernetes bash -</span>
   </div>
-</div>
-</pre>-->
+</div> -->
 <!-- <script src="../../assets/js/terminal.js" data-termynal-container="#termynal0"></script> -->
 
 <pre class="codeblock-pre">

--- a/docs/static/js/main.js
+++ b/docs/static/js/main.js
@@ -65,8 +65,20 @@ getcodeelement.each(function () {
 
 var clipboard = new Clipboard('.clipbtn', {
     text: function (trigger) {
-        var container = trigger.closest('pre') || trigger.closest('.highlight');
-        var content = container ? container.querySelector('.clipboardjs') : null;
+        var btnWrap = trigger.closest('.btn-copy-wrap');
+        var prev = btnWrap ? btnWrap.previousElementSibling : null;
+        var content = null;
+        if (prev) {
+            if (prev.classList && prev.classList.contains('clipboardjs')) {
+                content = prev;
+            } else if (prev.querySelector) {
+                content = prev.querySelector('.clipboardjs');
+            }
+        }
+        if (!content) {
+            var container = trigger.closest('pre') || trigger.closest('.highlight') || trigger.closest('.codeblock');
+            content = container ? container.querySelector('.clipboardjs') : null;
+        }
         var text = content ? content.textContent : '';
         return text.trim().replace(/^\s*\$\s+/gm, '');
     }
@@ -74,6 +86,7 @@ var clipboard = new Clipboard('.clipbtn', {
 
 /* Change copy icon to check icon when successfully copied*/
 clipboard.on("success", (e) => {
+    e.clearSelection();
     const button = e.trigger;
     if (button.dataset.isCopying === "true") {
         return;


### PR DESCRIPTION
Move the copy button to the right side of the code block for better visibility and consistency. Closes #20803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying so it reliably captures the correct code across code blocks and terminal examples.
* **Style**
  * Refined copy-button positioning, spacing, visibility, and interaction states.
  * Updated terminal window styling, including rounded corners, padding, header bar, and button placement.
* **Documentation**
  * Refreshed Docker extension and quick-start code snippets to align with updated code block, clipboard, and terminal presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->