### PR TITLE
[Models] Add Azure Cache Redis to Virtual Network Subnet relationship

### DIFF
--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rdsub.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rdsub.json
@@ -1,0 +1,95 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-cache",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Redis",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-cache",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                ["configuration", "spec", "subnetReference", "group"],
+                ["configuration", "spec", "subnetReference", "kind"],
+                ["configuration", "spec", "subnetReference", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VirtualNetworksSubnet",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                ["configuration", "group"],
+                ["configuration", "kind"],
+                ["configuration", "spec", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rdsub.json
+++ b/models/azure-cache/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-rdsub.json
@@ -1,0 +1,95 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-cache",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Redis",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-cache",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                ["configuration", "spec", "subnetReference", "group"],
+                ["configuration", "spec", "subnetReference", "kind"],
+                ["configuration", "spec", "subnetReference", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VirtualNetworksSubnet",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                ["configuration", "group"],
+                ["configuration", "kind"],
+                ["configuration", "spec", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## Notes for Reviewers

Related to [Models] Component relationships for Azure services #14793

## Summary

This PR adds non-binding reference relationships between Azure Cache for Redis and VirtualNetworksSubnet resources.

Added relationships for:

- Azure Cache for Redis → VirtualNetworksSubnet

The relationships were added for Azure Service Operator (ASO) v2.13.0 and v2.14.0.

## Validation

- Verified that `subnetReference` exists in the Redis schemas.
- Compared the implementation with existing Azure subnet reference relationships (for example, ApplicationGateway and OpenShiftCluster) to ensure consistency.
- Validated the new relationship JSON files.
- Verified the relationship visually in Kanvas.

## Screenshot

<img width="1942" height="946" alt="Screenshot 2026-07-21 031350" src="https://github.com/user-attachments/assets/c1f606c4-77df-4622-88a9-22421742784a" />
<img width="2880" height="1484" alt="Screenshot 2026-07-21 031330" src="https://github.com/user-attachments/assets/afccc5dc-1a16-450e-80b0-cd259584df0e" />


## Signed commits

- [x] Yes, I signed my commits.