### PR TITLE
[Server] Fix compilation error in auto-registration helper

### DIFF
--- a/server/machines/helpers/auto_register.go
+++ b/server/machines/helpers/auto_register.go
@@ -176,6 +176,8 @@ func (arh *AutoRegistrationHelper) getConnectionDefinitions(connType string) []c
 // The asserted pointer is checked for nil because a typed nil pointer in an entity.Entity passes
 // the type assertion with ok == true.
 func toConnectionDefinitions(connectionEntities []entity.Entity) []component.ComponentDefinition {
+	connectionDefs := make([]component.ComponentDefinition, 0, len(connectionEntities))
+	for _, connectionEntity := range connectionEntities {
 		def, ok := connectionEntity.(*component.ComponentDefinition)
 		if !ok || def == nil || def.Model == nil {
 			continue


### PR DESCRIPTION
## Description

This PR fixes a compilation/syntax error in the server's auto-registration helper function (`toConnectionDefinitions`), where the `connectionDefs` initialization and the `for` loop header iterating over `connectionEntities` were accidentally deleted.

## Changes

* Restored the missing variable initialization and `for` loop header in `toConnectionDefinitions` inside [server/machines/helpers/auto_register.go](file:///Users/rishiraj/Desktop/meshery/server/machines/helpers/auto_register.go).


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
