### PR TITLE
[Server] Synchronize MesheryControllersHelper controller state

### DIFF
--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -89,8 +89,9 @@ type MesheryControllersHelper struct {
 	// rebuilt by the connect, mode-reconcile and server-wide config-apply
 	// goroutines while the controllers-status SSE stream and the operator /
 	// MeshSync / broker status HTTP handlers read it: ctxControllerHandlers,
-	// ctxOperatorStatus, meshsyncDeploymentMode and controllersConfig.
-	// (ctxMeshsyncDataHandler / brokerPortForward have their own lifecycle.)
+	// ctxOperatorStatus, ctxMeshsyncDataHandler, meshsyncDeploymentMode and
+	// controllersConfig.
+	// (brokerPortForward has its own lifecycle.)
 	stateMu sync.RWMutex
 
 	// event broadcasting dependencies
@@ -139,6 +140,8 @@ func (mch *MesheryControllersHelper) GetControllerHandlersForEachContext() map[M
 }
 
 func (mch *MesheryControllersHelper) GetMeshSyncDataHandlersForEachContext() *MeshsyncDataHandler {
+	mch.stateMu.RLock()
+	defer mch.stateMu.RUnlock()
 	return mch.ctxMeshsyncDataHandler
 }
 
@@ -242,8 +245,9 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 	ctxID := k8scontext.ID
 	mch.stateMu.RLock()
 	deploymentMode := mch.meshsyncDeploymentMode
+	dataHandler := mch.ctxMeshsyncDataHandler
 	mch.stateMu.RUnlock()
-	if mch.ctxMeshsyncDataHandler == nil {
+	if dataHandler == nil {
 		var brokerHandler broker.Handler
 		var stopFunc func()
 
@@ -303,7 +307,10 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 			}, userID)
 			return mch
 		}
+		mch.stateMu.Lock()
 		mch.ctxMeshsyncDataHandler = msDataHandler
+		mch.stateMu.Unlock()
+		dataHandler = msDataHandler
 		mch.log.Info(fmt.Sprintf("MeshSync connected for Kubernetes context (%s)", ctxID))
 	}
 
@@ -316,8 +323,8 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 	// later AddMeshsyncDataHandlers call (once IsConnected) emits the event once.
 	// Deduplicate so repeated reconcile calls do not spam the same snackbar.
 	// CompareAndSwap so concurrent AddMeshsyncDataHandlers callers emit once.
-	if mch.ctxMeshsyncDataHandler != nil &&
-		mch.ctxMeshsyncDataHandler.IsConnected() &&
+	if dataHandler != nil &&
+		dataHandler.IsConnected() &&
 		mch.meshsyncConnectedEventEmitted.CompareAndSwap(false, true) {
 		description := "MeshSync connected"
 		if deploymentMode != "" {
@@ -656,10 +663,15 @@ func (mch *MesheryControllersHelper) meshsyncDataHandlersStartLibMeshsyncRun(
 }
 
 func (mch *MesheryControllersHelper) RemoveMeshSyncDataHandler(ctx context.Context, contextID string) {
-	if mch.ctxMeshsyncDataHandler != nil {
+	mch.stateMu.RLock()
+	dataHandler := mch.ctxMeshsyncDataHandler
+	mch.stateMu.RUnlock()
+	if dataHandler != nil {
 		mch.log.Infof("MesheryControllersHelper::RemoveMeshSyncDataHandler for contextID = %s", contextID)
-		mch.ctxMeshsyncDataHandler.Stop()
+		dataHandler.Stop()
+		mch.stateMu.Lock()
 		mch.ctxMeshsyncDataHandler = nil
+		mch.stateMu.Unlock()
 	}
 	// Allow a fresh "MeshSync connected" event when a new handler is attached.
 	mch.meshsyncConnectedEventEmitted.Store(false)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -94,6 +94,17 @@ type MesheryControllersHelper struct {
 	// (brokerPortForward has its own lifecycle.)
 	stateMu sync.RWMutex
 
+	// ctrlHandlerMu serializes calls into the meshkit controller handlers held in
+	// ctxControllerHandlers. Those handlers cache their status in place — their
+	// GetStatus (and the operator's Deploy/Undeploy) mutate the receiver's status
+	// field — and are not safe for concurrent use, so the controllers-status SSE
+	// stream, the status REST handlers and the FSM reconcile goroutines must not
+	// invoke the same handler at once. stateMu only guards the map pointer; it
+	// cannot protect the shared objects the map's values reference. This lock is
+	// acquired only for a single handler method call and never while stateMu is
+	// held, so the two never nest.
+	ctrlHandlerMu sync.Mutex
+
 	// event broadcasting dependencies
 	eventBroadcaster *Broadcast
 	provider         Provider
@@ -125,17 +136,84 @@ func (mch *MesheryControllersHelper) GetOperatorError() error {
 	return mch.lastOperatorError
 }
 
+// lockedController wraps a meshkit controller handler so that every method call
+// is serialized through mu (the owning helper's ctrlHandlerMu). The meshkit
+// handlers cache their status in place and are not safe for concurrent use, so
+// the helper hands out these wrappers — and takes the same lock around its own
+// controller calls — to guarantee no underlying handler is ever invoked
+// concurrently. See GetControllerHandlersForEachContext.
+type lockedController struct {
+	inner controllers.IMesheryController
+	mu    *sync.Mutex
+}
+
+func (l lockedController) GetName() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.GetName()
+}
+
+func (l lockedController) GetStatus() controllers.MesheryControllerStatus {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.GetStatus()
+}
+
+func (l lockedController) Deploy(force bool) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.Deploy(force)
+}
+
+func (l lockedController) Undeploy() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.Undeploy()
+}
+
+func (l lockedController) GetPublicEndpoint() (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.GetPublicEndpoint()
+}
+
+func (l lockedController) GetVersion() (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.GetVersion()
+}
+
+func (l lockedController) GetEndpointForPort(portName string) (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inner.GetEndpointForPort(portName)
+}
+
+// GetControllerHandlersForEachContext returns the per-controller handlers for
+// this context, each wrapped so that every method call is serialized through
+// ctrlHandlerMu. The meshkit handlers cache their status in place (GetStatus
+// mutates the receiver) and are not safe for concurrent use, so returning the
+// raw handlers — even in a copied map — would let the SSE stream, the status
+// REST handlers and the FSM reconcile goroutines invoke the same handler at
+// once. The map itself is a fresh copy, so callers may range it without racing
+// an AddCtxControllerHandlers / RemoveCtxControllerHandler that replaces the
+// live map.
 func (mch *MesheryControllersHelper) GetControllerHandlersForEachContext() map[MesheryController]controllers.IMesheryController {
 	mch.stateMu.RLock()
 	defer mch.stateMu.RUnlock()
 	if mch.ctxControllerHandlers == nil {
 		return nil
 	}
-	// Return a copy: callers range/read the result outside this lock, so handing
-	// back the live map would still race a concurrent AddCtxControllerHandlers /
-	// RemoveCtxControllerHandler that replaces it.
 	handlers := make(map[MesheryController]controllers.IMesheryController, len(mch.ctxControllerHandlers))
-	maps.Copy(handlers, mch.ctxControllerHandlers)
+	for controller, handler := range mch.ctxControllerHandlers {
+		if handler == nil {
+			// Preserve the present-but-nil semantics callers nil-check against;
+			// wrapping nil would hand back a non-nil wrapper over a nil handler.
+			handlers[controller] = nil
+			continue
+		}
+		handlers[controller] = lockedController{inner: handler, mu: &mch.ctrlHandlerMu}
+	}
 	return handlers
 }
 
@@ -762,13 +840,17 @@ func (mch *MesheryControllersHelper) UpdateOperatorsStatusMap(ot *OperatorTracke
 	}
 
 	// Resolve the new status first — GetStatus reaches the cluster, so it must
-	// not run under the lock — then commit it under the write lock.
+	// not run under stateMu — then commit it under the write lock. GetStatus
+	// mutates the shared handler's cached status, so serialize it through
+	// ctrlHandlerMu against the status handlers reading the same handler.
 	var newStatus controllers.MesheryControllerStatus
 	if ot.IsUndeployed(mch.contextID) {
 		// this code is probably never reached as mch.contextID is never set
 		newStatus = controllers.Undeployed
 	} else if hasOperator {
+		mch.ctrlHandlerMu.Lock()
 		newStatus = operatorHandler.GetStatus()
+		mch.ctrlHandlerMu.Unlock()
 	} else {
 		return mch
 	}
@@ -832,7 +914,14 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 	}
 
 	if operatorStatus == controllers.NotDeployed && hasOperator {
+		// Deploy mutates the shared handler's cached status, so serialize it
+		// through ctrlHandlerMu against the status handlers reading the same
+		// handler. The lock is held across the deploy — deploys are per-connection
+		// and infrequent, so briefly serializing this connection's status reads is
+		// an acceptable price for a race-free handler.
+		mch.ctrlHandlerMu.Lock()
 		err := operatorHandler.Deploy(false)
+		mch.ctrlHandlerMu.Unlock()
 
 		if err != nil {
 			mch.setOperatorError(err)
@@ -855,7 +944,11 @@ func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTrack
 	mch.stateMu.RUnlock()
 
 	if operatorStatus != controllers.Undeployed && hasOperator {
+		// Undeploy mutates the shared handler's cached status; serialize it through
+		// ctrlHandlerMu against the status handlers reading the same handler.
+		mch.ctrlHandlerMu.Lock()
 		err := operatorHandler.Undeploy()
+		mch.ctrlHandlerMu.Unlock()
 
 		if err != nil {
 			mch.log.Error(err)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -85,6 +85,14 @@ type MesheryControllersHelper struct {
 	// configuration changes; consumed by the embedded meshsync run options.
 	controllersConfig *controllersconfig.MesheryControllersConfig
 
+	// stateMu guards the mutable per-connection controller state above that is
+	// rebuilt by the connect, mode-reconcile and server-wide config-apply
+	// goroutines while the controllers-status SSE stream and the operator /
+	// MeshSync / broker status HTTP handlers read it: ctxControllerHandlers,
+	// ctxOperatorStatus, meshsyncDeploymentMode and controllersConfig.
+	// (ctxMeshsyncDataHandler / brokerPortForward have their own lifecycle.)
+	stateMu sync.RWMutex
+
 	// event broadcasting dependencies
 	eventBroadcaster *Broadcast
 	provider         Provider
@@ -117,7 +125,17 @@ func (mch *MesheryControllersHelper) GetOperatorError() error {
 }
 
 func (mch *MesheryControllersHelper) GetControllerHandlersForEachContext() map[MesheryController]controllers.IMesheryController {
-	return mch.ctxControllerHandlers
+	mch.stateMu.RLock()
+	defer mch.stateMu.RUnlock()
+	if mch.ctxControllerHandlers == nil {
+		return nil
+	}
+	// Return a copy: callers range/read the result outside this lock, so handing
+	// back the live map would still race a concurrent AddCtxControllerHandlers /
+	// RemoveCtxControllerHandler that replaces it.
+	handlers := make(map[MesheryController]controllers.IMesheryController, len(mch.ctxControllerHandlers))
+	maps.Copy(handlers, mch.ctxControllerHandlers)
+	return handlers
 }
 
 func (mch *MesheryControllersHelper) GetMeshSyncDataHandlersForEachContext() *MeshsyncDataHandler {
@@ -125,6 +143,8 @@ func (mch *MesheryControllersHelper) GetMeshSyncDataHandlersForEachContext() *Me
 }
 
 func (mch *MesheryControllersHelper) GetOperatorsStatusMap() controllers.MesheryControllerStatus {
+	mch.stateMu.RLock()
+	defer mch.stateMu.RUnlock()
 	return mch.ctxOperatorStatus
 }
 
@@ -154,11 +174,15 @@ func NewMesheryControllersHelper(
 }
 
 func (mch *MesheryControllersHelper) SetMeshsyncDeploymentMode(value connections.MeshsyncDeploymentMode) *MesheryControllersHelper {
+	mch.stateMu.Lock()
 	mch.meshsyncDeploymentMode = value
+	mch.stateMu.Unlock()
 	return mch
 }
 
 func (mch *MesheryControllersHelper) GetMeshsyncDeploymentMode() connections.MeshsyncDeploymentMode {
+	mch.stateMu.RLock()
+	defer mch.stateMu.RUnlock()
 	return mch.meshsyncDeploymentMode
 }
 
@@ -175,7 +199,9 @@ func (mch *MesheryControllersHelper) GetBrokerPortForwardAddr() string {
 // SetControllersConfig stashes the resolved controllers configuration for the
 // context this helper serves. Chainable, mirroring SetMeshsyncDeploymentMode.
 func (mch *MesheryControllersHelper) SetControllersConfig(value *controllersconfig.MesheryControllersConfig) *MesheryControllersHelper {
+	mch.stateMu.Lock()
 	mch.controllersConfig = value
+	mch.stateMu.Unlock()
 	return mch
 }
 
@@ -214,11 +240,14 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 	// go func(mch *MesheryControllersHelper) {
 
 	ctxID := k8scontext.ID
+	mch.stateMu.RLock()
+	deploymentMode := mch.meshsyncDeploymentMode
+	mch.stateMu.RUnlock()
 	if mch.ctxMeshsyncDataHandler == nil {
 		var brokerHandler broker.Handler
 		var stopFunc func()
 
-		switch mch.meshsyncDeploymentMode {
+		switch deploymentMode {
 		case connections.MeshsyncDeploymentModeOperator:
 			brokerHandler = mch.meshsyncDataHandlersNatsBroker(k8scontext, userID)
 		case connections.MeshsyncDeploymentModeEmbedded:
@@ -233,7 +262,7 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 					"k8sContextID":           ctxID,
 					"k8sContextName":         k8scontext.Name,
 					"connectionID":           k8scontext.ConnectionID,
-					"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
+					"meshsyncDeploymentMode": deploymentMode,
 				}, userID)
 				return mch
 			}
@@ -241,13 +270,13 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 		default:
 			mch.log.Warnf(
 				"MesheryControllersHelper unsupported meshsyncDeploymentMode %s",
-				mch.meshsyncDeploymentMode,
+				deploymentMode,
 			)
 			mch.emitWarningEvent("Unsupported MeshSync deployment mode", nil, map[string]any{
 				"k8sContextID":           ctxID,
 				"k8sContextName":         k8scontext.Name,
 				"connectionID":           k8scontext.ConnectionID,
-				"meshsyncDeploymentMode": string(mch.meshsyncDeploymentMode),
+				"meshsyncDeploymentMode": string(deploymentMode),
 			}, userID)
 			return mch
 		}
@@ -291,8 +320,8 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 		mch.ctxMeshsyncDataHandler.IsConnected() &&
 		mch.meshsyncConnectedEventEmitted.CompareAndSwap(false, true) {
 		description := "MeshSync connected"
-		if mch.meshsyncDeploymentMode != "" {
-			description = fmt.Sprintf("MeshSync connected in %s mode", string(mch.meshsyncDeploymentMode))
+		if deploymentMode != "" {
+			description = fmt.Sprintf("MeshSync connected in %s mode", string(deploymentMode))
 		}
 		mch.emitEvent(
 			description,
@@ -301,7 +330,7 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 				"k8sContextID":           k8scontext.ID,
 				"k8sContextName":         k8scontext.Name,
 				"connectionID":           k8scontext.ConnectionID,
-				"meshsyncDeploymentMode": string(mch.meshsyncDeploymentMode),
+				"meshsyncDeploymentMode": string(deploymentMode),
 			},
 			userID,
 		)
@@ -349,7 +378,9 @@ func (mch *MesheryControllersHelper) meshsyncDataHandlersNatsBroker(
 	userID core.Uuid,
 ) broker.Handler {
 	ctxID := k8scontext.ID
+	mch.stateMu.RLock()
 	controllerHandlers := mch.ctxControllerHandlers
+	mch.stateMu.RUnlock()
 
 	// The broker controller handler is only populated by AddCtxControllerHandlers,
 	// which bails early (leaving ctxControllerHandlers empty) when it can't read
@@ -579,6 +610,11 @@ func (mch *MesheryControllersHelper) meshsyncDataHandlersStartLibMeshsyncRun(
 
 	cancelCtx, stopFunc := context.WithCancel(ctx)
 
+	mch.stateMu.RLock()
+	controllersConfig := mch.controllersConfig
+	deploymentMode := mch.meshsyncDeploymentMode
+	mch.stateMu.RUnlock()
+
 	runOptions := []libmeshsync.OptionsSetter{
 		libmeshsync.WithOutputMode("broker"),
 		libmeshsync.WithBrokerHandler(brokerHandler),
@@ -591,7 +627,7 @@ func (mch *MesheryControllersHelper) meshsyncDataHandlersStartLibMeshsyncRun(
 	// logging) follow the Meshery Server process environment in embedded
 	// mode, and the watch-list is read from the MeshSync CR when the target
 	// cluster has one. The run restarts whenever the configuration changes.
-	if cfg := mch.controllersConfig; cfg != nil && cfg.Meshsync != nil {
+	if cfg := controllersConfig; cfg != nil && cfg.Meshsync != nil {
 		if len(cfg.Meshsync.OutputNamespaces) > 0 {
 			runOptions = append(runOptions, libmeshsync.WithOnlyK8sNamespaces(cfg.Meshsync.OutputNamespaces...))
 		}
@@ -611,7 +647,7 @@ func (mch *MesheryControllersHelper) meshsyncDataHandlersStartLibMeshsyncRun(
 				"k8sContextID":           k8sContext.ID,
 				"k8sContextName":         k8sContext.Name,
 				"connectionID":           k8sContext.ConnectionID,
-				"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
+				"meshsyncDeploymentMode": deploymentMode,
 			}, userID)
 		}
 	}()
@@ -680,42 +716,54 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 		return mch
 	}
 
-	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{
+	handlers := map[MesheryController]controllers.IMesheryController{
 		MesheryBroker:   controllers.NewMesheryBrokerHandler(client),
 		MesheryOperator: controllers.NewMesheryOperatorHandler(client, mch.oprDepConfig),
 		Meshsync:        controllers.NewMeshsyncHandler(client),
 	}
+
+	mch.stateMu.Lock()
+	mch.ctxControllerHandlers = handlers
+	mch.stateMu.Unlock()
 
 	// }(mch)
 	return mch
 }
 
 func (mch *MesheryControllersHelper) RemoveCtxControllerHandler(ctx context.Context, contextID string) {
+	mch.stateMu.Lock()
 	mch.ctxControllerHandlers = nil
+	mch.stateMu.Unlock()
 }
 
 // update the status of MesheryOperator in all the contexts
 // for whom MesheryControllers are attached
 // should be called after AddCtxControllerHandlers
 func (mch *MesheryControllersHelper) UpdateOperatorsStatusMap(ot *OperatorTracker) *MesheryControllersHelper {
-	// go func(mch *MesheryControllersHelper) {
-	if mch.meshsyncDeploymentMode != connections.MeshsyncDeploymentModeOperator {
+	mch.stateMu.RLock()
+	deploymentMode := mch.meshsyncDeploymentMode
+	operatorHandler, hasOperator := mch.ctxControllerHandlers[MesheryOperator]
+	mch.stateMu.RUnlock()
+
+	if deploymentMode != connections.MeshsyncDeploymentModeOperator {
 		return mch
 	}
 
+	// Resolve the new status first — GetStatus reaches the cluster, so it must
+	// not run under the lock — then commit it under the write lock.
+	var newStatus controllers.MesheryControllerStatus
 	if ot.IsUndeployed(mch.contextID) {
 		// this code is probably never reached as mch.contextID is never set
-		mch.ctxOperatorStatus = controllers.Undeployed
+		newStatus = controllers.Undeployed
+	} else if hasOperator {
+		newStatus = operatorHandler.GetStatus()
 	} else {
-		if mch.ctxControllerHandlers != nil {
-			operatorHandler, ok := mch.ctxControllerHandlers[MesheryOperator]
-			if ok {
-				mch.ctxOperatorStatus = operatorHandler.GetStatus()
-			}
-		}
+		return mch
 	}
 
-	// }(mch)
+	mch.stateMu.Lock()
+	mch.ctxOperatorStatus = newStatus
+	mch.stateMu.Unlock()
 	return mch
 }
 
@@ -760,58 +808,52 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 	if ot.DisableOperator { //Return true everytime so that operators stay in undeployed state across all contexts
 		return mch
 	}
-	if mch.meshsyncDeploymentMode != connections.MeshsyncDeploymentModeOperator {
+
+	mch.stateMu.RLock()
+	deploymentMode := mch.meshsyncDeploymentMode
+	operatorStatus := mch.ctxOperatorStatus
+	operatorHandler, hasOperator := mch.ctxControllerHandlers[MesheryOperator]
+	mch.stateMu.RUnlock()
+
+	if deploymentMode != connections.MeshsyncDeploymentModeOperator {
 		return mch
 	}
-	// go func(mch *MesheryControllersHelper) {
 
-	if mch.ctxOperatorStatus == controllers.NotDeployed {
-		if mch.ctxControllerHandlers != nil {
-			operatorHandler, ok := mch.ctxControllerHandlers[MesheryOperator]
-			if ok {
-				err := operatorHandler.Deploy(false)
+	if operatorStatus == controllers.NotDeployed && hasOperator {
+		err := operatorHandler.Deploy(false)
 
-				if err != nil {
-					mch.setOperatorError(err)
-					mch.log.Error(err)
-					mch.emitErrorEvent("Failed to deploy Meshery Operator", err, map[string]any{
-						"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
-						"operatorStatus":         mch.ctxOperatorStatus,
-					}, uuid.Nil)
-				}
-			}
+		if err != nil {
+			mch.setOperatorError(err)
+			mch.log.Error(err)
+			mch.emitErrorEvent("Failed to deploy Meshery Operator", err, map[string]any{
+				"meshsyncDeploymentMode": deploymentMode,
+				"operatorStatus":         operatorStatus,
+			}, uuid.Nil)
 		}
 	}
-
-	// }(mch)
 
 	return mch
 }
 
 func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTracker) *MesheryControllersHelper {
-	// go func(mch *MesheryControllersHelper) {
+	mch.stateMu.RLock()
+	deploymentMode := mch.meshsyncDeploymentMode
+	operatorStatus := mch.ctxOperatorStatus
+	operatorHandler, hasOperator := mch.ctxControllerHandlers[MesheryOperator]
+	mch.stateMu.RUnlock()
 
-	oprStatus := mch.ctxOperatorStatus
+	if operatorStatus != controllers.Undeployed && hasOperator {
+		err := operatorHandler.Undeploy()
 
-	if oprStatus != controllers.Undeployed {
-
-		if mch.ctxControllerHandlers != nil {
-			operatorHandler, ok := mch.ctxControllerHandlers[MesheryOperator]
-			if ok {
-				err := operatorHandler.Undeploy()
-
-				if err != nil {
-					mch.log.Error(err)
-					mch.emitErrorEvent("Failed to undeploy Meshery Operator", err, map[string]any{
-						"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
-						"operatorStatus":         mch.ctxOperatorStatus,
-					}, uuid.Nil)
-				}
-			}
+		if err != nil {
+			mch.log.Error(err)
+			mch.emitErrorEvent("Failed to undeploy Meshery Operator", err, map[string]any{
+				"meshsyncDeploymentMode": deploymentMode,
+				"operatorStatus":         operatorStatus,
+			}, uuid.Nil)
 		}
 	}
 
-	// }(mch)
 	return mch
 }
 

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -832,7 +832,7 @@ func (mch *MesheryControllersHelper) RemoveCtxControllerHandler(ctx context.Cont
 func (mch *MesheryControllersHelper) UpdateOperatorsStatusMap(ot *OperatorTracker) *MesheryControllersHelper {
 	mch.stateMu.RLock()
 	deploymentMode := mch.meshsyncDeploymentMode
-	operatorHandler, hasOperator := mch.ctxControllerHandlers[MesheryOperator]
+	operatorHandler := mch.ctxControllerHandlers[MesheryOperator]
 	mch.stateMu.RUnlock()
 
 	if deploymentMode != connections.MeshsyncDeploymentModeOperator {
@@ -847,7 +847,7 @@ func (mch *MesheryControllersHelper) UpdateOperatorsStatusMap(ot *OperatorTracke
 	if ot.IsUndeployed(mch.contextID) {
 		// this code is probably never reached as mch.contextID is never set
 		newStatus = controllers.Undeployed
-	} else if hasOperator {
+	} else if operatorHandler != nil {
 		mch.ctrlHandlerMu.Lock()
 		newStatus = operatorHandler.GetStatus()
 		mch.ctrlHandlerMu.Unlock()
@@ -906,14 +906,14 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 	mch.stateMu.RLock()
 	deploymentMode := mch.meshsyncDeploymentMode
 	operatorStatus := mch.ctxOperatorStatus
-	operatorHandler, hasOperator := mch.ctxControllerHandlers[MesheryOperator]
+	operatorHandler := mch.ctxControllerHandlers[MesheryOperator]
 	mch.stateMu.RUnlock()
 
 	if deploymentMode != connections.MeshsyncDeploymentModeOperator {
 		return mch
 	}
 
-	if operatorStatus == controllers.NotDeployed && hasOperator {
+	if operatorStatus == controllers.NotDeployed && operatorHandler != nil {
 		// Deploy mutates the shared handler's cached status, so serialize it
 		// through ctrlHandlerMu against the status handlers reading the same
 		// handler. The lock is held across the deploy — deploys are per-connection
@@ -940,10 +940,10 @@ func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTrack
 	mch.stateMu.RLock()
 	deploymentMode := mch.meshsyncDeploymentMode
 	operatorStatus := mch.ctxOperatorStatus
-	operatorHandler, hasOperator := mch.ctxControllerHandlers[MesheryOperator]
+	operatorHandler := mch.ctxControllerHandlers[MesheryOperator]
 	mch.stateMu.RUnlock()
 
-	if operatorStatus != controllers.Undeployed && hasOperator {
+	if operatorStatus != controllers.Undeployed && operatorHandler != nil {
 		// Undeploy mutates the shared handler's cached status; serialize it through
 		// ctrlHandlerMu against the status handlers reading the same handler.
 		mch.ctrlHandlerMu.Lock()

--- a/server/models/meshery_controllers_test.go
+++ b/server/models/meshery_controllers_test.go
@@ -1,11 +1,15 @@
 package models
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/controllers"
+	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
 )
 
 func TestControllerEventActedUponPrefersConnectionID(t *testing.T) {
@@ -93,4 +97,79 @@ func TestAddCtxControllerHandlersReturnsEarlyOnInvalidConfig(t *testing.T) {
 	if len(mch.ctxControllerHandlers) != 0 {
 		t.Fatalf("expected ctxControllerHandlers to be empty, got %d", len(mch.ctxControllerHandlers))
 	}
+}
+
+func TestGetControllerHandlersForEachContextReturnsCopy(t *testing.T) {
+	mch := &MesheryControllersHelper{
+		ctxControllerHandlers: map[MesheryController]controllers.IMesheryController{
+			MesheryOperator: nil,
+		},
+	}
+
+	got := mch.GetControllerHandlersForEachContext()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 handler in the returned map, got %d", len(got))
+	}
+
+	// The returned map must be a copy: callers range it outside the lock, so
+	// mutating it must not leak into the helper's internal state.
+	got[MesheryBroker] = nil
+	delete(got, MesheryOperator)
+
+	if _, ok := mch.ctxControllerHandlers[MesheryOperator]; !ok {
+		t.Fatal("deleting from the returned map removed an entry from the helper's internal map")
+	}
+	if _, ok := mch.ctxControllerHandlers[MesheryBroker]; ok {
+		t.Fatal("adding to the returned map added an entry to the helper's internal map")
+	}
+
+	// A helper with no handlers attached returns nil, not a shared empty map.
+	if (&MesheryControllersHelper{}).GetControllerHandlersForEachContext() != nil {
+		t.Fatal("expected nil for a helper with no controller handlers")
+	}
+}
+
+// TestMesheryControllersHelperConcurrentStateAccess drives the controller-state
+// writers (the connect / reconcile / config-apply goroutines) against the
+// readers (the controllers-status SSE stream and the status REST handlers) the
+// way they run in production. It guards the data race fixed in #20807 and is
+// meaningful under `go test -race`.
+func TestMesheryControllersHelperConcurrentStateAccess(t *testing.T) {
+	mch := &MesheryControllersHelper{
+		ctxControllerHandlers:  map[MesheryController]controllers.IMesheryController{MesheryBroker: nil},
+		ctxOperatorStatus:      controllers.Unknown,
+		meshsyncDeploymentMode: connections.MeshsyncDeploymentModeOperator,
+	}
+
+	// Seed the tracker single-threaded, before any goroutine starts, so that
+	// during the concurrent phase IsUndeployed only reads its own map — the
+	// tracker's accessors are unsynchronized and out of scope for this test.
+	ot := NewOperatorTracker(false)
+	ot.Undeployed(mch.contextID, true)
+
+	ops := []func(){
+		// writers
+		func() { mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator) },
+		func() { mch.SetControllersConfig(&controllersconfig.MesheryControllersConfig{}) },
+		func() { mch.RemoveCtxControllerHandler(context.Background(), "ctx") },
+		func() { mch.UpdateOperatorsStatusMap(ot) },
+		// readers
+		func() { _ = mch.GetControllerHandlersForEachContext() },
+		func() { _ = mch.GetOperatorsStatusMap() },
+		func() { _ = mch.GetMeshsyncDeploymentMode() },
+	}
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	for _, op := range ops {
+		op := op
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				op()
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/server/models/meshery_controllers_test.go
+++ b/server/models/meshery_controllers_test.go
@@ -293,3 +293,25 @@ func TestControllerHandlerCallsSerialized(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestOperatorFSMHandlesNilHandler ensures the operator FSM methods don't panic
+// when ctxControllerHandlers holds a present-but-nil MesheryOperator entry — the
+// map type allows it and the handler getter guards against it, so the FSM must
+// gate on the handler value, not merely the map key's presence.
+func TestOperatorFSMHandlesNilHandler(t *testing.T) {
+	log, _ := logger.New("test", logger.Options{})
+	mch := &MesheryControllersHelper{
+		log:                    log,
+		ctxControllerHandlers:  map[MesheryController]controllers.IMesheryController{MesheryOperator: nil},
+		ctxOperatorStatus:      controllers.NotDeployed,
+		meshsyncDeploymentMode: connections.MeshsyncDeploymentModeOperator,
+	}
+
+	ot := NewOperatorTracker(false)
+	ot.Undeployed(mch.contextID, false)
+
+	// A present-but-nil handler must be skipped, not dereferenced.
+	mch.UpdateOperatorsStatusMap(ot)
+	mch.DeployUndeployedOperators(ot)
+	mch.UndeployDeployedOperators(ot)
+}

--- a/server/models/meshery_controllers_test.go
+++ b/server/models/meshery_controllers_test.go
@@ -135,9 +135,23 @@ func TestGetControllerHandlersForEachContextReturnsCopy(t *testing.T) {
 // way they run in production. It guards the data race fixed in #20807 and is
 // meaningful under `go test -race`.
 func TestMesheryControllersHelperConcurrentStateAccess(t *testing.T) {
+	log, _ := logger.New("test", logger.Options{})
+
+	// Seed a MeshSync data handler so RemoveMeshSyncDataHandler actually
+	// exercises the clear-the-pointer-under-lock path. broker is nil and no
+	// listeners are registered, so Stop() closes stopCh once and returns
+	// immediately — safe to drive from the concurrent phase.
+	seededHandler := &MeshsyncDataHandler{
+		stopCh:     make(chan struct{}),
+		stopOnce:   &sync.Once{},
+		listenerWg: &sync.WaitGroup{},
+	}
+
 	mch := &MesheryControllersHelper{
+		log:                    log,
 		ctxControllerHandlers:  map[MesheryController]controllers.IMesheryController{MesheryBroker: nil},
 		ctxOperatorStatus:      controllers.Unknown,
+		ctxMeshsyncDataHandler: seededHandler,
 		meshsyncDeploymentMode: connections.MeshsyncDeploymentModeOperator,
 	}
 
@@ -147,16 +161,23 @@ func TestMesheryControllersHelperConcurrentStateAccess(t *testing.T) {
 	ot := NewOperatorTracker(false)
 	ot.Undeployed(mch.contextID, true)
 
+	k8scontext := K8sContext{ID: "ctx", Name: "test"}
+
 	ops := []func(){
 		// writers
 		func() { mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator) },
 		func() { mch.SetControllersConfig(&controllersconfig.MesheryControllersConfig{}) },
 		func() { mch.RemoveCtxControllerHandler(context.Background(), "ctx") },
 		func() { mch.UpdateOperatorsStatusMap(ot) },
+		func() {
+			mch.AddMeshsyncDataHandlers(context.Background(), k8scontext, uuid.Nil, uuid.Nil, nil)
+		},
+		func() { mch.RemoveMeshSyncDataHandler(context.Background(), "ctx") },
 		// readers
 		func() { _ = mch.GetControllerHandlersForEachContext() },
 		func() { _ = mch.GetOperatorsStatusMap() },
 		func() { _ = mch.GetMeshsyncDeploymentMode() },
+		func() { _ = mch.GetMeshSyncDataHandlersForEachContext() },
 	}
 
 	const iterations = 1000

--- a/server/models/meshery_controllers_test.go
+++ b/server/models/meshery_controllers_test.go
@@ -194,3 +194,102 @@ func TestMesheryControllersHelperConcurrentStateAccess(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// fakeController is a controllers.IMesheryController whose methods mutate an
+// internal counter instead of reaching a cluster, so a data race on a shared
+// handler surfaces under `go test -race`. It mirrors how the real meshkit
+// handlers cache their status in place.
+type fakeController struct {
+	calls int
+}
+
+func (f *fakeController) GetName() string {
+	f.calls++
+	return "fake"
+}
+
+func (f *fakeController) GetStatus() controllers.MesheryControllerStatus {
+	f.calls++
+	return controllers.Deployed
+}
+
+func (f *fakeController) Deploy(force bool) error {
+	f.calls++
+	return nil
+}
+
+func (f *fakeController) Undeploy() error {
+	f.calls++
+	return nil
+}
+
+func (f *fakeController) GetPublicEndpoint() (string, error) {
+	f.calls++
+	return "", nil
+}
+
+func (f *fakeController) GetVersion() (string, error) {
+	f.calls++
+	return "v1", nil
+}
+
+func (f *fakeController) GetEndpointForPort(string) (string, error) {
+	f.calls++
+	return "", nil
+}
+
+// TestControllerHandlerCallsSerialized drives the shared meshkit controller
+// handler concurrently from both paths that use it in production — the status
+// handlers (through the wrappers GetControllerHandlersForEachContext hands out)
+// and the FSM reconcile (UpdateOperatorsStatusMap) — against a handler that
+// mutates internal state on every call. It guards the data race raised in review
+// on #20887 (a copied map still leaks the underlying mutable handlers) and is
+// meaningful under `go test -race`.
+func TestControllerHandlerCallsSerialized(t *testing.T) {
+	mch := &MesheryControllersHelper{
+		ctxControllerHandlers: map[MesheryController]controllers.IMesheryController{
+			MesheryOperator: &fakeController{},
+		},
+		meshsyncDeploymentMode: connections.MeshsyncDeploymentModeOperator,
+	}
+
+	// Seed the tracker single-threaded so IsUndeployed only reads during the
+	// concurrent phase, and return false so UpdateOperatorsStatusMap actually
+	// invokes the operator handler's GetStatus — the call being serialized.
+	ot := NewOperatorTracker(false)
+	ot.Undeployed(mch.contextID, false)
+
+	ops := []func(){
+		// reader: the status handlers only ever touch the handlers via these wrappers
+		func() {
+			for _, h := range mch.GetControllerHandlersForEachContext() {
+				if h == nil {
+					continue
+				}
+				_ = h.GetStatus()
+				_, _ = h.GetVersion()
+			}
+		},
+		// writer: the FSM reconcile invokes the same handler's GetStatus
+		func() { mch.UpdateOperatorsStatusMap(ot) },
+	}
+
+	const (
+		iterations  = 1000
+		concurrency = 4
+	)
+	var wg sync.WaitGroup
+	for _, op := range ops {
+		op := op
+		for g := 0; g < concurrency; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < iterations; i++ {
+					op()
+				}
+			}()
+		}
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20807 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when controller status, configuration, and connection updates occur simultaneously.
  * Prevented data races by synchronizing access to per-context controller and MeshSync handler state.
  * Serialized concurrent controller-handler method calls to avoid unsafe shared-handler mutations.
  * Ensured MeshSync decisions and “connected” event metadata are based on consistent snapshotted state.
  * Returned controller-handler mappings are now isolated from external mutation.
* **Tests**
  * Added race-focused coverage for concurrent state access and handler-map copy behavior.
  * Added a concurrency test to verify controller-handler calls are properly serialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->