### PR TITLE
Fix historical compatibility matrix redirects

### DIFF
--- a/docs/content/en/project/compatibility-matrix/_index.md
+++ b/docs/content/en/project/compatibility-matrix/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Compatibility Matrix"
+cascade:
+  type: compatibility-matrix
+---

--- a/docs/layouts/shortcodes/compatibility-matrix-kubernetes.html
+++ b/docs/layouts/shortcodes/compatibility-matrix-kubernetes.html
@@ -219,7 +219,7 @@
       'meshery-istio': 'meshery-istio-past-results',
       'meshery-linkerd': 'meshery-linkerd-past-results',
       'meshery-kuma': 'meshery-kuma-past-results',
-      'meshery-nginx-sm': 'meshery-nginx-sm-past-results',
+      'meshery-nginx-sm': 'meshery-nginx-past-results',
       'meshery-traefik-mesh': 'meshery-traefik-mesh-past-results',
       'meshery-cilium': 'meshery-cilium-past-results',
       'meshery-consul': 'meshery-consul-past-results'
@@ -227,7 +227,7 @@
     
     const page = adapterMap[adapter];
     if (page) {
-      window.location.href = `{{ "installation/compatibility-matrix/" | relURL }}${page}`;
+      window.location.href = `{{ "project/compatibility-matrix/" | relURL }}${page}`;
     }
   }
   


### PR DESCRIPTION
**Notes for Reviewers**
- This PR fixes #20788

### Summary
This PR fixes broken redirects for historical Compatibility Matrix results.
Restores rendering of the historical compatibility pages by ensuring they use the compatibility-matrix layout.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

**After**
https://github.com/user-attachments/assets/16406e3e-f2a4-4560-8dbb-00b82f5275cb

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Compatibility Matrix page to the project documentation with appropriate page metadata.
  * Updated the Kubernetes and service-mesh compatibility matrix navigation to use the current project documentation path.
  * Corrected navigation for the Meshery NGINX Service Mesh adapter’s past results.

* **Bug Fixes**
  * Compatibility matrix status cells now consistently link to the intended historical results pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->