### PR TITLE
Make select all button disappear and no notifications badge appear when all events are deleted

### DIFF
--- a/ui/store/slices/events.ts
+++ b/ui/store/slices/events.ts
@@ -77,6 +77,12 @@ export const eventsSlice = createSlice({
 
     updateEvent: eventsEntityAdapter.updateOne,
     updateEvents: eventsEntityAdapter.updateMany,
+    removeEvent: (state, { payload }) => {
+      eventsEntityAdapter.removeOne(state, payload.id);
+    },
+    removeEvents: (state, { payload }) => {
+      eventsEntityAdapter.removeMany(state, payload.ids);
+    },
     updateIsEventChecked: (state, { payload }) => {
       const { id, value } = payload;
       eventsEntityAdapter.updateOne(state, {
@@ -152,6 +158,8 @@ export const {
   toggleNotificationCenter,
   closeNotificationCenter,
   updateEvents,
+  removeEvent,
+  removeEvents,
 } = eventsSlice.actions;
 
 export default eventsSlice.reducer;
@@ -197,27 +205,16 @@ export const updateEventStatus =
     );
   };
 
-// does a soft deletion on ui
 export const deleteEvent =
   ({ id }) =>
   (dispatch) => {
-    dispatch(updateEvent({ id, changes: { is_deleted: true } }));
-    //mutator({ id });
+    dispatch(removeEvent({ id }));
   };
 
 export const deleteEvents =
   ({ ids }) =>
   (dispatch) => {
-    dispatch(
-      updateEvents(
-        ids.map((id) => ({
-          id,
-          changes: {
-            is_deleted: true,
-          },
-        })),
-      ),
-    );
+    dispatch(removeEvents({ ids }));
   };
 
 //selectors


### PR DESCRIPTION
**Notes for Reviewers**

Previously, the delete button used to trigger a soft-delete in the notification store. However, I could find no other functionality that relied on soft-deletion of notifications, so I changed it a hard delete since the store was updated only after deletion was successful in the backend anyways.

- This PR fixes #20806

https://github.com/user-attachments/assets/5744eda0-68af-490e-b024-582862a83a4a

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted events are now permanently removed instead of being marked as deleted.
  * Added support for removing a single event or multiple events at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->