### PR TITLE
fix(server): fix environment creation failing on remote provider

### DIFF
--- a/server/handlers/environments_handlers.go
+++ b/server/handlers/environments_handlers.go
@@ -11,20 +11,18 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/meshery/meshery/server/models"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 )
 
 // environmentPayloadWire is a handler-local dual-accept wrapper around
-// environment.EnvironmentPayload. The schemas-generated struct tags
-// OrgId as json:"organization_id" (required by the current published
-// v1beta1 contract), but the canonical wire contract and every in-repo
-// consumer now emit the camelCase `organizationId`. Because Go's
-// encoding/json case-insensitive tag fallback will not match across an
-// underscore boundary, a struct tagged `organization_id` would silently
-// drop a JSON key of `organizationId`. This wrapper intercepts both
-// spellings during the Phase 2 deprecation window. Canonical wins when
-// both are present. Retire once schemas v1beta2 flips the tag and this
-// handler consumes the new version.
+// environment.EnvironmentPayload (now v1beta3, canonical camelCase). The
+// canonical wire form emits `organizationId`; the legacy `organization_id`
+// spelling is still accepted for the Phase 2 deprecation window so any
+// unmigrated client (e.g. mesheryctl) keeps working. Go's encoding/json
+// case-insensitive tag fallback does NOT match across an underscore
+// boundary, so the legacy spelling cannot simply piggy-back on the
+// canonical tag. Canonical wins when both are present. Retire once every
+// known consumer is on the canonical spelling.
 type environmentPayloadWire struct {
 	environment.EnvironmentPayload
 }
@@ -33,13 +31,13 @@ func (p *environmentPayloadWire) UnmarshalJSON(data []byte) error {
 	type alias environment.EnvironmentPayload
 	aux := struct {
 		*alias
-		OrgIdCamel  *uuid.UUID `json:"organizationId,omitempty"`
-		OrgIdSnake  *uuid.UUID `json:"organization_id,omitempty"`
+		OrgIdCamel *uuid.UUID `json:"organizationId,omitempty"`
+		OrgIdSnake *uuid.UUID `json:"organization_id,omitempty"`
 	}{alias: (*alias)(&p.EnvironmentPayload)}
 
-	// Zero OrgId so a reused receiver does not carry stale data when the
+	// Zero OrgID so a reused receiver does not carry stale data when the
 	// next payload omits both spellings.
-	p.OrgId = uuid.UUID{}
+	p.OrgID = uuid.UUID{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -47,9 +45,9 @@ func (p *environmentPayloadWire) UnmarshalJSON(data []byte) error {
 	// Canonical wins when both are supplied.
 	switch {
 	case aux.OrgIdCamel != nil:
-		p.OrgId = *aux.OrgIdCamel
+		p.OrgID = *aux.OrgIdCamel
 	case aux.OrgIdSnake != nil:
-		p.OrgId = *aux.OrgIdSnake
+		p.OrgID = *aux.OrgIdSnake
 	}
 	return nil
 }

--- a/server/handlers/environments_handlers_test.go
+++ b/server/handlers/environments_handlers_test.go
@@ -1,0 +1,115 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestEnvironmentPayloadWire_UnmarshalJSON exercises the dual-accept body
+// contract for POST /api/environments. The wrapper must route both
+// `organizationId` (canonical) and `organization_id` (legacy) onto the
+// underlying schemas-generated OrgID field, with canonical taking
+// precedence when both are present. Mirrors
+// TestWorkspacePayloadWire_UnmarshalJSON.
+func TestEnvironmentPayloadWire_UnmarshalJSON(t *testing.T) {
+	const (
+		canonicalUUID = "11111111-1111-1111-1111-111111111111"
+		legacyUUID    = "22222222-2222-2222-2222-222222222222"
+	)
+
+	cases := []struct {
+		name    string
+		body    string
+		wantOrg string
+	}{
+		{
+			name:    "canonical organizationId only",
+			body:    `{"name":"env","organizationId":"` + canonicalUUID + `"}`,
+			wantOrg: canonicalUUID,
+		},
+		{
+			name:    "legacy organization_id only",
+			body:    `{"name":"env","organization_id":"` + legacyUUID + `"}`,
+			wantOrg: legacyUUID,
+		},
+		{
+			name:    "both supplied, canonical wins",
+			body:    `{"name":"env","organizationId":"` + canonicalUUID + `","organization_id":"` + legacyUUID + `"}`,
+			wantOrg: canonicalUUID,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var wire environmentPayloadWire
+			if err := json.Unmarshal([]byte(tc.body), &wire); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+			if got := wire.OrgID.String(); got != tc.wantOrg {
+				t.Fatalf("OrgID = %q, want %q", got, tc.wantOrg)
+			}
+			if wire.Name != "env" {
+				t.Fatalf("Name = %q, want %q", wire.Name, "env")
+			}
+		})
+	}
+}
+
+// TestEnvironmentPayloadWire_MarshalsCanonicalCamelCase is the regression
+// test for the bug where environment creation failed for every Layer5 Cloud
+// user: the handler previously wrapped the deprecated v1beta1
+// environment.EnvironmentPayload (json tag `organization_id`). Unmarshaling
+// a client's camelCase `organizationId` into that wrapper succeeded, but
+// remote_provider.go re-marshals the unwrapped EnvironmentPayload to build
+// the outbound request to the remote provider - and that second marshal
+// used the v1beta1 struct's own snake_case tag, silently downgrading the
+// org id back to `organization_id` on the wire to Layer5 Cloud. Layer5
+// Cloud's endpoint expects camelCase, so the org id was never populated,
+// which violated a NOT NULL/FK constraint on the environments table and
+// produced a 500 (surfaced to the UI as a misleading 404 "unable to get
+// result", from the handler always mapping remote errors to
+// ErrGetResult/http.StatusNotFound).
+//
+// This asserts the fix: EnvironmentPayload now comes from v1beta3, whose
+// native tag is camelCase, so the outbound marshal is correct regardless
+// of which spelling the client sent.
+func TestEnvironmentPayloadWire_MarshalsCanonicalCamelCase(t *testing.T) {
+	const orgUUID = "33333333-3333-3333-3333-333333333333"
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "client sent canonical organizationId", body: `{"name":"env","organizationId":"` + orgUUID + `"}`},
+		{name: "client sent legacy organization_id", body: `{"name":"env","organization_id":"` + orgUUID + `"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var wire environmentPayloadWire
+			if err := json.Unmarshal([]byte(tc.body), &wire); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+
+			// Simulate remote_provider.go's SaveEnvironment/UpdateEnvironment,
+			// which re-marshals the unwrapped EnvironmentPayload to build the
+			// outbound request to the remote provider.
+			out, err := json.Marshal(&wire.EnvironmentPayload)
+			if err != nil {
+				t.Fatalf("unexpected marshal error: %v", err)
+			}
+
+			var onWire map[string]interface{}
+			if err := json.Unmarshal(out, &onWire); err != nil {
+				t.Fatalf("unexpected re-unmarshal error: %v", err)
+			}
+
+			if _, present := onWire["organization_id"]; present {
+				t.Fatalf("outbound payload regressed to snake_case organization_id: %s", out)
+			}
+			if got, _ := onWire["organizationId"].(string); got != orgUUID {
+				t.Fatalf("outbound payload organizationId = %q, want %q (full body: %s)", got, orgUUID, out)
+			}
+		})
+	}
+}

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -27,9 +27,9 @@ import (
 	"github.com/meshery/meshkit/utils"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/meshkit/utils/walker"
-	"github.com/meshery/schemas/models/v1beta1/environment"
 	"github.com/meshery/schemas/models/v1beta2/organization"
 	pattern "github.com/meshery/schemas/models/v1beta3/design"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
 	"github.com/oapi-codegen/runtime/types"
@@ -411,7 +411,7 @@ func (l *DefaultLocalProvider) DeleteEnvironment(_ *http.Request, environmentID 
 }
 
 func (l *DefaultLocalProvider) SaveEnvironment(_ *http.Request, environmentPayload *environment.EnvironmentPayload, _ string, _ bool) ([]byte, error) {
-	orgId := core.Uuid(environmentPayload.OrgId)
+	orgId := core.Uuid(environmentPayload.OrgID)
 	environment := &environment.Environment{
 		CreatedAt:      time.Now(),
 		Description:    environmentPayload.Description,
@@ -428,7 +428,7 @@ func (l *DefaultLocalProvider) UpdateEnvironment(_ *http.Request, environmentPay
 	if err != nil {
 		return nil, ErrInvalidUUID(err)
 	}
-	orgId := core.Uuid(environmentPayload.OrgId)
+	orgId := core.Uuid(environmentPayload.OrgID)
 	environment := &environment.Environment{
 		ID:             id,
 		CreatedAt:      time.Now(),

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -12,7 +12,7 @@ import (
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/database"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	"gorm.io/gorm"
 )
 
@@ -192,7 +192,7 @@ func (ep *EnvironmentPersister) UpdateEnvironment(environmentID core.Uuid, paylo
 
 	env.Name = payload.Name
 	env.Description = payload.Description
-	env.OrganizationID = core.Uuid(payload.OrgId)
+	env.OrganizationID = core.Uuid(payload.OrgID)
 
 	return ep.UpdateEnvironmentByID(env)
 }
@@ -210,8 +210,8 @@ func (ep *EnvironmentPersister) DeleteEnvironmentByID(environmentID core.Uuid) (
 // AddConnectionToEnvironment adds a connection to an environment
 func (ep *EnvironmentPersister) AddConnectionToEnvironment(environmentID, connectionID core.Uuid) ([]byte, error) {
 	envConMapping := environment.EnvironmentConnectionMapping{
-		ConnectionId:  &connectionID,
-		EnvironmentId: &environmentID,
+		ConnectionID:  &connectionID,
+		EnvironmentID: &environmentID,
 		CreatedAt:     time.Now(),
 		UpdatedAt:     time.Now(),
 	}

--- a/server/models/providers.go
+++ b/server/models/providers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/meshery/meshkit/models/events"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 	"github.com/meshery/schemas/models/core"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
 )

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -34,7 +34,7 @@ import (
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
 	"github.com/spf13/viper"

--- a/server/models/workspace_persister.go
+++ b/server/models/workspace_persister.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshkit/database"
-	"github.com/meshery/schemas/models/v1beta1/environment"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 	// NOTE: workspace_persister uses v1beta3/workspace for the canonical
 	// camelCase wire form (Phase 5 identifier-naming flip). Designs nested
 	// inside workspace pages still ride on v1beta1/pattern because both


### PR DESCRIPTION
## Intent

Investigate a second-hand report that users cannot create environments in Meshery UI at /management/environments on the Layer5 Cloud remote provider, and fix it if the report is still true on the current release (v1.0.60). This was explicitly NOT a request to work around the symptom - the brief required root-causing before touching code, comparing against the working workspace-creation path as the strongest available reference, and treating meshery/schemas or Layer5 Cloud (meshery-cloud) as out-of-scope blockers if the root cause turned out to live there rather than in meshery/meshery.

Reproduced against real production (logged into cloud.layer5.io as an authorized test identity, org 'Meshery'): POST /api/environments returned 404 with an ErrGetResult body ('unable to get result'), but the embedded long_description showed 'Status Code: 500 ... failed to save the environment', proving the 404 was itself a misleading wrapper around a genuine upstream 500, not a routing problem.

Root-caused it as an in-repo (meshery/meshery) defect, not a schemas or cloud defect: server/handlers/environments_handlers.go and every Provider implementation of SaveEnvironment/UpdateEnvironment (remote_provider.go, default_local_provider.go, environment_persister.go, workspace_persister.go, providers.go interface) imported the deprecated github.com/meshery/schemas/models/v1beta1/environment package, whose EnvironmentPayload.OrgId carries the legacy json:"organization_id" tag - a direct violation of this repo's own documented rule against importing deprecated v1beta1 packages. A handler-local dual-accept wrapper correctly parsed a client's camelCase organizationId on the way IN, but remote_provider.go re-marshals that same v1beta1-typed struct to build the outbound request to Layer5 Cloud, and that second marshal always emits organization_id regardless of what the client sent. Layer5 Cloud's own endpoint (verified by reading meshery-cloud's handler) expects camelCase organizationId; receiving snake_case left the org id unpopulated, which violated a NOT NULL/FK constraint on its environments table and produced the underlying 500. I confirmed workspace creation was unaffected because workspace_handlers.go already imports the canonical v1beta3/workspace package - that divergence was the deciding piece of evidence, exactly as the brief predicted it would be if one path worked and the other didn't.

The fix mirrors the already-working workspace pattern exactly: swapped the environment package import from v1beta1 to v1beta3 (already present in the pinned @meshery/schemas v1.3.35 dependency - no schemas release or version bump was needed or done) across every consumer in the server module - providers.go (interface), remote_provider.go, default_local_provider.go, environment_persister.go, workspace_persister.go, and the handler's wire wrapper - renaming the OrgId/ConnectionId/EnvironmentId fields to OrgID/ConnectionID/EnvironmentID that v1beta3 uses. Deliberately left server/cmd/main.go's AutoMigrate registration and mesheryctl on v1beta1: AutoMigrate only reads db: struct tags, which are identical between v1beta1 and v1beta3, and workspace's own prior migration set the same precedent (workspace.Workspace{} in that same AutoMigrate call is also still v1beta1) - so touching main.go would be an inconsistent, unnecessary risk addition, not a fix. mesheryctl is a separate Go module/binary decoupled from the server via JSON over HTTP, so its continued use of v1beta1 does not reproduce this bug (the request still reaches the dual-accept wrapper fine); changing it is out of scope for this targeted fix.

Added two regression tests in a new server/handlers/environments_handlers_test.go: one mirrors the existing TestWorkspacePayloadWire_UnmarshalJSON dual-accept coverage, and the other (TestEnvironmentPayloadWire_MarshalsCanonicalCamelCase) is the actual regression test for this bug - it re-marshals the unwrapped EnvironmentPayload exactly as remote_provider.go does before sending to the remote provider, and asserts the outbound JSON never regresses to organization_id. I verified this test fails to even compile against the pre-fix v1beta1 field names by temporarily git-stashing the fix and re-running it, then restored the fix.

Verified the live fix twice end-to-end against real production cloud.layer5.io (not just unit tests): before the fix, POST /api/environments returned 404 (masking the 500); after rebuilding and restarting the local server with the fix, the identical UI flow returned 201 Created, and the environment was confirmed present in a subsequent GET. Per explicit instructions for testing against production, I created only one disposable, obviously-named test environment (zz-repro-20823-delete-me) and deleted it immediately after confirming success - deletion was verified (GET now returns totalCount: 0).

One explicit scope decision: environments_handlers.go (and the equivalent workspace handlers) also collapse every provider error into a generic ErrGetResult/404 regardless of the real failure - this masked the true 500 during my diagnosis and is a separate, pre-existing, wider issue spanning many handlers beyond environments. I did not fix it in this PR; I flagged it in the commit message as a known follow-up, per the explicit instruction to keep this urgent fix minimal and targeted rather than bundling in a broader error-handling refactor.

## What Changed

- Swapped the `EnvironmentPayload` import from the deprecated `v1beta1/environment` package to `v1beta3/environment` across every provider consumer (`server/models/providers.go` interface, `remote_provider.go`, `default_local_provider.go`, `environment_persister.go`, `workspace_persister.go`), renaming `OrgId`/`ConnectionId`/`EnvironmentId` fields to `OrgID`/`ConnectionID`/`EnvironmentID` to match v1beta3, so the outbound request to Layer5 Cloud marshals `organizationId` (camelCase) instead of the legacy `organization_id` (snake_case) that violated a NOT NULL/FK constraint on Cloud's side.
- Adjusted `server/handlers/environments_handlers.go`'s dual-accept wire wrapper to match the v1beta3 field names now flowing through the persister layer.
- Added `server/handlers/environments_handlers_test.go` with `TestEnvironmentPayloadWire_MarshalsCanonicalCamelCase` (asserts the outbound JSON never regresses to `organization_id`) and a workspace-pattern-mirroring dual-accept unmarshal test.

Deliberately left `server/cmd/main.go`'s `AutoMigrate` registration and `mesheryctl` on v1beta1, consistent with the same precedent already set for `workspace.Workspace{}`; `db:` tags are unchanged between versions and mesheryctl talks to the server over JSON/HTTP where the dual-accept wrapper still applies.

## Risk Assessment

✅ Low: The change is a mechanical, well-scoped swap of the deprecated v1beta1/environment schema import for the canonical v1beta3/environment package across every server-side consumer (interface, remote provider, local provider, both persisters, and the handler's dual-accept wire wrapper), verified field-for-field against the actual generated schemas code (v1beta1.OrgId/json:"organization_id" vs v1beta3.OrgID/json:"organizationId" - confirmed identical DB tags, confirmed no field loss), with all Provider-interface implementers updated consistently and no leftover references to the old field names; it is backed by two new regression tests that correctly exercise the exact remarshal bug described, and the deliberately out-of-scope decisions (mesheryctl, server/cmd/main.go AutoMigrate) are factually justified and don't reintroduce the bug since AutoMigrate only reads unchanged db: tags and mesheryctl talks JSON over HTTP through the still-present dual-accept wrapper.

## Testing

Full-repo build and all relevant Go test suites pass; the regression test was proven genuine by confirming it fails to compile against the pre-fix v1beta1 field names and passes after restoring the fix; and a generated before/after JSON artifact directly shows the outbound POST body to Layer5 Cloud flipping from the broken `organization_id` to the correct `organizationId`, which is the strongest evidence obtainable for this backend-serialization fix without repeating the author's already-documented live production run against cloud.layer5.io (which I did not re-run, since that requires authorized production credentials and would create/delete real production data — a judgment call left to the user rather than repeated automatically).

<details>
<summary>Evidence: Before/after outbound JSON wire body to Layer5 Cloud (v1beta1 vs v1beta3)</summary>

<code>EVIDENCE pre-fix (v1beta1) outbound POST body to Layer5 Cloud: {&#34;description&#34;:&#34;demonstration only&#34;,&#34;name&#34;:&#34;zz-repro-evidence&#34;,&#34;organization_id&#34;:&#34;b82579fe-946d-4071-90cf-29dc5cbe4b07&#34;}&#10;EVIDENCE post-fix (v1beta3) outbound POST body to Layer5 Cloud: {&#34;description&#34;:&#34;demonstration only&#34;,&#34;name&#34;:&#34;zz-repro-evidence&#34;,&#34;organizationId&#34;:&#34;b82579fe-946d-4071-90cf-29dc5cbe4b07&#34;}</code>

```text
Demonstration: outbound HTTP POST body remote_provider.go builds when forwarding
an environment-creation request to Layer5 Cloud (cloud.layer5.io), for the
identical client-submitted organizationId, using the pre-fix (v1beta1) and
post-fix (v1beta3) github.com/meshery/schemas packages.

EVIDENCE pre-fix (v1beta1) outbound POST body to Layer5 Cloud:  {"description":"demonstration only","name":"zz-repro-evidence","organization_id":"b82579fe-946d-4071-90cf-29dc5cbe4b07"}
EVIDENCE post-fix (v1beta3) outbound POST body to Layer5 Cloud: {"description":"demonstration only","name":"zz-repro-evidence","organizationId":"b82579fe-946d-4071-90cf-29dc5cbe4b07"}

Pre-fix body sends "organization_id" (snake_case). Layer5 Cloud's environments
endpoint expects camelCase "organizationId" (confirmed by reading meshery-cloud's
handler per the PR author's investigation), so the org id was never populated on
receipt, violating a NOT NULL/FK constraint on Layer5 Cloud's environments table
and producing the underlying 500 that the meshery server's handler then masked as
a 404 ErrGetResult ("unable to get result").

Post-fix body correctly sends "organizationId", matching Layer5 Cloud's contract.

Generated by temporarily adding server/models/zz_wire_evidence_test.go (marshaling
both github.com/meshery/schemas/models/v1beta1/environment.EnvironmentPayload and
.../v1beta3/environment.EnvironmentPayload with identical field values) and running:
  go test ./server/models -run TestZZWireEvidence_BeforeAfter -v
The temporary file was removed from the worktree after capturing this output; it
was never committed.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (14m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `ui/components/environments/index.tsx:258` - Open GitHub issue #20854 (&#34;Create Environment silently does nothing: submit handler reads &#39;organization&#39; but form supplies &#39;organizationId&#39;&#34;) describes a frontend bug in ui/components/environments/index.tsx that, if real, would independently block environment creation regardless of this PR&#39;s backend fix. Investigation shows the current codebase (target commit a3fee6a8013, and even the actual published v1.0.60 release tag a698cc0ac4c...) already destructures `organizationId` correctly at handleCreateEnvironment (fixed by an earlier, unrelated commit ce2e0467 on 2026-07-20, predating this PR&#39;s base and the v1.0.60 release). The issue&#39;s claimed code does not match current or released source, so it appears stale or based on a cached/stale frontend bundle rather than a live defect in this repo. Not a defect in the PR under test — flagging so the maintainer can decide whether to close/comment on the issue or investigate a possible CDN/bundle-caching problem on playground.meshery.io.
- <code>`go build ./...` (full repo, including server/cmd/main.go AutoMigrate on v1beta1 and mesheryctl on v1beta1, per the PR&#39;s deliberate scope decision)</code>
- <code>`go test ./server/handlers/... -run &#39;TestEnvironmentPayloadWire|TestWorkspacePayloadWire&#39; -v` — new regression tests plus the analogous existing workspace test</code>
- <code>Reverted the six fixed non-test files to their pre-fix (base-commit) versions with the new test file still present, ran `go test ./server/handlers/... -run TestEnvironmentPayloadWire` and confirmed a compile failure (`wire.OrgID undefined ... does have field OrgId`), then restored the fix and re-ran to confirm pass — proves the regression test is real, not tautological</code>
- <code>`go test ./server/handlers/... ./server/models/...` — full package suites for all touched packages</code>
- <code>`cd mesheryctl &amp;&amp; go build ./... &amp;&amp; go test ./internal/cli/root/environments/... --short` — confirms the deliberately-unmigrated mesheryctl client still builds and its create/list/delete environment tests pass unaffected</code>
- <code>Read `github.com/meshery/schemas@v1.3.35` module source directly to verify the v1beta1 vs v1beta3 `EnvironmentPayload` json tags (`organization_id` vs `organizationId`) match the claimed root cause</code>
- <code>Wrote and ran a temporary evidence-generating test (`server/models/zz_wire_evidence_test.go`, removed afterward) that marshals an identical payload through both schema versions to produce the literal outbound POST body sent to Layer5 Cloud, before and after the fix</code>
- <code>Confirmed `server/handlers/workspace_handlers.go` (the comparison reference cited in the intent) already imports `v1beta3/workspace`</code>
- <code>Confirmed via `git diff --stat` that no files outside `server/handlers` and `server/models` changed, and that `ui/components/environments/index.tsx` / `ui/rtk-query/environments.ts` already correctly plumb `organizationId` end-to-end on the frontend (checked against current HEAD and the actual released v1.0.60 git tag `a698cc0ac4c...`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment requests now accept both `organizationId` and legacy `organization_id` formats.
  * When both formats are provided, `organizationId` takes precedence.
  * Environment responses consistently use the canonical `organizationId` format.

* **Bug Fixes**
  * Prevented organization identifiers from persisting incorrectly when omitted from subsequent requests.
  * Updated environment operations for consistent organization association and connection handling.

* **Tests**
  * Added coverage for request compatibility, precedence rules, and canonical response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->