### PR TITLE
[CI] Add connections/credentials doc links to model issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/model-catalog.md
+++ b/.github/ISSUE_TEMPLATE/model-catalog.md
@@ -40,6 +40,8 @@ Now to publish your model to catalog:
 - 📚 [Models](https://docs.meshery.io/concepts/logical/models)
 - 📚 [Creating models](https://docs.meshery.io/guides/configuration-management/creating-models#create-models)
 - 📚 [Components](https://docs.meshery.io/concepts/logical/components)
+- 📚 [Connections](https://docs.meshery.io/concepts/logical/connections)
+- 📚 [Credentials](https://docs.meshery.io/concepts/logical/credentials)
 - 📚 [Relationships](https://docs.meshery.io/concepts/logical/relationships)
 - 👨‍💻 [Models Repository](https://github.com/meshery/meshery/tree/master/models)
 - 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/models.md
+++ b/.github/ISSUE_TEMPLATE/models.md
@@ -28,11 +28,11 @@ assignees: ''
   - 📚 [Credentials](https://docs.meshery.io/concepts/logical/credentials)
 - 👨‍💻[Models Repository](https://github.com/meshery/meshery/tree/master/models)
 
- ### Contributing to Meshery Models
- - [Contributing to Models](https://docs.meshery.io/project/contributing/models/models)
-   - [Contributing to Components](https://docs.meshery.io/project/contributing/models/components)
-   - [Contributing to Connections](https://docs.meshery.io/project/contributing/models/connections)
-   - [Contributing to Relationships](https://docs.meshery.io/project/contributing/models/relationships)
+### Contributing to Meshery Models
+- [Contributing to Models](https://docs.meshery.io/project/contributing/models/models)
+  - [Contributing to Components](https://docs.meshery.io/project/contributing/models/components)
+  - [Contributing to Connections](https://docs.meshery.io/project/contributing/models/connections)
+  - [Contributing to Relationships](https://docs.meshery.io/project/contributing/models/relationships)
 - 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 
  <!-- ### Instructions for Policies

--- a/.github/ISSUE_TEMPLATE/models.md
+++ b/.github/ISSUE_TEMPLATE/models.md
@@ -23,14 +23,17 @@ assignees: ''
 
 - 📚 [Models](https://docs.meshery.io/concepts/logical/models)
   - 📚 [Components](https://docs.meshery.io/concepts/logical/components)
-  - 📚 [Relationships](https://docs.meshery.io/concepts/logical/components)
+  - 📚 [Relationships](https://docs.meshery.io/concepts/logical/relationships)
+  - 📚 [Connections](https://docs.meshery.io/concepts/logical/connections)
+  - 📚 [Credentials](https://docs.meshery.io/concepts/logical/credentials)
 - 👨‍💻[Models Repository](https://github.com/meshery/meshery/tree/master/models)
 
  ### Contributing to Meshery Models
- - [Contributing Models](https://docs.meshery.io/project/contributing/contributing-models)
-   - [Contributing Components](https://docs.meshery.io/project/contributing/contributing-components)
-   - [Contributing Relationships](https://docs.meshery.io/project/contributing/contributing-relationships)
-   - 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+ - [Contributing to Models](https://docs.meshery.io/project/contributing/models/models)
+   - [Contributing to Components](https://docs.meshery.io/project/contributing/models/components)
+   - [Contributing to Connections](https://docs.meshery.io/project/contributing/models/connections)
+   - [Contributing to Relationships](https://docs.meshery.io/project/contributing/models/relationships)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 
  <!-- ### Instructions for Policies
  - [Contributing Policies](https://docs.meshery.io/project/contributing/contributing-policies)


### PR DESCRIPTION
Fixes #20893

- Added Connections and Credentials doc links to both model-related issue templates (models.md and model-catalog.md).
- Fixed a broken Relationships link that was pointing to the Components doc page.
- Updated Contributing to Models/Components/Relationships links to their current doc URLs, and added a Contributing to Connections link.
- Outdented the Self-paced Contributor Trainings link so it's a sibling of "Contributing to Models" rather than nested under it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Model Catalog issue template to include new “Connections” and “Credentials” documentation links.
  * Revised “Understanding Meshery Models” guidance to add “Relationships,” “Connections,” and “Credentials” links, including a corrected “Relationships” URL.
  * Refreshed “Contributing to Meshery Models” links to new docs paths for models, components, connections, and relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->