### PR TITLE
fix(mesheryctl): repair design import, model init scaffold, and registry flag bugs

### DIFF
--- a/docs/content/en/guides/configuration-management/creating-models/index.md
+++ b/docs/content/en/guides/configuration-management/creating-models/index.md
@@ -132,18 +132,71 @@ Meshery Server is not required to generate models. The Meshery CLI can be used t
 
 {{< tabs id="mesheryctl-tabs" level="2" >}}
 <!-- tab -->
+Using Scaffold (model init) | fa fa-folder-tree
+
+<p>The scaffold workflow is the most direct way to hand-author a model - especially an <strong>annotation-only</strong> model (a curated set of icons used purely for visual diagramming). Unlike the CSV and Spreadsheet workflows, it does not require forking <code>meshery/meshery</code> or a Google Spreadsheet credential; it produces model files locally, packages them as an OCI image, and registers them into a running Meshery Server.</p>
+
+<h4>1. Scaffold the model</h4>
+<p>Generate the folder structure with <code>mesheryctl model init</code>:</p>
+<code>mesheryctl model init digitalocean-icons --version v0.1.0</code>
+<p>This creates:</p>
+<code>
+digitalocean-icons/
+<br />└── v0.1.0/
+<br />&nbsp;&nbsp;&nbsp;&nbsp;├── model.json          # model definition (name and displayName are pre-filled from the argument)
+<br />&nbsp;&nbsp;&nbsp;&nbsp;├── components/          # one sample component; add one JSON file per component
+<br />&nbsp;&nbsp;&nbsp;&nbsp;├── relationships/
+<br />&nbsp;&nbsp;&nbsp;&nbsp;├── connections/
+<br />&nbsp;&nbsp;&nbsp;&nbsp;└── credentials/
+</code>
+
+<h4>2. Edit <code>model.json</code></h4>
+<p>Open <code>digitalocean-icons/v0.1.0/model.json</code> and set the model's identity and appearance:</p>
+<ul>
+  <li><code>category.name</code> and <code>subCategory</code> - e.g. <code>Platform</code> / <code>Cloud Provider</code>.</li>
+  <li><code>registrant.kind</code> - e.g. <code>meshery</code>.</li>
+  <li><code>description</code> - a short summary of what the model provides.</li>
+  <li><code>metadata.svgColor</code> and <code>metadata.svgWhite</code> - the model's display icon, as an inline SVG string (strip any <code>&lt;?xml ...?&gt;</code> header and collapse the SVG to a single line).</li>
+  <li><code>metadata.isAnnotation</code> - set to <code>true</code> for an annotation-only (visual diagramming) model.</li>
+</ul>
+
+<h4>3. Add one component per capability</h4>
+<p><code>model init</code> drops a single sample component under <code>components/</code>. Add one JSON file per component (delete the sample if unused). For each component set:</p>
+<ul>
+  <li><code>displayName</code> - the human-readable name shown in the UI (e.g. <code>DO Logo Icon Blue</code>).</li>
+  <li><code>component.kind</code> - the unique identifier for the component (e.g. <code>do-logo-icon-blue</code>).</li>
+  <li><code>styles.svgColor</code> and <code>styles.svgWhite</code> - the component's inline SVG.</li>
+  <li><code>metadata.isAnnotation</code> - <code>true</code> for annotation components.</li>
+</ul>
+
+{{% alert color="warning" title="Component schemaVersion compatibility" %}}
+For the widest server compatibility, set each component's <code>schemaVersion</code> to <code>components.meshery.io/v1beta1</code> and the model's to <code>models.meshery.io/v1beta2</code>. Meshery Servers only accept the <code>v1beta3</code> component wire format once they ship a MeshKit new enough to recognize it; a released server that predates that support rejects <code>v1beta3</code> components with a generic "No valid component or relationship found in the Model provided" error at import time.
+{{% /alert %}}
+
+<h4>4. Package the model as an OCI image</h4>
+<code>mesheryctl model build digitalocean-icons/v0.1.0</code>
+<p>This writes an OCI artifact named <code>&lt;model&gt;-&lt;version&gt;.tar</code> (e.g. <code>digitalocean-icons-v0-1-0.tar</code>) to your current directory.</p>
+
+<h4>5. Register the model into a Meshery Server</h4>
+<p>Import the packaged artifact (or the model directory) into your connected Meshery Server. This step requires a running server and an authenticated <code>mesheryctl</code> context (see <a href="{{< ref "reference/references/mesheryctl/system/login.md" >}}"><code>mesheryctl system login</code></a>):</p>
+<code>mesheryctl model import -f digitalocean-icons-v0-1-0.tar</code>
+<p>Verify the result:</p>
+<code>mesheryctl model view digitalocean-icons</code>
+<p>See <a href="{{< ref "guides/configuration-management/importing-models/index.md" >}}">Importing Models</a> for the full set of import sources and <a href="{{< ref "guides/configuration-management/push-pull-model-image.md" >}}">Push or Pull a Model Image</a> for packaging details.</p>
+
+<!-- tab -->
 Using CSV | fa fa-list
 
 <h4>1. Understanding the Template Directory</h4>
-<p>Inside your forked Meshery repository, you'll find the templates-csvs directory containing three essential CSV files:</p>
+<p>Inside your forked Meshery repository, you'll find the <code>template-csvs</code> directory containing three essential CSV files:</p>
 <code>
-    mesheryctl/templates/templates-csvs/
+    mesheryctl/templates/template-csvs/
     <br />
-    ├── models.csv       # Define model metadata and core properties
+    ├── Models.csv       # Define model metadata and core properties
     <br />
-    ├── components.csv   # Specify individual components and their characteristics
+    ├── Components.csv   # Specify individual components and their characteristics
     <br />
-    └── relationships.csv # Define how components interact and connect
+    └── Relationships.csv # Define how components interact and connect
     <br />
 </code>
 
@@ -152,7 +205,8 @@ Using CSV | fa fa-list
 
 <h4>3. Generating Your Model</h4>
 <p>Once you've customized your CSV files, you can generate your model using a single command. Ensure you're in the root directory of your forked Meshery repository, as this maintains the correct file path relationships:</p>
-<code>mesheryctl registry generate --directory templates-csvs --model "YOUR_MODEL_NAME"</code>
+<code>mesheryctl registry generate --directory mesheryctl/templates/template-csvs --model "YOUR_MODEL_NAME"</code>
+<p>The <code>--directory</code> flag takes the path to the folder that contains <code>Models.csv</code> and <code>Components.csv</code> (<code>Relationships.csv</code> is optional). This path is CSV-driven and does <strong>not</strong> require a Google Spreadsheet credential.</p>
 
 <h4>4. Locating Generated Files</h4>
 <p>After successful generation, your model's files will be created in the repository's <code>models/</code> directory. You can find these files at <code>meshery/models/[YOUR_MODEL_NAME]/</code>. Take time to review these generated files to ensure they accurately reflect your intended model structure.</p>
@@ -206,6 +260,11 @@ Using Integration Spreadsheet | fa fa-table
 <code>
   source ~/.bashrc
 </code>
+<p>The value passed to <code>--spreadsheet-cred</code> is the <strong>base64-encoded contents of the service-account JSON</strong> (the string itself), not a file path and not <code>GOOGLE_APPLICATION_CREDENTIALS</code>. Pass it as <code>--spreadsheet-cred "$SHEET_CRED"</code>.</p>
+
+{{% alert color="warning" title="Trap: a misleading &quot;Invalid JWT Token&quot; error" %}}
+If <code>$SHEET_CRED</code> is empty or is not valid base64, <code>mesheryctl</code> reports <code>Invalid JWT Token</code> even though the real problem is the credential never decoded. Before running <code>registry generate</code>/<code>registry update</code>, confirm the variable is set and decodes cleanly: <code>echo "$SHEET_CRED" | base64 --decode | head -c 20</code> should print the start of the JSON (e.g. <code>{"type": "service_</code>).
+{{% /alert %}}
 
 <h4>4. Spreadsheet Access Configuration</h4>
 <ol>

--- a/docs/content/en/guides/configuration-management/push-pull-model-image.md
+++ b/docs/content/en/guides/configuration-management/push-pull-model-image.md
@@ -6,4 +6,61 @@ description: Push or pull a model image to or from an OCI-compatible image repos
 
 ## Use mesheryctl to Push or Pull a Model Image
 
-You can push or pull Meshery model images to or from any OCI-compatible image repository. 
+A Meshery [Model]({{< ref "concepts/logical/models/index.md" >}}) can be packaged as an
+**OCI image** - a portable, versioned artifact that bundles the model definition together with
+all of its components and relationships. Because the package is OCI-compliant, it can be moved
+between Meshery Servers and stored in any OCI-compatible image repository (Docker Hub, GitHub
+Container Registry, AWS ECR, and so on), exactly like a container image.
+
+### Package (build) a model image
+
+Package model files that follow the [scaffold layout]({{< ref "guides/configuration-management/creating-models/index.md" >}})
+(`[model-name]/[model-version]`) into an OCI artifact:
+
+```bash
+mesheryctl model build [model-name]/[model-version]
+```
+
+`model build` writes an OCI artifact named `<model-name>-<version>.tar` to your current
+directory (for example, `mesheryctl model build digitalocean-icons/v0.1.0` produces
+`digitalocean-icons-v0-1-0.tar`). This command is local - it does not require a running Meshery
+Server.
+
+### Push a model image into a Meshery Server
+
+"Pushing" a model into a Meshery Server means registering it into that server's
+[Registry]({{< ref "concepts/logical/registry.md" >}}). Import the packaged artifact (or the
+model directory) with:
+
+```bash
+mesheryctl model import -f digitalocean-icons-v0-1-0.tar
+```
+
+`mesheryctl model import` talks to the Meshery Server of your current context, so you must be
+logged in (see [`mesheryctl system login`]({{< ref "reference/references/mesheryctl/system/login.md" >}})).
+The file can be an OCI `.tar`, a compressed `tar.gz`, a model directory, or a remote URL - see
+[Importing Models]({{< ref "guides/configuration-management/importing-models/index.md" >}}) for
+the full list of supported sources.
+
+### Pull a model image from a Meshery Server
+
+"Pulling" a model retrieves an already-registered model from a Meshery Server as an OCI image
+(or a compressed archive) so it can be inspected, versioned, or moved to another server:
+
+```bash
+mesheryctl model export [model-name] -o oci
+```
+
+Use `-o` to choose the output format (`oci` or `tar`), `-t` for the file type of the definitions
+inside the archive (`yaml`, the default, or `json`), and `-l` to choose the output directory
+(the directory must already exist). See
+[Exporting Models]({{< ref "guides/configuration-management/exporting-models/index.md" >}}) for
+details.
+
+### Push to or pull from an external OCI registry
+
+Because the artifact produced by `mesheryctl model build`/`model export` is a standard OCI
+image, you can push it to - or pull it from - any OCI-compatible registry using your existing
+container tooling (for example [ORAS](https://oras.land/) or `docker`), then `mesheryctl model
+import` it into a server on the other side. This makes model images easy to share across teams
+and environments alongside your other OCI artifacts.

--- a/docs/content/en/reference/references/mesheryctl/model/init.md
+++ b/docs/content/en/reference/references/mesheryctl/model/init.md
@@ -49,7 +49,7 @@ mesheryctl model init [model-name] --path [path-to-location] (default is current
 generate a folder structure in json format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model init [model-name] --output-format [json|yaml|csv] (default is json)
+mesheryctl model init [model-name] --output-format [json|yaml] (default is json)
 
 </div>
 </pre> 

--- a/mesheryctl/internal/cli/root/design/import.go
+++ b/mesheryctl/internal/cli/root/design/import.go
@@ -129,11 +129,15 @@ func importPattern(sourceType string, file string, patternURL string, save bool)
 			return nil, utils.ErrFileRead(err)
 		}
 
+		// The /api/pattern/import File-import variant expects camelCase `fileName`
+		// (the canonical wire form per the schemas naming conventions). Sending the
+		// legacy snake_case `file_name` leaves the server's oneOf unmatched and the
+		// request is rejected with "Invalid design import request" (meshery-server-1422).
 		jsonValues, err := json.Marshal(map[string]interface{}{
-			"name":      patternName,
-			"file":      content,
-			"file_name": fileName,
-			"save":      save,
+			"name":     patternName,
+			"file":     content,
+			"fileName": fileName,
+			"save":     save,
 		})
 		if err != nil {
 			return nil, utils.ErrMarshal(err)

--- a/mesheryctl/internal/cli/root/design/import_test.go
+++ b/mesheryctl/internal/cli/root/design/import_test.go
@@ -1,7 +1,14 @@
 package design
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_importPattern_DisplayErrorsMissingFlags(t *testing.T) {
@@ -40,4 +47,53 @@ func Test_importPattern_DisplayErrorsMissingFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_importPattern_SendsCamelCaseFileName is a regression test for the design
+// import wire-contract fix. The /api/pattern/import File-import oneOf variant
+// requires the camelCase `fileName` field; the legacy snake_case `file_name`
+// left the variant unmatched and every file import failed with
+// "Invalid design import request" (meshery-server-1422). This captures the exact
+// JSON body mesheryctl puts on the wire and asserts the canonical field is sent.
+func Test_importPattern_SendsCamelCaseFileName(t *testing.T) {
+	testContext := utils.InitTestEnvironment(t)
+	_ = utils.SetupMeshkitLoggerTesting(t, false)
+	defer utils.StopMockery(t)
+	defer resetVariables()
+	defer utils.ResetCommandFlags(DesignCmd, t)
+
+	utils.TokenFlag = utils.GetToken(t)
+
+	var capturedBody map[string]interface{}
+	httpmock.RegisterResponder(
+		"POST",
+		testContext.BaseURL+"/api/pattern/import",
+		func(req *http.Request) (*http.Response, error) {
+			raw, err := io.ReadAll(req.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, json.Unmarshal(raw, &capturedBody))
+			t.Logf("Captured /api/pattern/import request body keys: %v", mapKeys(capturedBody))
+			t.Logf("fileName field value: %q", capturedBody["fileName"])
+			return httpmock.NewStringResponse(
+				200,
+				`[{"id":"3817ec9a-1d83-4f6f-9154-0fd4408ba9f0","name":"SampleApp"}]`,
+			), nil
+		},
+	)
+
+	DesignCmd.SetArgs([]string{"import", "-f", "fixtures/sampleDesign.golden", "-n", "SampleApp"})
+	assert.NoError(t, DesignCmd.Execute())
+
+	// The fix: canonical camelCase `fileName` present, legacy snake_case absent.
+	assert.Contains(t, capturedBody, "fileName", "request body must carry camelCase fileName")
+	assert.NotContains(t, capturedBody, "file_name", "request body must not carry legacy snake_case file_name")
+	assert.Equal(t, "sampleDesign.golden", capturedBody["fileName"])
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/mesheryctl/internal/cli/root/model/init.go
+++ b/mesheryctl/internal/cli/root/model/init.go
@@ -1,12 +1,14 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
 
 	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
@@ -39,7 +41,7 @@ mesheryctl model init [model-name] --version [version] (default is v0.1.0)
 mesheryctl model init [model-name] --path [path-to-location] (default is current folder)
 
 // generate a folder structure in json format
-mesheryctl model init [model-name] --output-format [json|yaml|csv] (default is json)
+mesheryctl model init [model-name] --output-format [json|yaml] (default is json)
     `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return mesheryctlflags.ValidateCmdFlags(cmd, &modelInitFlags)
@@ -121,6 +123,16 @@ mesheryctl model init [model-name] --output-format [json|yaml|csv] (default is j
 					if err != nil {
 						return ErrModelInit(err)
 					}
+					// The scaffold templates ship with placeholder identifiers
+					// ("untitled-model"/"Untitled Model"). Write the user-supplied
+					// model name into the generated model definition so the model
+					// is usable without a manual find-and-replace.
+					if templatePath == initModelTemplatePathModel {
+						content, err = initModelInjectName(content, modelInitFlags.OutputFormat, modelName)
+						if err != nil {
+							return ErrModelInit(err)
+						}
+					}
 					filePath := filepath.Join(
 
 						itemFolderPath,
@@ -172,9 +184,56 @@ mesheryctl model init [model-name] --output-format [json|yaml|csv] (default is j
 			return err
 		}
 
-		// TODO put a model name into generated model file
 		return nil
 	},
+}
+
+// initModelInjectName sets the top-level name (system identifier) and a derived,
+// human-readable displayName on the scaffolded model definition. The scaffold
+// templates ship with placeholder values, so without this the generated model
+// would register as "untitled-model"/"Untitled Model" regardless of the name the
+// user passed to `model init`. Decode/encode via a generic map so every template
+// field is preserved and only the two identity fields are overwritten.
+func initModelInjectName(content []byte, outputFormat string, modelName string) ([]byte, error) {
+	displayName := initModelDeriveDisplayName(modelName)
+
+	var model map[string]interface{}
+	switch outputFormat {
+	case "json":
+		if err := json.Unmarshal(content, &model); err != nil {
+			return nil, err
+		}
+		model["name"] = modelName
+		model["displayName"] = displayName
+		out, err := json.MarshalIndent(model, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return append(out, '\n'), nil
+	case "yaml":
+		if err := yaml.Unmarshal(content, &model); err != nil {
+			return nil, err
+		}
+		model["name"] = modelName
+		model["displayName"] = displayName
+		return yaml.Marshal(model)
+	}
+	// Output format is validated in PreRunE; any other value is unreachable.
+	return content, nil
+}
+
+// initModelDeriveDisplayName turns a system model name (e.g. "digitalocean-icons")
+// into a human-readable display name (e.g. "Digitalocean Icons"). It is only a
+// sensible default; users are expected to refine it during editing.
+func initModelDeriveDisplayName(modelName string) string {
+	replacer := strings.NewReplacer("-", " ", "_", " ")
+	words := strings.Fields(replacer.Replace(modelName))
+	for i, word := range words {
+		runes := []rune(word)
+		runes[0] = unicode.ToUpper(runes[0])
+		words[i] = string(runes)
+	}
+	return strings.Join(words, " ")
 }
 
 func init() {
@@ -213,7 +272,7 @@ $ mesheryctl model import {modelFolder}
 To export this model as OCI image:
 $ mesheryctl model build {modelName}/{modelVersion} --path {path}
 
-Detailed guide: https://docs.meshery.io/guides/creating-new-model-with-mesheryctl`
+Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models`
 
 // TODO
 // initModelData fits well for json and yaml format

--- a/mesheryctl/internal/cli/root/model/init.go
+++ b/mesheryctl/internal/cli/root/model/init.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -205,11 +206,14 @@ func initModelInjectName(content []byte, outputFormat string, modelName string) 
 		}
 		model["name"] = modelName
 		model["displayName"] = displayName
-		out, err := json.MarshalIndent(model, "", "  ")
-		if err != nil {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(model); err != nil {
 			return nil, err
 		}
-		return append(out, '\n'), nil
+		return buf.Bytes(), nil
 	case "yaml":
 		if err := yaml.Unmarshal(content, &model); err != nil {
 			return nil, err

--- a/mesheryctl/internal/cli/root/model/init_test.go
+++ b/mesheryctl/internal/cli/root/model/init_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestModelInit(t *testing.T) {
@@ -335,4 +337,54 @@ func TestModelInit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInitModelDeriveDisplayName(t *testing.T) {
+	cases := map[string]string{
+		"digitalocean-icons": "Digitalocean Icons",
+		"cert-manager":       "Cert Manager",
+		"aws_ec2_controller": "Aws Ec2 Controller",
+		"istio":              "Istio",
+		"a-b-c":              "A B C",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, initModelDeriveDisplayName(in), "deriving display name for %q", in)
+	}
+}
+
+func TestInitModelInjectName(t *testing.T) {
+	// Verify that the scaffold's placeholder identifiers are replaced with the
+	// user-supplied model name while every other template field is preserved.
+	// Regression test for the model definition being left as "untitled-model".
+	modelName := "digitalocean-icons"
+
+	t.Run("json", func(t *testing.T) {
+		content, err := getTemplateInOutputFormat(initModelTemplatePathModel, "json")
+		assert.NoError(t, err)
+
+		out, err := initModelInjectName(content, "json", modelName)
+		assert.NoError(t, err)
+
+		var got map[string]interface{}
+		assert.NoError(t, json.Unmarshal(out, &got))
+		assert.Equal(t, modelName, got["name"])
+		assert.Equal(t, "Digitalocean Icons", got["displayName"])
+		// a representative untouched field must survive the round-trip
+		assert.Contains(t, got, "schemaVersion")
+		assert.Contains(t, got, "metadata")
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		content, err := getTemplateInOutputFormat(initModelTemplatePathModel, "yaml")
+		assert.NoError(t, err)
+
+		out, err := initModelInjectName(content, "yaml", modelName)
+		assert.NoError(t, err)
+
+		var got map[string]interface{}
+		assert.NoError(t, yaml.Unmarshal(out, &got))
+		assert.Equal(t, modelName, got["name"])
+		assert.Equal(t, "Digitalocean Icons", got["displayName"])
+		assert.Contains(t, got, "schemaVersion")
+	})
 }

--- a/mesheryctl/internal/cli/root/model/init_test.go
+++ b/mesheryctl/internal/cli/root/model/init_test.go
@@ -372,6 +372,7 @@ func TestInitModelInjectName(t *testing.T) {
 		// a representative untouched field must survive the round-trip
 		assert.Contains(t, got, "schemaVersion")
 		assert.Contains(t, got, "metadata")
+		assert.Contains(t, string(out), "<svg")
 	})
 
 	t.Run("yaml", func(t *testing.T) {

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.aws-dynamodb-controller-in-yaml.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.aws-dynamodb-controller-in-yaml.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test-case-aws-dynamodb-controller
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-dynamodb-controller/v0.1.0 --path .
 
-Detailed guide: https://docs.meshery.io/guides/creating-new-model-with-mesheryctl
+Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test-case-aws-ec2-controller
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v0.1.0 --path .
 
-Detailed guide: https://docs.meshery.io/guides/creating-new-model-with-mesheryctl
+Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir-2.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir-2.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test_case_some_other_custom_dir/with/trailing/separato
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path test_case_some_other_custom_dir/with/trailing/separator
 
-Detailed guide: https://docs.meshery.io/guides/creating-new-model-with-mesheryctl
+Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test_case_some_custom_dir/subdir/one_more_subdir/test-
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path test_case_some_custom_dir/subdir/one_more_subdir
 
-Detailed guide: https://docs.meshery.io/guides/creating-new-model-with-mesheryctl
+Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-relative-parent-dir.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-relative-parent-dir.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import ../test_case_some_custom_dir/subdir/one_more_subdir/te
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path ../test_case_some_custom_dir/subdir/one_more_subdir
 
-Detailed guide: https://docs.meshery.io/guides/creating-new-model-with-mesheryctl
+Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models

--- a/mesheryctl/internal/cli/root/registry/update.go
+++ b/mesheryctl/internal/cli/root/registry/update.go
@@ -253,7 +253,10 @@ func logModelUpdateSummary(modelToCompUpdateTracker *store.GenerticThreadSafeSto
 
 func init() {
 	updateCmd.PersistentFlags().StringVarP(&modelLocation, "input", "i", "./models", "relative or absolute input path to the models directory; when unset, the repo-root models directory is auto-detected (models from the repo root, ../models from a subdirectory)")
-	_ = updateCmd.MarkPersistentFlagRequired("path")
+	// NOTE: `input` is intentionally not marked required - it has a default and is
+	// auto-detected in RunE. A prior version called MarkPersistentFlagRequired("path")
+	// here, which silently no-op'd (the flag is named `input`, not `path`, and the
+	// returned error was discarded), so the requirement never took effect. See #18633.
 
 	updateCmd.PersistentFlags().StringVar(&spreadsheeetID, "spreadsheet-id", "", "spreadsheet ID for the integration spreadsheet")
 	updateCmd.PersistentFlags().StringVar(&spreadsheeetCred, "spreadsheet-cred", "", "base64 encoded credential to download the spreadsheet")


### PR DESCRIPTION
## Intent

Create, validate, and publish an annotation-only Meshery model 'digitalocean-icons' (9 DigitalOcean logo components: horizontal/vertical/icon in black/blue/white; Platform / Cloud Provider; registrant Meshery; isAnnotation) modeled on the existing exoscale-icons model, plus a sample design placing all 9 components - done live against playground.meshery.io. This exercise doubled as a validation of Meshery's model/design docs and mesheryctl tooling, so this PR ships the mesheryctl bug fixes and docs updates I found while doing it (the model artifact and published design are live-server actions, not committed).

Committed changes and the reasoning behind them (a reviewer reading only the diff would not know these were verified live):
- mesheryctl design import: changed the request body field from snake_case file_name to camelCase fileName. The /api/pattern/import File-import oneOf requires fileName (canonical wire form); the old file_name left the variant unmatched and every design import failed with 'Invalid design import request' (meshery-server-1422). Verified end-to-end on playground: import failed before, succeeded after.
- mesheryctl model init: now writes the user-supplied model name into the scaffolded model.json (name + a derived displayName) instead of leaving the placeholder 'untitled-model'/'Untitled Model' (fixes #19013, #18982). Implemented via a map decode/set/encode so every template field is preserved; this reorders JSON keys, which is acceptable for a scaffold meant to be edited. Added unit tests for the injection and display-name derivation.
- mesheryctl registry update: removed the dead MarkPersistentFlagRequired("path") call - the flag is named 'input' (has a default and is auto-detected in RunE), the returned error was discarded, so the requirement never took effect (fixes #18633).
- mesheryctl model init: corrected the --output-format example to [json|yaml] (csv was advertised but dead) and pointed the next-steps 'Detailed guide' link at an existing docs page (the old creating-new-model-with-mesheryctl page does not exist). The 5 model.init.*.output.golden files are updated only to reflect that corrected link.
- docs: filled the previously-empty push-pull-model-image guide; added a 'Using Scaffold (model init)' workflow to the Create Models guide with a component schemaVersion compatibility warning (released servers accept components.meshery.io/v1beta1, not v1beta3 - see filed issue #20901); fixed the templates-csvs -> template-csvs directory path and CSV filenames; documented the base64 spreadsheet-cred process and the misleading 'Invalid JWT Token' trap.

Out-of-scope issues were filed rather than fixed here: #20901 (model init scaffolds v1beta3 components that released servers reject with an opaque 'No valid component' error) and #20902 (registry generate/update report success on a non-200 sheet fetch).

## What Changed

- `design import` now sends the design filename as camelCase `fileName` instead of snake_case `file_name`, so the request matches the `/api/pattern/import` File-import `oneOf` variant that previously left every import failing with "Invalid design import request" (meshery-server-1422); added a unit test covering the request body.
- `model init` writes the user-supplied model name (plus a derived `displayName`) into the scaffolded `model.json`/`.yaml` via a decode/set/encode over a generic map that preserves all template fields, replacing the `untitled-model`/`Untitled Model` placeholders (#19013, #18982); JSON is re-serialized with HTML-escaping disabled so inline SVG stays readable, and unit tests cover the injection and display-name derivation.
- `registry update` drops the dead `MarkPersistentFlagRequired("path")` call whose discarded error meant the requirement never applied (the flag is `input`, #18633); the `model init` help text corrects `--output-format` to `[json|yaml]` and repoints the next-steps guide link to an existing docs page (refreshing the 5 `model.init.*.output.golden` fixtures), and the push/pull-model-image and create-models docs are filled out with the scaffold workflow.

## Risk Assessment

✅ Low: The only change since the prior round is the exact, correct fix for the previously-reported SVG HTML-escaping issue (now covered by a unit assertion), and all other branch changes were already verified correct against the server contract, schema templates, and repo layout.

## Testing

All committed mesheryctl fixes validated; model init injects name/displayName, design import sends camelCase fileName; all tests pass.

<details>
<summary>Evidence: Generated model.json</summary>

```text
{
  "category": {
    "id": "00000000-0000-0000-0000-000000000000",
    "name": "Uncategorized"
  },
  "categoryId": "00000000-0000-0000-0000-000000000000",
  "componentsCount": 0,
  "createdAt": "0001-01-01T00:00:00Z",
  "description": "A new Meshery model.",
  "displayName": "Digitalocean Icons",
  "id": "00000000-0000-0000-0000-000000000000",
  "metadata": {
    "capabilities": [],
    "isAnnotation": false,
    "primaryColor": "#00b39f",
    "secondaryColor": "#00D3A9",
    "shape": "circle",
    "svgColor": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Layer_1\" data-name=\"Layer 1\" viewBox=\"0 0 134.95 135.02\"><defs><style>.cls-1{fill:#00d3a9}.cls-2{fill:#00b39f}</style></defs><title>meshery-logo-light</title><polygon points=\"69.49 31.82 69.49 64.07 97.44 47.89 69.49 31.82\" class=\"cls-1\"/><polygon points=\"69.49 70.81 69.49 103.22 97.7 87.09 69.49 70.81\" class=\"cls-1\"/><polygon points=\"65.47 63.85 65.47 32.09 37.87 47.92 65.47 63.85\" class=\"cls-2\"/><path d=\"M10.1,103.1a67.79,67.79,0,0,0,21.41,21.55V90.71Z\" class=\"cls-2\"/><polygon points=\"65.47 103.06 65.47 71.05 37.8 87.07 65.47 103.06\" class=\"cls-2\"/><polygon points=\"35.54 122.63 63.56 106.61 35.54 90.41 35.54 122.63\" class=\"cls-1\"/><polygon points=\"99.61 122.8 99.61 90.63 71.63 106.63 99.61 122.8\" class=\"cls-2\"/><path d=\"M127,99.37a67.22,67.22,0,0,0,7.91-28.94L105.78,87.11Z\" class=\"cls-2\"/><polygon points=\"103.64 83.69 131.76 67.61 103.64 51.45 103.64 83.69\" class=\"cls-1\"/><polygon points=\"99.61 44.5 99.61 12.52 71.76 28.49 99.61 44.5\" class=\"cls-2\"/><polygon points=\"99.61 83.55 99.61 51.28 71.7 67.44 99.61 83.55\" class=\"cls-2\"/><polygon points=\"67.48 135.02 67.49 135.02 67.48 135.02 67.48 135.02\" class=\"cls-2\"/><polygon points=\"35.54 51.22 35.54 83.73 63.66 67.45 35.54 51.22\" class=\"cls-1\"/><path d=\"M65.47,0A67.2,67.2,0,0,0,35.83,7.83l29.64,17Z\" class=\"cls-2\"/><polygon points=\"35.54 12.3 35.54 44.62 63.68 28.48 35.54 12.3\" class=\"cls-1\"/><path d=\"M31.51,10.34A67.89,67.89,0,0,0,10.1,31.89L31.51,44.25Z\" class=\"cls-2\"/><path d=\"M99.43,8A67.23,67.23,0,0,0,69.49,0V25.15Z\" class=\"cls-1\"/><path d=\"M0,69.87A67.27,67.27,0,0,0,8.07,99.63L29.76,87.07Z\" class=\"cls-1\"/><path d=\"M8.07,35.37A67.16,67.16,0,0,0,0,65L29.79,47.91Z\" class=\"cls-1\"/><path d=\"M35.78,127.13A67.13,67.13,0,0,0,65.47,135V110.15Z\" class=\"cls-2\"/><path d=\"M124.92,32a67.9,67.9,0,0,0-21.28-21.52V44.3Z\" class=\"cls-1\"/><path d=\"M103.64,124.54A68,68,0,0,0,125,102.86L103.64,90.52Z\" class=\"cls-1\"/><path d=\"M135,64.81a67.06,67.06,0,0,0-8-29.35L105.49,47.88Z\" class=\"cls-2\"/><path d=\"M69.49,135a67.12,67.12,0,0,0,29.63-7.83L69.49,110Z\" class=\"cls-1\"/><polygon points=\"31.51 83.44 31.51 51.56 3.83 67.43 31.51 83.44\" class=\"cls-2\"/></svg>",
    "svgComplete": "",
    "svgWhite": "<svg width=\"32\" height=\"32\" viewBox=\"0 0 32 32\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M16.405 8.732v6.57l5.694-3.297-5.694-3.273Zm0 7.942v6.602l5.747-3.285-5.747-3.317Z\" fill=\"#fff\"/><path d=\"M15.586 15.256v-6.47l-5.622 3.225 5.622 3.245ZM4.307 23.252a13.809 13.809 0 0 0 4.362 4.39v-6.914l-4.362 2.524Zm11.279-.008v-6.52L9.95 19.985l5.636 3.258Z\" fill=\"#fff\" fill-opacity=\".8\"/><path d=\"m9.49 27.23 5.707-3.263-5.707-3.3v6.563Z\" fill=\"#fff\"/><path d=\"M22.54 27.265v-6.553l-5.699 3.259 5.7 3.294Zm5.58-4.773a13.697 13.697 0 0 0 1.612-5.895l-5.934 3.397 4.323 2.498Z\" fill=\"#fff\" fill-opacity=\".8\"/><path d=\"m23.362 19.298 5.728-3.276-5.728-3.291v6.567Z\" fill=\"#fff\"/><path d=\"M22.541 11.315V4.8l-5.673 3.253 5.673 3.262Zm0 7.955v-6.574l-5.685 3.292 5.685 3.281Z\" fill=\"#fff\" fill-opacity=\".8\"/><path d=\"M9.49 12.684v6.622l5.728-3.316-5.728-3.306Z\" fill=\"#fff\"/><path d=\"M15.586 2.25a13.69 13.69 0 0 0-6.037 1.595l6.037 3.463V2.25Z\" fill=\"#fff\" fill-opacity=\".8\"/><path d=\"M9.49 4.756v6.583l5.732-3.288L9.49 4.756Z\" fill=\"#fff\"/><path d=\"M8.669 4.356a13.83 13.83 0 0 0-4.362 4.39l4.362 2.518V4.356Z\" fill=\"#fff\" fill-opacity=\".8\"/><path d=\"M22.504 3.88a13.695 13.695 0 0 0-6.099-1.63v5.123l6.1-3.493ZM2.25 16.483c.071 2.12.634 4.196 1.644 6.062l4.418-2.559-6.062-3.503Zm1.644-7.028a13.68 13.68 0 0 0-1.644 6.036l6.068-3.482-4.424-2.554Z\" fill=\"#fff\"/><path d=\"M9.539 28.147a13.673 13.673 0 0 0 6.047 1.603v-5.062L9.54 28.147Z\" fill=\"#fff\" fill-opacity=\".8\"/><path d=\"M27.697 8.768a13.83 13.83 0 0 0-4.335-4.383v6.889l4.335-2.506ZM23.362 27.62a13.851 13.851 0 0 0 4.351-4.417l-4.351-2.514v6.93Z\" fill=\"#fff\"/><path d=\"M29.75 15.452a13.659 13.659 0 0 0-1.63-5.979l-4.381 2.53 6.011 3.45Z\" fill=\"#fff\" fill-opacity=\".8\"/><path d=\"M16.405 29.75a13.673 13.673 0 0 0 6.036-1.595l-6.036-3.498v5.093Z\" fill=\"#fff\"/><path d=\"M8.669 19.247v-6.494L3.03 15.986l5.639 3.261Z\" fill=\"#fff\" fill-opacity=\".8\"/></svg>"
  },
  "model": {
    "version": "v0.0.1"
  },
  "name": "digitalocean-icons",
  "registrant": {
    "createdAt": "0001-01-01T00:00:00Z",
    "credentialId": "00000000-0000-0000-0000-000000000000",
    "deletedAt": null,
    "environments": [
      {
        "createdAt": "0001-01-01T00:00:00Z",
        "deletedAt": null,
        "description": "",
        "id": "00000000-0000-0000-0000-000000000000",
        "name": "",
        "organizationId": "00000000-0000-0000-0000-000000000000",
        "owner": "00000000-0000-0000-0000-000000000000",
        "schemaVersion": "environments.meshery.io/v1beta3",
        "updatedAt": "0001-01-01T00:00:00Z"
      }
    ],
    "id": "00000000-0000-0000-0000-000000000000",
    "kind": "artifacthub",
    "name": "",
    "schemaVersion": "connections.meshery.io/v1beta3",
    "status": "",
    "subType": "",
    "type": "",
    "updatedAt": "0001-01-01T00:00:00Z",
    "userId": "00000000-0000-0000-0000-000000000000"
  },
  "registrantId": "00000000-0000-0000-0000-000000000000",
  "relationshipsCount": 0,
  "schemaVersion": "models.meshery.io/v1beta2",
  "status": "enabled",
  "subCategory": "Uncategorized",
  "updatedAt": "0001-01-01T00:00:00Z",
  "version": "v0.0.1"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `mesheryctl/internal/cli/root/model/init.go:208` - initModelInjectName re-serializes model.json with json.MarshalIndent, which HTML-escapes &#39;&lt;&#39;, &#39;&gt;&#39; and &#39;&amp;&#39; to &lt;/&gt;/&amp; by default. The template&#39;s metadata.svgColor and metadata.svgWhite are inline SVG strings, so the scaffolded model.json now ships those two fields as unreadable escaped-unicode blobs (e.g. &#34;&lt;svg width=...&#34;). This degrades exactly the fields the new &#39;Using Scaffold&#39; docs instruct users to hand-edit, is a regression from the prior behavior where the raw template was written verbatim with readable SVG, and is inconsistent with the sibling component.json (which is not round-tripped and keeps readable SVG). Fix: serialize with a json.Encoder that has SetEscapeHTML(false) (and SetIndent(&#34;&#34;, &#34;  &#34;)); note Encoder.Encode already appends a trailing newline, so the manual append(out, &#39;\n&#39;) becomes unnecessary. The YAML path is unaffected.

🔧 Fix: disable JSON HTML-escaping so scaffolded model.json keeps readable SVG
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test --short ./internal/cli/root/model/... ./internal/cli/root/design/... ./internal/cli/root/registry/...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded model scaffolding guidance for `mesheryctl model init`, including injecting the provided model name and display name.
  * Added/updated documentation for building, importing, exporting, and transferring models as OCI artifacts via external OCI-compatible registries.
* **Bug Fixes**
  * Fixed pattern file import payload to use the expected camelCase `fileName` field.
  * Corrected CLI flag handling related to registry updates.
* **Documentation**
  * Updated “creating models” and “push/pull model image” guides, clarified CSV/template paths and `--directory`, and documented spreadsheet credential base64 handling and the empty/invalid-base64 “Invalid JWT Token” warning.
  * Restricted `mesheryctl model init` `--output-format` examples to `json|yaml` and refreshed “Detailed guide” links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->