### PR TITLE
 Update Self-paced Contributor Training emoji in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -25,4 +25,4 @@ assignees: ''
 - 🎨 Wireframes and designs for Meshery UI in [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
 - 🧪 [Meshery Test Plan Spreadsheet](https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit#gid=0)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -20,4 +20,4 @@ assignees: ''
 - 🛠 [Meshery Build & Release Strategy](https://docs.meshery.io/project/contributing/build-and-release)
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/fbug_report.md
+++ b/.github/ISSUE_TEMPLATE/fbug_report.md
@@ -35,5 +35,5 @@ assignees: ''
 - 📚 [Instructions for contributing to documentation](https://docs.meshery.io/project/contributing/contributing-docs)
    - Meshery documentation [site](https://docs.meshery.io/) and [source](https://github.com/meshery/meshery/tree/master/docs)
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,5 +26,5 @@ assignees: ''
 - 📚 [Instructions for contributing to documentation](https://docs.meshery.io/project/contributing/contributing-docs)
    - Meshery documentation [site](https://docs.meshery.io/) and [source](https://github.com/meshery/meshery/tree/master/docs)
 - 🎨 Wireframes and designs for Meshery UI in [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)

--- a/.github/ISSUE_TEMPLATE/meshery-design.md
+++ b/.github/ISSUE_TEMPLATE/meshery-design.md
@@ -45,4 +45,4 @@ meshery/hacktoberfest_contributions/<design-name>/<design.yaml>
 - 📚 [Components](https://docs.meshery.io/concepts/logical/components)
 - 📚 [Relationships](https://docs.meshery.io/concepts/logical/relationships)
 - 👨‍💻 [Models Repository](https://github.com/meshery/meshery/tree/master/models)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/meshery-extensions_bug.md
+++ b/.github/ISSUE_TEMPLATE/meshery-extensions_bug.md
@@ -31,5 +31,5 @@ assignees: ''
 - 🎨 UI Design For Meshery Extensions [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 📚 [Meshery Extensibility Providers](https://docs.meshery.io/extensibility/providers)
 - ⌨️ [Meshery API Docs](https://docs.meshery.io/extensibility/api)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)

--- a/.github/ISSUE_TEMPLATE/meshery-extensions_feature.md
+++ b/.github/ISSUE_TEMPLATE/meshery-extensions_feature.md
@@ -29,5 +29,5 @@ assignees: ''
 - 🎨 UI Design For Meshery Extensions [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 📚 [Meshery Extensibility Providers](https://docs.meshery.io/extensibility/providers)
 - ⌨️ [Meshery API Docs](https://docs.meshery.io/extensibility/api)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)

--- a/.github/ISSUE_TEMPLATE/meshery-ui_bug.md
+++ b/.github/ISSUE_TEMPLATE/meshery-ui_bug.md
@@ -29,4 +29,4 @@ assignees: ''
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🖥 [Contributing to Meshery UI](https://docs.meshery.io/project/contributing/contributing-ui)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/meshery-ui_feature.md
+++ b/.github/ISSUE_TEMPLATE/meshery-ui_feature.md
@@ -28,4 +28,4 @@ assignees: ''
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🖥 [Contributing to Meshery UI](https://docs.meshery.io/project/contributing/contributing-ui)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/mesheryctl_bug.md
+++ b/.github/ISSUE_TEMPLATE/mesheryctl_bug.md
@@ -34,4 +34,4 @@ _See [mesheryctl Command Tracker](https://bit.ly/3dqXy1q) for current status of 
 - ⌨️ [Meshery CLI Commands and Documentation](https://docs.google.com/document/d/1xRlFpElRmybJ3WacgPKXgCSiQ2poJl3iCCV1dAalf0k/edit#heading=h.5fucij4hc5wt)
 - ⌨️ [Meshkit errors Guide](https://docs.meshery.io/project/contributing/contributing-error)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/mesheryctl_feature.md
+++ b/.github/ISSUE_TEMPLATE/mesheryctl_feature.md
@@ -34,4 +34,4 @@ _See [mesheryctl Command Tracker](https://bit.ly/3dqXy1q) for current status of 
 - [Meshery CLI Commands and Documentation](https://docs.google.com/document/d/1xRlFpElRmybJ3WacgPKXgCSiQ2poJl3iCCV1dAalf0k/edit#heading=h.5fucij4hc5wt)
 - ⌨️ [Meshkit errors guide](https://docs.meshery.io/project/contributing/contributing-error)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/model-catalog.md
+++ b/.github/ISSUE_TEMPLATE/model-catalog.md
@@ -42,4 +42,4 @@ Now to publish your model to catalog:
 - 📚 [Components](https://docs.meshery.io/concepts/logical/components)
 - 📚 [Relationships](https://docs.meshery.io/concepts/logical/relationships)
 - 👨‍💻 [Models Repository](https://github.com/meshery/meshery/tree/master/models)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/models.md
+++ b/.github/ISSUE_TEMPLATE/models.md
@@ -30,7 +30,7 @@ assignees: ''
  - [Contributing Models](https://docs.meshery.io/project/contributing/contributing-models)
    - [Contributing Components](https://docs.meshery.io/project/contributing/contributing-components)
    - [Contributing Relationships](https://docs.meshery.io/project/contributing/contributing-relationships)
-   - 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+   - 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 
  <!-- ### Instructions for Policies
  - [Contributing Policies](https://docs.meshery.io/project/contributing/contributing-policies)

--- a/.github/ISSUE_TEMPLATE/playground.md
+++ b/.github/ISSUE_TEMPLATE/playground.md
@@ -19,4 +19,4 @@ assignees: ''
    - Meshery documentation [site](https://docs.meshery.io/) and [source](https://github.com/meshery/meshery/tree/master/docs)
 - 🎨 Wireframes and designs for Meshery UI in [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#community-forums) and [Community Slack](https://slack.meshery.io)
-- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+- 🖥️ [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)


### PR DESCRIPTION
**Description**
This PR updates the **Self-paced Contributor Trainings** link prefix in all GitHub issue templates, replacing the television emoji (`📺`) with the desktop monitor emoji (`🖥️`) to align with the issue requirements.
**Changes:**
- Replaced `- 📺` with `- 🖥️` for the contributor training link in all 14 issue templates in `.github/ISSUE_TEMPLATE/`.
- Ensured all templates consistent with the community handbook guidelines.