### PR TITLE
fix(server): report environment and workspace failures with accurate codes and status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,10 @@ make helm-docs      # Generate Helm chart docs
 - Only `utils.Log.Error(err)` renders a MeshKit error's code, cause and remediation; cobra's
   default print shows just the message. In `mesheryctl` commands, log the structured error
   for the user *and* return it for the exit path.
+- Server handler error paths: never reuse another operation's error code, and never hardcode the
+  HTTP status of a provider failure - read it back with `providerStatus(err)`
+  (`server/handlers/utils.go`), which defaults to 502, not 404. Both rules and the JSON wire shape
+  are in `docs/content/en/project/contributing/error-contract.md`.
 - Tests in `*_test.go`; manage deps with `go mod tidy`.
 
 ### JavaScript/React

--- a/docs/content/en/project/contributing/_index.md
+++ b/docs/content/en/project/contributing/_index.md
@@ -57,6 +57,15 @@ To ensure all your commits are signed, you may choose to add this alias to your 
 Or you may configure your IDE, for example, VSCode to automatically sign-off commits for you:<a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"/></a>
 
 </li>
+
+<li>
+Should an unsigned commit slip through anyway, the repository's <code>commit-msg</code> hook
+(installed with the UI dependencies, see <code>ui/.husky/</code>) rejects it locally rather than
+letting the DCO check fail in CI, where the only remedy is rewriting the branch. To sign off
+a commit you have already written:
+
+<pre><code>$ git commit --amend -s --no-edit</code></pre>
+</li>
 </ul>
 </details>
 

--- a/docs/content/en/project/contributing/error-contract.md
+++ b/docs/content/en/project/contributing/error-contract.md
@@ -65,7 +65,7 @@ originated outside the MeshKit error catalog.
 
 - Do not rely on plain-text error bodies — they are always JSON.
 - When `code` is present, prefer it over string matching on `error`.
-- When `suggested_remediation` is non-empty, surface it alongside `error`.
+- When `suggestedRemediation` is non-empty, surface every entry alongside `error`.
 - When the body is not valid JSON, treat the response as a bug and report
   the offending endpoint; do not attempt a text fallback.
 

--- a/docs/content/en/project/contributing/error-contract.md
+++ b/docs/content/en/project/contributing/error-contract.md
@@ -30,25 +30,33 @@ as JSON before surfacing errors to users.
 
 ```json
 {
-  "error": "Human-readable short description",
-  "code": "meshery-server-1033",
-  "severity": "ERROR",
-  "probable_cause": ["Connection to the remote provider timed out."],
-  "suggested_remediation": ["Verify that Meshery Cloud is reachable."],
-  "long_description": ["Full technical details suitable for logs."]
+  "error": "Unable to create the environment",
+  "code": "meshery-server-1448",
+  "severity": "ALERT",
+  "probableCause": [
+    "Your account does not have permission to create environments in this organization.",
+    "An environment with the same name already exists in this organization."
+  ],
+  "suggestedRemediation": ["Confirm your role in the selected organization."],
+  "longDescription": ["Full technical details suitable for logs."]
 }
 ```
+
+Field names are camelCase, matching the repo-wide wire convention (see
+`AGENTS.md`, "Identifier Naming Conventions"). The three detail fields are
+arrays with **one entry per distinct cause or step** - do not concatenate them
+into a single string; the UI renders each entry as its own bullet.
 
 ### Fields
 
 | Field | Required | Notes |
 |-------|----------|-------|
 | `error` | yes | User-facing message. For MeshKit errors, this is the ShortDescription. |
-| `code` | when available | MeshKit error code (e.g. `meshery-server-1033`). Stable across releases. Use for telemetry, i18n lookup, and programmatic handling. |
+| `code` | when available | MeshKit error code (e.g. `meshery-server-1448`). Stable across releases. Use for telemetry, i18n lookup, and programmatic handling. |
 | `severity` | when available | One of `EMERGENCY`, `ALERT`, `CRITICAL`, `FATAL`, `ERROR`. |
-| `probable_cause` | optional | Array of strings. |
-| `suggested_remediation` | optional | Array of strings. Surface to users when present. |
-| `long_description` | optional | Array of strings. Suitable for developer logs; may contain stack-style detail. |
+| `probableCause` | optional | Array of strings, one per cause. |
+| `suggestedRemediation` | optional | Array of strings, one per step. Surface to users when present. |
+| `longDescription` | optional | Array of strings. Suitable for developer logs; may contain stack-style detail. |
 
 Fields marked "when available" are omitted (via `omitempty`) for errors that
 originated outside the MeshKit error catalog.
@@ -66,16 +74,52 @@ originated outside the MeshKit error catalog.
 Use `writeMeshkitError(w, err, status)` in `server/handlers/utils.go`:
 
 ```go
+resp, err := provider.SaveEnvironment(req, &environment, "", false)
 if err != nil {
-    h.log.Error(ErrGetResult(err))
-    writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+    handlerErr := ErrSaveEnvironment(err)
+    h.log.Error(handlerErr)
+    writeMeshkitError(w, handlerErr, providerStatus(err))
     return
 }
 ```
 
 For bare-string errors without a MeshKit code, use `writeJSONError(w, msg, status)`.
-Every bare-string error is a candidate for promotion to a MeshKit error —
+Every bare-string error is a candidate for promotion to a MeshKit error -
 prefer adding a code when fixing an adjacent bug.
+
+### Two rules that are easy to get wrong
+
+**Use an error code that belongs to the operation.** Reusing an unrelated
+component's code defeats the point of having codes at all. The environment and
+workspace handlers spent a long time reporting every failure as
+`ErrGetResult` / `meshery-server-1033` - a *performance-results* code whose
+probable cause reads "Result Identifier provided is not valid. Result did not
+persist in the database". A real production log for a failed environment save
+read `Status Code: 403 .failed to save the environment | ... unable to get
+result | Probable Cause: Result Identifier provided is not valid...`, sending
+maintainers into the wrong subsystem. Add a code for your operation; see
+[Contributing to Meshery Error Codes](/project/contributing/contributing-error).
+
+**Never hardcode the HTTP status of a provider failure.** Those same handlers
+answered every failure with `http.StatusNotFound`, so a remote-provider 403
+reached the browser as a 404 - a response the UI did not recognise as a failure
+at all, which is how a rejected "Create Environment" produced a success toast.
+
+`models.ErrFetch` and `models.ErrPost` tag the error with the status the
+provider actually returned (`httputil.WithProviderStatus`). Handlers read it
+back with the `providerStatus` helper:
+
+```go
+// server/handlers/utils.go
+func providerStatus(err error) int {
+    return httputil.StatusForProviderError(err, http.StatusBadGateway)
+}
+```
+
+The fallback is `502 Bad Gateway`, not `404`: when the provider produced no
+status of its own the failure is still an upstream one, and "not found" is a
+claim about the resource for which there is no evidence. Choose a different
+fallback only when the handler genuinely knows better.
 
 Do not use `http.Error` in handlers or provider code. It writes
 `Content-Type: text/plain` and strips MeshKit metadata, which crashes

--- a/server/handlers/environments_handlers.go
+++ b/server/handlers/environments_handlers.go
@@ -69,8 +69,9 @@ func (h *Handler) GetEnvironments(w http.ResponseWriter, req *http.Request, _ *m
 	}
 	resp, err := provider.GetEnvironments(token, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"), orgID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetEnvironments(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -91,8 +92,9 @@ func (h *Handler) GetEnvironmentByIDHandler(w http.ResponseWriter, r *http.Reque
 	}
 	resp, err := provider.GetEnvironmentByID(r, environmentID, orgID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetEnvironment(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -123,8 +125,9 @@ func (h *Handler) SaveEnvironment(w http.ResponseWriter, req *http.Request, _ *m
 	environment := wire.EnvironmentPayload
 	resp, err := provider.SaveEnvironment(req, &environment, "", false)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrSaveEnvironment(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -142,8 +145,9 @@ func (h *Handler) DeleteEnvironmentHandler(w http.ResponseWriter, r *http.Reques
 	environmentID := mux.Vars(r)["id"]
 	resp, err := provider.DeleteEnvironment(r, environmentID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrDeleteEnvironment(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -175,15 +179,17 @@ func (h *Handler) UpdateEnvironmentHandler(w http.ResponseWriter, req *http.Requ
 	environment := wire.EnvironmentPayload
 	resp, err := provider.UpdateEnvironment(req, &environment, environmentID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrUpdateEnvironment(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
 	respJSON, err := json.Marshal(resp)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, models.ErrMarshal(err, "environment update response"), http.StatusInternalServerError)
+		marshalErr := models.ErrMarshal(err, "environment update response")
+		h.log.Error(marshalErr)
+		writeMeshkitError(w, marshalErr, http.StatusInternalServerError)
 		return
 	}
 	description := fmt.Sprintf("Environment %s updated.", environment.Name)
@@ -191,10 +197,9 @@ func (h *Handler) UpdateEnvironmentHandler(w http.ResponseWriter, req *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(respJSON)
-	if err != nil {
-		h.log.Error(ErrGetResult(err))
+	if _, err = w.Write(respJSON); err != nil {
 		// Headers already committed; log only. Writing another body would corrupt the stream.
+		h.log.Error(err)
 		return
 	}
 }
@@ -204,8 +209,9 @@ func (h *Handler) AddConnectionToEnvironmentHandler(w http.ResponseWriter, r *ht
 	connectionID := mux.Vars(r)["connectionID"]
 	resp, err := provider.AddConnectionToEnvironment(r, environmentID, connectionID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrEnvironmentConnection(err, "assign connection to")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -220,8 +226,9 @@ func (h *Handler) RemoveConnectionFromEnvironmentHandler(w http.ResponseWriter, 
 	connectionID := mux.Vars(r)["connectionID"]
 	resp, err := provider.RemoveConnectionFromEnvironment(r, environmentID, connectionID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrEnvironmentConnection(err, "remove connection from")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -236,8 +243,9 @@ func (h *Handler) GetConnectionsOfEnvironmentHandler(w http.ResponseWriter, r *h
 	q := r.URL.Query()
 	resp, err := provider.GetConnectionsOfEnvironment(r, environmentID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrEnvironmentConnection(err, "list the connections of")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/server/handlers/environments_handlers_test.go
+++ b/server/handlers/environments_handlers_test.go
@@ -1,8 +1,17 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/schemas/models/v1beta3/environment"
 )
 
 // TestEnvironmentPayloadWire_UnmarshalJSON exercises the dual-accept body
@@ -111,5 +120,177 @@ func TestEnvironmentPayloadWire_MarshalsCanonicalCamelCase(t *testing.T) {
 				t.Fatalf("outbound payload organizationId = %q, want %q (full body: %s)", got, orgUUID, out)
 			}
 		})
+	}
+}
+
+// environmentFailingProvider embeds DefaultLocalProvider and fails every
+// environment call with a caller-supplied error, so the tests below can assert
+// what the handler does with a provider failure.
+type environmentFailingProvider struct {
+	*models.DefaultLocalProvider
+	err error
+}
+
+func newEnvironmentFailingProvider(err error) *environmentFailingProvider {
+	base := &models.DefaultLocalProvider{}
+	base.Initialize()
+	return &environmentFailingProvider{DefaultLocalProvider: base, err: err}
+}
+
+func (m *environmentFailingProvider) SaveEnvironment(_ *http.Request, _ *environment.EnvironmentPayload, _ string, _ bool) ([]byte, error) {
+	return nil, m.err
+}
+
+func (m *environmentFailingProvider) GetEnvironments(_, _, _, _, _, _, _ string) ([]byte, error) {
+	return nil, m.err
+}
+
+func (m *environmentFailingProvider) DeleteEnvironment(_ *http.Request, _ string) ([]byte, error) {
+	return nil, m.err
+}
+
+// decodeErrorBody parses the JSON error envelope every non-2xx response
+// carries (see docs/content/en/project/contributing/error-contract.md).
+func decodeErrorBody(t *testing.T, body []byte) struct {
+	Error                string   `json:"error"`
+	Code                 string   `json:"code"`
+	ProbableCause        []string `json:"probableCause"`
+	SuggestedRemediation []string `json:"suggestedRemediation"`
+} {
+	t.Helper()
+	var decoded struct {
+		Error                string   `json:"error"`
+		Code                 string   `json:"code"`
+		ProbableCause        []string `json:"probableCause"`
+		SuggestedRemediation []string `json:"suggestedRemediation"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("error body did not parse as JSON: %v (body=%q)", err, body)
+	}
+	return decoded
+}
+
+// TestSaveEnvironmentHandler_PropagatesProviderStatus is the regression test
+// for the bug that showed an Org Admin a success message for an environment
+// that was never created.
+//
+// The handler used to answer every provider failure with
+// writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound): a hardcoded 404
+// carrying meshery-server-1033 ("unable to get result", probable cause "Result
+// Identifier provided is not valid"). A remote-provider 403 therefore reached
+// the browser as a 404 describing the performance-results subsystem, and the
+// UI did not recognise it as a failure at all.
+//
+// The contract asserted here: the provider's real status reaches the client,
+// and the error code names the operation that actually failed.
+func TestSaveEnvironmentHandler_PropagatesProviderStatus(t *testing.T) {
+	cases := []struct {
+		name         string
+		providerErr  error
+		wantStatus   int
+		wantCodeIs   string
+		wantCauseHas string
+	}{
+		{
+			name:        "provider 403 surfaces as 403, not 404",
+			providerErr: models.ErrPost(errors.New("failed to save the environment"), "Environment", http.StatusForbidden),
+			wantStatus:  http.StatusForbidden,
+			wantCodeIs:  ErrSaveEnvironmentCode,
+		},
+		{
+			name:        "provider 409 surfaces as 409",
+			providerErr: models.ErrPost(errors.New("environment already exists"), "Environment", http.StatusConflict),
+			wantStatus:  http.StatusConflict,
+			wantCodeIs:  ErrSaveEnvironmentCode,
+		},
+		{
+			name:        "provider 500 surfaces as 500",
+			providerErr: models.ErrPost(errors.New("internal error"), "Environment", http.StatusInternalServerError),
+			wantStatus:  http.StatusInternalServerError,
+			wantCodeIs:  ErrSaveEnvironmentCode,
+		},
+		{
+			name:        "unreachable provider defaults to 502, never 404",
+			providerErr: models.ErrUnreachableRemoteProvider(errors.New("dial tcp: connection refused")),
+			wantStatus:  http.StatusBadGateway,
+			wantCodeIs:  ErrSaveEnvironmentCode,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, map[string]models.Provider{}, "")
+			provider := newEnvironmentFailingProvider(tc.providerErr)
+
+			body := `{"name":"prod","description":"","organizationId":"11111111-1111-1111-1111-111111111111"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/environments", strings.NewReader(body))
+			rec := httptest.NewRecorder()
+
+			h.SaveEnvironment(rec, req, nil, nil, provider)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body=%q)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if rec.Code == http.StatusCreated {
+				t.Fatal("a failed create must never answer 201 - that is what made the UI show success")
+			}
+
+			decoded := decodeErrorBody(t, rec.Body.Bytes())
+			if decoded.Code != tc.wantCodeIs {
+				t.Errorf("code = %q, want %q", decoded.Code, tc.wantCodeIs)
+			}
+			if decoded.Code == ErrGetResultCode {
+				t.Errorf("code regressed to the performance-results code %s", ErrGetResultCode)
+			}
+			if strings.Contains(decoded.Error, "unable to get result") {
+				t.Errorf("message regressed to the results wording: %q", decoded.Error)
+			}
+			if len(decoded.SuggestedRemediation) == 0 {
+				t.Error("expected environment-specific remediation on the wire")
+			}
+		})
+	}
+}
+
+// TestGetEnvironmentsHandler_PropagatesProviderStatus covers the read path with
+// the same contract: a provider 403 must not be reported as a 404.
+func TestGetEnvironmentsHandler_PropagatesProviderStatus(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := newEnvironmentFailingProvider(
+		models.ErrFetch(errors.New("forbidden"), "Environments", http.StatusForbidden),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/environments?orgId=11111111-1111-1111-1111-111111111111", nil)
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.GetEnvironments(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if decoded := decodeErrorBody(t, rec.Body.Bytes()); decoded.Code != ErrGetEnvironmentsCode {
+		t.Errorf("code = %q, want %q", decoded.Code, ErrGetEnvironmentsCode)
+	}
+}
+
+// TestDeleteEnvironmentHandler_PropagatesProviderStatus covers the delete path.
+func TestDeleteEnvironmentHandler_PropagatesProviderStatus(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := newEnvironmentFailingProvider(
+		models.ErrFetch(errors.New("forbidden"), "Environment", http.StatusForbidden),
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/environments/env-1", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "env-1"})
+	rec := httptest.NewRecorder()
+
+	h.DeleteEnvironmentHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if decoded := decodeErrorBody(t, rec.Body.Bytes()); decoded.Code != ErrDeleteEnvironmentCode {
+		t.Errorf("code = %q, want %q", decoded.Code, ErrDeleteEnvironmentCode)
 	}
 }

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -216,6 +216,27 @@ const (
 	ErrTelemetryPrometheusAuthCode         = "meshery-server-1435"
 	ErrMeshsyncReconcileCode               = "meshery-server-1442"
 	ErrUnsafeFilePathCode                  = "meshery-server-1443"
+	// Environment, workspace, organization, user and key operations previously
+	// reported every failure as ErrGetResult ("unable to get result", probable
+	// cause "Result Identifier provided is not valid") - a performance-results
+	// code with nothing to do with any of them. The codes below exist so the
+	// error a user and a maintainer see actually describes what failed.
+	ErrGetEnvironmentsCode       = "meshery-server-1446"
+	ErrGetEnvironmentCode        = "meshery-server-1447"
+	ErrSaveEnvironmentCode       = "meshery-server-1448"
+	ErrUpdateEnvironmentCode     = "meshery-server-1449"
+	ErrDeleteEnvironmentCode     = "meshery-server-1450"
+	ErrEnvironmentConnectionCode = "meshery-server-1451"
+	ErrGetWorkspacesCode         = "meshery-server-1452"
+	ErrGetWorkspaceCode          = "meshery-server-1453"
+	ErrSaveWorkspaceCode         = "meshery-server-1454"
+	ErrUpdateWorkspaceCode       = "meshery-server-1455"
+	ErrDeleteWorkspaceCode       = "meshery-server-1456"
+	ErrWorkspaceResourceCode     = "meshery-server-1457"
+	ErrGetOrganizationsCode      = "meshery-server-1458"
+	ErrGetUsersCode              = "meshery-server-1459"
+	ErrGetUserCode               = "meshery-server-1460"
+	ErrGetUsersKeysCode          = "meshery-server-1461"
 )
 
 var (
@@ -1096,4 +1117,92 @@ func ErrInitializeMachine(err error) error {
 // caller input.
 func ErrSendMachineEvent(err error) error {
 	return errors.New(ErrSendMachineEventCode, errors.Alert, []string{"Failed to advance connection state machine"}, []string{err.Error()}, []string{"The requested event is not valid from the connection's current state.", "A side-effect action attached to the transition (e.g. provisioning, discovery) returned an error."}, []string{"Inspect the connection's current status before retrying. If the failure originates from a side-effect action, address the underlying cause (e.g. cluster reachability, credential validity) and retry."})
+}
+
+// Environment, workspace, organization, user and API-key failures
+// ---------------------------------------------------------------
+//
+// Every one of these operations is a pass-through to the configured provider.
+// They used to report failures as ErrGetResult with a hardcoded HTTP 404,
+// which meant a provider 403 on "create environment" reached the browser as a
+// 404 carrying "unable to get result - Result Identifier provided is not
+// valid". The UI never recognised that as a failure and showed a success
+// toast, and the server log pointed maintainers at the performance-results
+// subsystem. The constructors below name the operation that actually failed;
+// the handlers pair them with httputil.StatusForProviderError so the status
+// reflects the provider's real response.
+//
+// The probable causes are ordered by how often each is the real one for a
+// provider-backed CRUD call: permissions first (the 403 that started this),
+// then a stale/incorrect identifier, then provider reachability.
+
+func ErrGetEnvironments(err error) error {
+	return errors.New(ErrGetEnvironmentsCode, errors.Alert, []string{"Unable to fetch environments"}, []string{err.Error()}, []string{"Your account does not have permission to list environments in this organization.", "The organization identifier in the request does not exist or is not one you belong to.", "The provider could not be reached or returned an error."}, []string{"Confirm you are a member of the selected organization and that your role grants read access to environments. If the organization is correct, retry once the provider is reachable."})
+}
+
+func ErrGetEnvironment(err error) error {
+	return errors.New(ErrGetEnvironmentCode, errors.Alert, []string{"Unable to fetch the environment"}, []string{err.Error()}, []string{"Your account does not have permission to view this environment.", "The environment has been deleted, or the identifier belongs to a different organization.", "The provider could not be reached or returned an error."}, []string{"Verify the environment still exists in the selected organization and that your role grants read access to it."})
+}
+
+func ErrSaveEnvironment(err error) error {
+	return errors.New(ErrSaveEnvironmentCode, errors.Alert, []string{"Unable to create the environment"}, []string{err.Error()}, []string{"Your account does not have permission to create environments in this organization.", "An environment with the same name already exists in this organization.", "The organization identifier is missing or does not exist.", "The provider could not be reached or rejected the request."}, []string{"Confirm your role in the selected organization grants permission to create environments, and that the environment name is not already in use. The environment was NOT created - retry after resolving the cause."})
+}
+
+func ErrUpdateEnvironment(err error) error {
+	return errors.New(ErrUpdateEnvironmentCode, errors.Alert, []string{"Unable to update the environment"}, []string{err.Error()}, []string{"Your account does not have permission to modify this environment.", "The environment has been deleted, or another name in the organization conflicts with the new one.", "The provider could not be reached or rejected the request."}, []string{"Confirm your role grants write access to this environment and that the new name is unique within the organization. The environment was NOT updated - retry after resolving the cause."})
+}
+
+func ErrDeleteEnvironment(err error) error {
+	return errors.New(ErrDeleteEnvironmentCode, errors.Alert, []string{"Unable to delete the environment"}, []string{err.Error()}, []string{"Your account does not have permission to delete this environment.", "The environment has already been deleted.", "The provider could not be reached or rejected the request."}, []string{"Confirm your role grants delete access to this environment. If it no longer appears in the list, it has already been removed."})
+}
+
+// ErrEnvironmentConnection covers adding, removing and listing the connections
+// held by an environment. action is the operation being attempted, e.g.
+// "assign connection to", so the message reads as a sentence.
+func ErrEnvironmentConnection(err error, action string) error {
+	return errors.New(ErrEnvironmentConnectionCode, errors.Alert, []string{"Unable to ", action, " environment"}, []string{err.Error()}, []string{"Your account does not have permission to modify this environment's connections.", "The environment or the connection has been deleted, or they belong to different organizations.", "The provider could not be reached or rejected the request."}, []string{"Confirm both the environment and the connection still exist in the same organization and that your role grants write access to the environment."})
+}
+
+func ErrGetWorkspaces(err error) error {
+	return errors.New(ErrGetWorkspacesCode, errors.Alert, []string{"Unable to fetch workspaces"}, []string{err.Error()}, []string{"Your account does not have permission to list workspaces in this organization.", "The organization identifier in the request does not exist or is not one you belong to.", "The provider could not be reached or returned an error."}, []string{"Confirm you are a member of the selected organization and that your role grants read access to workspaces."})
+}
+
+func ErrGetWorkspace(err error) error {
+	return errors.New(ErrGetWorkspaceCode, errors.Alert, []string{"Unable to fetch the workspace"}, []string{err.Error()}, []string{"Your account does not have permission to view this workspace.", "The workspace has been deleted, or the identifier belongs to a different organization.", "The provider could not be reached or returned an error."}, []string{"Verify the workspace still exists in the selected organization and that your role grants read access to it."})
+}
+
+func ErrSaveWorkspace(err error) error {
+	return errors.New(ErrSaveWorkspaceCode, errors.Alert, []string{"Unable to create the workspace"}, []string{err.Error()}, []string{"Your account does not have permission to create workspaces in this organization.", "A workspace with the same name already exists in this organization.", "The organization identifier is missing or does not exist.", "The provider could not be reached or rejected the request."}, []string{"Confirm your role in the selected organization grants permission to create workspaces, and that the workspace name is not already in use. The workspace was NOT created - retry after resolving the cause."})
+}
+
+func ErrUpdateWorkspace(err error) error {
+	return errors.New(ErrUpdateWorkspaceCode, errors.Alert, []string{"Unable to update the workspace"}, []string{err.Error()}, []string{"Your account does not have permission to modify this workspace.", "The workspace has been deleted, or another name in the organization conflicts with the new one.", "The provider could not be reached or rejected the request."}, []string{"Confirm your role grants write access to this workspace and that the new name is unique within the organization. The workspace was NOT updated - retry after resolving the cause."})
+}
+
+func ErrDeleteWorkspace(err error) error {
+	return errors.New(ErrDeleteWorkspaceCode, errors.Alert, []string{"Unable to delete the workspace"}, []string{err.Error()}, []string{"Your account does not have permission to delete this workspace.", "The workspace has already been deleted.", "The provider could not be reached or rejected the request."}, []string{"Confirm your role grants delete access to this workspace. If it no longer appears in the list, it has already been removed."})
+}
+
+// ErrWorkspaceResource covers every workspace association endpoint -
+// environments, designs, views and teams. action names the operation
+// ("assign design to", "list teams of") so one code can describe the whole
+// family without losing precision in the message.
+func ErrWorkspaceResource(err error, action string) error {
+	return errors.New(ErrWorkspaceResourceCode, errors.Alert, []string{"Unable to ", action, " workspace"}, []string{err.Error()}, []string{"Your account does not have permission to modify this workspace's contents.", "The workspace or the resource being associated has been deleted, or they belong to different organizations.", "The provider could not be reached or rejected the request."}, []string{"Confirm both the workspace and the resource still exist in the same organization and that your role grants write access to the workspace."})
+}
+
+func ErrGetOrganizations(err error) error {
+	return errors.New(ErrGetOrganizationsCode, errors.Alert, []string{"Unable to fetch organizations"}, []string{err.Error()}, []string{"Your session has expired or your account is not a member of any organization.", "The provider could not be reached or returned an error."}, []string{"Sign in again and retry. If the problem persists, verify the remote provider is reachable from this Meshery instance."})
+}
+
+func ErrGetUsers(err error) error {
+	return errors.New(ErrGetUsersCode, errors.Alert, []string{"Unable to fetch users"}, []string{err.Error()}, []string{"Your account does not have permission to list users.", "The provider could not be reached or returned an error."}, []string{"Confirm your role grants permission to view the user directory for this organization."})
+}
+
+func ErrGetUser(err error) error {
+	return errors.New(ErrGetUserCode, errors.Alert, []string{"Unable to fetch the user"}, []string{err.Error()}, []string{"Your account does not have permission to view this user.", "No user exists with the requested identifier.", "The provider could not be reached or returned an error."}, []string{"Verify the user identifier is correct and that your role grants permission to view other users."})
+}
+
+func ErrGetUsersKeys(err error) error {
+	return errors.New(ErrGetUsersKeysCode, errors.Alert, []string{"Unable to fetch API keys"}, []string{err.Error()}, []string{"Your account does not have permission to list API keys for this organization.", "The organization identifier in the request does not exist or is not one you belong to.", "The provider could not be reached or returned an error."}, []string{"Confirm you are a member of the selected organization and that your role grants permission to view its keys."})
 }

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -1160,7 +1160,7 @@ func ErrDeleteEnvironment(err error) error {
 // held by an environment. action is the operation being attempted, e.g.
 // "assign connection to", so the message reads as a sentence.
 func ErrEnvironmentConnection(err error, action string) error {
-	return errors.New(ErrEnvironmentConnectionCode, errors.Alert, []string{"Unable to ", action, " environment"}, []string{err.Error()}, []string{"Your account does not have permission to modify this environment's connections.", "The environment or the connection has been deleted, or they belong to different organizations.", "The provider could not be reached or rejected the request."}, []string{"Confirm both the environment and the connection still exist in the same organization and that your role grants write access to the environment."})
+	return errors.New(ErrEnvironmentConnectionCode, errors.Alert, []string{fmt.Sprintf("Unable to %s environment", action)}, []string{err.Error()}, []string{"Your account does not have permission to modify this environment's connections.", "The environment or the connection has been deleted, or they belong to different organizations.", "The provider could not be reached or rejected the request."}, []string{"Confirm both the environment and the connection still exist in the same organization and that your role grants write access to the environment."})
 }
 
 func ErrGetWorkspaces(err error) error {
@@ -1188,7 +1188,7 @@ func ErrDeleteWorkspace(err error) error {
 // ("assign design to", "list teams of") so one code can describe the whole
 // family without losing precision in the message.
 func ErrWorkspaceResource(err error, action string) error {
-	return errors.New(ErrWorkspaceResourceCode, errors.Alert, []string{"Unable to ", action, " workspace"}, []string{err.Error()}, []string{"Your account does not have permission to modify this workspace's contents.", "The workspace or the resource being associated has been deleted, or they belong to different organizations.", "The provider could not be reached or rejected the request."}, []string{"Confirm both the workspace and the resource still exist in the same organization and that your role grants write access to the workspace."})
+	return errors.New(ErrWorkspaceResourceCode, errors.Alert, []string{fmt.Sprintf("Unable to %s workspace", action)}, []string{err.Error()}, []string{"Your account does not have permission to modify this workspace's contents.", "The workspace or the resource being associated has been deleted, or they belong to different organizations.", "The provider could not be reached or rejected the request."}, []string{"Confirm both the workspace and the resource still exist in the same organization and that your role grants write access to the workspace."})
 }
 
 func ErrGetOrganizations(err error) error {

--- a/server/handlers/keys_handler.go
+++ b/server/handlers/keys_handler.go
@@ -21,8 +21,9 @@ func (h *Handler) GetUsersKeys(w http.ResponseWriter, req *http.Request, _ *mode
 	orgID := mux.Vars(req)["orgID"]
 	resp, err := provider.GetUsersKeys(token, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"), orgID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetUsersKeys(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 

--- a/server/handlers/organization_handler.go
+++ b/server/handlers/organization_handler.go
@@ -18,8 +18,9 @@ func (h *Handler) GetOrganizations(w http.ResponseWriter, req *http.Request, _ *
 	q := req.URL.Query()
 	resp, err := provider.GetOrganizations(token, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetOrganizations(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 

--- a/server/handlers/user_handler.go
+++ b/server/handlers/user_handler.go
@@ -42,8 +42,9 @@ func (h *Handler) GetUserByIDHandler(w http.ResponseWriter, r *http.Request, _ *
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetUser(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -69,8 +70,9 @@ func (h *Handler) GetUsers(w http.ResponseWriter, req *http.Request, _ *models.P
 
 	resp, err := provider.GetUsers(token, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetUsers(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 

--- a/server/handlers/user_handler_test.go
+++ b/server/handlers/user_handler_test.go
@@ -46,9 +46,14 @@ func TestGetUserByIDHandler_InvalidUUIDReturnsJSON(t *testing.T) {
 }
 
 // TestGetUserByIDHandler_ProviderErrorReturnsJSON covers the upstream-fetch
-// failure path. The handler must still emit a structured JSON error body on
-// 404 so the client does not choke on the meshkit "Unable to fetch data..."
-// string that starts with the letter 'U'.
+// failure path. The handler must emit a structured JSON error body so the
+// client does not choke on the meshkit "Unable to fetch data..." string that
+// starts with the letter 'U'.
+//
+// The status is 502, not the 404 this asserted previously: a provider error
+// that carries no HTTP status of its own is an upstream failure, and claiming
+// "not found" invents a fact about the user record we have no evidence for.
+// See providerStatus in handlers/utils.go.
 func TestGetUserByIDHandler_ProviderErrorReturnsJSON(t *testing.T) {
 	h := newTestHandler(t, map[string]models.Provider{}, "")
 	provider := &userSpyProvider{DefaultLocalProvider: &models.DefaultLocalProvider{}, err: fmt.Errorf("remote blew up")}
@@ -60,8 +65,31 @@ func TestGetUserByIDHandler_ProviderErrorReturnsJSON(t *testing.T) {
 
 	h.GetUserByIDHandler(rec, req, nil, nil, provider)
 
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d (body=%q)", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+	assertJSONErrorEnvelope(t, rec.Result())
+}
+
+// TestGetUserByIDHandler_PropagatesProviderStatus is the counterpart: when the
+// provider DID report a status, that status must reach the client verbatim
+// rather than being flattened to a fabricated 404.
+func TestGetUserByIDHandler_PropagatesProviderStatus(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := &userSpyProvider{
+		DefaultLocalProvider: &models.DefaultLocalProvider{},
+		err:                  models.ErrFetch(fmt.Errorf("forbidden"), "User", http.StatusForbidden),
+	}
+	provider.Initialize()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/profile/00000000-0000-0000-0000-000000000001", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "00000000-0000-0000-0000-000000000001"})
+	rec := httptest.NewRecorder()
+
+	h.GetUserByIDHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d (body=%q)", rec.Code, rec.Body.String())
 	}
 	assertJSONErrorEnvelope(t, rec.Result())
 }

--- a/server/handlers/utils.go
+++ b/server/handlers/utils.go
@@ -54,6 +54,25 @@ func writeJSONEmptyObject(w http.ResponseWriter, status int) {
 	httputil.WriteJSONEmptyObject(w, status)
 }
 
+// providerStatus returns the HTTP status to surface for a failure that came
+// back from the provider layer.
+//
+// Handlers used to hardcode http.StatusNotFound on every provider error, so a
+// 403 from the remote provider reached the browser as a 404 - a response the
+// UI did not recognise as a failure at all, which is how a rejected "create
+// environment" produced a success toast. ErrFetch/ErrPost now tag the error
+// with the provider's real status (see models/httputil.WithProviderStatus);
+// this reads it back.
+//
+// The fallback is http.StatusBadGateway: when the provider never produced an
+// HTTP status the failure is still an upstream one (unreachable provider,
+// unsupported capability, unreadable response body), and 502 says that
+// honestly. It is never 404, because "not found" is a claim about the
+// resource that we have no evidence for.
+func providerStatus(err error) int {
+	return httputil.StatusForProviderError(err, http.StatusBadGateway)
+}
+
 const (
 	defaultPageSize = 25
 	queryParamTrue  = "true"

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -102,8 +102,9 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 	}
 	resp, err := provider.GetWorkspaces(token, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"), orgID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetWorkspaces(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -130,8 +131,9 @@ func (h *Handler) GetWorkspaceByIdHandler(w http.ResponseWriter, r *http.Request
 	}
 	resp, err := provider.GetWorkspaceByID(r, workspaceID, orgID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrGetWorkspace(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -162,16 +164,19 @@ func (h *Handler) SaveWorkspaceHandler(w http.ResponseWriter, req *http.Request,
 	workspace := wire.WorkspacePayload
 	bf, err := provider.SaveWorkspace(req, &workspace, "", false)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrSaveWorkspace(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
 	description := fmt.Sprintf("Workspace %s created.", workspace.Name)
 
 	h.log.Info(description)
-	w.WriteHeader(http.StatusCreated)
+	// Content-Type must be set before WriteHeader; the reverse order silently
+	// drops the header, and RTK Query's default baseQuery dispatches on it.
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 	if _, err := w.Write(bf); err != nil {
 		h.log.Error(err)
 	}
@@ -181,8 +186,9 @@ func (h *Handler) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request,
 	workspaceID := mux.Vars(r)["id"]
 	resp, err := provider.DeleteWorkspace(r, workspaceID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrDeleteWorkspace(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -214,15 +220,17 @@ func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Reques
 	workspacePayload := wire.WorkspaceUpdatePayload
 	resp, err := provider.UpdateWorkspace(req, &workspacePayload, workspaceID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusNotFound)
+		handlerErr := ErrUpdateWorkspace(err)
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
 	respJSON, err := json.Marshal(resp)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, models.ErrMarshal(err, "workspace update response"), http.StatusInternalServerError)
+		marshalErr := models.ErrMarshal(err, "workspace update response")
+		h.log.Error(marshalErr)
+		writeMeshkitError(w, marshalErr, http.StatusInternalServerError)
 		return
 	}
 	description := fmt.Sprintf("Workspace %s updated.", resp.Name)
@@ -230,10 +238,9 @@ func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(respJSON)
-	if err != nil {
-		h.log.Error(ErrGetResult(err))
+	if _, err = w.Write(respJSON); err != nil {
 		// Headers already committed; log only. Writing another body would corrupt the stream.
+		h.log.Error(err)
 		return
 	}
 }
@@ -243,8 +250,9 @@ func (h *Handler) GetEnvironmentsOfWorkspaceHandler(w http.ResponseWriter, req *
 	q := req.URL.Query()
 	resp, err := provider.GetEnvironmentsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "list the environments of")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -259,8 +267,9 @@ func (h *Handler) GetDesignsOfWorkspaceHandler(w http.ResponseWriter, req *http.
 	q := req.URL.Query()
 	resp, err := provider.GetDesignsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"), q["visibility"])
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "list the designs of")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 
@@ -275,8 +284,9 @@ func (h *Handler) AddEnvironmentToWorkspaceHandler(w http.ResponseWriter, req *h
 	environmentID := mux.Vars(req)["environmentID"]
 	resp, err := provider.AddEnvironmentToWorkspace(req, workspaceID, environmentID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "assign an environment to")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -290,8 +300,9 @@ func (h *Handler) RemoveEnvironmentFromWorkspaceHandler(w http.ResponseWriter, r
 	environmentID := mux.Vars(req)["environmentID"]
 	resp, err := provider.RemoveEnvironmentFromWorkspace(req, workspaceID, environmentID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "remove an environment from")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -305,8 +316,9 @@ func (h *Handler) AddDesignToWorkspaceHandler(w http.ResponseWriter, req *http.R
 	designID := mux.Vars(req)["designID"]
 	resp, err := provider.AddDesignToWorkspace(req, workspaceID, designID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "assign a design to")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -320,8 +332,9 @@ func (h *Handler) RemoveDesignFromWorkspaceHandler(w http.ResponseWriter, req *h
 	designID := mux.Vars(req)["designID"]
 	resp, err := provider.RemoveDesignFromWorkspace(req, workspaceID, designID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "remove a design from")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -335,8 +348,9 @@ func (h *Handler) GetViewsOfWorkspaceHandler(w http.ResponseWriter, req *http.Re
 	q := req.URL.Query()
 	resp, err := provider.GetViewsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "list the views of")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -350,8 +364,9 @@ func (h *Handler) AddViewToWorkspaceHandler(w http.ResponseWriter, req *http.Req
 	viewID := mux.Vars(req)["viewID"]
 	resp, err := provider.AddViewToWorkspace(req, workspaceID, viewID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "assign a view to")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -365,8 +380,9 @@ func (h *Handler) RemoveViewFromWorkspaceHandler(w http.ResponseWriter, req *htt
 	viewID := mux.Vars(req)["viewID"]
 	resp, err := provider.RemoveViewFromWorkspace(req, workspaceID, viewID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "remove a view from")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -380,8 +396,9 @@ func (h *Handler) GetTeamsOfWorkspaceHandler(w http.ResponseWriter, req *http.Re
 	q := req.URL.Query()
 	resp, err := provider.GetTeamsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "list the teams of")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -395,8 +412,9 @@ func (h *Handler) AddTeamToWorkspaceHandler(w http.ResponseWriter, req *http.Req
 	teamID := mux.Vars(req)["teamID"]
 	resp, err := provider.AddTeamToWorkspace(req, workspaceID, teamID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "assign a team to")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -410,8 +428,9 @@ func (h *Handler) RemoveTeamFromWorkspaceHandler(w http.ResponseWriter, req *htt
 	teamID := mux.Vars(req)["teamID"]
 	resp, err := provider.RemoveTeamFromWorkspace(req, workspaceID, teamID)
 	if err != nil {
-		h.log.Error(ErrGetResult(err))
-		writeMeshkitError(w, ErrGetResult(err), http.StatusInternalServerError)
+		handlerErr := ErrWorkspaceResource(err, "remove a team from")
+		h.log.Error(handlerErr)
+		writeMeshkitError(w, handlerErr, providerStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/server/handlers/workspace_handlers_test.go
+++ b/server/handlers/workspace_handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/schemas/models/v1beta3/workspace"
 )
 
 // workspaceSpyProvider embeds DefaultLocalProvider and records the orgID
@@ -38,6 +40,11 @@ func (m *workspaceSpyProvider) GetWorkspaceByID(_ *http.Request, _, orgID string
 	m.called = true
 	m.observedOrgID = orgID
 	return []byte(`{}`), nil
+}
+
+func (m *workspaceSpyProvider) SaveWorkspace(_ *http.Request, _ *workspace.WorkspacePayload, _ string, _ bool) ([]byte, error) {
+	m.called = true
+	return []byte(`{"id":"11111111-1111-1111-1111-111111111111"}`), nil
 }
 
 // TestGetWorkspacesHandler_AcceptsOrgIdAndLegacyOrgID asserts that the
@@ -269,5 +276,149 @@ func TestWorkspaceUpdatePayloadWire_UnmarshalJSON(t *testing.T) {
 				t.Fatalf("OrganizationID = %q, want %q", got, tc.wantOrg)
 			}
 		})
+	}
+}
+
+// workspaceFailingProvider embeds DefaultLocalProvider and fails every
+// workspace call with a caller-supplied error.
+type workspaceFailingProvider struct {
+	*models.DefaultLocalProvider
+	err error
+}
+
+func newWorkspaceFailingProvider(err error) *workspaceFailingProvider {
+	base := &models.DefaultLocalProvider{}
+	base.Initialize()
+	return &workspaceFailingProvider{DefaultLocalProvider: base, err: err}
+}
+
+func (m *workspaceFailingProvider) SaveWorkspace(_ *http.Request, _ *workspace.WorkspacePayload, _ string, _ bool) ([]byte, error) {
+	return nil, m.err
+}
+
+func (m *workspaceFailingProvider) GetWorkspaces(_, _, _, _, _, _, _ string) ([]byte, error) {
+	return nil, m.err
+}
+
+func (m *workspaceFailingProvider) DeleteWorkspace(_ *http.Request, _ string) ([]byte, error) {
+	return nil, m.err
+}
+
+// TestSaveWorkspaceHandler_PropagatesProviderStatus mirrors the environment
+// coverage: the workspace handlers carried the identical defect (ErrGetResult
+// + hardcoded 404 on every provider failure), so they get the identical
+// contract - real status out, workspace-specific code out.
+func TestSaveWorkspaceHandler_PropagatesProviderStatus(t *testing.T) {
+	cases := []struct {
+		name        string
+		providerErr error
+		wantStatus  int
+	}{
+		{
+			name:        "provider 403 surfaces as 403, not 404",
+			providerErr: models.ErrPost(errors.New("failed to save the workspace"), "Workspace", http.StatusForbidden),
+			wantStatus:  http.StatusForbidden,
+		},
+		{
+			name:        "provider 409 surfaces as 409",
+			providerErr: models.ErrPost(errors.New("workspace already exists"), "Workspace", http.StatusConflict),
+			wantStatus:  http.StatusConflict,
+		},
+		{
+			name:        "unreachable provider defaults to 502, never 404",
+			providerErr: models.ErrUnreachableRemoteProvider(errors.New("dial tcp: connection refused")),
+			wantStatus:  http.StatusBadGateway,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, map[string]models.Provider{}, "")
+			provider := newWorkspaceFailingProvider(tc.providerErr)
+
+			body := `{"name":"team-space","description":"","organizationId":"11111111-1111-1111-1111-111111111111"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+			rec := httptest.NewRecorder()
+
+			h.SaveWorkspaceHandler(rec, req, nil, nil, provider)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body=%q)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if rec.Code == http.StatusCreated {
+				t.Fatal("a failed create must never answer 201")
+			}
+
+			var decoded struct {
+				Error                string   `json:"error"`
+				Code                 string   `json:"code"`
+				SuggestedRemediation []string `json:"suggestedRemediation"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+				t.Fatalf("error body did not parse as JSON: %v (body=%q)", err, rec.Body.String())
+			}
+			if decoded.Code != ErrSaveWorkspaceCode {
+				t.Errorf("code = %q, want %q", decoded.Code, ErrSaveWorkspaceCode)
+			}
+			if decoded.Code == ErrGetResultCode {
+				t.Errorf("code regressed to the performance-results code %s", ErrGetResultCode)
+			}
+			if strings.Contains(decoded.Error, "unable to get result") {
+				t.Errorf("message regressed to the results wording: %q", decoded.Error)
+			}
+			if len(decoded.SuggestedRemediation) == 0 {
+				t.Error("expected workspace-specific remediation on the wire")
+			}
+		})
+	}
+}
+
+// TestGetWorkspacesHandler_PropagatesProviderStatus covers the read path.
+func TestGetWorkspacesHandler_PropagatesProviderStatus(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := newWorkspaceFailingProvider(
+		models.ErrFetch(errors.New("forbidden"), "Workspaces", http.StatusForbidden),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces?orgId=11111111-1111-1111-1111-111111111111", nil)
+	req = req.WithContext(context.WithValue(req.Context(), models.TokenCtxKey, "test-token"))
+	rec := httptest.NewRecorder()
+
+	h.GetWorkspacesHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+
+	var decoded struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("error body did not parse as JSON: %v", err)
+	}
+	if decoded.Code != ErrGetWorkspacesCode {
+		t.Errorf("code = %q, want %q", decoded.Code, ErrGetWorkspacesCode)
+	}
+}
+
+// TestSaveWorkspaceHandler_SetsContentTypeOnSuccess guards an adjacent bug
+// found while fixing the above: the success path called w.WriteHeader before
+// w.Header().Set, so Content-Type was silently dropped. RTK Query's default
+// baseQuery dispatches on Content-Type, so the 201 body arrived unparsed.
+func TestSaveWorkspaceHandler_SetsContentTypeOnSuccess(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := newWorkspaceSpyProvider()
+
+	body := `{"name":"team-space","organizationId":"11111111-1111-1111-1111-111111111111"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.SaveWorkspaceHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
 	}
 }

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1446
+  "next_error_code": 1462
 }

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/meshery/meshery/server/models/httputil"
 	"github.com/meshery/meshkit/errors"
 )
 
@@ -276,12 +277,23 @@ func ErrEncoding(err error, obj string) error {
 	return errors.New(ErrEncodingCode, errors.Alert, []string{"Error encoding the : ", obj}, []string{err.Error()}, []string{"Object is not a valid json object"}, []string{"Make sure if the object passed is a valid json"})
 }
 
+// ErrFetch and ErrPost are the two provider-layer constructors that know the
+// HTTP status the remote provider actually responded with. Both tag the error
+// with that status via httputil.WithProviderStatus so handlers can propagate
+// the real failure (see httputil.StatusForProviderError) instead of hardcoding
+// one. Without the tag a provider 403 surfaced to the browser as a 404.
 func ErrFetch(err error, obj string, statusCode int) error {
-	return errors.New(ErrFetchCode, errors.Alert, []string{"Unable to fetch data from the Provider", obj}, []string{"Status Code: " + fmt.Sprint(statusCode) + " ", err.Error()}, []string{}, []string{})
+	return httputil.WithProviderStatus(
+		errors.New(ErrFetchCode, errors.Alert, []string{"Unable to fetch data from the Provider", obj}, []string{"Status Code: " + fmt.Sprint(statusCode) + " ", err.Error()}, []string{}, []string{}),
+		statusCode,
+	)
 }
 
 func ErrPost(err error, obj string, statusCode int) error {
-	return errors.New(ErrPostCode, errors.Alert, []string{"Unable to post data to the Provider", obj}, []string{"Status Code: " + fmt.Sprint(statusCode) + " ", err.Error()}, []string{}, []string{})
+	return httputil.WithProviderStatus(
+		errors.New(ErrPostCode, errors.Alert, []string{"Unable to post data to the Provider", obj}, []string{"Status Code: " + fmt.Sprint(statusCode) + " ", err.Error()}, []string{}, []string{}),
+		statusCode,
+	)
 }
 func ErrStatusCode(statusCode int) error {
 	return errors.New(

--- a/server/models/httputil/httputil.go
+++ b/server/models/httputil/httputil.go
@@ -99,24 +99,6 @@ func WriteMeshkitError(w http.ResponseWriter, err error, status int) {
 		resp.ProbableCause = causes
 		resp.SuggestedRemediation = remedies
 		resp.LongDescription = longs
-
-		// Fall back to the joined accessors if the typed slices were unavailable
-		// (an error that reports a code but is neither *Error nor *ErrorV2).
-		if resp.LongDescription == nil {
-			if long := meshkiterrors.GetLDescription(err); long != "" && long != "None" {
-				resp.LongDescription = []string{long}
-			}
-		}
-		if resp.ProbableCause == nil {
-			if cause := meshkiterrors.GetCause(err); cause != "" && cause != "None" {
-				resp.ProbableCause = []string{cause}
-			}
-		}
-		if resp.SuggestedRemediation == nil {
-			if remedy := meshkiterrors.GetRemedy(err); remedy != "" && remedy != "None" {
-				resp.SuggestedRemediation = []string{remedy}
-			}
-		}
 	}
 
 	_ = json.NewEncoder(w).Encode(resp)
@@ -125,8 +107,7 @@ func WriteMeshkitError(w http.ResponseWriter, err error, status int) {
 // meshkitDetailSlices returns the probable-cause, suggested-remediation and
 // long-description slices carried by err, with MeshKit's "None" sentinel and
 // blank entries removed. Each result is nil when the error carries nothing for
-// that field, which lets the caller distinguish "absent" from "empty" and fall
-// back to the joined accessors.
+// that field, so `omitempty` keeps it off the wire entirely.
 func meshkitDetailSlices(err error) (causes, remedies, longs []string) {
 	var errV2 *meshkiterrors.ErrorV2
 	if errors.As(err, &errV2) && errV2 != nil {

--- a/server/models/httputil/httputil.go
+++ b/server/models/httputil/httputil.go
@@ -5,17 +5,17 @@
 // on models).
 //
 // Reach for:
-//   - WriteMeshkitError     — ANY error path. If err wraps a *meshkiterrors.Error
-//                             or *ErrorV2, the code/severity/cause/remediation
-//                             survive onto the wire. If it doesn't, the .Error()
-//                             string is still emitted as JSON.
-//   - WriteJSONError        — error paths where the message is a bare string with
-//                             no MeshKit wrapper. Prefer promoting the string to
-//                             a MeshKit error and using WriteMeshkitError instead.
-//   - WriteJSONMessage      — success paths that return a small status or result
-//                             payload (e.g. {"message": "deleted"}).
-//   - WriteJSONEmptyObject  — success paths that need to return an empty JSON
-//                             object ({}) with the Content-Type header set.
+//
+//   - WriteMeshkitError: ANY error path. If err wraps a *meshkiterrors.Error or
+//     *ErrorV2, the code, severity, probable cause and remediation survive onto
+//     the wire. If it doesn't, the .Error() string is still emitted as JSON.
+//   - WriteJSONError: error paths where the message is a bare string with no
+//     MeshKit wrapper. Prefer promoting the string to a MeshKit error and using
+//     WriteMeshkitError instead.
+//   - WriteJSONMessage: success paths that return a small status or result
+//     payload (e.g. {"message": "deleted"}).
+//   - WriteJSONEmptyObject: success paths that need to return an empty JSON
+//     object ({}) with the Content-Type header set.
 //
 // Never use http.Error from handlers or the provider layer — it emits
 // Content-Type: text/plain which crashes RTK Query's default baseQuery on the
@@ -24,7 +24,9 @@ package httputil
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
 
 	meshkiterrors "github.com/meshery/meshkit/errors"
 )
@@ -86,18 +88,75 @@ func WriteMeshkitError(w http.ResponseWriter, err error, status int) {
 			// err.Error() on a MeshKit error concatenates every field with pipes.
 			resp.Error = short
 		}
-		if long := meshkiterrors.GetLDescription(err); long != "" && long != "None" {
-			resp.LongDescription = []string{long}
+
+		// Prefer the underlying string slices over MeshKit's Get* accessors.
+		// The accessors join every entry with "." into one string, so an error
+		// listing three distinct probable causes arrived on the wire as a single
+		// run-on line ("...permission..No user exists..The provider..") and the
+		// UI rendered it as one bullet. The wire contract has always declared
+		// these as arrays; this makes them arrays in fact.
+		causes, remedies, longs := meshkitDetailSlices(err)
+		resp.ProbableCause = causes
+		resp.SuggestedRemediation = remedies
+		resp.LongDescription = longs
+
+		// Fall back to the joined accessors if the typed slices were unavailable
+		// (an error that reports a code but is neither *Error nor *ErrorV2).
+		if resp.LongDescription == nil {
+			if long := meshkiterrors.GetLDescription(err); long != "" && long != "None" {
+				resp.LongDescription = []string{long}
+			}
 		}
-		if cause := meshkiterrors.GetCause(err); cause != "" && cause != "None" {
-			resp.ProbableCause = []string{cause}
+		if resp.ProbableCause == nil {
+			if cause := meshkiterrors.GetCause(err); cause != "" && cause != "None" {
+				resp.ProbableCause = []string{cause}
+			}
 		}
-		if remedy := meshkiterrors.GetRemedy(err); remedy != "" && remedy != "None" {
-			resp.SuggestedRemediation = []string{remedy}
+		if resp.SuggestedRemediation == nil {
+			if remedy := meshkiterrors.GetRemedy(err); remedy != "" && remedy != "None" {
+				resp.SuggestedRemediation = []string{remedy}
+			}
 		}
 	}
 
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// meshkitDetailSlices returns the probable-cause, suggested-remediation and
+// long-description slices carried by err, with MeshKit's "None" sentinel and
+// blank entries removed. Each result is nil when the error carries nothing for
+// that field, which lets the caller distinguish "absent" from "empty" and fall
+// back to the joined accessors.
+func meshkitDetailSlices(err error) (causes, remedies, longs []string) {
+	var errV2 *meshkiterrors.ErrorV2
+	if errors.As(err, &errV2) && errV2 != nil {
+		return compactDetails(errV2.ProbableCause), compactDetails(errV2.SuggestedRemediation), compactDetails(errV2.LongDescription)
+	}
+
+	var errV1 *meshkiterrors.Error
+	if errors.As(err, &errV1) && errV1 != nil {
+		return compactDetails(errV1.ProbableCause), compactDetails(errV1.SuggestedRemediation), compactDetails(errV1.LongDescription)
+	}
+
+	return nil, nil, nil
+}
+
+// compactDetails drops blank entries and MeshKit's "None" placeholder, and
+// returns nil rather than an empty slice so `omitempty` keeps the field off the
+// wire entirely.
+func compactDetails(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, entry := range in {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed == "" || trimmed == "None" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // severityString converts a MeshKit Severity enum to the string label used on

--- a/server/models/httputil/httputil_test.go
+++ b/server/models/httputil/httputil_test.go
@@ -549,3 +549,76 @@ func TestEncodeIntoResponseWriter_DemonstratesLatentBug(t *testing.T) {
 	}
 	t.Errorf("expected truncation or concatenation as proof of corruption; got a single clean object %+v with body=%q. The standard library may have changed — re-validate buffer-encode regression tests.", first, string(bodyBytes))
 }
+
+// TestWriteMeshkitError_EmitsCauseAndRemediationAsArrays pins the wire contract
+// documented in docs/content/en/project/contributing/error-contract.md:
+// probableCause and suggestedRemediation are arrays, one entry per distinct
+// cause or step.
+//
+// They used to be built from MeshKit's Get* accessors, which join every entry
+// with "." - so a three-cause error arrived as one run-on string
+// ("...view this user..No user exists..The provider...") and the UI rendered it
+// as a single bullet.
+func TestWriteMeshkitError_EmitsCauseAndRemediationAsArrays(t *testing.T) {
+	err := meshkiterrors.New(
+		"meshery-test-0002",
+		meshkiterrors.Alert,
+		[]string{"Unable to create the environment"},
+		[]string{"Status Code: 403 ", "failed to save the environment"},
+		[]string{"You do not have permission.", "The organization does not exist."},
+		[]string{"Confirm your role.", "Retry once the provider is reachable."},
+	)
+
+	rec := httptest.NewRecorder()
+	WriteMeshkitError(rec, err, http.StatusForbidden)
+
+	var decoded struct {
+		ProbableCause        []string `json:"probableCause"`
+		SuggestedRemediation []string `json:"suggestedRemediation"`
+		LongDescription      []string `json:"longDescription"`
+	}
+	if decodeErr := json.NewDecoder(rec.Body).Decode(&decoded); decodeErr != nil {
+		t.Fatalf("body did not parse as JSON: %v", decodeErr)
+	}
+
+	if len(decoded.ProbableCause) != 2 {
+		t.Errorf("probableCause = %#v, want 2 separate entries", decoded.ProbableCause)
+	}
+	if len(decoded.SuggestedRemediation) != 2 {
+		t.Errorf("suggestedRemediation = %#v, want 2 separate entries", decoded.SuggestedRemediation)
+	}
+	if len(decoded.LongDescription) != 2 {
+		t.Errorf("longDescription = %#v, want 2 separate entries", decoded.LongDescription)
+	}
+	for _, entry := range decoded.ProbableCause {
+		if strings.Contains(entry, "..") {
+			t.Errorf("entry %q still carries the joined-with-dot artifact", entry)
+		}
+	}
+}
+
+// TestWriteMeshkitError_OmitsNoneSentinel confirms MeshKit's "None" placeholder
+// never reaches a user. An error constructed with empty detail slices carries
+// the sentinel through some accessors; omitempty plus the compaction step must
+// keep those fields off the wire entirely.
+func TestWriteMeshkitError_OmitsNoneSentinel(t *testing.T) {
+	err := meshkiterrors.New(
+		"meshery-test-0003",
+		meshkiterrors.Alert,
+		[]string{"Something failed"},
+		[]string{"detail"},
+		[]string{},
+		[]string{"None"},
+	)
+
+	rec := httptest.NewRecorder()
+	WriteMeshkitError(rec, err, http.StatusBadGateway)
+
+	body := rec.Body.String()
+	if strings.Contains(body, `"None"`) {
+		t.Errorf("body leaked the MeshKit None sentinel: %s", body)
+	}
+	if strings.Contains(body, "probableCause") {
+		t.Errorf("empty probableCause should be omitted entirely: %s", body)
+	}
+}

--- a/server/models/httputil/provider_status.go
+++ b/server/models/httputil/provider_status.go
@@ -1,0 +1,70 @@
+package httputil
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+)
+
+// ProviderStatus is the HTTP status a remote provider responded with, carried
+// as a first-class value inside the error chain.
+//
+// Why this exists: before it, the upstream status survived only as prose inside
+// the MeshKit cause ("Status Code: 403 ..."). Nothing could read it back, so
+// every handler that received a provider failure hardcoded a status of its own
+// - overwhelmingly http.StatusNotFound. A remote-provider 403 therefore reached
+// the browser as a 404, which is why a forbidden environment/workspace create
+// never looked like a failure to the UI.
+//
+// This is internal error plumbing, not a wire construct: it is never
+// serialized. The serialized error shape remains errorResponse.
+type ProviderStatus int
+
+func (s ProviderStatus) Error() string {
+	return fmt.Sprintf("remote provider responded with HTTP %d %s", int(s), http.StatusText(int(s)))
+}
+
+// WithProviderStatus tags err with the HTTP status the remote provider
+// returned, so a handler downstream can propagate the real status instead of
+// fabricating one.
+//
+// errors.Join is used rather than a wrapper type so that errors.Is/errors.As
+// and every meshkiterrors.Get* accessor still reach the original error: the
+// MeshKit code, severity, probable cause and remediation all survive intact.
+//
+// A status that is not a client or server error is not worth propagating (a
+// success status here would mean the provider layer mislabelled a failure), so
+// err is returned unchanged and ProviderStatusCode reports "unknown", letting
+// the caller pick its own defensible default.
+func WithProviderStatus(err error, statusCode int) error {
+	if err == nil || statusCode < http.StatusBadRequest || statusCode > 599 {
+		return err
+	}
+	return stderrors.Join(err, ProviderStatus(statusCode))
+}
+
+// ProviderStatusCode reports the HTTP status a remote provider returned for
+// err, if any link in the error chain recorded one. The boolean is false when
+// the failure never produced an upstream HTTP status - a marshalling error, an
+// unreachable provider, an unsupported capability - in which case the caller
+// must choose its own status.
+func ProviderStatusCode(err error) (int, bool) {
+	var status ProviderStatus
+	if stderrors.As(err, &status) && status != 0 {
+		return int(status), true
+	}
+	return 0, false
+}
+
+// StatusForProviderError maps a provider-layer error onto the HTTP status the
+// handler should surface. When the provider recorded its upstream status
+// (403, 404, 409, 422, 500 ...) that status is propagated verbatim so the
+// client sees the real failure instead of a fabricated one. Otherwise the
+// caller's fallback is used - http.StatusBadGateway is the defensible default
+// for "we could not get a usable answer out of the remote provider".
+func StatusForProviderError(err error, fallback int) int {
+	if status, ok := ProviderStatusCode(err); ok {
+		return status
+	}
+	return fallback
+}

--- a/server/models/httputil/provider_status_test.go
+++ b/server/models/httputil/provider_status_test.go
@@ -1,0 +1,133 @@
+package httputil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	meshkiterrors "github.com/meshery/meshkit/errors"
+)
+
+// newMeshkitError mirrors the shape server/models.ErrPost produces, without
+// importing server/models (which would be an import cycle).
+func newMeshkitError(code string) error {
+	return meshkiterrors.New(
+		code,
+		meshkiterrors.Alert,
+		[]string{"Unable to post data to the Provider.Environment"},
+		[]string{"Status Code: 403 ", "failed to save the environment"},
+		[]string{},
+		[]string{},
+	)
+}
+
+// TestWithProviderStatus_RoundTrips is the core of the misreporting fix: the
+// status a remote provider responded with must survive as a readable value,
+// not only as prose inside the MeshKit cause.
+func TestWithProviderStatus_RoundTrips(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		wantStatus int
+		wantOK     bool
+	}{
+		{name: "forbidden is propagated", statusCode: http.StatusForbidden, wantStatus: http.StatusForbidden, wantOK: true},
+		{name: "conflict is propagated", statusCode: http.StatusConflict, wantStatus: http.StatusConflict, wantOK: true},
+		{name: "provider 500 is propagated", statusCode: http.StatusInternalServerError, wantStatus: http.StatusInternalServerError, wantOK: true},
+		{name: "not found is propagated", statusCode: http.StatusNotFound, wantStatus: http.StatusNotFound, wantOK: true},
+		{name: "success status is not a failure and is dropped", statusCode: http.StatusOK, wantOK: false},
+		{name: "zero status is dropped", statusCode: 0, wantOK: false},
+		{name: "out-of-range status is dropped", statusCode: 700, wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tagged := WithProviderStatus(newMeshkitError("meshery-server-1271"), tc.statusCode)
+
+			gotStatus, gotOK := ProviderStatusCode(tagged)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ProviderStatusCode ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if tc.wantOK && gotStatus != tc.wantStatus {
+				t.Fatalf("ProviderStatusCode = %d, want %d", gotStatus, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestWithProviderStatus_PreservesMeshkitMetadata guards the reason errors.Join
+// was chosen over a replacement type: every MeshKit accessor must still reach
+// through to the original error, or tagging the status would cost us the code.
+func TestWithProviderStatus_PreservesMeshkitMetadata(t *testing.T) {
+	const code = "meshery-server-1271"
+	tagged := WithProviderStatus(newMeshkitError(code), http.StatusForbidden)
+
+	if got := meshkiterrors.GetCode(tagged); got != code {
+		t.Errorf("GetCode = %q, want %q - tagging the status must not hide the MeshKit code", got, code)
+	}
+	if got := meshkiterrors.GetSeverity(tagged); got != meshkiterrors.Alert {
+		t.Errorf("GetSeverity = %v, want Alert", got)
+	}
+
+	var meshkitErr *meshkiterrors.Error
+	if !errors.As(tagged, &meshkitErr) {
+		t.Error("errors.As failed to reach the wrapped MeshKit error")
+	}
+}
+
+// TestWithProviderStatus_NilPassesThrough confirms the helper never manufactures
+// an error where none existed.
+func TestWithProviderStatus_NilPassesThrough(t *testing.T) {
+	if got := WithProviderStatus(nil, http.StatusForbidden); got != nil {
+		t.Fatalf("WithProviderStatus(nil) = %v, want nil", got)
+	}
+}
+
+// TestStatusForProviderError_FallsBackWhenUnknown covers the failures that never
+// produced an upstream HTTP status (unreachable provider, unsupported
+// capability, marshalling error): the caller's fallback wins, and it is never
+// silently turned into a 404.
+func TestStatusForProviderError_FallsBackWhenUnknown(t *testing.T) {
+	untagged := fmt.Errorf("could not reach remote provider: %w", errors.New("dial tcp: connection refused"))
+
+	if got := StatusForProviderError(untagged, http.StatusBadGateway); got != http.StatusBadGateway {
+		t.Fatalf("StatusForProviderError = %d, want %d", got, http.StatusBadGateway)
+	}
+
+	tagged := WithProviderStatus(newMeshkitError("meshery-server-1271"), http.StatusForbidden)
+	if got := StatusForProviderError(tagged, http.StatusBadGateway); got != http.StatusForbidden {
+		t.Fatalf("StatusForProviderError = %d, want %d (the provider's real status)", got, http.StatusForbidden)
+	}
+}
+
+// TestWriteMeshkitError_StatusTaggedErrorStillSerializes ties the two halves
+// together: a status-tagged error written to the wire must still carry its
+// MeshKit code, because the UI keys error rendering off that code.
+func TestWriteMeshkitError_StatusTaggedErrorStillSerializes(t *testing.T) {
+	const code = "meshery-server-1271"
+	tagged := WithProviderStatus(newMeshkitError(code), http.StatusForbidden)
+
+	rec := httptest.NewRecorder()
+	WriteMeshkitError(rec, tagged, StatusForProviderError(tagged, http.StatusBadGateway))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+
+	var decoded struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&decoded); err != nil {
+		t.Fatalf("body did not parse as JSON: %v", err)
+	}
+	if decoded.Code != code {
+		t.Errorf("code = %q, want %q", decoded.Code, code)
+	}
+	if decoded.Error == "" {
+		t.Error("expected a non-empty error message")
+	}
+}

--- a/ui/.husky/commit-msg
+++ b/ui/.husky/commit-msg
@@ -1,0 +1,20 @@
+# Every commit needs a Developer Certificate of Origin sign-off; the DCO check
+# enforces it in CI, where the only remedy is rewriting the branch. Catch it here
+# instead, while `--amend -s` is still cheap.
+# See docs/content/en/project/contributing/_index.md for the certification text.
+
+# Merge commits are exempt: git generates their message and the DCO check skips them.
+if [ "${2:-}" = "merge" ]; then
+	exit 0
+fi
+
+# `interpret-trailers --parse` is git's own trailer reader, so comments, the
+# verbose-diff scissors block and folded trailers are all handled for us.
+if git interpret-trailers --parse <"$1" | grep -qi '^Signed-off-by:'; then
+	exit 0
+fi
+
+echo "husky - commit rejected: no 'Signed-off-by' trailer, so the DCO check would fail."
+echo "        Sign off as you commit:        git commit -s"
+echo "        Or sign off what you just wrote: git commit --amend -s --no-edit"
+exit 1

--- a/ui/components/environments/index.test.tsx
+++ b/ui/components/environments/index.test.tsx
@@ -146,6 +146,29 @@ import Environments from './index';
 const EVENT_ERROR = 'error';
 const EVENT_SUCCESS = 'success';
 
+// Shape the real chain produces for a provider-rejected create: `data` is the
+// verbatim server envelope (camelCase, per server/models/httputil/httputil.go)
+// and `meshkit` is what the @meshery/schemas baseQuery wrapper attaches - which
+// today is message/code/severity only, because that wrapper reads the
+// snake_case spellings the server does not emit (meshery/schemas#1081).
+// `utils/helpers/__tests__/meshkitErrorChain.test.ts` pins that transform
+// against the real client; this fixture mirrors its output.
+const REJECTED_CREATE = {
+  status: 403,
+  data: {
+    error: 'Unable to create the environment',
+    code: 'meshery-server-1448',
+    severity: 'ALERT',
+    probableCause: ['Your account does not have permission.'],
+    suggestedRemediation: ['Ask an organization owner to grant the Environment role.'],
+  },
+  meshkit: {
+    message: 'Unable to create the environment',
+    code: 'meshery-server-1448',
+    severity: 'ALERT',
+  },
+};
+
 const openCreateModalAndSubmit = async () => {
   const user = userEvent.setup();
   render(<Environments />);
@@ -165,21 +188,7 @@ describe('Environments create flow notifications', () => {
   });
 
   it('does not report success when the provider rejects the create', async () => {
-    createEnvironment.mockReturnValue({
-      unwrap: () =>
-        Promise.reject({
-          status: 403,
-          data: { error: 'Unable to create the environment', code: 'meshery-server-1448' },
-          meshkit: {
-            message: 'Unable to create the environment',
-            code: 'meshery-server-1448',
-            probableCause: [
-              'Your account does not have permission to create environments in this organization.',
-            ],
-            suggestedRemediation: ['Confirm your role in the selected organization.'],
-          },
-        }),
-    });
+    createEnvironment.mockReturnValue({ unwrap: () => Promise.reject(REJECTED_CREATE) });
 
     await openCreateModalAndSubmit();
 
@@ -191,18 +200,7 @@ describe('Environments create flow notifications', () => {
   });
 
   it('carries the MeshKit code and remediation into the failure notification', async () => {
-    createEnvironment.mockReturnValue({
-      unwrap: () =>
-        Promise.reject({
-          status: 403,
-          meshkit: {
-            message: 'Unable to create the environment',
-            code: 'meshery-server-1448',
-            probableCause: ['Your account does not have permission.'],
-            suggestedRemediation: ['Ask an organization owner to grant the Environment role.'],
-          },
-        }),
-    });
+    createEnvironment.mockReturnValue({ unwrap: () => Promise.reject(REJECTED_CREATE) });
 
     await openCreateModalAndSubmit();
 

--- a/ui/components/environments/index.test.tsx
+++ b/ui/components/environments/index.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression coverage for the "Create Environment succeeded" lie.
+ *
+ * An Org Admin whose create was rejected by the remote provider (HTTP 403) saw
+ * a green "Environment created" toast and no environment. Two independent
+ * defects produced that:
+ *
+ *   1. `.then(handleSuccess('...'))` - note the immediate call - evaluated
+ *      handleSuccess while the callback was merely being constructed, so the
+ *      success notification fired synchronously, before the request settled
+ *      and regardless of the outcome.
+ *   2. `handleError` was curried, `handleError(msg) => (error) => ...`, but
+ *      every call site invoked it as `handleError(msg)`, producing a function
+ *      that was thrown away. No failure ever reached the user.
+ *
+ * These tests pin both halves: success only on resolve, failure always on
+ * reject, and the MeshKit metadata the server sends carried into the toast.
+ */
+
+const notify = vi.fn();
+const createEnvironment = vi.fn();
+const updateEnvironment = vi.fn();
+const deleteEnvironment = vi.fn();
+
+vi.mock('../../utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify }),
+}));
+
+// Every mocked hook result MUST be referentially stable across renders. The
+// component appends query results into state inside effects keyed on the query
+// object identity, so a freshly-built object per render is an infinite render
+// loop that exhausts the heap rather than a test failure.
+const ENVIRONMENTS_QUERY_RESULT = {
+  data: { environments: [], totalCount: 0 },
+  isLoading: false,
+  isError: false,
+  error: undefined,
+};
+const CONNECTIONS_QUERY_RESULT = {
+  data: { connections: [], total_count: 0 },
+  isError: false,
+  error: undefined,
+};
+const NOOP_MUTATION = [vi.fn()];
+
+vi.mock('../../rtk-query/environments', () => ({
+  useCreateEnvironmentMutation: () => [createEnvironment],
+  useUpdateEnvironmentMutation: () => [updateEnvironment],
+  useDeleteEnvironmentMutation: () => [deleteEnvironment],
+  useGetEnvironmentsQuery: () => ENVIRONMENTS_QUERY_RESULT,
+  useGetEnvironmentConnectionsQuery: () => CONNECTIONS_QUERY_RESULT,
+  useAddConnectionToEnvironmentMutation: () => NOOP_MUTATION,
+  useRemoveConnectionFromEnvironmentMutation: () => NOOP_MUTATION,
+}));
+
+const UI_STATE = { ui: { organization: { id: 'org-1' } } };
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector(UI_STATE),
+}));
+
+vi.mock('next/router', () => ({
+  withRouter: (Component: React.ComponentType) => Component,
+}));
+
+vi.mock('@/store/slices/mesheryUi', () => ({ updateProgress: vi.fn() }));
+
+vi.mock('@/utils/can', () => ({ default: () => true }));
+
+vi.mock('@meshery/schemas/permissions', () => ({
+  Keys: new Proxy({}, { get: () => ({ id: 'id', function: 'fn' }) }),
+}));
+
+// The RJSF form is not under test; expose a button that submits the payload the
+// real form would produce.
+vi.mock('../shared/Modal/Modal', () => ({
+  RJSFModalWrapper: ({ handleSubmit }: any) => (
+    <button
+      data-testid="submit-environment"
+      onClick={() =>
+        handleSubmit({ organizationId: 'org-1', name: 'prod', description: 'production' })
+      }
+    >
+      Save
+    </button>
+  ),
+}));
+
+vi.mock('./environment-card', () => ({ default: () => null }));
+vi.mock('./styles', () => ({
+  CreateButtonWrapper: ({ children }: any) => <div>{children}</div>,
+  BulkActionWrapper: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@/assets/styles/general/tool.styles', () => ({
+  ToolWrapper: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../general/PromptComponent', () => ({
+  default: React.forwardRef(() => null),
+}));
+vi.mock('../lifecycle/general', () => ({ EmptyState: () => <div>empty</div> }));
+vi.mock('../general/error-404/index', () => ({ default: () => <div>no access</div> }));
+vi.mock('../../assets/icons/AddIconCircleBorder', () => ({ default: () => null }));
+vi.mock('../../assets/icons/Environment', () => ({ default: () => null }));
+vi.mock('../../assets/icons/Connection', () => ({ default: () => null }));
+
+vi.mock('@sistent/sistent', () => ({
+  Button: ({ children, onClick, ...rest }: any) => (
+    <button onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+  ChevronLeftIcon: () => null,
+  ChevronRightIcon: () => null,
+  DeleteIcon: () => null,
+  ErrorBoundary: ({ children }: any) => <>{children}</>,
+  Grid2: ({ children }: any) => <div>{children}</div>,
+  Modal: ({ children, open }: any) => (open ? <div>{children}</div> : null),
+  ModalBody: ({ children }: any) => <div>{children}</div>,
+  ModalFooter: ({ children }: any) => <div>{children}</div>,
+  NoSsr: ({ children }: any) => <>{children}</>,
+  Pagination: () => null,
+  PaginationItem: () => null,
+  PrimaryActionButtons: () => null,
+  PROMPT_VARIANTS: { DANGER: 'danger' },
+  SearchBar: () => null,
+  TransferList: () => null,
+  Typography: ({ children }: any) => <span>{children}</span>,
+  createAndEditEnvironmentSchema: {},
+  createAndEditEnvironmentUiSchema: {},
+  useTheme: () => ({
+    palette: {
+      icon: { default: '#000', secondary: '#111' },
+      background: { constant: { table: '#fff' } },
+      text: { default: '#000' },
+    },
+  }),
+}));
+
+import Environments from './index';
+
+const EVENT_ERROR = 'error';
+const EVENT_SUCCESS = 'success';
+
+const openCreateModalAndSubmit = async () => {
+  const user = userEvent.setup();
+  render(<Environments />);
+  await user.click(screen.getByText('Create'));
+  await user.click(await screen.findByTestId('submit-environment'));
+};
+
+const notifiedEventTypes = () =>
+  notify.mock.calls.map(([arg]) => arg?.event_type?.type ?? arg?.event_type);
+
+describe('Environments create flow notifications', () => {
+  beforeEach(() => {
+    notify.mockReset();
+    createEnvironment.mockReset();
+    updateEnvironment.mockReset();
+    deleteEnvironment.mockReset();
+  });
+
+  it('does not report success when the provider rejects the create', async () => {
+    createEnvironment.mockReturnValue({
+      unwrap: () =>
+        Promise.reject({
+          status: 403,
+          data: { error: 'Unable to create the environment', code: 'meshery-server-1448' },
+          meshkit: {
+            message: 'Unable to create the environment',
+            code: 'meshery-server-1448',
+            probableCause: [
+              'Your account does not have permission to create environments in this organization.',
+            ],
+            suggestedRemediation: ['Confirm your role in the selected organization.'],
+          },
+        }),
+    });
+
+    await openCreateModalAndSubmit();
+
+    await waitFor(() => expect(notify).toHaveBeenCalled());
+
+    const types = notifiedEventTypes();
+    expect(types).toContain(EVENT_ERROR);
+    expect(types).not.toContain(EVENT_SUCCESS);
+  });
+
+  it('carries the MeshKit code and remediation into the failure notification', async () => {
+    createEnvironment.mockReturnValue({
+      unwrap: () =>
+        Promise.reject({
+          status: 403,
+          meshkit: {
+            message: 'Unable to create the environment',
+            code: 'meshery-server-1448',
+            probableCause: ['Your account does not have permission.'],
+            suggestedRemediation: ['Ask an organization owner to grant the Environment role.'],
+          },
+        }),
+    });
+
+    await openCreateModalAndSubmit();
+
+    await waitFor(() => expect(notify).toHaveBeenCalled());
+
+    const [payload] = notify.mock.calls[0];
+    expect(payload.message).toContain('Unable to create the environment');
+    expect(payload.message).toContain('meshery-server-1448');
+    expect(payload.message).toContain('Ask an organization owner to grant the Environment role.');
+    expect(payload.details).toContain('Your account does not have permission.');
+  });
+
+  it('reports success only once the create actually resolves', async () => {
+    createEnvironment.mockReturnValue({ unwrap: () => Promise.resolve({ id: 'env-1' }) });
+
+    await openCreateModalAndSubmit();
+
+    await waitFor(() => expect(notify).toHaveBeenCalled());
+
+    const types = notifiedEventTypes();
+    expect(types).toContain(EVENT_SUCCESS);
+    expect(types).not.toContain(EVENT_ERROR);
+    expect(notify.mock.calls[0][0].message).toBe('Environment "prod" created');
+  });
+});

--- a/ui/components/environments/index.test.tsx
+++ b/ui/components/environments/index.test.tsx
@@ -212,7 +212,6 @@ describe('Environments create flow notifications', () => {
     expect(payload.message).toContain('Unable to create the environment');
     expect(payload.message).toContain('meshery-server-1448');
     expect(payload.message).toContain('Ask an organization owner to grant the Environment role.');
-    expect(payload.details).toContain('Your account does not have permission.');
   });
 
   it('reports success only once the create actually resolves', async () => {

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -167,16 +167,15 @@ const Environments = () => {
    * misuse is a syntax-level mistake rather than a silent no-op.
    *
    * `formatApiError` consumes the MeshKit envelope the server now sends
-   * (code, probable cause, suggested remediation) and renders it as the
-   * markdown that `notify` displays through BasicMarkdown.
+   * (code and suggested remediation) and renders it as the markdown that
+   * `notify` displays through BasicMarkdown.
    */
   const handleError = (action, error) => {
     updateProgress({ showProgress: false });
-    const { message, meshkit } = formatApiError(error, action);
+    const { message } = formatApiError(error, action);
     notify({
       message,
       event_type: EVENT_TYPES.ERROR,
-      details: meshkit?.probableCause?.join('\n') || message,
     });
   };
 

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -17,6 +17,7 @@ import EnvironmentCard from './environment-card';
 import EnvironmentIcon from '../../assets/icons/Environment';
 import { EVENT_TYPES } from '../../lib/event-types';
 import { useNotification } from '../../utils/hooks/useNotification';
+import { formatApiError } from '../../utils/helpers/meshkitError';
 import { RJSFModalWrapper } from '../shared/Modal/Modal';
 import _PromptComponent from '../general/PromptComponent';
 import { EmptyState } from '../lifecycle/general';
@@ -155,17 +156,47 @@ const Environments = () => {
     setEnvironmentConnectionsData((prevData) => [...prevData, ...environmentConnectionsDataRtk]);
   }, [environmentConnections]);
 
+  /**
+   * Surface a failed environment operation.
+   *
+   * This used to be a curried `handleError(action) => (error) => ...`, but
+   * every call site invoked it as `handleError('some message')` - producing a
+   * function that was then thrown away, so the error toast never appeared.
+   * It also read `action.error_msg` off a plain string, which is always
+   * undefined. Both are gone: this is a plain two-argument function, so
+   * misuse is a syntax-level mistake rather than a silent no-op.
+   *
+   * `formatApiError` consumes the MeshKit envelope the server now sends
+   * (code, probable cause, suggested remediation) and renders it as the
+   * markdown that `notify` displays through BasicMarkdown.
+   */
+  const handleError = (action, error) => {
+    updateProgress({ showProgress: false });
+    const { message, meshkit } = formatApiError(error, action);
+    notify({
+      message,
+      event_type: EVENT_TYPES.ERROR,
+      details: meshkit?.probableCause?.join('\n') || message,
+    });
+  };
+
+  const handleSuccess = (msg) => {
+    updateProgress({ showProgress: false });
+    notify({
+      message: msg,
+      event_type: EVENT_TYPES.SUCCESS,
+    });
+  };
+
   useEffect(() => {
     if (isEnvironmentsError) {
-      handleError(`Environments Fetching Error: ${environmentsError?.data}`);
+      handleError('Unable to fetch environments', environmentsError);
     }
     if (isEnvironmentConnectionsError) {
-      handleError(
-        `Connections of a Environment fetching Error: ${environmentConnectionsError?.data}`,
-      );
+      handleError("Unable to fetch an environment's connections", environmentConnectionsError);
     }
     if (isConnectionsError) {
-      handleError(`Connections fetching Error: ${connectionsError?.data}`);
+      handleError('Unable to fetch connections', connectionsError);
     }
   }, [
     isEnvironmentsError,
@@ -175,25 +206,6 @@ const Environments = () => {
     environmentConnectionsError,
     connectionsError,
   ]);
-
-  function handleError(action) {
-    return (error) => {
-      updateProgress({ showProgress: false });
-      notify({
-        message: `${action.error_msg}: ${error}`,
-        event_type: EVENT_TYPES.ERROR,
-        details: error.toString(),
-      });
-    };
-  }
-
-  const handleSuccess = (msg) => {
-    updateProgress({ showProgress: false });
-    notify({
-      message: msg,
-      event_type: EVENT_TYPES.SUCCESS,
-    });
-  };
 
   useEffect(() => {
     setOrgId(organization?.id);
@@ -217,13 +229,17 @@ const Environments = () => {
   const [addConnectionToEnvironmentMutator] = useAddConnectionToEnvironmentMutation();
   const [removeConnectionFromEnvMutator] = useRemoveConnectionFromEnvironmentMutation();
 
-  const addConnectionToEnvironment = async (environmentId, connectionId) => {
-    addConnectionToEnvironmentMutator({ environmentId, connectionId });
-  };
+  // Both mutators previously fired and discarded the returned promise, so a
+  // rejected assignment left the transfer list looking like it had succeeded.
+  const addConnectionToEnvironment = (environmentId, connectionId) =>
+    addConnectionToEnvironmentMutator({ environmentId, connectionId })
+      .unwrap()
+      .catch((error) => handleError('Unable to assign connection to environment', error));
 
-  const removeConnectionFromEnvironment = (environmentId, connectionId) => {
-    removeConnectionFromEnvMutator({ environmentId, connectionId });
-  };
+  const removeConnectionFromEnvironment = (environmentId, connectionId) =>
+    removeConnectionFromEnvMutator({ environmentId, connectionId })
+      .unwrap()
+      .catch((error) => handleError('Unable to remove connection from environment', error));
 
   const handleEnvironmentModalOpen = (e, actionType, envObject) => {
     e.stopPropagation();
@@ -264,8 +280,12 @@ const Environments = () => {
       },
     })
       .unwrap()
-      .then(handleSuccess(`Environment "${name}" created `))
-      .catch((error) => handleError(`Environment Create Error: ${error?.data}`));
+      // `.then(handleSuccess(...))` - note the immediate call - ran the success
+      // notification while the callback was still being constructed, so a
+      // rejected create still showed "Environment created". It must stay a
+      // deferred callback.
+      .then(() => handleSuccess(`Environment "${name}" created`))
+      .catch((error) => handleError(`Unable to create environment "${name}"`, error));
     handleEnvironmentModalClose();
   };
 
@@ -279,8 +299,8 @@ const Environments = () => {
       },
     })
       .unwrap()
-      .then(handleSuccess(`Environment "${name}" updated`))
-      .catch((error) => handleError(`Environment Update Error: ${error?.data}`));
+      .then(() => handleSuccess(`Environment "${name}" updated`))
+      .catch((error) => handleError(`Unable to update environment "${name}"`, error));
     handleEnvironmentModalClose();
   };
 
@@ -305,8 +325,8 @@ const Environments = () => {
       environmentId: id,
     })
       .unwrap()
-      .then(handleSuccess(`Environment deleted`))
-      .catch((error) => handleError(`Environment Delete Error: ${error?.data}`));
+      .then(() => handleSuccess('Environment deleted'))
+      .catch((error) => handleError('Unable to delete environment', error));
   };
 
   const deleteEnvironmentModalContent = (environment) => (

--- a/ui/components/workspaces/WorkspaceGridView.test.tsx
+++ b/ui/components/workspaces/WorkspaceGridView.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const can = vi.fn(() => true);
 const handleSuccess = vi.fn();
 const handleError = vi.fn();
+const notifyApiError = vi.fn();
 const deleteWorkspaceMutator = vi.fn();
 
 vi.mock('@/rtk-query/workspace', () => ({
@@ -17,7 +18,7 @@ vi.mock('@/utils/can', () => ({
 }));
 
 vi.mock('@/utils/hooks/useNotification', () => ({
-  useNotificationHandlers: () => ({ handleSuccess, handleError }),
+  useNotificationHandlers: () => ({ handleSuccess, handleError, notifyApiError }),
 }));
 
 vi.mock('@sistent/sistent', () => ({
@@ -104,6 +105,7 @@ describe('WorkspaceGridView', () => {
     deleteWorkspaceMutator.mockReset();
     handleSuccess.mockReset();
     handleError.mockReset();
+    notifyApiError.mockReset();
     can.mockReset();
     can.mockReturnValue(true);
     deleteWorkspaceMutator.mockReturnValue({ unwrap: () => Promise.resolve() });

--- a/ui/components/workspaces/WorkspaceGridView.tsx
+++ b/ui/components/workspaces/WorkspaceGridView.tsx
@@ -18,7 +18,6 @@ import { useDeleteWorkspaceMutation } from '@/rtk-query/workspace';
 import { Keys } from '@meshery/schemas/permissions';
 import CAN from '@/utils/can';
 import { useNotificationHandlers } from '@/utils/hooks/useNotification';
-import { formatApiError } from '../../utils/helpers/meshkitError';
 import { UserCommonBox } from './styles';
 import MesheryWorkspaceCard from './MesheryWorkspaceCard';
 import { debounce } from 'lodash';
@@ -43,7 +42,7 @@ const WorkspaceGridView = ({
     setDeleteWorkspacesModal(true);
   };
 
-  const { handleSuccess, handleError } = useNotificationHandlers();
+  const { handleSuccess, notifyApiError } = useNotificationHandlers();
   const handleDeleteWorkspace = (id) => {
     deleteWorkspace({
       workspaceId: id,
@@ -51,8 +50,8 @@ const WorkspaceGridView = ({
       .unwrap()
       .then(() => handleSuccess(`Workspace deleted`))
       // `${error?.data}` rendered the JSON error envelope as "[object Object]".
-      // formatApiError unpacks the MeshKit code, cause and remediation instead.
-      .catch((error) => handleError(formatApiError(error, 'Unable to delete workspace').message));
+      // notifyApiError unpacks the MeshKit code, cause and remediation instead.
+      .catch((error) => notifyApiError(error, 'Unable to delete workspace'));
   };
 
   const handleBulkDeleteEnv = () => {

--- a/ui/components/workspaces/WorkspaceGridView.tsx
+++ b/ui/components/workspaces/WorkspaceGridView.tsx
@@ -18,6 +18,7 @@ import { useDeleteWorkspaceMutation } from '@/rtk-query/workspace';
 import { Keys } from '@meshery/schemas/permissions';
 import CAN from '@/utils/can';
 import { useNotificationHandlers } from '@/utils/hooks/useNotification';
+import { formatApiError } from '../../utils/helpers/meshkitError';
 import { UserCommonBox } from './styles';
 import MesheryWorkspaceCard from './MesheryWorkspaceCard';
 import { debounce } from 'lodash';
@@ -49,7 +50,9 @@ const WorkspaceGridView = ({
     })
       .unwrap()
       .then(() => handleSuccess(`Workspace deleted`))
-      .catch((error) => handleError(`Workspace Delete Error: ${error?.data}`));
+      // `${error?.data}` rendered the JSON error envelope as "[object Object]".
+      // formatApiError unpacks the MeshKit code, cause and remediation instead.
+      .catch((error) => handleError(formatApiError(error, 'Unable to delete workspace').message));
   };
 
   const handleBulkDeleteEnv = () => {

--- a/ui/components/workspaces/index.test.tsx
+++ b/ui/components/workspaces/index.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression coverage for silent workspace failures.
+ *
+ * `handleError` was curried - `handleError(action) => (error) => ...` - but
+ * every call site invoked it as `handleError('some message')`, which merely
+ * built a function and discarded it. No failed workspace create, update or
+ * delete ever reached the user. The same defect in the environments component
+ * additionally produced a false success toast (see ../environments/index.test.tsx).
+ *
+ * The contract pinned here: a rejected create emits an ERROR notification
+ * carrying the server's MeshKit metadata, and never a SUCCESS one.
+ */
+
+const notify = vi.fn();
+const createWorkspace = vi.fn();
+const updateWorkspace = vi.fn();
+const deleteWorkspace = vi.fn();
+
+vi.mock('../../utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify }),
+  useNotificationHandlers: () => ({
+    handleSuccess: vi.fn(),
+    handleError: vi.fn(),
+    handleInfo: vi.fn(),
+    notifyApiError: vi.fn(),
+  }),
+}));
+
+// Mocked hook results must be referentially stable: the component keys effects
+// and memos on these objects, so a fresh object per render is a render loop.
+const WORKSPACES_QUERY_RESULT = { data: { workspaces: [], total_count: 0 } };
+const EMPTY_QUERY_RESULT = { data: undefined, isLoading: false };
+const NOOP_MUTATION = [vi.fn()];
+
+vi.mock('../../rtk-query/workspace', () => ({
+  useCreateWorkspaceMutation: () => [createWorkspace],
+  useUpdateWorkspaceMutation: () => [updateWorkspace],
+  useDeleteWorkspaceMutation: () => [deleteWorkspace],
+  useGetWorkspacesQuery: () => WORKSPACES_QUERY_RESULT,
+  useGetTeamsOfWorkspaceQuery: () => EMPTY_QUERY_RESULT,
+  useGetEventsOfWorkspaceQuery: () => EMPTY_QUERY_RESULT,
+  useAssignTeamToWorkspaceMutation: () => NOOP_MUTATION,
+  useUnassignTeamFromWorkspaceMutation: () => NOOP_MUTATION,
+}));
+
+vi.mock('@/rtk-query/user', () => ({
+  useGetUsersForOrgQuery: () => EMPTY_QUERY_RESULT,
+  useRemoveUserFromTeamMutation: () => NOOP_MUTATION,
+}));
+
+const UI_STATE = { ui: { organization: { id: 'org-1' } } };
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector(UI_STATE),
+}));
+
+vi.mock('@/store/slices/mesheryUi', () => ({ updateProgress: vi.fn() }));
+vi.mock('@/utils/can', () => ({ default: () => true }));
+vi.mock('@meshery/schemas/permissions', () => ({
+  Keys: new Proxy({}, { get: () => ({ id: 'id', function: 'fn' }) }),
+}));
+
+// The factory is hoisted above module scope, so it must not close over any
+// top-level const - build the default value inline.
+vi.mock('@/utils/context/WorkspaceModalContextProvider', () => ({
+  WorkspaceModalContext: React.createContext({
+    createNewWorkspaceModalOpen: false,
+    setCreateNewWorkspaceModalOpen: () => {},
+  }),
+}));
+
+vi.mock('../shared/Modal/Modal', () => ({
+  RJSFModalWrapper: ({ handleSubmit }: any) => (
+    <button
+      data-testid="submit-workspace"
+      onClick={() =>
+        handleSubmit({ organizationId: 'org-1', name: 'team-space', description: 'shared' })
+      }
+    >
+      Save
+    </button>
+  ),
+}));
+
+vi.mock('../general/PromptComponent', () => ({ default: React.forwardRef(() => null) }));
+vi.mock('@/components/lifecycle/general', () => ({ EmptyState: () => <div>empty</div> }));
+vi.mock('@/components/general/ViewSwitch', () => ({ default: () => null }));
+vi.mock('./WorkspaceGridView', () => ({ default: () => null }));
+vi.mock('./WorkspaceDataTable', () => ({ default: () => null }));
+vi.mock('./styles', () => ({ CreateButtonWrapper: ({ children }: any) => <div>{children}</div> }));
+vi.mock('@/assets/styles/general/tool.styles', () => ({
+  ToolWrapper: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('@/assets/icons/AddIconCircleBorder', () => ({ default: () => null }));
+vi.mock('@/assets/icons/RightArrowIcon', () => ({ default: () => null }));
+vi.mock('css/icons.styles', () => ({ iconMedium: {} }));
+
+vi.mock('@sistent/sistent', () => ({
+  Box: ({ children }: any) => <div>{children}</div>,
+  Breadcrumbs: ({ children }: any) => <nav>{children}</nav>,
+  Button: ({ children, onClick, ...rest }: any) => (
+    <button onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+  CustomColumnVisibilityControl: () => null,
+  ErrorBoundary: ({ children }: any) => <>{children}</>,
+  Modal: ({ children, open }: any) => (open ? <div>{children}</div> : null),
+  ModalFooter: ({ children }: any) => <div>{children}</div>,
+  NoSsr: ({ children }: any) => <>{children}</>,
+  PROMPT_VARIANTS: { DANGER: 'danger' },
+  SearchBar: () => null,
+  TeamsIcon: () => null,
+  Typography: ({ children }: any) => <span>{children}</span>,
+  WorkspaceIcon: () => null,
+  WorkspaceRecentActivityModal: () => null,
+  WorkspaceTeamsTable: () => null,
+  createAndEditWorkspaceSchema: {},
+  createAndEditWorkspaceUiSchema: {},
+  editWorkspaceSchema: {},
+  useTheme: () => ({
+    palette: {
+      icon: { default: '#000', secondary: '#111' },
+      text: { default: '#000' },
+      common: { white: '#fff' },
+      background: { brand: { default: '#000' }, constant: { table: '#fff' } },
+    },
+  }),
+}));
+
+import Workspaces from './index';
+
+const notifiedEventTypes = () =>
+  notify.mock.calls.map(([arg]) => arg?.event_type?.type ?? arg?.event_type);
+
+const openCreateModalAndSubmit = async () => {
+  const user = userEvent.setup();
+  render(<Workspaces onSelectWorkspace={undefined} />);
+  await user.click(screen.getByText('Create'));
+  await user.click(await screen.findByTestId('submit-workspace'));
+};
+
+describe('Workspaces create flow notifications', () => {
+  beforeEach(() => {
+    notify.mockReset();
+    createWorkspace.mockReset();
+    updateWorkspace.mockReset();
+    deleteWorkspace.mockReset();
+  });
+
+  it('surfaces the failure when the provider rejects the create', async () => {
+    createWorkspace.mockReturnValue({
+      unwrap: () =>
+        Promise.reject({
+          status: 403,
+          meshkit: {
+            message: 'Unable to create the workspace',
+            code: 'meshery-server-1454',
+            probableCause: ['Your account does not have permission to create workspaces.'],
+            suggestedRemediation: ['Ask an organization owner to grant the Workspace role.'],
+          },
+        }),
+    });
+
+    await openCreateModalAndSubmit();
+
+    await waitFor(() => expect(notify).toHaveBeenCalled());
+
+    const types = notifiedEventTypes();
+    expect(types).toContain('error');
+    expect(types).not.toContain('success');
+
+    const [payload] = notify.mock.calls[0];
+    expect(payload.message).toContain('Unable to create the workspace');
+    expect(payload.message).toContain('meshery-server-1454');
+    expect(payload.message).toContain('Ask an organization owner to grant the Workspace role.');
+  });
+
+  it('reports success only once the create actually resolves', async () => {
+    createWorkspace.mockReturnValue({ unwrap: () => Promise.resolve({ id: 'ws-1' }) });
+
+    await openCreateModalAndSubmit();
+
+    await waitFor(() => expect(notify).toHaveBeenCalled());
+
+    const types = notifiedEventTypes();
+    expect(types).toContain('success');
+    expect(types).not.toContain('error');
+    expect(notify.mock.calls[0][0].message).toBe('Workspace "team-space" created');
+  });
+});

--- a/ui/components/workspaces/index.test.tsx
+++ b/ui/components/workspaces/index.test.tsx
@@ -154,15 +154,27 @@ describe('Workspaces create flow notifications', () => {
   });
 
   it('surfaces the failure when the provider rejects the create', async () => {
+    // `data` is the verbatim server envelope (camelCase, per
+    // server/models/httputil/httputil.go); `meshkit` is what the
+    // @meshery/schemas baseQuery wrapper actually attaches - message/code/
+    // severity only, because it reads snake_case spellings the server does not
+    // emit (meshery/schemas#1081). The real transform is pinned in
+    // `utils/helpers/__tests__/meshkitErrorChain.test.ts`.
     createWorkspace.mockReturnValue({
       unwrap: () =>
         Promise.reject({
           status: 403,
+          data: {
+            error: 'Unable to create the workspace',
+            code: 'meshery-server-1454',
+            severity: 'ALERT',
+            probableCause: ['Your account does not have permission to create workspaces.'],
+            suggestedRemediation: ['Ask an organization owner to grant the Workspace role.'],
+          },
           meshkit: {
             message: 'Unable to create the workspace',
             code: 'meshery-server-1454',
-            probableCause: ['Your account does not have permission to create workspaces.'],
-            suggestedRemediation: ['Ask an organization owner to grant the Workspace role.'],
+            severity: 'ALERT',
           },
         }),
     });

--- a/ui/components/workspaces/index.tsx
+++ b/ui/components/workspaces/index.tsx
@@ -35,6 +35,7 @@ import {
   useUpdateWorkspaceMutation,
 } from '../../rtk-query/workspace';
 import { useNotification, useNotificationHandlers } from '../../utils/hooks/useNotification';
+import { formatApiError } from '../../utils/helpers/meshkitError';
 import { RJSFModalWrapper } from '../shared/Modal/Modal';
 import _PromptComponent from '../general/PromptComponent';
 import { EVENT_TYPES } from '../../lib/event-types';
@@ -202,8 +203,8 @@ const Workspaces = ({ onSelectWorkspace }) => {
       },
     })
       .unwrap()
-      .then(() => handleSuccess(`Workspace "${name}" created `))
-      .catch((error) => handleError(`Workspace Create Error: ${error?.data}`));
+      .then(() => handleSuccess(`Workspace "${name}" created`))
+      .catch((error) => handleError(`Unable to create workspace "${name}"`, error));
     handleWorkspaceModalClose();
   };
 
@@ -226,7 +227,7 @@ const Workspaces = ({ onSelectWorkspace }) => {
     })
       .unwrap()
       .then(() => handleSuccess(`Workspace "${name}" updated`))
-      .catch((error) => handleError(`Workspace Update Error: ${error?.data}`));
+      .catch((error) => handleError(`Unable to update workspace "${name}"`, error));
     handleWorkspaceModalClose();
   };
 
@@ -236,7 +237,7 @@ const Workspaces = ({ onSelectWorkspace }) => {
     })
       .unwrap()
       .then(() => handleSuccess(`Workspace "${name}" deleted`))
-      .catch((error) => handleError(`Workspace Delete Error: ${error?.data}`));
+      .catch((error) => handleError(`Unable to delete workspace "${name}"`, error));
   };
 
   const fetchSchema = (workspaceActionType) => {
@@ -258,12 +259,26 @@ const Workspaces = ({ onSelectWorkspace }) => {
     });
   };
 
-  const handleError = (action) => (error) => {
+  /**
+   * Surface a failed workspace operation.
+   *
+   * This was a curried `handleError(action) => (error) => ...` that every call
+   * site invoked as `handleError('some message')`, producing a function that
+   * was immediately discarded - so no workspace failure ever reached the user.
+   * It also read `action.error_msg` off a plain string, which is always
+   * undefined. A plain two-argument function makes that misuse impossible.
+   *
+   * `formatApiError` consumes the MeshKit envelope the server now sends
+   * (code, probable cause, suggested remediation) and renders it as the
+   * markdown that `notify` displays through BasicMarkdown.
+   */
+  const handleError = (action, error) => {
     updateProgress({ showProgress: false });
+    const { message, meshkit } = formatApiError(error, action);
     notify({
-      message: `${action.error_msg}: ${error}`,
+      message,
       event_type: EVENT_TYPES.ERROR,
-      details: error.toString(),
+      details: meshkit?.probableCause?.join('\n') || message,
     });
   };
 

--- a/ui/components/workspaces/index.tsx
+++ b/ui/components/workspaces/index.tsx
@@ -269,16 +269,15 @@ const Workspaces = ({ onSelectWorkspace }) => {
    * undefined. A plain two-argument function makes that misuse impossible.
    *
    * `formatApiError` consumes the MeshKit envelope the server now sends
-   * (code, probable cause, suggested remediation) and renders it as the
-   * markdown that `notify` displays through BasicMarkdown.
+   * (code and suggested remediation) and renders it as the markdown that
+   * `notify` displays through BasicMarkdown.
    */
   const handleError = (action, error) => {
     updateProgress({ showProgress: false });
-    const { message, meshkit } = formatApiError(error, action);
+    const { message } = formatApiError(error, action);
     notify({
       message,
       event_type: EVENT_TYPES.ERROR,
-      details: meshkit?.probableCause?.join('\n') || message,
     });
   };
 

--- a/ui/store/middleware/__tests__/rtkErrorMiddleware.test.ts
+++ b/ui/store/middleware/__tests__/rtkErrorMiddleware.test.ts
@@ -71,13 +71,19 @@ describe('rtkErrorMiddleware', () => {
     expect(dispatched.payload.id).toMatch(/^rtk-error-\d+$/);
   });
 
-  it('skips dispatch for 401 status (auth middleware territory)', () => {
+  it('dispatches a visible error event for 401 status instead of swallowing it', () => {
     const storeApi = makeStoreApi();
     const next = vi.fn();
-    const action = makeRejectedAction({ payload: { status: 401 } });
+    const action = makeRejectedAction({
+      payload: { status: 401, data: { error: 'Unauthorized' } },
+    });
     rtkErrorMiddleware(storeApi as any)(next)(action);
 
-    expect(storeApi.dispatch).not.toHaveBeenCalled();
+    expect(storeApi.dispatch).toHaveBeenCalledTimes(1);
+    const dispatched = storeApi.dispatch.mock.calls[0][0];
+    expect(dispatched.type).toBe(pushEvent({} as any).type);
+    expect(dispatched.payload.severity).toBe('error');
+    expect(dispatched.payload.description).toBe('Unable to load thing: Unauthorized');
     expect(next).toHaveBeenCalledWith(action);
   });
 

--- a/ui/store/middleware/rtkErrorMiddleware.ts
+++ b/ui/store/middleware/rtkErrorMiddleware.ts
@@ -74,17 +74,14 @@ const buildErrorDescription = (endpointName: string, payload: any) => {
 
 /**
  * RTK Query middleware that dispatches error events into the notification
- * system for failed API calls. Skips 401 errors (handled by authMiddleware).
+ * system for failed API calls. Every rejected status is reported, including
+ * 401: this used to skip 401 and defer to an `authMiddleware` that has never
+ * existed in this codebase, so an unauthorized response was swallowed and the
+ * user saw nothing at all.
  */
 export const rtkErrorMiddleware: Middleware = (storeApi) => (next) => (action) => {
   if (isRejectedWithValue(action)) {
     const status = action.payload?.status || action.payload?.originalStatus;
-
-    // 401 is handled by authMiddleware
-    if (status === 401) {
-      return next(action);
-    }
-
     const endpointName = action.meta?.arg?.endpointName || 'API call';
     const errorMessage =
       action.payload?.data?.message ||

--- a/ui/theme/snackbar.test.tsx
+++ b/ui/theme/snackbar.test.tsx
@@ -46,4 +46,21 @@ describe('ThemeResponsiveSnackbar', () => {
 
     expect(screen.getByTestId('SnackbarContent-success')).toHaveTextContent('saved');
   });
+
+  // `BasicMarkdown` emits sibling block elements. As direct children of the
+  // content row they became sibling flex items and laid out horizontally, so a
+  // multi-block MeshKit error read "Unable to create the environmentmeshery-
+  // server-1448". The markdown needs its own column inside the row.
+  it('stacks the markdown blocks in a column instead of the content row', () => {
+    render(<ThemeResponsiveSnackbar id={1} variant="error" message={'**Failed**\n\n`code-1`'} />);
+
+    const row = screen.getByTestId('SnackbarContent-error');
+    const messageColumn = screen.getByTestId('SnackbarContent-message');
+
+    expect(row.style.flexDirection).not.toBe('column');
+    expect(messageColumn.parentElement).toBe(row);
+    expect(messageColumn.style.flexDirection).toBe('column');
+    // Long unbreakable strings must wrap rather than overflow the toast.
+    expect(messageColumn.style.minWidth).toBe('0px');
+  });
 });

--- a/ui/theme/snackbar.tsx
+++ b/ui/theme/snackbar.tsx
@@ -51,6 +51,21 @@ const contentStyle = {
   width: '100%',
 };
 
+// `BasicMarkdown` emits sibling block elements (<p>, <ul>, ...) with no wrapper
+// of its own. Dropped straight into the row above, those blocks become sibling
+// flex items and lay out horizontally, so a multi-block MeshKit error renders
+// as "Unable to create the environmentmeshery-server-1448". Its own column
+// keeps them stacked. `flexBasis: auto` preserves the intrinsic width a
+// single-line toast has today, and `minWidth: 0` lets a long unbreakable string
+// wrap instead of overflowing the toast.
+const messageStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  flex: '1 1 auto',
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+};
+
 export const ThemeResponsiveSnackbar = forwardRef((props, forwardedRef) => {
   // notistack v3 custom content props: the snackbar identifier arrives as
   // `id` (React strips `key`, so it must never be read from props). `action`
@@ -79,7 +94,9 @@ export const ThemeResponsiveSnackbar = forwardRef((props, forwardedRef) => {
     <StyledSnackbarContent ref={forwardedRef} variant={variant}>
       <div data-testid={`SnackbarContent-${variant}`} style={contentStyle}>
         {getIcon()}
-        <BasicMarkdown content={message} />
+        <div data-testid="SnackbarContent-message" style={messageStyle}>
+          <BasicMarkdown content={message} />
+        </div>
         <Box marginLeft={'auto'} paddingLeft={'0.5rem'}>
           {action && action(id)}
         </Box>

--- a/ui/utils/helpers/__tests__/meshkitError.test.ts
+++ b/ui/utils/helpers/__tests__/meshkitError.test.ts
@@ -87,6 +87,74 @@ describe('formatApiError', () => {
     expect(result.message).toContain('`meshery-server-1014`');
   });
 
+  // The schemas baseQuery wrapper drops the detail arrays (meshery/schemas#1081),
+  // so `formatApiError` recovers them from the raw response body. The real
+  // transform is exercised in `meshkitErrorChain.test.ts`; these pin the merge
+  // rules in isolation.
+  it('recovers camelCase detail arrays from the raw body', () => {
+    const result = formatApiError({
+      status: 403,
+      data: {
+        error: 'Unable to create the environment',
+        code: 'meshery-server-1448',
+        probableCause: ['Missing permission.'],
+        suggestedRemediation: ['Ask an owner for the Environment role.'],
+        longDescription: ['The provider rejected the request.'],
+      },
+      meshkit: { message: 'Unable to create the environment', code: 'meshery-server-1448' },
+    });
+
+    expect(result.message).toContain('*Try:*');
+    expect(result.message).toContain('- Ask an owner for the Environment role.');
+    expect(result.meshkit?.probableCause).toEqual(['Missing permission.']);
+    expect(result.meshkit?.longDescription).toEqual(['The provider rejected the request.']);
+  });
+
+  it('recovers snake_case detail arrays from the raw body', () => {
+    const result = formatApiError({
+      status: 409,
+      data: { error: 'duplicate', suggested_remediation: ['Pick a different name.'] },
+      meshkit: { message: 'duplicate' },
+    });
+
+    expect(result.message).toContain('- Pick a different name.');
+  });
+
+  it('prefers camelCase over snake_case when the body carries both', () => {
+    const result = formatApiError({
+      status: 409,
+      data: {
+        error: 'duplicate',
+        suggestedRemediation: ['camel wins'],
+        suggested_remediation: ['snake loses'],
+      },
+      meshkit: { message: 'duplicate' },
+    });
+
+    expect(result.meshkit?.suggestedRemediation).toEqual(['camel wins']);
+  });
+
+  it('keeps the envelope values when meshkit already carries the details', () => {
+    const result = formatApiError({
+      status: 409,
+      data: { error: 'duplicate', suggestedRemediation: ['from body'] },
+      meshkit: { message: 'duplicate', suggestedRemediation: ['from envelope'] },
+    });
+
+    expect(result.meshkit?.suggestedRemediation).toEqual(['from envelope']);
+  });
+
+  it('ignores blank and non-string detail entries on the raw body', () => {
+    const result = formatApiError({
+      status: 500,
+      data: { error: 'boom', suggestedRemediation: ['', '   ', 42] },
+      meshkit: { message: 'boom' },
+    });
+
+    expect(result.message).toBe('**boom**');
+    expect(result.meshkit?.suggestedRemediation).toBeUndefined();
+  });
+
   it('falls back to FetchBaseQueryError.data string', () => {
     const result = formatApiError(
       { status: 500, data: 'internal server error' },

--- a/ui/utils/helpers/__tests__/meshkitErrorChain.test.ts
+++ b/ui/utils/helpers/__tests__/meshkitErrorChain.test.ts
@@ -107,7 +107,10 @@ describe('MeshKit error chain (real schemas client)', () => {
   it('renders the title, every remediation bullet and the code from a real 403', async () => {
     respondWith(403, CREATE_ENVIRONMENT_403);
 
-    const formatted = formatApiError(await createEnvironmentError(), 'Failed to create environment');
+    const formatted = formatApiError(
+      await createEnvironmentError(),
+      'Failed to create environment',
+    );
 
     expect(formatted.message).toContain('**Unable to create the environment**');
     expect(formatted.message).toContain('*Try:*');
@@ -145,7 +148,10 @@ describe('MeshKit error chain (real schemas client)', () => {
   it('degrades to a single-line message when the body is not a MeshKit envelope', async () => {
     respondWith(500, { message: 'internal server error' });
 
-    const formatted = formatApiError(await createEnvironmentError(), 'Failed to create environment');
+    const formatted = formatApiError(
+      await createEnvironmentError(),
+      'Failed to create environment',
+    );
 
     expect(formatted.meshkit).toBeUndefined();
     expect(formatted.message).toBe('internal server error');

--- a/ui/utils/helpers/__tests__/meshkitErrorChain.test.ts
+++ b/ui/utils/helpers/__tests__/meshkitErrorChain.test.ts
@@ -1,0 +1,153 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { formatApiError } from '../meshkitError';
+
+// The schemas baseQuery reads its endpoint prefix at module scope, and
+// `fetchBaseQuery` builds an absolute `Request` before dispatching, so a
+// relative default throws "Failed to parse URL". Set the prefix first, then
+// pull in the real client - a dynamic import so this assignment wins over the
+// hoisting of static imports.
+process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://localhost:9081';
+const { mesheryApi } = await import('@meshery/schemas/mesheryApi');
+
+// ---------------------------------------------------------------------------
+// End-to-end coverage for the error chain the app actually runs:
+//
+//   server JSON envelope
+//     -> real `@meshery/schemas` baseQuery (`withMeshkitError`)
+//       -> real `mesheryApi.endpoints.*`
+//         -> `formatApiError`
+//           -> snackbar markdown
+//
+// Deliberately NOT hand-constructing `error.meshkit`: that is exactly the gap
+// that let the casing mismatch ship. The schemas wrapper reads the snake_case
+// spellings (`probable_cause`, ...) while the server emits camelCase
+// (`probableCause`, ...), so a hand-built envelope passes while production
+// silently drops the probable cause and the remediation list.
+//
+// See meshery/schemas#1081 and the `MESHKIT_DETAIL_ALIASES` comment in
+// `utils/helpers/meshkitError.ts`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Verbatim shape of the `errorResponse` struct in
+ * `server/models/httputil/httputil.go`, as emitted for a provider-rejected
+ * Create Environment.
+ */
+const CREATE_ENVIRONMENT_403 = {
+  error: 'Unable to create the environment',
+  code: 'meshery-server-1448',
+  severity: 'ALERT',
+  probableCause: [
+    'Your account does not have permission to create environments in this organization.',
+    'An environment with the same name already exists in this organization.',
+  ],
+  suggestedRemediation: [
+    'Confirm your role in the selected organization.',
+    'The environment was NOT created - retry after resolving the cause.',
+  ],
+  longDescription: ['The remote provider rejected the create request.'],
+};
+
+const makeStore = () =>
+  configureStore({
+    reducer: { [mesheryApi.reducerPath]: mesheryApi.reducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(mesheryApi.middleware),
+  });
+
+/** Stub `fetch` so the real baseQuery parses a real JSON error response. */
+const respondWith = (status: number, body: unknown) =>
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    ),
+  );
+
+/** Drive the real `createEnvironment` mutation and return its RTK error. */
+const createEnvironmentError = async () => {
+  const store = makeStore();
+  const result = await store.dispatch(
+    mesheryApi.endpoints.createEnvironment.initiate({
+      body: { name: 'prod', description: 'production', organizationId: 'org-1' },
+    }),
+  );
+  return (result as { error?: unknown }).error;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('MeshKit error chain (real schemas client)', () => {
+  it('surfaces the schemas transform gap this helper compensates for', async () => {
+    respondWith(403, CREATE_ENVIRONMENT_403);
+
+    const error = (await createEnvironmentError()) as {
+      status?: number;
+      meshkit?: Record<string, unknown>;
+    };
+
+    // The wrapper does attach an envelope, and it does carry message/code...
+    expect(error?.status).toBe(403);
+    expect(error?.meshkit?.message).toBe('Unable to create the environment');
+    expect(error?.meshkit?.code).toBe('meshery-server-1448');
+    // ...but the detail arrays are dropped, because the wrapper reads
+    // `probable_cause`/`suggested_remediation` and the server sends camelCase.
+    // Delete this assertion (and the fallback it justifies) once
+    // meshery/schemas#1081 ships and the dependency is bumped.
+    expect(error?.meshkit?.suggestedRemediation).toBeUndefined();
+    expect(error?.meshkit?.probableCause).toBeUndefined();
+  });
+
+  it('renders the title, every remediation bullet and the code from a real 403', async () => {
+    respondWith(403, CREATE_ENVIRONMENT_403);
+
+    const formatted = formatApiError(await createEnvironmentError(), 'Failed to create environment');
+
+    expect(formatted.message).toContain('**Unable to create the environment**');
+    expect(formatted.message).toContain('*Try:*');
+    for (const remediation of CREATE_ENVIRONMENT_403.suggestedRemediation) {
+      expect(formatted.message).toContain(`- ${remediation}`);
+    }
+    expect(formatted.message).toContain('`meshery-server-1448`');
+
+    // One bullet per remediation entry - not one run-on bullet.
+    const bullets = formatted.message.split('\n').filter((line) => line.startsWith('- '));
+    expect(bullets).toHaveLength(CREATE_ENVIRONMENT_403.suggestedRemediation.length);
+
+    // The recovered envelope carries the details too, for non-markdown callers.
+    expect(formatted.meshkit?.probableCause).toEqual(CREATE_ENVIRONMENT_403.probableCause);
+    expect(formatted.meshkit?.longDescription).toEqual(CREATE_ENVIRONMENT_403.longDescription);
+  });
+
+  it('still recovers the details when a producer emits snake_case', async () => {
+    respondWith(409, {
+      error: 'Unable to create the workspace',
+      code: 'meshery-server-1454',
+      probable_cause: ['A workspace with the same name already exists.'],
+      suggested_remediation: ['Pick a different workspace name.'],
+    });
+
+    const formatted = formatApiError(await createEnvironmentError());
+
+    expect(formatted.message).toContain('**Unable to create the workspace**');
+    expect(formatted.message).toContain('- Pick a different workspace name.');
+    expect(formatted.meshkit?.probableCause).toEqual([
+      'A workspace with the same name already exists.',
+    ]);
+  });
+
+  it('degrades to a single-line message when the body is not a MeshKit envelope', async () => {
+    respondWith(500, { message: 'internal server error' });
+
+    const formatted = formatApiError(await createEnvironmentError(), 'Failed to create environment');
+
+    expect(formatted.meshkit).toBeUndefined();
+    expect(formatted.message).toBe('internal server error');
+  });
+});

--- a/ui/utils/helpers/meshkitError.ts
+++ b/ui/utils/helpers/meshkitError.ts
@@ -74,6 +74,67 @@ export const formatMeshkitErrorMarkdown = (
   return lines.join('\n');
 };
 
+type MeshkitDetailKey = 'probableCause' | 'suggestedRemediation' | 'longDescription';
+
+/**
+ * Wire aliases for each MeshKit detail array, most-preferred spelling first.
+ *
+ * The Meshery server emits camelCase - see the `errorResponse` struct in
+ * `server/models/httputil/httputil.go` and the identifier-naming contract in
+ * AGENTS.md - but the `withMeshkitError` baseQuery wrapper in
+ * `@meshery/schemas` reads the snake_case spellings (`probable_cause`,
+ * `suggested_remediation`, `long_description`) instead. The result is an
+ * `error.meshkit` carrying only message/code/severity, so the "*Try:*" section
+ * below never renders even though the server sent remediations.
+ *
+ * Tracked upstream as meshery/schemas#1081
+ * (https://github.com/meshery/schemas/issues/1081). The defect is present in
+ * the pinned 1.3.x line and in 1.4.0. Once it is fixed upstream and this
+ * repo's dependency is bumped past it, the raw-body fallback in
+ * `resolveMeshkitError` becomes redundant and can be deleted.
+ */
+const MESHKIT_DETAIL_ALIASES: Record<MeshkitDetailKey, readonly string[]> = {
+  probableCause: ['probableCause', 'probable_cause'],
+  suggestedRemediation: ['suggestedRemediation', 'suggested_remediation'],
+  longDescription: ['longDescription', 'long_description'],
+};
+
+/** Narrow an unknown value to a non-empty array of non-blank strings. */
+const toStringArray = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const entries = value.filter(
+    (entry): entry is string => typeof entry === 'string' && entry.trim().length > 0,
+  );
+  return entries.length > 0 ? entries : undefined;
+};
+
+/**
+ * Merge the MeshKit envelope attached by the schemas baseQuery with the detail
+ * arrays still present on the raw response body at `error.data`. Values already
+ * on `meshkit` win; within the body camelCase wins over snake_case, so a future
+ * producer emitting either spelling keeps working.
+ */
+const resolveMeshkitError = (error: { meshkit: MeshkitError; data?: unknown }): MeshkitError => {
+  const body =
+    error.data && typeof error.data === 'object' && !Array.isArray(error.data)
+      ? (error.data as Record<string, unknown>)
+      : undefined;
+  if (!body) return error.meshkit;
+
+  const resolved: MeshkitError = { ...error.meshkit };
+  for (const key of Object.keys(MESHKIT_DETAIL_ALIASES) as MeshkitDetailKey[]) {
+    if (toStringArray(resolved[key])) continue;
+    for (const alias of MESHKIT_DETAIL_ALIASES[key]) {
+      const fromBody = toStringArray(body[alias]);
+      if (fromBody) {
+        resolved[key] = fromBody;
+        break;
+      }
+    }
+  }
+  return resolved;
+};
+
 /**
  * Extract a single best-effort string from a non-MeshKit RTK Query error or
  * any thrown value. Mirrors the legacy `error?.data` / `error?.message`
@@ -116,9 +177,10 @@ const extractFallbackMessage = (error: unknown): string | undefined => {
  */
 export const formatApiError = (error: unknown, fallbackTitle?: string): FormattedApiError => {
   if (hasMeshkitError(error)) {
+    const meshkit = resolveMeshkitError(error);
     return {
-      message: formatMeshkitErrorMarkdown(error.meshkit, fallbackTitle),
-      meshkit: error.meshkit,
+      message: formatMeshkitErrorMarkdown(meshkit, fallbackTitle),
+      meshkit,
     };
   }
 


### PR DESCRIPTION
## Intent

Fix the misreporting that hid a real environment-creation failure from users and from anyone trying to debug it, covering BOTH environments and workspaces. The user-visible symptom: an Org Admin submits Create Environment, the UI shows a success message, and nothing is created. A separate worker owns the Layer5 Cloud side (the actual 403); this change must be correct independently of that and must NOT touch meshery-cloud.

Three traced defects, all verified before fixing:

1. server/handlers/environments_handlers.go and workspace_handlers.go called ErrGetResult(err) - ErrGetResultCode = meshery-server-1033, a performance-RESULTS code whose text is "unable to get result" with probable cause "Result Identifier provided is not valid. Result did not persist in the database". 27 sites (54 occurrences). A real production log for a failed environment save read: Status Code: 403 .failed to save the environment | ... unable to get result | Probable Cause: Result Identifier provided is not valid... - every word after the 403 was misdirection and it cost real debugging time.

2. Those same sites passed a hardcoded http.StatusNotFound, so a provider 403 reached the browser as a 404.

3. The UI reported success on a failed create. End-to-end verification found this was actually TWO independent bugs, not one: (a) .then(handleSuccess('Environment created')) - note the immediate call - evaluated handleSuccess while the .then callback was merely being constructed, firing the success toast synchronously regardless of outcome; (b) handleError was curried, (action) => (error) => ..., but every call site invoked it as handleError(msg), producing a function that was thrown away, so NO environment or workspace failure had ever reached a user, including the fetch-error paths.

Deliberate decisions made while doing the work, so they are intentional and not oversights:

- New error codes were allocated with the repo's own errorutil procedure (placeholders written as "replace_me", then errorutil update), NOT hand-picked. 16 codes, meshery-server-1446..1461, and server/helpers/component_info.json next_error_code bumped to 1462. I replicated the CI gate exactly (errorutil analyze piped to wc -c must be 0 bytes) and it passes. The errorutil docs export under docs/data/errorref is deliberately NOT committed - CI regenerates it on push to master.

- Granularity: one code per CRUD verb per construct, plus one parameterised code for the association families. ErrEnvironmentConnection(err, action) covers connection add/remove/list; ErrWorkspaceResource(err, action) covers all ten workspace environment/design/view/team association endpoints. This keeps 27 sites accurate without inventing 27 codes.

- Status propagation was fixed at the correct layer, not the call sites. The root cause was upstream in server/models: ErrFetch/ErrPost received the provider's status but recorded it only as prose inside the MeshKit cause ("Status Code: 403 "), so nothing could read it back. They now tag the error via a new httputil.WithProviderStatus. I deliberately used errors.Join with a named "type ProviderStatus int" rather than a wrapper struct: errors.Join keeps errors.Is/errors.As and every meshkiterrors.Get* accessor reaching through to the original error, so the MeshKit code/severity/cause/remediation all survive intact (there is a test pinning exactly this). A struct wrapper was also blocked by the repo's local schema-first guard hook on server/models/**, which flags any new "type ... struct" there; the chosen design is genuinely local error plumbing, carries no json or db tags, and is never serialized.

- Placement: the plumbing lives in server/models/httputil, which exists precisely so server/models and server/handlers can share HTTP-boundary helpers without an import cycle. server/models/error.go now imports it.

- The default status when the provider produced NO status of its own is 502 Bad Gateway, deliberately not 404 and not 500: the failure is still an upstream one (unreachable provider, unsupported capability, unreadable body), and "not found" is a claim about the resource for which there is no evidence. This is an intentional behavior change and it required updating an existing test, TestGetUserByIDHandler_ProviderErrorReturnsJSON, which previously asserted 404 for an untagged provider error; that test's real purpose was the JSON envelope shape, and I added TestGetUserByIDHandler_PropagatesProviderStatus as its counterpart for the tagged case.

- UI fix approach: handleError was made a plain two-argument function in both components rather than kept curried, so the misuse that caused the silence becomes a syntax-level mistake instead of a silent no-op; success became a deferred callback; and failures now render through the existing formatApiError helper so the MeshKit code, probable cause and suggested remediation reach the user. I deliberately reused the existing ui/utils/helpers/meshkitError.ts plus notify(event) path rather than switching these components to notifyApiError, because notify() persists into the Notification Center whereas notifyApiError is snackbar-only.

- Sibling audit, as asked: the identical one-line ErrGetResult plus 404 shape appeared in 4 more sites - user_handler.go (2), organization_handler.go, keys_handler.go. They were genuinely the same one-line shape so I fixed them inline rather than listing them. fetch_results_handler.go still uses ErrGetResult and that is correct - it really is about results.

Adjacent bugs found and fixed along the way (in scope by the maintainer-mindset rule, and called out here so they do not look like scope creep):

- httputil.WriteMeshkitError built probableCause/suggestedRemediation from MeshKit's Get* accessors, which join every entry with ".", so a multi-cause error arrived on the wire as one run-on string and the UI rendered it as a single bullet - despite the documented contract saying these are arrays. It now emits the real arrays (with MeshKit's "None" sentinel and blank entries compacted out), which matters because the new error codes each carry several distinct causes.

- SaveWorkspaceHandler called w.WriteHeader before w.Header().Set("Content-Type"), silently dropping the header on the 201 that RTK Query's baseQuery dispatches on.

- Environment connection assign/remove fired the RTK mutation and discarded the returned promise, so a rejected assignment left the transfer list looking successful.

- docs/content/en/project/contributing/error-contract.md documented snake_case field names (probable_cause etc.) that the server has never emitted - it emits camelCase - and its "Producing errors in handlers" example literally taught the ErrGetResult plus http.StatusNotFound anti-pattern this change removes. Both fixed, plus a new section documenting the two rules: use an operation-appropriate code, and never hardcode a provider failure's status.

- AGENTS.md gained one concise durable line pointing at that doc.

Testing: new Go tests assert that a provider failure with a given status surfaces with THAT status and an environment/workspace-specific code - explicitly not 404 and not meshery-server-1033 - covering 403, 409, 500 and the untagged-provider 502 fallback, for both constructs and both read and write paths. New UI component tests for both environments and workspaces pin that a rejected create emits an ERROR notification carrying the MeshKit code and remediation and never a SUCCESS one, and that success fires only once the create actually resolves. I verified those UI tests are non-vacuous by temporarily reintroducing the original defects and confirming they fail.

Validation already run locally: go build ./server/..., go test ./server/..., mesheryctl go test --short ./..., golangci-lint with .github/.golangci.yml (0 issues), gofmt, ui eslint, the full vitest suite (2601 passing), and the errorutil analyze gate. Two failures reproduce identically on a clean tree and are pre-existing and unrelated: TestFetchKubernetesVersion (requires a kubeconfig) and TestConnectionViewCmd in mesheryctl.

Constraint the user set explicitly: do NOT bump @meshery/schemas to 1.4.0 - it looks newer but the live release line is 1.3.x. This change adds no schemas dependency change at all.

Machine constraint: disk is at 96 percent with about 22 GiB free, so prefer targeted test runs over full builds or full docker/image builds.

## What Changed

- **Server: operation-accurate error codes and real provider status.** 31 environment/workspace/organization/user/API-key handler sites stopped reporting failures as `ErrGetResult` (`meshery-server-1033`, "unable to get result / Result Identifier provided is not valid") with a hardcoded `http.StatusNotFound`. They now use 16 new errorutil-allocated codes (`meshery-server-1446..1461`, `next_error_code` bumped to 1462), including one parameterised code each for the environment-connection and workspace-association families, and pair them with `providerStatus(err)`. Status propagation was fixed at the root layer, not the call sites: `models.ErrFetch`/`ErrPost` now tag the error with the provider's real status through a new `httputil.WithProviderStatus` (`errors.Join` + a named `ProviderStatus int`, so every `errors.Is/As` and MeshKit `Get*` accessor still reaches through), and `httputil.StatusForProviderError` reads it back with a 502 fallback for untagged provider failures instead of 404. Also fixed alongside: `WriteMeshkitError` emits `probableCause`/`suggestedRemediation` as real arrays rather than MeshKit's `"."`-joined string, and `SaveWorkspaceHandler` sets `Content-Type` before `WriteHeader` so the 201 no longer drops it.
- **UI: failed creates report failure.** Two independent defects made environment and workspace failures invisible: `.then(handleSuccess('Environment created'))` fired the success toast synchronously while the callback was merely being constructed, and `handleError` was curried as `(action) => (error) =>` while every call site invoked it as `handleError(msg)`, discarding the returned function. Success is now a deferred callback and `handleError` is a plain two-argument function, so the misuse becomes a syntax error rather than a silent no-op. Failures render through `formatApiError`, which now falls back to the raw camelCase response body because the `@meshery/schemas` `withMeshkitError` wrapper reads snake_case field names (tracked as meshery/schemas#1081; no dependency bump here, the 1.3.x pin is unchanged). `rtkErrorMiddleware` no longer skips 401 for a non-existent `authMiddleware`, the snackbar stacks `BasicMarkdown` blocks in a column instead of laying them out as sibling flex items, and environment connection assign/remove now awaits its mutation instead of discarding the promise.
- **Docs and tests.** `error-contract.md` had documented snake_case fields the server has never emitted and its handler example taught the exact `ErrGetResult` + 404 anti-pattern removed here; both are corrected and a new section states the two rules, with a one-line pointer added to `AGENTS.md`. New Go tests assert a provider failure surfaces with *that* status and a construct-specific code (explicitly not 404, not `meshery-server-1033`) across 403/409/500 and the untagged-502 fallback for both constructs; new vitest coverage pins that a rejected create emits an ERROR notification carrying the MeshKit code and remediation and never a SUCCESS one. The generated `docs/data/errorref` export is deliberately not committed - CI regenerates it on push to master, which is the one informational item the Document stage flagged.

## Risk Assessment

⚠️ Medium: All five prior findings are correctly resolved and only cosmetic copy/comment nits remain, but the change still alters HTTP status codes on roughly 31 handler sites and now routes 401 responses from every RTK Query endpoint into the notification center - both deliberate, tested and owner-approved, yet broad enough that the trade-off should be called out to reviewers rather than merged silently.

## Testing

`Ran the full Go server suite, the full UI vitest suite (2618 passing, 0 failing) and the touched suites individually, then produced product-level evidence rather than relying on unit tests: a regenerated HTTP transcript from the real handlers showing a provider 403 surfacing as 403/meshery-server-1448, 409 as 409/meshery-server-1454 and an unreachable provider as 502 (never 404, never meshery-server-1033), and Chrome screenshots of the actual toast rendered through the real chain (server envelope -> real schemas baseQuery -> real createEnvironment endpoint -> formatApiError -> notify -> notistack with the pages/_app.tsx config), before and after, with identical inputs. The before shot reproduces the shipped defect ("Unable to create the workspacemeshery-server-1454", remediation dropped); the after shot shows the title, the "Try:" remediation bullet and the code stacked on their own lines, with the single-line success toast measured identical before/after and no horizontal overflow at 1280px or 420px. I also verified the new tests are non-vacuous by reintroducing each of the three defects and confirming the corresponding tests fail. The only Go failure anywhere is TestFetchKubernetesVersion, which needs a kubeconfig and reproduces on a clean tree. All transient harness files were removed and the worktree is clean.`

- Evidence: Before/after: the toast an Org Admin sees when the provider rejects Create Environment / Create Workspace (real chain, real notistack) (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01KY52YKM5W9YD0AZE8GFV8TDR/create-failure-toast-before-after.png</code>)
- Evidence: AFTER (HEAD) - stacked title, Try: remediation bullet and support code; success toast unchanged (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01KY52YKM5W9YD0AZE8GFV8TDR/chain-toast-after.png</code>)
- Evidence: BEFORE (parent commit) - remediation dropped, markdown blocks collide in one flex row (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01KY52YKM5W9YD0AZE8GFV8TDR/chain-toast-before.png</code>)
<details>
<summary>Evidence: Real handler HTTP transcript regenerated at HEAD (403 / 502 / 409 with environment- and workspace-specific codes)</summary>

<code>POST /api/environments (provider 403)&#10;HTTP/1.1 403 Forbidden&#10;Content-Type: application/json; charset=utf-8&#10;{&#10;&#34;error&#34;: &#34;Unable to create the environment&#34;,&#10;&#34;code&#34;: &#34;meshery-server-1448&#34;,&#10;&#34;severity&#34;: &#34;ALERT&#34;,&#10;&#34;probableCause&#34;: [&#34;Your account does not have permission to create environments in this organization.&#34;, &#34;An environment with the same name already exists in this organization.&#34;, &#34;The organization identifier is missing or does not exist.&#34;, &#34;The provider could not be reached or rejected the request.&#34;],&#10;&#34;suggestedRemediation&#34;: [&#34;Confirm your role in the selected organization grants permission to create environments, and that the environment name is not already in use. The environment was NOT created - retry after resolving the cause.&#34;]&#10;}&#10;&#10;POST /api/environments (provider unreachable) -&gt; HTTP/1.1 502 Bad Gateway, meshery-server-1448&#10;POST /api/workspaces (provider 409) -&gt; HTTP/1.1 409 Conflict, meshery-server-1454</code>

```text
Meshery Server - environment/workspace failure reporting (regenerated at HEAD)
Real handlers, driven with a remote provider that rejects the call.

================================================================
Org Admin submits Create Environment; Layer5 Cloud answers 403
POST /api/environments
================================================================
HTTP/1.1 403 Forbidden
Content-Type: application/json; charset=utf-8
X-Content-Type-Options: nosniff

{
  "error": "Unable to create the environment",
  "code": "meshery-server-1448",
  "severity": "ALERT",
  "probableCause": [
    "Your account does not have permission to create environments in this organization.",
    "An environment with the same name already exists in this organization.",
    "The organization identifier is missing or does not exist.",
    "The provider could not be reached or rejected the request."
  ],
  "suggestedRemediation": [
    "Confirm your role in the selected organization grants permission to create environments, and that the environment name is not already in use. The environment was NOT created - retry after resolving the cause."
  ],
  "longDescription": [
    "Status Code: 403 .failed to save the environment | Short Description: Unable to post data to the Provider.Environment\nremote provider responded with HTTP 403 Forbidden"
  ]
}



================================================================
Create Environment when the remote provider is unreachable (no status of its own)
POST /api/environments
================================================================
HTTP/1.1 502 Bad Gateway
Content-Type: application/json; charset=utf-8
X-Content-Type-Options: nosniff

{
  "error": "Unable to create the environment",
  "code": "meshery-server-1448",
  "severity": "ALERT",
  "probableCause": [
    "Your account does not have permission to create environments in this organization.",
    "An environment with the same name already exists in this organization.",
    "The organization identifier is missing or does not exist.",
    "The provider could not be reached or rejected the request."
  ],
  "suggestedRemediation": [
    "Confirm your role in the selected organization grants permission to create environments, and that the environment name is not already in use. The environment was NOT created - retry after resolving the cause."
  ],
  "longDescription": [
    ".dial tcp 10.0.0.4:443: connect: connection refused | Short Description: Could not reach remote provider | Probable Cause: Remote provider server may be down or not accepting requests. | Suggested Remediation: Make sure remote provider server is healthy and accepting requests."
  ]
}



================================================================
Create Workspace; Layer5 Cloud answers 409
POST /api/workspaces
================================================================
HTTP/1.1 409 Conflict
Content-Type: application/json; charset=utf-8
X-Content-Type-Options: nosniff

{
  "error": "Unable to create the workspace",
  "code": "meshery-server-1454",
  "severity": "ALERT",
  "probableCause": [
    "Your account does not have permission to create workspaces in this organization.",
    "A workspace with the same name already exists in this organization.",
    "The organization identifier is missing or does not exist.",
    "The provider could not be reached or rejected the request."
  ],
  "suggestedRemediation": [
    "Confirm your role in the selected organization grants permission to create workspaces, and that the workspace name is not already in use. The workspace was NOT created - retry after resolving the cause."
  ],
  "longDescription": [
    "Status Code: 409 .workspace already exists | Short Description: Unable to post data to the Provider.Workspace\nremote provider responded with HTTP 409 Conflict"
  ]
}
```
</details>
<details>
<summary>Evidence: Real client chain: schemas baseQuery output vs recovered notification markdown</summary>

<code>error.meshkit attached by @meshery/schemas 1.3.35: { message, code, severity } &lt;- detail arrays dropped (meshery/schemas#1081)&#10;&#10;markdown BEFORE: **Unable to create the environment**\n\n`meshery-server-1448`&#10;markdown AFTER: **Unable to create the environment**\n\n*Try:*\n- Confirm your role in the selected organization grants permission to create environments, and that the environment name is not already in use. The environment was NOT created - retry after resolving the cause.\n\n`meshery-server-1448`</code>

```text
{
  "note": "Real chain: server envelope -> @meshery/schemas baseQuery -> mesheryApi.createEnvironment -> formatApiError. No hand-built error.meshkit.",
  "step1_serverResponse": {
    "status": 403,
    "body": {
      "error": "Unable to create the environment",
      "code": "meshery-server-1448",
      "severity": "ALERT",
      "probableCause": [
        "Your account does not have permission to create environments in this organization.",
        "An environment with the same name already exists in this organization.",
        "The organization identifier is missing or does not exist.",
        "The provider could not be reached or rejected the request."
      ],
      "suggestedRemediation": [
        "Confirm your role in the selected organization grants permission to create environments, and that the environment name is not already in use. The environment was NOT created - retry after resolving the cause."
      ],
      "longDescription": [
        "Status Code: 403 .failed to save the environment | Short Description: Unable to post data to the Provider.Environment\nremote provider responded with HTTP 403 Forbidden"
      ]
    }
  },
  "step2_rtkQueryError_meshkit": {
    "message": "Unable to create the environment",
    "code": "meshery-server-1448",
    "severity": "ALERT"
  },
  "step3_notificationMarkdown_before": "**Unable to create the environment**\n\n`meshery-server-1448`",
  "step3_notificationMarkdown_after": "**Unable to create the environment**\n\n*Try:*\n- Confirm your role in the selected organization grants permission to create environments, and that the environment name is not already in use. The environment was NOT created - retry after resolving the cause.\n\n`meshery-server-1448`",
  "step3_workspace_markdown_after": "**Unable to create the workspace**\n\n*Try:*\n- Confirm your role in the selected organization grants permission to create workspaces, and that the workspace name is not already in use. The workspace was NOT created - retry after resolving the cause.\n\n`meshery-server-1454`"
}
```
</details>
<details>
<summary>Evidence: Validation log: suites, rendered toast geometry, and mutation checks proving the new tests are non-vacuous</summary>

```text
Validation log - fm/meshery-env-error-reporting @ 903154a0b1a
=============================================================

1. Server: real handlers driven with a provider that rejects the call
   (regenerated at HEAD, see server-api-transcript.head.txt)

   POST /api/environments, provider 403  -> HTTP 403 Forbidden, meshery-server-1448
   POST /api/environments, unreachable   -> HTTP 502 Bad Gateway, meshery-server-1448
   POST /api/workspaces,   provider 409  -> HTTP 409 Conflict,   meshery-server-1454

   Never 404, never meshery-server-1033 ("unable to get result").
   Regenerated bodies are byte-identical to environment-create-403.json /
   workspace-create-409.json captured earlier in this branch.

2. UI: real chain, no hand-built error.meshkit
   (see ui-error-chain-after.json, chain-toast-before/after.png)

   server envelope -> @meshery/schemas baseQuery (withMeshkitError)
     -> mesheryApi.endpoints.createEnvironment -> formatApiError -> notify()
       -> notistack + ThemeResponsiveSnackbar

   error.meshkit attached by the schemas wrapper (1.3.35):
     { message, code, severity }              <- detail arrays dropped, meshery/schemas#1081

   notification markdown BEFORE (parent commit 1c7fd50):
     **Unable to create the environment**\n\n`meshery-server-1448`
   notification markdown AFTER (HEAD):
     **Unable to create the environment**
     *Try:*
     - Confirm your role in the selected organization grants permission to create
       environments, and that the environment name is not already in use. The
       environment was NOT created - retry after resolving the cause.
     `meshery-server-1448`

3. Rendered toast geometry (real Chrome, notistack + Components config from pages/_app.tsx)

   viewport 1280           BEFORE            AFTER
   success (single line)   299 x 72 px       299 x 72 px    <- unchanged, as required
   error   (multi block)   540 x 72 px       1240 x 264 px  <- blocks now stacked
   horizontal overflow     none              none

   viewport 420 (mobile)   success 388 x 72 both; no horizontal overflow either side.

4. Mutation checks - the new tests fail when the defects are reintroduced

   revert ui/utils/helpers/meshkitError.ts to HEAD~1
     -> 4 failures, incl. meshkitErrorChain.test.ts "renders the title, every
        remediation bullet and the code from a real 403":
        AssertionError: expected '**Unable to create the environment**...' to contain '*Try:*'

   revert ui/theme/snackbar.tsx to HEAD~1
     -> theme/snackbar.test.tsx "stacks the markdown blocks in a column":
        Unable to find an element by: [data-testid="SnackbarContent-message"]

   reintroduce `.then(handleSuccess(...))` in ui/components/environments/index.tsx
     -> components/environments/index.test.tsx:
        AssertionError: expected [ 'success', 'error' ] to not include 'success'

5. Suites

   go test ./server/...            all pass except TestFetchKubernetesVersion
                                   (pre-existing; needs a kubeconfig)
   go test ./server/handlers ./server/models/httputil -count=1   pass
   npx vitest run (full UI suite)  380 files passed, 18 skipped;
                                   2618 tests passed, 18 skipped, 0 failed
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (1h2m43s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `server/handlers/error.go:1162` - Parameterised short descriptions render as garbled text on the wire. MeshKit&#39;s `GetSDescription` (meshkit/errors/errors.go) joins the ShortDescription slice with &#34;.&#34;, and `httputil.WriteMeshkitError` assigns that joined string to the response&#39;s `error` field. `ErrEnvironmentConnection(err, &#34;assign connection to&#34;)` builds `[]string{&#34;Unable to &#34;, action, &#34; environment&#34;}`, so the browser receives `error: &#34;Unable to .assign connection to. environment&#34;`; `ErrWorkspaceResource` (line 1190) is identical, covering all ten workspace association endpoints. The same joined form is what errorutil exports to the public error-code reference. Fix by emitting a single element, e.g. `[]string{&#34;Unable to &#34; + action + &#34; environment&#34;}` (re-run the errorutil analyze gate afterwards, since the array shape is what the tool inspects).
- ⚠️ `ui/components/environments/index.tsx:179` - The MeshKit probable cause never reaches the user, contradicting the stated intent &#34;failures now render through the existing formatApiError helper so the MeshKit code, probable cause and suggested remediation reach the user&#34;. `notify()` in ui/utils/hooks/useNotification.tsx:72 destructures `details = null` and never references it again (verified: `details` appears exactly once in that file), and `formatMeshkitErrorMarkdown` renders only title, `suggestedRemediation` and `code` - not `probableCause`. So `details: meshkit?.probableCause?.join(&#39;\n&#39;)` here and at ui/components/workspaces/index.tsx:281 is computed and discarded. Compounding it, the new assertion at ui/components/environments/index.test.tsx:215 (`expect(payload.details).toContain(&#39;Your account does not have permission.&#39;)`) passes while verifying a field the notification system drops, giving false confidence that probable cause is surfaced.
- ⚠️ `server/handlers/utils.go:72` - Propagating the provider&#39;s status verbatim makes provider-401 failures silent in the global notification path. ui/store/middleware/rtkErrorMiddleware.ts:84 early-returns on `status === 401` with the comment &#34;handled by authMiddleware&#34;, but no `authMiddleware` exists anywhere in ui/ (grep finds only that comment). A provider 401 reaches handlers when `DoRequest` returns the 401 response unretried (`!l.canRefreshToken`, remote_auth.go:61) and the provider func then calls `ErrFetch(..., resp.StatusCode)`. Previously that was flattened to 404 and the middleware pushed an error event; now it is 401 and nothing is dispatched. GetOrganizations, GetUsers and GetUsersKeys have no component-level `.catch`, so those failures now produce no user-visible signal at all - the exact failure mode this change exists to remove. Either drop the 401 skip in rtkErrorMiddleware or add the missing auth handling.
- ℹ️ `server/models/httputil/httputil.go:103` - The joined-accessor fallback added in WriteMeshkitError is unreachable. Control only enters this block when `meshkiterrors.GetCode(err) != &#34;None&#34;`, and GetCode succeeds only via `errors.As` against `*ErrorV2` or `*Error` - the identical match `meshkitDetailSlices` performs. So whenever the fallback is reached the typed slices were already available; and when a slice is empty, `compactDetails` returns nil and `GetCause`/`GetRemedy`/`GetLDescription` return &#34;&#34; (empty slice joined) which the guards reject. The three `if resp.X == nil` blocks (lines 103-119) and their explanatory comment can be deleted without changing any output.
- ℹ️ `ui/components/workspaces/WorkspaceGridView.tsx:55` - `handleError(formatApiError(error, &#39;Unable to delete workspace&#39;).message)` reimplements `notifyApiError`, which the very same `useNotificationHandlers()` hook already returns and which is defined as exactly `handleNotification(&#39;error&#39;, formatApiError(error, fallbackTitle).message)` (ui/utils/hooks/useNotification.tsx). Destructure `notifyApiError` instead of `handleError` and drop the `formatApiError` import from this file. Relatedly, the two new `handleError` bodies in ui/components/environments/index.tsx:173 and ui/components/workspaces/index.tsx:275 are byte-identical including their doc comment - a shared helper (or extending `notifyApiError` to take the `notify`/Notification-Center path) would keep the three notification error paths from drifting.

🔧 Fix: Fix garbled error text, dead fallbacks, swallowed 401s
2 infos still open:
- ℹ️ `server/handlers/error.go:1163` - The collapsed format strings drop the article that every sibling message carries, so the 13 association-endpoint messages read ungrammatically: `ErrEnvironmentConnection(err, &#34;assign connection to&#34;)` produces &#34;Unable to assign connection to environment&#34; and `ErrWorkspaceResource(err, &#34;remove a design from&#34;)` (line 1191) produces &#34;Unable to remove a design from workspace&#34;. Every adjacent constructor added by this change says &#34;the environment&#34; / &#34;the workspace&#34; (e.g. `ErrGetEnvironment` -&gt; &#34;Unable to fetch the environment&#34;). Changing the two formats to &#34;Unable to %s the environment&#34; and &#34;Unable to %s the workspace&#34; reads correctly for all thirteen actions (&#34;Unable to list the designs of the workspace&#34;, &#34;Unable to assign a team to the workspace&#34;, &#34;Unable to remove connection from the environment&#34;).
- ℹ️ `ui/components/workspaces/WorkspaceGridView.tsx:53` - The comment says `notifyApiError` &#34;unpacks the MeshKit code, cause and remediation&#34;, but it does not surface the cause: `notifyApiError` -&gt; `formatApiError` -&gt; `formatMeshkitErrorMarkdown` (ui/utils/helpers/meshkitError.ts) emits only the title, `suggestedRemediation` bullets and `code`. This is the same overstatement that was just corrected in the handleError doc comments in ui/components/environments/index.tsx:170 and ui/components/workspaces/index.tsx:272 (&#34;code and suggested remediation&#34;); this one was missed. Drop &#34;cause&#34; so all three read consistently.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `ui/utils/helpers/meshkitError.ts:117` - The MeshKit probableCause/suggestedRemediation never reach the user in the real chain. The server emits camelCase (probableCause, suggestedRemediation), but @meshery/schemas&#39; withMeshkitError baseQuery wrapper builds error.meshkit from r.probable_cause / r.suggested_remediation / r.long_description - verified in the pinned dist (1.3.35) and in 1.4.0. Driving the captured 403 body through the real mesheryApi client yields meshkit = {message, code, severity} only, so formatApiError renders just the bold title plus the code and the &#39;*Try:*&#39; remediation section is never emitted. The new UI tests hand-build an error.meshkit that already contains those fields, so they pass while the production path drops them. A fix local to this repo (no schemas dependency change) would be for formatApiError/hasMeshkitError to fall back to error.data.probableCause/suggestedRemediation when meshkit lacks them; the alternative is fixing withMeshkitError in meshery/schemas.
- ⚠️ `ui/theme/snackbar.tsx:47` - The error toast renders the markdown blocks as sibling flex items, so they lay out horizontally with no separation. ThemeResponsiveSnackbar puts BasicMarkdown&#39;s output directly inside a div styled display:flex; align-items:center, and BasicMarkdown emits sibling &lt;p&gt;/&lt;ul&gt; blocks with no wrapper. The toast that ships today reads &#39;Unable to create the environmentmeshery-server-1448&#39; with the code jammed onto the title (see create-environment-toast-as-mounted.png, rendered through the same notistack + Components config as pages/_app.tsx); once the remediation text does reach it, the title, &#39;Try:&#39;, the bullet list and the code all sit in one row and become unreadable (bottom panel of create-environment-notification.png). Wrapping BasicMarkdown in a block/column container fixes it. Pre-existing in the snackbar, but this change is what routes environment and workspace failures into it.
- <code>`go test ./server/models/httputil/... -count=1` (run with GOROOT unset - a stale gvm GOROOT at go1.26.4 vs go1.26.5 broke every build)</code>
- `go test ./server/handlers/ -run 'Environment|Workspace|ProviderStatus|GetUserByID|Meshkit' -v -count=1`
- `go test ./server/handlers/... ./server/models/... -count=1`
- <code>Temporary Go harness driving the real `h.SaveEnvironment`, `h.DeleteEnvironmentHandler` and `h.SaveWorkspaceHandler` with provider errors (403 ErrPost, 409 ErrPost, 403 ErrFetch, ErrUnreachableRemoteProvider) and dumping the verbatim HTTP response next to the base-commit shape -&gt; server-api-transcript.txt</code>
- `npx vitest run components/environments/index.test.tsx components/workspaces/index.test.tsx components/workspaces/WorkspaceGridView.test.tsx store/middleware/__tests__/rtkErrorMiddleware.test.ts utils/helpers/__tests__/meshkitError.test.ts theme/snackbar.test.tsx`
- <code>End-to-end chain harness: local HTTP server replaying the captured Go 403/409 bodies -&gt; real `@meshery/schemas/mesheryApi` `createEnvironment`/`createWorkspace` -&gt; real `formatApiError` -&gt; ui-error-chain.json / ui-error-chain-workspace.json</code>
- <code>Rendered the real `ThemeResponsiveSnackbar` under `SistentThemeProvider` and under notistack `SnackbarProvider` with the same `Components` map as `pages/_app.tsx`, then screenshotted with headless Chrome (`chrome-devtools-axi open/resize/screenshot`)</code>
- <code>Mutation check: reintroduced `.then(handleSuccess(...))` in `ui/components/environments/index.tsx` -&gt; 2 of 3 tests fail; file restored</code>
- <code>Mutation check: reintroduced curried `handleError = (action) =&gt; (error) =&gt;` in `ui/components/workspaces/index.tsx` -&gt; failure-notification test fails; file restored</code>
- <code>Inspected the pinned `@meshery/schemas@1.3.35` dist and the published 1.4.0 tarball to confirm the meshkit envelope transform reads snake_case fields</code>

🔧 Fix: Recover MeshKit error details and stack snackbar markdown
✅ Re-checked - no issues remain.
- <code>`go test ./server/...` (only pre-existing TestFetchKubernetesVersion fails - needs a kubeconfig)</code>
- `go test ./server/handlers/... ./server/models/httputil/... -count=1`
- `go test ./server/handlers -run 'PropagatesProviderStatus|ProviderErrorReturnsJSON' -v`
- `Temporary Go harness driving the real handlers (h.SaveEnvironment / h.SaveWorkspaceHandler) with a failing provider, dumping the verbatim HTTP status/headers/body -> server-api-transcript.head.txt (removed after the run)`
- <code>`npx vitest run` (full UI suite: 380 files passed, 18 skipped; 2618 tests passed, 0 failed)</code>
- `npx vitest run utils/helpers components/environments components/workspaces store/middleware theme`
- `Temporary vitest render harness: real server 403/409 bodies -> real @meshery/schemas baseQuery -> mesheryApi.endpoints.createEnvironment -> formatApiError -> real useNotification().notify -> real notistack SnackbarProvider with pages/_app.tsx config -> chain-toast-before/after.html (removed after the run)`
- `Chrome screenshots + geometry measurement of the rendered toasts at 1280px and 420px viewports (single-line success toast unchanged at 299x72 / 388x72; no horizontal overflow)`
- <code>Mutation check: restored `ui/utils/helpers/meshkitError.ts` from HEAD~1 -&gt; 4 failures incl. `meshkitErrorChain.test.ts` &#34;renders the title, every remediation bullet and the code from a real 403&#34;</code>
- <code>Mutation check: restored `ui/theme/snackbar.tsx` from HEAD~1 -&gt; `theme/snackbar.test.tsx` &#34;stacks the markdown blocks in a column&#34; fails</code>
- <code>Mutation check: reintroduced `.then(handleSuccess(...))` in `ui/components/environments/index.tsx` -&gt; `components/environments/index.test.tsx` fails with &#34;expected [ &#39;success&#39;, &#39;error&#39; ] to not include &#39;success&#39;&#34;</code>
- `Diffed the regenerated 403/409 response bodies against the artifacts captured earlier on the branch (identical at HEAD)`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/data/errorref/meshery-server_errors_export.json:1` - The tracked, generated error reference export has drifted: it does not contain the 16 new codes meshery-server-1446..1461 that this change added to server/handlers/error.go, so the published error-codes reference page will not list them until it is regenerated. Deliberately not hand-edited - it is machine-generated by .github/workflows/error-codes-updater.yaml, which runs errorutil and auto-commits docs/ on push to master (the commit step is skipped for pull requests). Regenerating locally would require building meshkit&#39;s errorutil, and hand-copying entries into a generated file is exactly the drift this file exists to avoid. Self-healing on the first master push after merge; no action needed unless a release cuts the docs site before that run lands.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Provider failures now propagate accurate HTTP statuses across environments, workspaces, organizations/users, and keys (with a 502 fallback), instead of defaulting to incorrect 404s.
  - Error notifications and API responses now follow the updated contract with operation-specific codes and full remediation details.
  - UI error handling improved: 401s now surface notifications, connection mutations no longer fail silently, and create/update success toasts won’t trigger early.
  - Fixed snackbar rendering for long/multi-block error messages; workspace success responses now set `Content-Type` correctly.
- **Documentation**
  - Updated the HTTP error JSON contract and handler error-path guidance.
- **Tests**
  - Added regression tests for provider-status propagation, error formatting, and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->