### PR TITLE
[UI] Fix dashboard detail view crash during loading

### DIFF
--- a/ui/components/dashboard/view.test.tsx
+++ b/ui/components/dashboard/view.test.tsx
@@ -146,6 +146,23 @@ describe('View', () => {
     expect(back).toHaveBeenCalled();
     expect(setView).toHaveBeenCalledWith('all');
   });
+
+  it('renders cleanly without crashing when connection data is loading (undefined)', () => {
+    useGetConnectionsQuery.mockReturnValue({ data: undefined });
+    render(
+      <View
+        setView={setView}
+        resource={{
+          kind: 'Pod',
+          cluster_id: 'cluster-1',
+          metadata: { name: 'pod-1' },
+          component_metadata: { styles: {} },
+        }}
+        k8sConfig={{}}
+      />,
+    );
+    expect(screen.getByText('pod-1')).toBeInTheDocument();
+  });
 });
 
 describe('Title', () => {

--- a/ui/components/dashboard/view.test.tsx
+++ b/ui/components/dashboard/view.test.tsx
@@ -55,8 +55,10 @@ vi.mock('@/utils/hooks/useKubernetesHook', () => ({
 }));
 
 vi.mock('../connections/ConnectionChip', () => ({
-  TooltipWrappedConnectionChip: ({ title }: any) => (
-    <div data-testid="connection-chip">{title}</div>
+  TooltipWrappedConnectionChip: ({ title, status }: any) => (
+    <div data-testid="connection-chip" data-status={status}>
+      {title}
+    </div>
   ),
 }));
 
@@ -89,6 +91,7 @@ vi.mock('../../utils/TooltipButton', () => ({
 
 vi.mock('./resources/config', () => ({ ALL_VIEW: 'all' }));
 
+import { CONNECTION_STATES } from '@/utils/Enum';
 import View, { Title } from './view';
 
 describe('View', () => {
@@ -162,6 +165,10 @@ describe('View', () => {
       />,
     );
     expect(screen.getByText('pod-1')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-chip')).toHaveAttribute(
+      'data-status',
+      CONNECTION_STATES.DISCONNECTED,
+    );
   });
 });
 

--- a/ui/components/dashboard/view.tsx
+++ b/ui/components/dashboard/view.tsx
@@ -92,7 +92,7 @@ const View = ({ setView, resource, k8sConfig }: DashboardViewProps) => {
   if (!resource) return null;
 
   const context = getK8sContextFromClusterId(resource.cluster_id, k8sConfig);
-  const connection = connections?.connections.find((conn) => conn.id === context?.connectionId);
+  const connection = connections?.connections?.find((conn) => conn.id === context?.connectionId);
   const connectionStatus = connection?.status || CONNECTION_STATES.DISCONNECTED;
   const iconSrc = normalizeStaticImagePath(resource.component_metadata?.styles?.svgColor);
 

--- a/ui/components/dashboard/view.tsx
+++ b/ui/components/dashboard/view.tsx
@@ -80,19 +80,24 @@ const View = ({ setView, resource, k8sConfig }: DashboardViewProps) => {
     [getResourceCleanData, resource, router],
   );
 
-  const { data: connections = [] } = useGetConnectionsQuery({
-    page: 0,
-    pagesize: 100,
-    search: '',
-    order: '',
-    status: '',
-    kind: JSON.stringify(['kubernetes']),
-  });
+  const { data: connectionsData } = useGetConnectionsQuery(
+    {
+      page: 0,
+      pagesize: 100,
+      search: '',
+      order: '',
+      status: '',
+      kind: JSON.stringify(['kubernetes']),
+    },
+    {},
+  );
 
   if (!resource) return null;
 
   const context = getK8sContextFromClusterId(resource.cluster_id, k8sConfig);
-  const connection = connections?.connections?.find((conn) => conn.id === context?.connectionId);
+  const connection = connectionsData?.connections?.find(
+    (conn) => conn.id === context?.connectionId,
+  );
   const connectionStatus = connection?.status || CONNECTION_STATES.DISCONNECTED;
   const iconSrc = normalizeStaticImagePath(resource.component_metadata?.styles?.svgColor);
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20897

This PR adds an optional chaining guard (`?.`) to `connections?.connections` in the dashboard details view. This prevents a runtime TypeError crash when the user clicks on a resource card (like a Namespace) while the connections query is still loading.

### Videos

<details>
<summary>Click here for video demos before and after</summary>

**Before:**

[2026-07-23_before.webm](https://github.com/user-attachments/assets/8cd04d3a-b9d1-4107-a109-e4fa56c6c4c1)


**After:**

[2026-07-23_after.webm](https://github.com/user-attachments/assets/5d3670b1-72ec-4bd5-9554-d58f65c0dbd8)

</details>

---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard reliability while connection data is loading or unavailable.
  - The dashboard continues displaying resource details without errors and shows the connection indicator as disconnected when appropriate.
  - Ensured the correct connection is selected and displayed once connection data becomes available.

- **Tests**
  - Added coverage for loading and unavailable connection states, including resource title rendering and disconnected status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->