### PR TITLE
Prevent duplicate submissions in Import Design modal

### DIFF
--- a/ui/components/designs/ImportDesignModal.tsx
+++ b/ui/components/designs/ImportDesignModal.tsx
@@ -24,11 +24,18 @@ export interface ImportDesignModalProps {
    * YAML/JSON) — same shape RJSF emits for `importDesignSchema`.
    */
   handleImportDesign: (formData: unknown) => void;
+  /**
+   * Whether an import request is currently in flight (e.g. the caller's
+   * `useImportPatternMutation()` `isLoading`). Disables the submit button so
+   * rapid/repeated clicks can't fire duplicate import requests.
+   */
+  isSubmitting?: boolean;
 }
 
 const ImportDesignModalComponent: FC<ImportDesignModalProps> = ({
   handleClose,
   handleImportDesign,
+  isSubmitting = false,
 }) => (
   <FormModal
     isOpen
@@ -40,6 +47,7 @@ const ImportDesignModalComponent: FC<ImportDesignModalProps> = ({
     uiSchema={importDesignUiSchema}
     submitText="Import"
     onSubmit={handleImportDesign}
+    isSubmitDisabled={isSubmitting}
   />
 );
 

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -130,7 +130,7 @@ function MesheryPatterns({
   const [publishCatalog] = usePublishPatternMutation();
   const [unpublishCatalog] = useUnpublishPatternMutation();
   const [deletePattern] = useDeletePatternMutation();
-  const [importPattern] = useImportPatternMutation();
+  const [importPattern, { isLoading: isImportingDesign }] = useImportPatternMutation();
   const [updatePattern] = useUpdatePatternFileMutation();
   const [uploadPatternFile] = useUploadPatternFileMutation();
   const [deletePatternFile] = useDeletePatternFileMutation();
@@ -571,6 +571,7 @@ function MesheryPatterns({
                 <ImportDesignModal
                   handleClose={handleUploadImportClose}
                   handleImportDesign={handleImportDesign}
+                  isSubmitting={isImportingDesign}
                 />
               )}
             <_PromptComponent ref={modalRef} />

--- a/ui/components/workspaces/SpacesSwitcher/components.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/components.tsx
@@ -323,7 +323,7 @@ export const ImportButton = ({ workspaceId, disabled = false, refetch }) => {
   const handleImportModalClose = () => {
     setImportModal(false);
   };
-  const [importPattern] = useImportPatternMutation();
+  const [importPattern, { isLoading: isImportingDesign }] = useImportPatternMutation();
   const { notify } = useNotification();
   const theme = useTheme();
   async function handleImportDesign(data) {
@@ -375,6 +375,7 @@ export const ImportButton = ({ workspaceId, disabled = false, refetch }) => {
         <ImportDesignModal
           handleClose={handleImportModalClose}
           handleImportDesign={handleImportDesign}
+          isSubmitting={isImportingDesign}
         />
       )}
       <StyledResponsiveButton


### PR DESCRIPTION
### What does this PR do?

This PR prevents duplicate design imports by disabling the **Import** button while an import request is in progress.

Previously, users could click the **Import** button multiple times before the first request completed, resulting in multiple import requests and duplicate design entries.

### Related Issue

Fixes #20845

### How has this been tested?

- Verified that rapidly clicking the **Import** button only sends a single import request.
- Verified that the **Import** button is disabled while the request is in progress.
- Verified that the button is re-enabled after both successful and failed requests.

---
### Demo Video

https://github.com/user-attachments/assets/c1bd802a-02a9-4172-873f-d0e418e1e693

**Notes for Reviewers**

- This PR reuses the existing RTK Query `isLoading` state to disable the submit button.
- No API or backend changes are included.
- The fix is applied to both usages of `ImportDesignModal`.

- [x] Yes, I signed my commits.