### PR TITLE
[UI] Source catalog compatibility widget from schemas (correct #20786)

### DIFF
--- a/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
+++ b/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
@@ -283,17 +283,12 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
 
   useEffect(() => {
     if (publishSchema) {
-      const newUiSchema = {
-        ...publishSchema.uiSchema,
-        // Force a multi-select dropdown for the compatibility/Technology field.
-        // RJSF v5 auto-selects CheckboxesWidget when schema has uniqueItems:true + items.enum,
-        // which causes formData.compatibility to be submitted as a string instead of an array.
-        // Explicitly setting 'ui:widget': 'select' restores multi-select array behaviour.
-        compatibility: {
-          ...(publishSchema.uiSchema?.compatibility || {}),
-          'ui:widget': 'select',
-        },
-      };
+      // The compatibility/Technology field's `ui:widget: select` is defined in
+      // the canonical catalog form UI schema in meshery/schemas
+      // (constructs/v1beta2/catalog/forms/publish.ui.json), so it flows in via
+      // publishSchema.uiSchema. Do not re-patch it here - keeping presentation
+      // in the construct's schema is the single source of truth.
+      const newUiSchema = { ...publishSchema.uiSchema };
 
       if (isReadOnly) {
         newUiSchema['ui:readonly'] = true;


### PR DESCRIPTION
## What

Make the "Publish to Catalog" / Publish Design form **schema-driven**: drop the local `compatibility` uiSchema patch in `LegacyInfoModal` and consume the widget from the canonical catalog form UI schema in `meshery/schemas`.

## Why

#20786 fixed a real multi-select bug, but did it by patching presentation onto the uiSchema at the call site:

```js
const newUiSchema = {
  ...publishSchema.uiSchema,
  compatibility: { ...publishSchema.uiSchema?.compatibility, 'ui:widget': 'select' },
};
```

`publishSchema.uiSchema` is `publishCatalogItemUiSchema` - re-exported from `@sistent/sistent` -> `@meshery/schemas` (`CatalogPublishRjsfUiSchemaV1Beta2`). A static widget choice for the catalog construct belongs **in that construct's UI schema**, not re-applied in every consumer (meshery, meshery-cloud). The same pattern was flagged on the sibling PR layer5io/meshery-cloud#5743 by a reviewer asking "why is this not in meshery/schemas?".

## Change

- Define the widget once, canonically: **meshery/schemas#1080** adds `"compatibility": { "ui:widget": "select" }` to `constructs/v1beta2/catalog/forms/publish.ui.json`.
- Here: remove the local patch so `LegacyInfoModal` renders the field from `publishSchema.uiSchema` directly.
- Kept as-is (legitimate consumer concerns): the `transformErrors` "Please select at least one technology." message, and the `CustomSelectWidget` string->array hardening from #20786.

`prettier --check` and `eslint` pass.

## ⚠️ Draft - release sequencing (must land in this order to avoid regression)

`@sistent/sistent` **bundles** `@meshery/schemas`, so the canonical widget only reaches this repo after the full chain:

1. Merge + release **meshery/schemas#1080** -> new `@meshery/schemas`.
2. Bump `@meshery/schemas` in `@sistent/sistent`, rebuild, release -> new `@sistent/sistent`.
3. Bump `@sistent/sistent` (+`@meshery/schemas`) here **in this PR**, then it's safe to merge.

Merging the patch removal before step 3 would revert `compatibility` to the default checkboxes rendering that #20786 fixed. I'll add the dep bump here once the upstream releases land.

Refs #20786
Refs meshery/schemas#1080
Refs layer5io/meshery-cloud#5743
