### PR TITLE
[UI] Type the host/extension event contract so renames fail at compile time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,20 @@ make ui-lint               # Lint UI code
 make ui-integration-tests  # Run E2E tests
 ```
 
+`ui/tsconfig.tsbuildinfo` is a tracked build artifact that is not gitignored, so any local
+`tsc --noEmit` leaves it modified and it has repeatedly been committed by accident. Stage
+explicit paths rather than `git add -A`, and `git checkout -- ui/tsconfig.tsbuildinfo`
+before committing.
+
+When a change depends on an unreleased `@sistent/sistent` (or any sibling-repo package),
+`ui/node_modules/@sistent/sistent` is often overwritten in place with a locally-built dist.
+A local test run is then green against code that is not published, and CI fails on the same
+commit. Re-verify with `npm ci` after any local sibling build before trusting a green run or
+declaring a dependency bump done - a local build usually keeps the published version string,
+so matching versions are not evidence that the installed contents are the published ones.
+A version *mismatch* against `ui/package.json` is a useful tell that this has happened, but
+a match proves nothing.
+
 ### CLI (mesheryctl)
 
 ```bash
@@ -289,7 +303,9 @@ Protocol: `server/meshes/meshops.proto` — adapters self-register on startup. E
 
 ### UI Extensions
 
-Remote Components loaded via `@paciolan/remote-component`. Bundle **must** expose `module.exports = { default: Component, __esModule: true }`. Silent-undefined gotcha: a mis-built bundle renders as `undefined` with no loader error — React throws "Element type is invalid" at render. Check bundle export shape first. See `ui/components/layout/Navigator/NavigatorExtension.tsx`.
+Remote Components loaded via `@paciolan/remote-component`. Bundle **must** expose `module.exports = { default: Component, __esModule: true }`; a bundle built without `output.library.type = "commonjs2"` resolves to `undefined` with no loader error, so `NavigatorExtension` guards for it explicitly and reports the export shape as the cause. See `ui/components/layout/Navigator/NavigatorExtension.tsx`.
+
+The host <-> extension contract (injected capability keys, event-bus event literals, contract version) is declared once in `@sistent/sistent`'s `mesheryExtensionContract` module and shared by both sides. Derive every event literal from `MESHERY_EXTENSION_EVENT` and every injected key from that module rather than typing strings: hand-duplicated literals are why `OPEN_DESIGN_IN_KANVAS` -> `OPEN_DESIGN_IN_EXTENSION` and `capabilitiesRegistry` -> `providerCapabilities` both shipped as silent runtime no-ops. `ui/utils/eventBus.ts` must stay typed as `EventBus<MesheryExtensionEvent>`; a bare `new EventBus()` widens `T` to its constraint and disables publish-site checking entirely. The `NavigatorExtension` unit test asserts the built `injectProps` bag against the contract, which is the gate that catches a capability rename before merge.
 
 ### GraphQL
 

--- a/ui/components/layout/Navigator/NavigatorExtension.test.tsx
+++ b/ui/components/layout/Navigator/NavigatorExtension.test.tsx
@@ -2,21 +2,27 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Hoisted state we can swap between tests.
-const remoteState: { loading: boolean; err: any; remoteProps: any | null } = {
+// Hoisted state we can swap between tests. `component` models what
+// `useRemoteComponent` resolved the bundle to, including `undefined` -- which
+// is what a bundle without a CommonJS default export yields, with no error.
+const RemoteComponentStub = ({ injectProps }: any) => {
+  remoteState.remoteProps = injectProps;
+  return <div data-testid="remote-component">remote</div>;
+};
+
+const remoteState: { loading: boolean; err: any; remoteProps: any | null; component: unknown } = {
   loading: false,
   err: null,
   remoteProps: null,
+  component: RemoteComponentStub,
 };
 
 vi.mock('@paciolan/remote-component', () => ({
-  createUseRemoteComponent: () => (_url: string) => {
-    const RemoteComponent = ({ injectProps }: any) => {
-      remoteState.remoteProps = injectProps;
-      return <div data-testid="remote-component">remote</div>;
-    };
-    return [remoteState.loading, remoteState.err, RemoteComponent];
-  },
+  createUseRemoteComponent: () => (_url: string) => [
+    remoteState.loading,
+    remoteState.err,
+    remoteState.component,
+  ],
   getDependencies: () => ({}),
   createRequires: () => () => ({}),
 }));
@@ -123,9 +129,11 @@ vi.mock('../../meshery-mesh-interface/PatternService/RJSF', () => ({
 }));
 
 vi.mock('../../shared/LoadingState/DynamicFullscreenLoader', () => ({
+  // The real loader withholds its children entirely while loading; the stub has
+  // to do the same or tests see a tree the app never renders.
   DynamicFullScreenLoader: ({ children, isLoading }: any) => (
     <div data-testid="dynamic-loader" data-loading={String(Boolean(isLoading))}>
-      {children}
+      {isLoading ? null : children}
     </div>
   ),
 }));
@@ -164,13 +172,21 @@ vi.mock('@/utils/hooks/useRegistryModal', () => ({
   useRegistryModal: () => ({ openModal: vi.fn() }),
 }));
 
-import NavigatorExtension from './NavigatorExtension';
+import {
+  MESHERY_EXTENSION_CONTRACT_VERSION,
+  describeInjectedCapabilityReport,
+  isInjectedCapabilityReportSatisfied,
+  reportInjectedCapabilities,
+} from '@sistent/sistent';
+
+import NavigatorExtension, { buildExtensionInjectProps } from './NavigatorExtension';
 
 describe('NavigatorExtension', () => {
   beforeEach(() => {
     remoteState.loading = false;
     remoteState.err = null;
     remoteState.remoteProps = null;
+    remoteState.component = RemoteComponentStub;
   });
 
   it('renders the remote component wrapped in a fullscreen loader', () => {
@@ -208,5 +224,75 @@ describe('NavigatorExtension', () => {
     expect(remoteState.remoteProps.CapabilitiesRegistryClass).toBe(
       remoteState.remoteProps.ProviderUiAccessControlClass,
     );
+    // Extensions read this to detect that they were built against a different
+    // contract revision than the host that loaded them.
+    expect(remoteState.remoteProps.contractVersion).toBe(MESHERY_EXTENSION_CONTRACT_VERSION);
+  });
+
+  it('surfaces the real cause when the bundle exposes no default export', () => {
+    // `useRemoteComponent` yields `undefined` with no error in this case, so
+    // without an explicit guard React fails with an opaque "Element type is
+    // invalid" far from the actual problem.
+    remoteState.component = undefined;
+    render(<NavigatorExtension url="https://remote.example/component.js" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/no CommonJS default export/i)).toBeInTheDocument();
+    // This is the bundler-config case, so the commonjs2 remedy is the right one.
+    expect(screen.getByText(/commonjs2/i)).toBeInTheDocument();
+    expect(screen.getByText(/https:\/\/remote\.example\/component\.js/)).toBeInTheDocument();
+  });
+
+  it('waits for loading to finish before reporting a missing default export', () => {
+    remoteState.loading = true;
+    remoteState.component = undefined;
+    render(<NavigatorExtension url="https://remote.example/component.js" />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['memo', () => React.memo(RemoteComponentStub)],
+    ['forwardRef', () => React.forwardRef((props: any) => <RemoteComponentStub {...props} />)],
+  ])('renders a %s-wrapped default export', (_label, makeComponent) => {
+    remoteState.component = makeComponent();
+    render(<NavigatorExtension url="https://remote.example/component.js" />);
+    expect(screen.getByTestId('remote-component')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('rejects a default export that is an element rather than a component', () => {
+    // A bundle that exports `<Foo />` instead of `Foo` still carries a
+    // `$$typeof` tag, so a bare "has $$typeof" check would wave it through and
+    // React would then fail with the opaque "Element type is invalid" this
+    // guard exists to replace. Only forwardRef/memo/lazy tags are components.
+    remoteState.component = <RemoteComponentStub />;
+    render(<NavigatorExtension url="https://remote.example/component.js" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/is not a React component/i)).toBeInTheDocument();
+    // The remedies differ: this bundle exported *something*, so pointing the
+    // author at the commonjs2 bundler setting would send them after the wrong fix.
+    expect(screen.queryByText(/commonjs2/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('buildExtensionInjectProps', () => {
+  it('satisfies every capability the extension contract declares', () => {
+    // The host <-> extension boundary has no compile-time link: extensions read
+    // these keys off an untyped bag, so a rename here is invisible until the
+    // feature that reads it is dead in production. This assertion is the gate.
+    const report = reportInjectedCapabilities(
+      buildExtensionInjectProps({
+        providerCapabilities: {},
+        selectedK8sContexts: [],
+        currentOrganization: { id: 'org-1' },
+        openWorkspaceModal: vi.fn(),
+        openRegistryModal: vi.fn(),
+        setCurrentLoadedResourceInOrgWorkspaceSession: vi.fn(),
+      }),
+    );
+
+    expect(
+      isInjectedCapabilityReportSatisfied(report),
+      String(describeInjectedCapabilityReport(report)),
+    ).toBe(true);
   });
 });

--- a/ui/components/layout/Navigator/NavigatorExtension.tsx
+++ b/ui/components/layout/Navigator/NavigatorExtension.tsx
@@ -36,6 +36,7 @@ import ProviderStoreWrapper from '@/store/ProviderStoreWrapper';
 import { WorkspaceModalContext } from '@/utils/context/WorkspaceModalContextProvider';
 import { RelationshipEvaluationTraceFormatter } from '../NotificationCenter/formatters/relationship_evaluation';
 import { useRegistryModal } from '@/utils/hooks/useRegistryModal';
+import { MESHERY_EXTENSION_CONTRACT_VERSION } from '@sistent/sistent';
 
 const requires = createRequires(getDependencies);
 const useRemoteComponent = createUseRemoteComponent({ requires });
@@ -66,6 +67,163 @@ function PerformanceTestComponent(props: React.ComponentProps<typeof MesheryPerf
     <ProviderStoreWrapper>
       <MesheryPerformanceComponent {...props} />
     </ProviderStoreWrapper>
+  );
+}
+
+/**
+ * Everything the injected capability bag needs from React state or context. The
+ * rest of the bag is module-scoped, so a caller only has to supply these.
+ */
+export type ExtensionInjectPropsDeps = {
+  providerCapabilities: unknown;
+  selectedK8sContexts: unknown;
+  currentOrganization: unknown;
+  openWorkspaceModal: unknown;
+  openRegistryModal: unknown;
+  setCurrentLoadedResourceInOrgWorkspaceSession: unknown;
+};
+
+/**
+ * Builds the capability bag handed to an extension bundle as `injectProps`.
+ *
+ * Every key here is part of the host <-> extension contract declared in sistent's
+ * `mesheryExtensionContract`: extensions read these off the injected bag, so
+ * renaming or dropping one resolves to `undefined` at the extension's use site
+ * rather than failing anywhere near here. Kept as a pure factory so a unit test
+ * can assert the bag against the contract and catch such a rename before merge.
+ */
+export const buildExtensionInjectProps = ({
+  providerCapabilities,
+  selectedK8sContexts,
+  currentOrganization,
+  openWorkspaceModal,
+  openRegistryModal,
+  setCurrentLoadedResourceInOrgWorkspaceSession,
+}: ExtensionInjectPropsDeps) => ({
+  // Lets an extension bundle detect that it was built against a different
+  // contract revision than the host it was loaded into, which no build-time
+  // check can catch: bundles are published artifacts loaded by whatever host
+  // version happens to be deployed.
+  contractVersion: MESHERY_EXTENSION_CONTRACT_VERSION,
+  PatternServiceFormCore,
+  RelationshipEvaluationResponseFormatter: RelationshipEvaluationTraceFormatter,
+  MesheryPerformanceComponent: PerformanceTestComponent,
+  selectedK8sContexts,
+  // Meshery Server no longer exposes any GraphQL subscription. `resolver` is
+  // kept only for backward compatibility with already-published extension
+  // bundles: they call `resolver.subscription.ConfigurationSubscription(cb, vars)`
+  // and later `.dispose()` on the result. Handing them `undefined` would throw
+  // at mount, so we hand them an inert subscription that never emits. New
+  // extensions should read designs/filters from the REST API instead.
+  resolver: {
+    query: {},
+    mutation: {},
+    subscription: {
+      ConfigurationSubscription: noopSubscription,
+    },
+  },
+  InfoModal,
+  ViewInfoModal,
+  ExportModal: ExportDesignModal,
+  GenericRJSFModal: Modal,
+  _PromptComponent,
+  providerCapabilities,
+  ProviderUiAccessControlClass: ProviderUiAccessControl,
+  // Backward-compatible alias for already-published remote extensions.
+  CapabilitiesRegistryClass: ProviderUiAccessControl,
+  TypingFilter,
+  useNotificationHook: useNotification,
+  StructuredDataFormatter: FormatStructuredData,
+  CreateModelModal,
+  ImportModelModal,
+  ValidateDesign,
+  DryRunDesign,
+  DeployStepper,
+  UnDeployStepper,
+  designValidationMachine,
+  mesheryEventBus,
+  ThemeTogglerCore,
+  RJSForm: RJSFForm,
+  hooks: {
+    CAN,
+    useFilterK8sContexts,
+    useDynamicComponent,
+  },
+  mesheryStore: extensionExposedMesheryStore,
+  currentOrganization,
+  openWorkspaceModal,
+  openRegistryModal,
+  SetCurrentLoadedResourceInOrgWorkspaceSession: setCurrentLoadedResourceInOrgWorkspaceSession,
+});
+
+/**
+ * The `$$typeof` tags of the object-shaped values React accepts as a *component*
+ * type. Deliberately an allow-list rather than a bare `'$$typeof' in component`
+ * check: many React-internal values carry `$$typeof` without being components —
+ * most notably an already-rendered element (`<Foo />`), which a bundle can export
+ * by accident. Accepting those would let the very failure this guard exists to
+ * diagnose through to React's opaque "Element type is invalid" error.
+ */
+const RENDERABLE_COMPONENT_TAGS: ReadonlySet<symbol> = new Set([
+  Symbol.for('react.forward_ref'),
+  Symbol.for('react.memo'),
+  Symbol.for('react.lazy'),
+]);
+
+/**
+ * Whether a value can legally be passed to `React.createElement` as an element
+ * type. Function components (and classes) are plain functions; `forwardRef`,
+ * `memo` and `lazy` results are objects tagged with `$$typeof`.
+ */
+function isRenderableComponent(
+  component: unknown,
+): component is React.ComponentType<{ injectProps: unknown }> {
+  if (typeof component === 'function') {
+    return true;
+  }
+  return (
+    typeof component === 'object' &&
+    component !== null &&
+    RENDERABLE_COMPONENT_TAGS.has((component as { $$typeof?: symbol }).$$typeof as symbol)
+  );
+}
+
+/**
+ * Best-effort description of what a bundle exported instead of a component, so
+ * the diagnostic names the actual value rather than just "not a component".
+ */
+function describeExportKind(exported: unknown): string {
+  if (exported && typeof exported === 'object') {
+    const tag = (exported as { $$typeof?: unknown }).$$typeof;
+    if (typeof tag === 'symbol') {
+      return `a React internal value tagged ${String(tag)}`;
+    }
+  }
+  return `a value of type "${typeof exported}"`;
+}
+
+/**
+ * Explains why a loaded bundle yielded nothing renderable.
+ *
+ * The two causes have different remedies and must not share a message: a missing
+ * default export is a bundler configuration problem, while a default export that
+ * is present but is not a component is a defect in the extension's own source.
+ * Telling an author to rebuild with `commonjs2` when they actually exported
+ * `<Foo />` instead of `Foo` sends them after the wrong fix entirely.
+ */
+function describeUnrenderableExport(url: string, exported: unknown): string {
+  if (exported === undefined || exported === null) {
+    return (
+      `The extension at ${url} loaded but exposed no CommonJS default export ` +
+      '(module.exports.default), so there is no component to render. The bundle was ' +
+      'most likely built without output.library.type = "commonjs2". Rebuild and ' +
+      'republish the extension, then reload this page.'
+    );
+  }
+  return (
+    `The extension at ${url} exposed a CommonJS default export, but it is not a React ` +
+    `component (received ${describeExportKind(exported)}). Export the component itself ` +
+    'rather than a rendered element or other value, then rebuild and republish the extension.'
   );
 }
 
@@ -110,57 +268,15 @@ function NavigatorExtension({ url }: NavigatorExtensionProps) {
   const registryModal = useRegistryModal();
 
   const injectProps = useMemo(
-    () => ({
-      PatternServiceFormCore,
-      RelationshipEvaluationResponseFormatter: RelationshipEvaluationTraceFormatter,
-      MesheryPerformanceComponent: PerformanceTestComponent,
-      selectedK8sContexts,
-      // Meshery Server no longer exposes any GraphQL subscription. `resolver` is
-      // kept only for backward compatibility with already-published extension
-      // bundles: they call `resolver.subscription.ConfigurationSubscription(cb, vars)`
-      // and later `.dispose()` on the result. Handing them `undefined` would throw
-      // at mount, so we hand them an inert subscription that never emits. New
-      // extensions should read designs/filters from the REST API instead.
-      resolver: {
-        query: {},
-        mutation: {},
-        subscription: {
-          ConfigurationSubscription: noopSubscription,
-        },
-      },
-      InfoModal,
-      ViewInfoModal,
-      ExportModal: ExportDesignModal,
-      GenericRJSFModal: Modal,
-      _PromptComponent,
-      providerCapabilities,
-      ProviderUiAccessControlClass: ProviderUiAccessControl,
-      // Backward-compatible alias for already-published remote extensions.
-      CapabilitiesRegistryClass: ProviderUiAccessControl,
-      TypingFilter,
-      useNotificationHook: useNotification,
-      StructuredDataFormatter: FormatStructuredData,
-      CreateModelModal,
-      ImportModelModal,
-      ValidateDesign,
-      DryRunDesign,
-      DeployStepper,
-      UnDeployStepper,
-      designValidationMachine,
-      mesheryEventBus,
-      ThemeTogglerCore,
-      RJSForm: RJSFForm,
-      hooks: {
-        CAN,
-        useFilterK8sContexts,
-        useDynamicComponent,
-      },
-      mesheryStore: extensionExposedMesheryStore,
-      currentOrganization,
-      openWorkspaceModal: openModalWithDefault,
-      openRegistryModal: registryModal,
-      SetCurrentLoadedResourceInOrgWorkspaceSession: onLoadResource,
-    }),
+    () =>
+      buildExtensionInjectProps({
+        providerCapabilities,
+        selectedK8sContexts,
+        currentOrganization,
+        openWorkspaceModal: openModalWithDefault,
+        openRegistryModal: registryModal,
+        setCurrentLoadedResourceInOrgWorkspaceSession: onLoadResource,
+      }),
     [
       providerCapabilities,
       currentOrganization,
@@ -175,9 +291,19 @@ function NavigatorExtension({ url }: NavigatorExtensionProps) {
     return <NavigatorExtensionError error={err} />;
   }
 
+  const hasComponent = isRenderableComponent(RemoteComponent);
+
+  // A bundle without a CommonJS default export leaves both `err` and
+  // `RemoteComponent` undefined, so this is the last point at which the actual
+  // cause is still known. Without it React reports only "Element type is
+  // invalid ... got: undefined" from inside the render tree.
+  if (!loading && !hasComponent) {
+    return <NavigatorExtensionError error={describeUnrenderableExport(url, RemoteComponent)} />;
+  }
+
   return (
     <DynamicFullScreenLoader isLoading={loading}>
-      <RemoteComponent injectProps={injectProps} />
+      {hasComponent ? <RemoteComponent injectProps={injectProps} /> : null}
     </DynamicFullScreenLoader>
   );
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -37,7 +37,7 @@
         "@rjsf/utils": "^6.6.2",
         "@rjsf/validator-ajv8": "^6.6.2",
         "@sistent/mui-datatables": "^8.0.0",
-        "@sistent/sistent": "^0.21.38",
+        "@sistent/sistent": "^0.21.40",
         "@tippyjs/react": "^4.2.6",
         "@uiw/codemirror-theme-material": "^4.25.10",
         "@uiw/react-codemirror": "^4.25.10",
@@ -3292,9 +3292,9 @@
       }
     },
     "node_modules/@sistent/sistent": {
-      "version": "0.21.38",
-      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.21.38.tgz",
-      "integrity": "sha512-QPOZNQw/esop9BtAthwRO4B/7Ubk11wNyPcScN427ucHNgw3l1L2DxRrLKgucbBKZKck8amkE5fJs7Odb0AxeQ==",
+      "version": "0.21.40",
+      "resolved": "https://registry.npmjs.org/@sistent/sistent/-/sistent-0.21.40.tgz",
+      "integrity": "sha512-kvro+66WsFS9sp2rstT50TwmRkEKVK4e1X9axyktWFyiUoXNkZSij9kCRXrkIhBAOSL+OlYUn5h95gxCnSP4GA==",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -65,7 +65,7 @@
     "@rjsf/utils": "^6.6.2",
     "@rjsf/validator-ajv8": "^6.6.2",
     "@sistent/mui-datatables": "^8.0.0",
-    "@sistent/sistent": "^0.21.38",
+    "@sistent/sistent": "^0.21.40",
     "@tippyjs/react": "^4.2.6",
     "@uiw/codemirror-theme-material": "^4.25.10",
     "@uiw/react-codemirror": "^4.25.10",

--- a/ui/store/index.ts
+++ b/ui/store/index.ts
@@ -6,6 +6,7 @@ import mesheryUiReducer from './slices/mesheryUi';
 import prefTestReducer from './slices/prefTest';
 import adapterReducer from './slices/adapter';
 import { rtkErrorMiddleware } from './middleware/rtkErrorMiddleware';
+import { MESHERY_EXTENSION_EVENT } from '@sistent/sistent';
 import { mesheryEventBus } from '@/utils/eventBus';
 
 export const store = configureStore({
@@ -23,7 +24,11 @@ export const store = configureStore({
 
 export type RootState = ReturnType<typeof store.getState>;
 
-mesheryEventBus.on('DISPATCH_TO_MESHERY_STORE').subscribe((event) => {
+mesheryEventBus.on(MESHERY_EXTENSION_EVENT.DispatchToMesheryStore).subscribe((event) => {
+  // `EventBus.on` filters at runtime but is typed as the full event union, so the
+  // discriminant has to be re-checked here for `event.data` to narrow to a
+  // dispatchable action rather than the union of every event payload.
+  if (event.type !== MESHERY_EXTENSION_EVENT.DispatchToMesheryStore) return;
   console.log('Dispatching to Meshery Store:', event.data);
   store.dispatch(event.data);
 });

--- a/ui/store/slices/__tests__/mesheryUi.test.ts
+++ b/ui/store/slices/__tests__/mesheryUi.test.ts
@@ -55,6 +55,7 @@ import mesheryUiReducer, {
   selectK8sConfig,
   selectedOrg,
 } from '../mesheryUi';
+import { MESHERY_EXTENSION_EVENT } from '@sistent/sistent';
 import { mesheryEventBus } from '@/utils/eventBus';
 import { store } from '../..';
 
@@ -216,7 +217,7 @@ describe('mesheryUi slice', () => {
       expect(dispatched.payload).toEqual(payload);
 
       expect(mesheryEventBus.publish).toHaveBeenCalledWith({
-        type: 'K8S_CONTEXTS_UPDATED',
+        type: MESHERY_EXTENSION_EVENT.K8sContextsUpdated,
         data: { selectedK8sContexts: ['ctx-1'] },
       });
     });

--- a/ui/store/slices/mesheryUi.ts
+++ b/ui/store/slices/mesheryUi.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { MESHERY_EXTENSION_EVENT } from '@sistent/sistent';
 import { getK8sClusterIdsFromCtxId, persistSelectedK8sContexts } from '@/utils/multi-ctx';
 import { mesheryEventBus } from '@/utils/eventBus';
 import { store } from '..';
@@ -123,7 +124,7 @@ export const setK8sContexts = (payload) => (dispatch) => {
   persistSelectedK8sContexts(payload.selectedK8sContexts);
 
   mesheryEventBus.publish({
-    type: 'K8S_CONTEXTS_UPDATED',
+    type: MESHERY_EXTENSION_EVENT.K8sContextsUpdated,
     data: {
       selectedK8sContexts: payload.selectedK8sContexts,
     },

--- a/ui/utils/__tests__/eventBus.test.ts
+++ b/ui/utils/__tests__/eventBus.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest';
+import { MESHERY_EXTENSION_EVENT, type MesheryExtensionEvent } from '@sistent/sistent';
 import { mesheryEventBus } from '../eventBus';
+
+const dispatchToStore: MesheryExtensionEvent = {
+  type: MESHERY_EXTENSION_EVENT.DispatchToMesheryStore,
+  data: { type: 'core/updateProgress', payload: { showProgress: true } },
+};
+
+const k8sContextsUpdated: MesheryExtensionEvent = {
+  type: MESHERY_EXTENSION_EVENT.K8sContextsUpdated,
+  data: { selectedK8sContexts: ['ctx-1'] },
+};
 
 describe('mesheryEventBus', () => {
   it('is a singleton EventBus instance with publish/on/onAny methods', () => {
@@ -9,54 +20,72 @@ describe('mesheryEventBus', () => {
     expect(typeof mesheryEventBus.onAny).toBe('function');
   });
 
+  it('rejects event types outside the extension contract at compile time', () => {
+    // @ts-expect-error - the whole point of typing the bus: an event literal the
+    // contract does not declare must fail the build. At runtime it would be
+    // published to nobody, which is indistinguishable from a working feature.
+    mesheryEventBus.publish({ type: 'NOT_IN_THE_CONTRACT', data: {} });
+  });
+
   it('delivers published events to subscribers of the matching type', async () => {
-    const received: Array<{ type: string; data: { count: number } }> = [];
+    const received: MesheryExtensionEvent[] = [];
     const subscription = mesheryEventBus
-      .on('DISPATCH_TO_MESHERY_STORE')
-      .subscribe((event: { type: string; data: { count: number } }) => {
+      .on(MESHERY_EXTENSION_EVENT.DispatchToMesheryStore)
+      .subscribe((event) => {
         received.push(event);
       });
 
-    mesheryEventBus.publish({ type: 'DISPATCH_TO_MESHERY_STORE', data: { count: 1 } });
-    mesheryEventBus.publish({ type: 'K8S_CONTEXTS_UPDATED', data: { count: 99 } });
+    mesheryEventBus.publish(dispatchToStore);
+    mesheryEventBus.publish(k8sContextsUpdated);
 
     // Allow rxjs microtask flush
     await Promise.resolve();
 
     expect(received).toHaveLength(1);
-    expect(received[0]).toEqual({ type: 'DISPATCH_TO_MESHERY_STORE', data: { count: 1 } });
+    expect(received[0]).toEqual(dispatchToStore);
     subscription.unsubscribe();
   });
 
   it('delivers events to onAny subscribers regardless of type', async () => {
     const seenTypes: string[] = [];
-    const subscription = mesheryEventBus.onAny().subscribe((event: { type: string }) => {
+    const subscription = mesheryEventBus.onAny().subscribe((event) => {
       seenTypes.push(event.type);
     });
 
-    mesheryEventBus.publish({ type: 'K8S_CONTEXTS_UPDATED', data: {} });
-    mesheryEventBus.publish({ type: 'DISPATCH_TO_MESHERY_STORE', data: {} });
+    mesheryEventBus.publish(k8sContextsUpdated);
+    mesheryEventBus.publish(dispatchToStore);
 
     await Promise.resolve();
 
     expect(seenTypes).toEqual(
-      expect.arrayContaining(['K8S_CONTEXTS_UPDATED', 'DISPATCH_TO_MESHERY_STORE']),
+      expect.arrayContaining([
+        MESHERY_EXTENSION_EVENT.K8sContextsUpdated,
+        MESHERY_EXTENSION_EVENT.DispatchToMesheryStore,
+      ]),
     );
     subscription.unsubscribe();
   });
 
   it('stops delivering events to a subscriber after it unsubscribes', async () => {
-    const received: unknown[] = [];
-    const subscription = mesheryEventBus.on('K8S_CONTEXTS_UPDATED').subscribe((event) => {
-      received.push(event);
-    });
+    const received: MesheryExtensionEvent[] = [];
+    const subscription = mesheryEventBus
+      .on(MESHERY_EXTENSION_EVENT.K8sContextsUpdated)
+      .subscribe((event) => {
+        received.push(event);
+      });
 
-    mesheryEventBus.publish({ type: 'K8S_CONTEXTS_UPDATED', data: { round: 1 } });
+    mesheryEventBus.publish({
+      type: MESHERY_EXTENSION_EVENT.K8sContextsUpdated,
+      data: { selectedK8sContexts: ['round-1'] },
+    });
     await Promise.resolve();
     expect(received).toHaveLength(1);
 
     subscription.unsubscribe();
-    mesheryEventBus.publish({ type: 'K8S_CONTEXTS_UPDATED', data: { round: 2 } });
+    mesheryEventBus.publish({
+      type: MESHERY_EXTENSION_EVENT.K8sContextsUpdated,
+      data: { selectedK8sContexts: ['round-2'] },
+    });
     await Promise.resolve();
     expect(received).toHaveLength(1);
   });

--- a/ui/utils/__tests__/utils.test.tsx
+++ b/ui/utils/__tests__/utils.test.tsx
@@ -31,6 +31,7 @@ vi.mock('react-redux', () => ({
   useSelector: (sel: (s: unknown) => unknown) => hoisted.useSelectorMock(sel),
 }));
 
+import { MESHERY_EXTENSION_EVENT } from '@sistent/sistent';
 import {
   ConditionalTooltip,
   ResizableCell,
@@ -574,7 +575,7 @@ describe('event-bus router helpers', () => {
     setLocation('http://localhost:9081/extension/meshmap');
     openViewScopedToDesignInOperator('My Design', 'd-1', { push: vi.fn() });
     expect(eventBus.publish).toHaveBeenCalledWith({
-      type: 'OPEN_VIEW_SCOPED_TO_DESIGN',
+      type: MESHERY_EXTENSION_EVENT.OpenViewScopedToDesign,
       data: { designId: 'd-1', designName: 'My Design' },
     });
   });
@@ -592,7 +593,7 @@ describe('event-bus router helpers', () => {
   it('publishes MERGE_DESIGN unconditionally', () => {
     mergeDesignWithCurrent('d-1', 'D1');
     expect(eventBus.publish).toHaveBeenCalledWith({
-      type: 'MERGE_DESIGN',
+      type: MESHERY_EXTENSION_EVENT.MergeDesign,
       data: { id: 'd-1', name: 'D1' },
     });
   });
@@ -600,7 +601,13 @@ describe('event-bus router helpers', () => {
   it('openDesignInExtension publishes inside extension and routes outside', () => {
     setLocation('http://localhost:9081/extension/meshmap');
     openDesignInExtension('d-1', 'D1', { push: vi.fn() });
-    expect(eventBus.publish).toHaveBeenCalled();
+    // Asserting the exact event, not just that something was published: the
+    // published literal is the half of the contract the extension matches on,
+    // and a rename of it is invisible to a bare `toHaveBeenCalled`.
+    expect(eventBus.publish).toHaveBeenCalledWith({
+      type: MESHERY_EXTENSION_EVENT.OpenDesignInExtension,
+      data: { designId: 'd-1', designName: 'D1' },
+    });
     eventBus.publish.mockClear();
     setLocation('http://localhost:9081/dashboard');
     const router = { push: vi.fn() };
@@ -611,7 +618,10 @@ describe('event-bus router helpers', () => {
   it('openViewInExtension publishes inside extension and routes outside', () => {
     setLocation('http://localhost:9081/extension/meshmap');
     openViewInExtension('v-1', 'V1', { push: vi.fn() });
-    expect(eventBus.publish).toHaveBeenCalled();
+    expect(eventBus.publish).toHaveBeenCalledWith({
+      type: MESHERY_EXTENSION_EVENT.OpenViewInExtension,
+      data: { viewId: 'v-1', viewName: 'V1' },
+    });
     eventBus.publish.mockClear();
     setLocation('http://localhost:9081/dashboard');
     const router = { push: vi.fn() };

--- a/ui/utils/eventBus.ts
+++ b/ui/utils/eventBus.ts
@@ -1,14 +1,24 @@
-import { EventBus } from '@sistent/sistent';
+import {
+  EventBus,
+  type MesheryExtensionEvent,
+  type MesheryExtensionEventBus,
+} from '@sistent/sistent';
 
 /**
  * Cross-boundary event bus for communication between the Meshery UI core
  * and Meshery extensions (which run in separate contexts).
  *
- * Event types:
- * - DISPATCH_TO_MESHERY_STORE: Extensions -> Redux store dispatch (subscribed in store/index.ts)
- * - K8S_CONTEXTS_UPDATED: Redux store -> Extensions notification (published in mesheryUi.ts)
+ * The set of events allowed on this bus is declared once, in sistent's
+ * `mesheryExtensionContract` module, and shared by the host and every extension
+ * bundle. Read that module for the event list and payload shapes; never widen
+ * this bus by publishing a literal that is not part of the union.
+ *
+ * The type argument is load-bearing. `EventBus<T>` has no default for `T`, so a
+ * bare `new EventBus()` collapses `T` to its constraint and `publish()` silently
+ * accepts any `{ type: string }`. A rename on either side of the boundary then
+ * compiles cleanly and the feature becomes a runtime no-op with no error.
  *
  * Do NOT use this for intra-UI communication -- use Redux dispatch or XState events instead.
  * This bus exists solely for the extension boundary.
  */
-export const mesheryEventBus = new EventBus();
+export const mesheryEventBus: MesheryExtensionEventBus = new EventBus<MesheryExtensionEvent>();

--- a/ui/utils/utils.tsx
+++ b/ui/utils/utils.tsx
@@ -5,7 +5,7 @@ import { APP_MODE, EVENT_TYPES } from './Enum';
 import _ from 'lodash';
 import { getWebAdress } from './webApis';
 import { APPLICATION, DESIGN, FILTER } from '../constants/navigator';
-import { Tooltip } from '@sistent/sistent';
+import { MESHERY_EXTENSION_EVENT, Tooltip } from '@sistent/sistent';
 import { mesheryExtensionRoute } from '../pages/_app';
 import { mesheryEventBus } from './eventBus';
 import { useSelector } from 'react-redux';
@@ -509,7 +509,7 @@ export const useIsDesignerEnabled = useIsExtensionEnabled;
 export const openViewScopedToDesignInOperator = (designName, designId, router) => {
   if (isExtensionOpen()) {
     mesheryEventBus.publish({
-      type: 'OPEN_VIEW_SCOPED_TO_DESIGN',
+      type: MESHERY_EXTENSION_EVENT.OpenViewScopedToDesign,
       data: {
         designId,
         designName,
@@ -523,7 +523,7 @@ export const openViewScopedToDesignInOperator = (designName, designId, router) =
 
 export const mergeDesignWithCurrent = (designId, designName) => {
   mesheryEventBus.publish({
-    type: 'MERGE_DESIGN',
+    type: MESHERY_EXTENSION_EVENT.MergeDesign,
     data: {
       id: designId,
       name: designName,
@@ -535,7 +535,7 @@ export const mergeDesignWithCurrent = (designId, designName) => {
 export const openDesignInExtension = (designId, designName, router) => {
   if (isExtensionOpen()) {
     mesheryEventBus.publish({
-      type: 'OPEN_DESIGN_IN_EXTENSION',
+      type: MESHERY_EXTENSION_EVENT.OpenDesignInExtension,
       data: {
         designId,
         designName,
@@ -548,10 +548,9 @@ export const openDesignInExtension = (designId, designName, router) => {
 };
 
 export const openViewInExtension = (viewId, viewName, router) => {
-  console.log('openViewInExtension', viewId, viewName, router);
   if (isExtensionOpen()) {
     mesheryEventBus.publish({
-      type: 'OPEN_VIEW_IN_EXTENSION',
+      type: MESHERY_EXTENSION_EVENT.OpenViewInExtension,
       data: {
         viewId,
         viewName,


### PR DESCRIPTION
## What and why

`ui/utils/eventBus.ts` instantiated the bus as a bare `new EventBus()`. That collapses the
generic parameter to its constraint, so `publish()` accepted any `{ type: string }`. Renaming
an event on one side of the host/extension boundary therefore compiled cleanly on *both*
sides and became a silent runtime no-op. `OPEN_DESIGN_IN_KANVAS` -> `OPEN_DESIGN_IN_EXTENSION`
and `capabilitiesRegistry` -> `providerCapabilities` both shipped that way.

This is the **host half** of a three-repo change. The contract itself - event literals,
injected capability keys, contract version - is declared once in `@sistent/sistent`'s
`mesheryExtensionContract` module and consumed here rather than re-typed.

| Repo | PR |
|---|---|
| `layer5io/sistent` (contract source) | #1732 |
| `meshery/meshery` (host) | this PR |
| `layer5labs/meshery-extensions` (Kanvas) | #4303 |

## Changes

- **`ui/utils/eventBus.ts`** - instantiate as `EventBus<MesheryExtensionEvent>`, so every
  publish site is checked against the contract instead of against `{ type: string }`. This is
  the fix for the root cause; the rest follows from it.
- **`ui/utils/utils.tsx`, `ui/store/slices/mesheryUi.ts`, `ui/store/index.ts`** - replace every
  hand-written event string literal with `MESHERY_EXTENSION_EVENT.*`.
- **`ui/components/layout/Navigator/NavigatorExtension.tsx`**
  - extract the injected capability bag into a pure `buildExtensionInjectProps()` factory, so a
    unit test can assert it against the contract and catch a capability rename before merge;
  - inject `contractVersion`, letting an already-published bundle detect it was built against a
    different contract revision than the host that loaded it - something no build-time check
    can catch, since bundles are artifacts loaded by whatever host happens to be deployed;
  - add `isRenderableComponent()`, so a bundle missing a CommonJS default export reports that
    as the cause instead of React's opaque "Element type is invalid".

## Notes for reviewers

- **Branch name is a leftover.** This PR is on `deps/update`, a name reused from an earlier,
  unrelated dependency-bump PR (#20846) that was already merged and deleted. The name has
  nothing to do with this change and carries none of that work - the branch now holds exactly
  one commit on top of current `master`. It was left in place deliberately: GitHub cannot
  change a PR's head branch, so renaming it would have meant closing this PR and losing its
  review history for a purely cosmetic gain.

- `isRenderableComponent()` allow-lists the `forwardRef`/`memo`/`lazy` `$$typeof` tags rather
  than accepting any `$$typeof`. A bundle that accidentally exports a rendered element
  (`<Foo />`) also carries a `$$typeof`, and waving it through would reproduce the exact opaque
  error this guard exists to replace.
- `resolver.subscription.ConfigurationSubscription` is retained as an inert never-emitting stub.
  Meshery Server no longer exposes any GraphQL subscription, but already-published bundles call
  it and then `.dispose()` the result; handing them `undefined` would throw at mount.
- **Drive-by, unrelated to the contract:** removed a stray `console.log` in
  `openViewInExtension` (pre-existing on `master` since `d5efb51`) that logged the router
  object to the console on every invocation.
- **Dependency:** bumps `@sistent/sistent` to `0.21.40`, the current release carrying
  `mesheryExtensionContract`. Verified against a clean `npm ci` from the published registry
  tarball (not a local build): full UI suite 2603 passed / 0 failed, `tsc --noEmit` exit 0,
  eslint exit 0, `next build` exit 0. `ui/package-lock.json` is regenerated by npm, not
  hand-edited.

Signed-off-by: marblom007 <158522975+marblom007@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added injected capability-bag creation for extensions, including contract version support.
  * Extension rendering now checks that remote bundles provide a valid, renderable component before display.
* **Bug Fixes**
  * Prevented rendering until remote loading completes.
  * Improved targeted error reporting for missing/invalid CommonJS default exports.
* **Documentation**
  * Added UI troubleshooting guidance for extension bundling and local build-artifact issues.
* **Tests**
  * Expanded Navigator extension tests for injection props, export validation timing, and wrapper compatibility.
  * Updated event-bus tests to use typed extension event constants.
* **Chores**
  * Bumped `@sistent/sistent` in the UI package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
