### PR TITLE
[Docs] Hide images and SVGs in Table of Contents sidebar

### DIFF
--- a/docs/assets/scss/_table-of-content.scss
+++ b/docs/assets/scss/_table-of-content.scss
@@ -89,6 +89,11 @@
     display: flex;
     flex-direction: column;
 
+    img,
+    svg {
+      display: none;
+    }
+
     // gap: 10px;
     & ul {
       font-size: .9rem;


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20850 

Removes inline heading images and icons from the right-sidebar Table of Contents (TOC) to keep the links text-only and clean.

### BEFORE
<img width="1920" height="917" alt="Screenshot from 2026-07-21 12-12-34" src="https://github.com/user-attachments/assets/270afc96-14c1-4591-8bce-ec1270254de4" />

### AFTER
<img width="1920" height="917" alt="Screenshot from 2026-07-21 12-23-29" src="https://github.com/user-attachments/assets/a5dc32a0-f3b5-4a64-81ca-489de0d6830f" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-of-contents presentation by hiding direct images and icons within the table of contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->