### PR TITLE
[Server] Return 500 on marshal failure in GetSystemDatabase handler

### DIFF
--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -67,7 +67,10 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 
 	val, err := json.Marshal(databaseSummary)
 	if err != nil {
-		fmt.Println(err)
+		merr := models.ErrMarshal(err, "database summary")
+		h.log.Error(merr)
+		writeMeshkitError(w, merr, http.StatusInternalServerError)
+		return
 	}
 	if _, err := fmt.Fprint(w, string(val)); err != nil {
 		h.log.Error(err)


### PR DESCRIPTION
**Notes for Reviewers**

Fixes a bug in `GetSystemDatabase` where a `json.Marshal` failure was logged to stdout via `fmt.Println` but execution continued, writing an empty body to the client with a 200 status. The handler now returns HTTP 500 with an error message and returns early.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when generating the system database summary fails.
  * The API now returns a clear HTTP 500 response instead of continuing with incomplete or invalid output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->