### PR TITLE
[Server] Stop per-request Error-notification spam for broken connections (SendEvent NoOp-halt bypasses de-dup)

### DIFF
--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -179,19 +179,21 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	var failureErr error
 	var failureEvent *events.Event
 
-	// haltedNoOp records that an action failed while reporting NoOp: it errored
-	// but emitted no recovery event, so the machine stays in place — no state
-	// transition, nothing to persist. Unlike a recovery-event failure (which
-	// converges on a persisted state, e.g. NOTFOUND, that the de-dup below keys
-	// off), this path never reaches a persisted status. It used to return inline
-	// here, bypassing that de-dup, so a permanently broken connection — e.g. one
-	// whose machine context never initialized, failing GetMachineCtx on every
-	// Discovery — re-persisted and re-broadcast a fresh Error event to the user on
-	// every single background re-drive (issue #20818). Route it through the same
-	// de-dup instead: skip the status write (there is no new state, and writing
-	// the un-advanced CurrentState would corrupt the persisted status) and treat
-	// it as no-change so the repeated background failure is suppressed.
-	haltedNoOp := false
+	// haltedWithoutTransition records that the machine aborted before advancing:
+	// it errored but never reached a new state, so there is no transition and
+	// nothing to persist. Two paths set it — an action failing while reporting
+	// NoOp (an error with no recovery event), and an exit action failing before
+	// entry. Unlike a recovery-event failure (which converges on a persisted
+	// state, e.g. NOTFOUND, that the de-dup below keys off), neither path ever
+	// reaches a persisted status. Both used to return inline, bypassing that
+	// de-dup, so a permanently broken connection — e.g. one whose machine context
+	// never initialized, failing GetMachineCtx on every Discovery — re-persisted
+	// and re-broadcast a fresh Error event to the user on every single background
+	// re-drive (issue #20818). Route them through the same de-dup instead: skip
+	// the status write (there is no new state, and writing the un-advanced
+	// CurrentState would corrupt the persisted status) and treat it as no-change
+	// so the repeated background failure is suppressed.
+	haltedWithoutTransition := false
 
 	for eventType != NoOp {
 		nextState, err := sm.getNextState(eventType)
@@ -228,7 +230,23 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 			_, event, err = action.ExecuteOnExit(ctx, sm.Context, nil)
 			if err != nil {
 				sm.Log.Error(err)
-				return event, err
+				sm.Log.Debug(event)
+				if failureErr == nil {
+					failureErr = err
+					failureEvent = event
+				}
+				// An exit action failing aborts the transition before the machine
+				// advances — the same "halted without transitioning" shape as a NoOp
+				// halt, so it takes the same route rather than returning inline.
+				// Returning inline here would bypass the de-dup below (re-spamming
+				// the user on a repeatedly re-driven background Discovery) and could
+				// hand callers a nil event alongside a non-nil error: every
+				// ExecuteOnExit in the tree returns a nil event, and callers such as
+				// K8sFSMMiddleware dereference (*event) whenever the error is
+				// non-nil. The terminal failureEvent fallback below guarantees a
+				// non-nil event instead.
+				haltedWithoutTransition = true
+				break
 			}
 		}
 
@@ -245,7 +263,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 					failureEvent = event
 				}
 				if eventType == NoOp {
-					haltedNoOp = true
+					haltedWithoutTransition = true
 					break
 				}
 			} else {
@@ -260,7 +278,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 						failureEvent = event
 					}
 					if eventType == NoOp {
-						haltedNoOp = true
+						haltedWithoutTransition = true
 						break
 					}
 
@@ -279,17 +297,18 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// request (notification spam). Emitting the failure only on an actual status
 	// transition de-duplicates that noise while still surfacing the first
 	// failure. Defaults to true so paths without a provider (or the Exit event)
-	// still report failures — except a NoOp halt, which made no transition (there
-	// is nothing to persist, and writing the un-advanced CurrentState would
-	// corrupt the persisted status), so it starts unchanged so the de-duplication
-	// below suppresses the repeated background failure (issue #20818).
-	statusChanged := !haltedNoOp
+	// still report failures — except a halt without transition, which never
+	// advanced (there is nothing to persist, and writing the un-advanced
+	// CurrentState would corrupt the persisted status), so it starts unchanged so
+	// the de-duplication below suppresses the repeated background failure
+	// (issue #20818).
+	statusChanged := !haltedWithoutTransition
 
 	// originalEventType (not eventType) is compared against Exit here: by the
 	// time the loop finishes, eventType has been overwritten to NoOp, so the
-	// caller's intent is only visible in the captured original. A NoOp halt skips
-	// this block too: it performed no transition, so there is nothing to persist.
-	if sm.Provider != nil && originalEventType != Exit && !haltedNoOp {
+	// caller's intent is only visible in the captured original. A halt without
+	// transition skips this block too: nothing advanced, so nothing to persist.
+	if sm.Provider != nil && originalEventType != Exit && !haltedWithoutTransition {
 		token, _ := ctx.Value(models.TokenCtxKey).(string)
 		connection, _, err := sm.Provider.GetConnectionByID(token, sm.ID)
 
@@ -336,11 +355,12 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// with the non-nil error so callers persist + broadcast it — this is the
 	// core fix for failures previously masked by a later recovery transition.
 	// For a recovery-event failure the connection-status update above has already
-	// moved the connection to its recovery state (e.g. NOTFOUND); for a NoOp halt
-	// no transition happened and statusChanged was forced false. Either way,
-	// suppress the emit when the persisted status did not change, so a repeatedly
-	// re-discovered down connection (or a permanently broken one halting on NoOp)
-	// does not spam a notification on every request.
+	// moved the connection to its recovery state (e.g. NOTFOUND); for a halt
+	// without transition nothing advanced and statusChanged was forced false.
+	// Either way, suppress the emit when the persisted status did not change, so
+	// a repeatedly re-discovered down connection — or a permanently broken one
+	// that halts without ever transitioning — does not spam a notification on
+	// every request.
 	if failureErr != nil {
 		// De-duplicate ONLY the background discovery path. K8sFSMMiddleware
 		// re-runs SendEvent(Discovery) on every request, so a cluster that stays

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -179,6 +179,20 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	var failureErr error
 	var failureEvent *events.Event
 
+	// haltedNoOp records that an action failed while reporting NoOp: it errored
+	// but emitted no recovery event, so the machine stays in place — no state
+	// transition, nothing to persist. Unlike a recovery-event failure (which
+	// converges on a persisted state, e.g. NOTFOUND, that the de-dup below keys
+	// off), this path never reaches a persisted status. It used to return inline
+	// here, bypassing that de-dup, so a permanently broken connection — e.g. one
+	// whose machine context never initialized, failing GetMachineCtx on every
+	// Discovery — re-persisted and re-broadcast a fresh Error event to the user on
+	// every single background re-drive (issue #20818). Route it through the same
+	// de-dup instead: skip the status write (there is no new state, and writing
+	// the un-advanced CurrentState would corrupt the persisted status) and treat
+	// it as no-change so the repeated background failure is suppressed.
+	haltedNoOp := false
+
 	for eventType != NoOp {
 		nextState, err := sm.getNextState(eventType)
 		if err != nil {
@@ -231,7 +245,8 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 					failureEvent = event
 				}
 				if eventType == NoOp {
-					return event, err
+					haltedNoOp = true
+					break
 				}
 			} else {
 				eventType, event, err = state.Action.Execute(ctx, sm.Context, payload)
@@ -245,7 +260,8 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 						failureEvent = event
 					}
 					if eventType == NoOp {
-						return event, err
+						haltedNoOp = true
+						break
 					}
 
 				}
@@ -263,13 +279,17 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// request (notification spam). Emitting the failure only on an actual status
 	// transition de-duplicates that noise while still surfacing the first
 	// failure. Defaults to true so paths without a provider (or the Exit event)
-	// still report failures.
-	statusChanged := true
+	// still report failures — except a NoOp halt, which made no transition (there
+	// is nothing to persist, and writing the un-advanced CurrentState would
+	// corrupt the persisted status), so it starts unchanged so the de-duplication
+	// below suppresses the repeated background failure (issue #20818).
+	statusChanged := !haltedNoOp
 
 	// originalEventType (not eventType) is compared against Exit here: by the
 	// time the loop finishes, eventType has been overwritten to NoOp, so the
-	// caller's intent is only visible in the captured original.
-	if sm.Provider != nil && originalEventType != Exit {
+	// caller's intent is only visible in the captured original. A NoOp halt skips
+	// this block too: it performed no transition, so there is nothing to persist.
+	if sm.Provider != nil && originalEventType != Exit && !haltedNoOp {
 		token, _ := ctx.Value(models.TokenCtxKey).(string)
 		connection, _, err := sm.Provider.GetConnectionByID(token, sm.ID)
 
@@ -315,11 +335,12 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// earlier in the transition loop. Return its ORIGINAL Error event together
 	// with the non-nil error so callers persist + broadcast it — this is the
 	// core fix for failures previously masked by a later recovery transition.
-	// The connection-status update above has already run, so the connection has
-	// been moved to its recovery state (e.g. NOTFOUND) regardless of what we
-	// return here. Suppress the emit when the persisted status did not change,
-	// so a repeatedly re-discovered down connection does not spam a notification
-	// on every request.
+	// For a recovery-event failure the connection-status update above has already
+	// moved the connection to its recovery state (e.g. NOTFOUND); for a NoOp halt
+	// no transition happened and statusChanged was forced false. Either way,
+	// suppress the emit when the persisted status did not change, so a repeatedly
+	// re-discovered down connection (or a permanently broken one halting on NoOp)
+	// does not spam a notification on every request.
 	if failureErr != nil {
 		// De-duplicate ONLY the background discovery path. K8sFSMMiddleware
 		// re-runs SendEvent(Discovery) on every request, so a cluster that stays

--- a/server/machines/models_test.go
+++ b/server/machines/models_test.go
@@ -391,3 +391,105 @@ func TestSendEvent_UserInitiatedFailureAlwaysPropagates(t *testing.T) {
 		t.Fatalf("expected the original Error event, got %#v", event)
 	}
 }
+
+// TestSendEvent_NoOpHaltOnDiscoveryIsDeduplicated covers issue #20818: an action
+// that fails while reporting NoOp (an error but no recovery event) — exactly what
+// DiscoverAction.Execute does when GetMachineCtx fails for a broken/zombie
+// connection — must NOT re-persist or re-broadcast an Error event on every
+// background Discovery re-drive. The failure halts the machine in place (no
+// transition, no status write), so on the background path it is suppressed every
+// time rather than returning inline and spamming the notification center.
+func TestSendEvent_NoOpHaltOnDiscoveryIsDeduplicated(t *testing.T) {
+	provider := &fakeProvider{status: connections.CONNECTED}
+
+	failErr := errors.New("nil interface cannot be type casted")
+	// A NoOp failure hands back an Error event but no recovery event (execNext=NoOp).
+	failEvent := events.NewEvent().
+		WithSeverity(events.Error).
+		WithDescription("Failed to interact with the connection.").
+		Build()
+	sm := newTestMachine(t, provider, &stubAction{execNext: NoOp, execEvent: failEvent, execErr: failErr})
+	ctx := newTestContext(t)
+
+	// The middleware re-runs ResetState()+SendEvent(Discovery) on every request;
+	// none of them should surface an event/error for a permanently broken machine.
+	for i := 0; i < 3; i++ {
+		sm.ResetState()
+		event, err := sm.SendEvent(ctx, Discovery, nil)
+		if err != nil {
+			t.Fatalf("run %d: expected a NoOp-halt Discovery failure to be suppressed, got error %v", i, err)
+		}
+		if event != nil {
+			t.Fatalf("run %d: expected no event on a suppressed NoOp-halt Discovery failure, got %#v", i, event)
+		}
+	}
+
+	// The machine must not have advanced past the reset InitialState, and the
+	// persisted status must be left untouched — writing the un-advanced
+	// CurrentState (InitialState) would corrupt CONNECTED into "initialized".
+	if provider.updateCalls != 0 {
+		t.Fatalf("expected no status write for a NoOp-halt failure, got %d UpdateConnectionById call(s)", provider.updateCalls)
+	}
+	if provider.status != connections.CONNECTED {
+		t.Fatalf("expected persisted status to remain CONNECTED, got %q", provider.status)
+	}
+	if sm.CurrentState != InitialState {
+		t.Fatalf("expected the machine to halt without transitioning (stay at %q), got %q", InitialState, sm.CurrentState)
+	}
+}
+
+// TestSendEvent_NoOpHaltOnUserEventPropagates guards the boundary of the #20818
+// fix: suppression is restricted to the background Discovery path. A
+// user-initiated event whose action fails with NoOp must still surface its Error
+// event + error (so a manual action never silently "succeeds"), and must not
+// write a status.
+func TestSendEvent_NoOpHaltOnUserEventPropagates(t *testing.T) {
+	log, err := logger.New("test", logger.Options{})
+	if err != nil {
+		t.Fatalf("failed to build test logger: %v", err)
+	}
+	connectionID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate connection UUID: %v", err)
+	}
+
+	provider := &fakeProvider{status: connections.DISCOVERED}
+	failErr := errors.New("registration failed")
+	failEvent := events.NewEvent().WithSeverity(events.Error).WithDescription("register failed").Build()
+
+	// InitialState --Register--> REGISTERED, whose action fails with NoOp.
+	sm := &StateMachine{
+		ID:            core.Uuid(connectionID),
+		Name:          "kubernetes",
+		InitialState:  InitialState,
+		CurrentState:  InitialState,
+		PreviousState: DefaultState,
+		Log:           log,
+		Provider:      provider,
+		States: States{
+			InitialState: State{
+				Events: Events{Register: REGISTERED},
+				Action: nil,
+			},
+			REGISTERED: State{
+				Events: Events{Connect: CONNECTED, Ignore: IGNORED},
+				Action: &stubAction{execNext: NoOp, execEvent: failEvent, execErr: failErr},
+			},
+		},
+	}
+	ctx := newTestContext(t)
+
+	event, err := sm.SendEvent(ctx, Register, nil)
+	if err == nil {
+		t.Fatal("expected a user-initiated NoOp-halt failure to propagate, got nil error")
+	}
+	if !errors.Is(err, failErr) {
+		t.Fatalf("expected the original action error to propagate, got %v", err)
+	}
+	if event == nil || event.Severity != events.Error {
+		t.Fatalf("expected the original Error event to propagate, got %#v", event)
+	}
+	if provider.updateCalls != 0 {
+		t.Fatalf("expected no status write on a NoOp-halt failure, got %d UpdateConnectionById call(s)", provider.updateCalls)
+	}
+}

--- a/server/machines/models_test.go
+++ b/server/machines/models_test.go
@@ -493,3 +493,92 @@ func TestSendEvent_NoOpHaltOnUserEventPropagates(t *testing.T) {
 		t.Fatalf("expected no status write on a NoOp-halt failure, got %d UpdateConnectionById call(s)", provider.updateCalls)
 	}
 }
+
+// failingExitAction fails in ExecuteOnExit with a nil event — matching every
+// real ExecuteOnExit in the tree, all of which currently return a nil event (and
+// today, a nil error). Entry/Execute succeed so the test isolates the exit path.
+type failingExitAction struct {
+	exitErr error
+}
+
+func (a *failingExitAction) ExecuteOnEntry(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+
+func (a *failingExitAction) Execute(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, nil
+}
+
+func (a *failingExitAction) ExecuteOnExit(context.Context, interface{}, interface{}) (EventType, *events.Event, error) {
+	return NoOp, nil, a.exitErr
+}
+
+// TestSendEvent_ExitActionFailureHaltsWithoutTransition covers the sibling of
+// the #20818 bypass: an exit action failing aborts the transition before the
+// machine advances, so like a NoOp halt it must route through the de-dup rather
+// than returning inline. Two guarantees are asserted:
+//
+//  1. No status is written — the machine never advanced, and persisting the
+//     un-advanced CurrentState would corrupt the connection's status.
+//  2. A user-initiated event still surfaces a NON-NIL Error event with its
+//     error. The old inline return handed back the action's event verbatim,
+//     which every ExecuteOnExit in the tree builds as nil — and callers such as
+//     K8sFSMMiddleware dereference (*event) whenever the error is non-nil, so
+//     that path was a latent nil-pointer panic.
+func TestSendEvent_ExitActionFailureHaltsWithoutTransition(t *testing.T) {
+	provider := &fakeProvider{status: connections.CONNECTED}
+	exitErr := errors.New("exit action failed")
+
+	sm := newTestMachine(t, provider, &stubAction{execNext: NoOp})
+	// The exit action that runs is the one on the CURRENT state, so attach the
+	// failing action to InitialState and drive a transition out of it.
+	sm.States[InitialState] = State{
+		Events: Events{Discovery: DISCOVERED, Register: REGISTERED},
+		Action: &failingExitAction{exitErr: exitErr},
+	}
+	sm.States[REGISTERED] = State{
+		Events: Events{Connect: CONNECTED},
+		Action: &stubAction{execNext: NoOp},
+	}
+	ctx := newTestContext(t)
+
+	// User-initiated: the failure must propagate, with a usable event.
+	event, err := sm.SendEvent(ctx, Register, nil)
+	if err == nil {
+		t.Fatal("expected an exit-action failure on a user-initiated event to propagate, got nil error")
+	}
+	if !errors.Is(err, exitErr) {
+		t.Fatalf("expected the original exit-action error to propagate, got %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected a non-nil Error event alongside the error (callers dereference it), got nil")
+	}
+	if event.Severity != events.Error {
+		t.Fatalf("expected an Error-severity event, got %q", event.Severity)
+	}
+	if provider.updateCalls != 0 {
+		t.Fatalf("expected no status write when the machine never advanced, got %d UpdateConnectionById call(s)", provider.updateCalls)
+	}
+	if sm.CurrentState != InitialState {
+		t.Fatalf("expected the machine to halt at %q, got %q", InitialState, sm.CurrentState)
+	}
+
+	// Background discovery: the same failure repeated must be suppressed rather
+	// than re-broadcast on every request.
+	for i := 0; i < 3; i++ {
+		sm.ResetState()
+		event, err := sm.SendEvent(ctx, Discovery, nil)
+		if err != nil {
+			t.Fatalf("run %d: expected a repeated background exit-action failure to be suppressed, got error %v", i, err)
+		}
+		if event != nil {
+			t.Fatalf("run %d: expected no event on a suppressed background failure, got %#v", i, event)
+		}
+	}
+	if provider.updateCalls != 0 {
+		t.Fatalf("expected no status write across background re-drives, got %d UpdateConnectionById call(s)", provider.updateCalls)
+	}
+	if provider.status != connections.CONNECTED {
+		t.Fatalf("expected persisted status to remain CONNECTED, got %q", provider.status)
+	}
+}


### PR DESCRIPTION
## Notes for Reviewers

Fixes #20818.

### Symptom
A permanently broken Kubernetes connection **persists and broadcasts a fresh Error-severity "Failed to interact with the connection" notification to the user on every single request** - not just once. (User-facing; worse than the `meshkit-11180` log spam fixed in #20812.)

### Root cause
`SendEvent` (`server/machines/models.go`) has two failure exits:

- **Recovery-event failure** (e.g. `DiscoverAction` returns `NotFound` on a reachability failure): the loop transitions to the recovery state, which is persisted, and the `statusChanged` de-dup at the end suppresses repeats once the connection has converged (e.g. to `NOTFOUND`).
- **NoOp halt** (an action returns an error **with `NoOp`** - no recovery event): the loop **returned inline**, *before* that de-dup block ever runs.

`DiscoverAction.Execute` hits the NoOp path whenever `GetMachineCtx` fails - i.e. a broken/zombie connection whose machine context never initialized (see #18771). `K8sFSMMiddleware` re-runs `ResetState()` + `SendEvent(Discovery)` on **every** `/api` request, and its goroutine does `PersistEvent(*event)` + `EventBroadcaster.Publish(event)` whenever `SendEvent` returns an error - so the same Error event was re-persisted and re-broadcast per request, indefinitely.

### Fix
Route the halt-without-transition paths through the **existing** de-dup instead of returning inline:

- `break` out of the loop (record `haltedWithoutTransition`) rather than `return event, err`.
- **Skip the status write** - the machine made no transition, and writing the un-advanced `CurrentState` (e.g. `InitialState` after `ResetState`) would corrupt the persisted status (e.g. `CONNECTED` -> `initialized`).
- Start `statusChanged` as `!haltedWithoutTransition` so the background `Discovery` failure is suppressed.

The **exit-action failure** branch is the sibling of the same defect and is fixed identically (second commit). An exit action failing aborts the transition before the machine advances - the same "halted without transitioning" shape - but it also returned inline. Two consequences: it bypassed the de-dup, and because *every* `ExecuteOnExit` in the tree builds a **nil** event, it handed callers a nil event alongside a non-nil error - and `K8sFSMMiddleware`/`addK8SConfig` dereference `(*event)` whenever the error is non-nil, so that path was a latent nil-pointer panic. It is unreachable today (all 11 `ExecuteOnExit` implementations return a nil error), but leaving it means the first real exit action reintroduces this bug verbatim. `haltedNoOp` is renamed to `haltedWithoutTransition` now that two paths set it.

Behavior after the fix:
- **Background `Discovery` halt** (NoOp or exit-action) -> suppressed (no event, no error, no status write) - no more per-request spam.
- **User-initiated event halt** (Register/Connect/...) -> still **propagates** a non-nil Error event + error (a manual action never silently "succeeds", and never returns a nil event on a non-nil error).
- **Recovery-event failures and the success path** -> unchanged.

### Scope note
This is one of the out-of-band findings from @leecalcote's review of #20812 (finding 3). The deeper root cause it depends on - a broken machine being cached and never retried - is tracked separately at #18771; this PR stops the notification spam regardless of that. The two are not coupled: #18771 is what keeps producing permanently-broken connections that reach this path, but the NoOp-halt de-dup bypass is a defect on its own and would spam for any other cause of a persistent NoOp halt.

This fix is a stopgap, not the intended final architecture. Quieting is currently decided independently at ~22 `PersistEvent`/`EventBroadcaster.Publish` call sites under `server/`, so every new failure path has to remember to hook into de-dup manually. Moving correlation and quieting into the eventing framework itself is tracked at #20879.

### Testing
`go test ./server/machines/` - adds three `SendEvent` tests:
- `TestSendEvent_NoOpHaltOnDiscoveryIsDeduplicated` - 3 repeated Discovery NoOp-halts yield no event/error, no `UpdateConnectionById` call, persisted status stays `CONNECTED`, machine stays at `InitialState`.
- `TestSendEvent_NoOpHaltOnUserEventPropagates` - a user `Register` NoOp-halt surfaces its Error event + error and writes no status.
- `TestSendEvent_ExitActionFailureHaltsWithoutTransition` - a failing exit action propagates a **non-nil** Error event on a user-initiated event, is suppressed across 3 background `Discovery` re-drives, and writes no status either way. Verified non-vacuous: it fails against the old inline return with `expected a non-nil Error event alongside the error, got nil`.

All 6 pre-existing `SendEvent` tests still pass (9 total). `go build ./server/...`, `go vet ./server/machines/...`, `golangci-lint run ./machines/...` (0 issues), and `go test -race ./server/machines/...` are clean.

**[Signed commits]**
- [x] Yes, I signed my commits.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failed state-machine transitions from recording or persisting an incorrect connection status.
  * Repeated background discovery failures no longer generate duplicate user-facing error events.
  * User-triggered failures continue to report the original error, even when no state transition occurs.
  * Failed exit actions now halt safely without advancing the machine state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->