### PR TITLE
[Server] Fix variable name typo sucess to success in design engine handler

### DIFF
--- a/server/handlers/design_engine_handler.go
+++ b/server/handlers/design_engine_handler.go
@@ -589,7 +589,7 @@ func (sap *serviceActionProvider) Provision(ccp stages.CompConfigPair) ([]patter
 			KubeConfigs:  kconfigs,
 			Declarations: []string{compStr},
 		})
-		sucess := err == nil
+		success := err == nil
 		msgs = append(msgs, patterns.DeploymentMessagePerContext{
 			SystemName: hostName,
 			Location:   fmt.Sprintf("%s:%s", hostName, strconv.Itoa(hostPort)),
@@ -599,7 +599,7 @@ func (sap *serviceActionProvider) Provision(ccp stages.CompConfigPair) ([]patter
 					Model:      ccp.Component.Model.Name,
 					CompName:   ccp.Component.DisplayName,
 					DesignName: sap.patternName,
-					Success:    sucess,
+					Success:    success,
 					Message:    resp.GetMessage(),
 					Error:      err,
 				},


### PR DESCRIPTION
**Notes for Reviewers**

This PR corrects a local variable typo (`sucess` to `success`) in `server/handlers/design_engine_handler.go`. No functional change.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.