### PR TITLE
feat(catalog): add DigitalOcean icons sample catalog design

### DIFF
--- a/docs/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
+++ b/docs/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
@@ -1,0 +1,20 @@
+---
+layout: item
+name: DigitalOcean Icons Design
+publishedVersion: 0.0.1
+userId: 637f0d76-d582-4269-a08c-e85e6e5e2312
+userName: Olaleye Oyewunmi
+userAvatarURL: 
+type: workloads
+compatibility:
+    - digitalocean-icons
+patternId: d0cc730d-2c44-4235-acb7-688f5e99750d
+image: /assets/images/logos/service-mesh-pattern.svg
+patternInfo: |
+  A simple design pattern showcasing the standalone icon and full wordmark logo for DigitalOcean whiteboard annotations.
+patternCaveats: |
+  Requires the digitalocean-icons model registered.
+permalink: catalog/workloads/digitalocean-icons-design-d0cc730d-2c44-4235-acb7-688f5e99750d.html
+URL: 'https://raw.githubusercontent.com/meshery/meshery/master/docs/data/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml'
+downloadLink: d0cc730d-2c44-4235-acb7-688f5e99750d/design.yml
+---

--- a/docs/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
+++ b/docs/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
@@ -13,7 +13,7 @@ image: /assets/images/logos/service-mesh-pattern.svg
 patternInfo: |
   A simple design pattern showcasing the standalone icon and full wordmark logo for DigitalOcean whiteboard annotations.
 patternCaveats: |
-  Requires the digitalocean-icons model registered.
+  Requires the digitalocean-icons model to be registered.
 permalink: catalog/workloads/digitalocean-icons-design-d0cc730d-2c44-4235-acb7-688f5e99750d.html
 URL: 'https://raw.githubusercontent.com/meshery/meshery/master/docs/data/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml'
 downloadLink: d0cc730d-2c44-4235-acb7-688f5e99750d/design.yml

--- a/docs/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
+++ b/docs/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md
@@ -15,6 +15,6 @@ patternInfo: |
 patternCaveats: |
   Requires the digitalocean-icons model to be registered.
 permalink: catalog/workloads/digitalocean-icons-design-d0cc730d-2c44-4235-acb7-688f5e99750d.html
-URL: 'https://raw.githubusercontent.com/meshery/meshery/master/docs/data/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml'
+URL: 'https://raw.githubusercontent.com/meshery/meshery.io/master/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml'
 downloadLink: d0cc730d-2c44-4235-acb7-688f5e99750d/design.yml
 ---

--- a/docs/data/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml
+++ b/docs/data/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml
@@ -1,0 +1,85 @@
+{
+  "id": "d0cc730d-2c44-4235-acb7-688f5e99750d",
+  "name": "DigitalOcean Icons Design",
+  "version": "0.0.1",
+  "components": [
+    {
+      "id": "e0aa730d-2c44-4235-acb7-688f5e99750d",
+      "model": {
+        "name": "digitalocean-icons",
+        "version": "v1.0.0",
+        "displayName": "DigitalOcean Icons",
+        "metadata": {
+          "isAnnotation": true,
+          "primaryColor": "#0080FF",
+          "secondaryColor": "#0069D9",
+          "shape": "circle"
+        }
+      },
+      "format": "JSON",
+      "status": "enabled",
+      "styles": {
+        "shape": "circle",
+        "primaryColor": "#0080FF",
+        "secondaryColor": "#0069D9",
+        "position": {
+          "x": 100,
+          "y": 100
+        }
+      },
+      "version": "v1.0.0",
+      "metadata": {
+        "isAnnotation": true,
+        "isNamespaced": false,
+        "published": true
+      },
+      "component": {
+        "kind": "digitalocean",
+        "schema": "",
+        "version": ""
+      },
+      "description": "DigitalOcean Logomark Icon",
+      "displayName": "digitalocean-icon-1"
+    },
+    {
+      "id": "e0ab730d-2c44-4235-acb7-688f5e99750d",
+      "model": {
+        "name": "digitalocean-icons",
+        "version": "v1.0.0",
+        "displayName": "DigitalOcean Icons",
+        "metadata": {
+          "isAnnotation": true,
+          "primaryColor": "#0080FF",
+          "secondaryColor": "#0069D9",
+          "shape": "circle"
+        }
+      },
+      "format": "JSON",
+      "status": "enabled",
+      "styles": {
+        "shape": "circle",
+        "primaryColor": "#0080FF",
+        "secondaryColor": "#0069D9",
+        "position": {
+          "x": 250,
+          "y": 100
+        }
+      },
+      "version": "v1.0.0",
+      "metadata": {
+        "isAnnotation": true,
+        "isNamespaced": false,
+        "published": true
+      },
+      "component": {
+        "kind": "digitalocean-logo",
+        "schema": "",
+        "version": ""
+      },
+      "description": "DigitalOcean Full Wordmark Logo",
+      "displayName": "digitalocean-logo-1"
+    }
+  ],
+  "relationships": [],
+  "schemaVersion": "designs.meshery.io/v1beta1"
+}


### PR DESCRIPTION
### Description

This PR registers a sample design containing the new DigitalOcean annotation components (`digitalocean` logomark and `digitalocean-logo` wordmark) to the Meshery Integration Catalog.

### Changes
- Added `docs/data/catalog/d0cc730d-2c44-4235-acb7-688f5e99750d/0.0.1/design.yml`
- Added Jekyll metadata page `docs/catalog/workloads/d0cc730d-2c44-4235-acb7-688f5e99750d.md`

### Links
Closes #20873

Signed-off-by: Olaleye Oyewunmi <junnexclusive@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “DigitalOcean Icons Design” entry to the workload catalog.
  * Published the catalog page with routing and workload metadata, including compatibility and description details.
  * Added a new design definition (v0.0.1) featuring enabled icon/logo components with positioning and styling (primary/secondary colors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->