### PR TITLE
[Server] Fix master build break: restore loop in auto_register.go toConnectionDefinitions

### DIFF
--- a/server/machines/helpers/auto_register.go
+++ b/server/machines/helpers/auto_register.go
@@ -176,6 +176,8 @@ func (arh *AutoRegistrationHelper) getConnectionDefinitions(connType string) []c
 // The asserted pointer is checked for nil because a typed nil pointer in an entity.Entity passes
 // the type assertion with ok == true.
 func toConnectionDefinitions(connectionEntities []entity.Entity) []component.ComponentDefinition {
+	connectionDefs := make([]component.ComponentDefinition, 0, len(connectionEntities))
+	for _, connectionEntity := range connectionEntities {
 		def, ok := connectionEntity.(*component.ComponentDefinition)
 		if !ok || def == nil || def.Model == nil {
 			continue


### PR DESCRIPTION
## Notes for Reviewers

**master currently does not compile** - a hotfix.

### What broke
A GitHub suggestion applied in #20733 (commit `d496a8a`, "Update auto_register.go") removed **two lines** from `toConnectionDefinitions` - the slice declaration and the `for _, connectionEntity := range connectionEntities {` loop header - but left the loop body intact. The result:

```
server/machines/helpers/auto_register.go:181:4: continue is not in a loop
server/machines/helpers/auto_register.go:185:2: syntax error: non-declaration statement outside function body (typecheck)
```

### Impact
`server/machines/helpers` is imported by both `server` and `mesheryctl`, so every dependent job is red on master and on every open PR (they build against master): `golangci-lint-server`, `golangci-lint-cli`, `build-meshery / Build image`, and the integration tests.

### Fix
Restore the `connectionDefs := make(...)` declaration and the `for range` header. No behavior change - it reinstates the function's original body.

Verified: `go build ./...` (server) + `go build ./...` (mesheryctl), `go vet`, and `golangci-lint run ./machines/helpers/` all clean.

**[Signed commits]**
- [x] Yes, I signed my commits.
