### PR TITLE
fix(server): retry transient remote-provider errors in SessionInjecto…

### DIFF
--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -231,8 +231,15 @@ func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http
 		// }
 
 		user, err := provider.GetUserDetails(req)
-		for attempt := 0; err != nil && isTransientProviderError(err) && attempt < transientRetryAttempts; attempt++ {
-			time.Sleep(transientRetryBackoff)
+	retryGetUserDetails:
+		for attempt := 1; err != nil && isTransientProviderError(err) && attempt < transientRetryAttempts; attempt++ {
+			timer := time.NewTimer(transientRetryBackoff)
+			select {
+			case <-timer.C:
+			case <-req.Context().Done():
+				timer.Stop()
+				break retryGetUserDetails
+			}
 			user, err = provider.GetUserDetails(req)
 		}
 		if err != nil {

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/machines"
@@ -201,6 +202,11 @@ func (h *Handler) KubernetesMiddleware(next func(http.ResponseWriter, *http.Requ
 	}
 }
 
+const (
+	transientRetryAttempts = 2
+	transientRetryBackoff  = 300 * time.Millisecond
+)
+
 // SessionInjectorMiddleware - is a middleware which injects user and session object
 func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http.Request, *models.Preference, *models.User, models.Provider)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -225,6 +231,10 @@ func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http
 		// }
 
 		user, err := provider.GetUserDetails(req)
+		for attempt := 0; err != nil && isTransientProviderError(err) && attempt < transientRetryAttempts; attempt++ {
+			time.Sleep(transientRetryBackoff)
+			user, err = provider.GetUserDetails(req)
+		}
 		if err != nil {
 			h.log.Error(ErrGetUserDetails(err))
 			// INTENTIONAL log/wire divergence. We log ErrGetUserDetails so the

--- a/server/handlers/middlewares_test.go
+++ b/server/handlers/middlewares_test.go
@@ -1,12 +1,15 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/meshery/meshery/server/models"
 )
 
 // TestResolveProviderName covers the precedence rules for picking the
@@ -272,5 +275,49 @@ func TestIsTransientProviderError(t *testing.T) {
 				t.Errorf("isTransientProviderError(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+type stubProvider struct {
+	models.Provider
+	getUserDetailsFunc func(*http.Request) (*models.User, error)
+}
+
+func (s *stubProvider) GetUserDetails(req *http.Request) (*models.User, error) {
+	return s.getUserDetailsFunc(req)
+}
+
+func (s *stubProvider) ReadFromPersister(userID string) (*models.Preference, error) {
+	return models.NewDefaultPreference(), nil
+}
+
+func (s *stubProvider) UpdateToken(w http.ResponseWriter, req *http.Request) string {
+	return "test-token"
+}
+func TestSessionInjectorMiddleware_RetriesTransientProviderError(t *testing.T) {
+	calls := 0
+	stub := &stubProvider{
+		getUserDetailsFunc: func(*http.Request) (*models.User, error) {
+			calls++
+			if calls == 1 {
+				return nil, errors.New("Could not reach remote provider: dial tcp: i/o timeout")
+			}
+			return &models.User{}, nil
+		},
+	}
+	h := &Handler{log: newTestLogger(t)}
+	req := httptest.NewRequest("GET", "/", nil)
+	req = req.WithContext(context.WithValue(req.Context(), models.ProviderCtxKey, models.Provider(stub)))
+	rec := httptest.NewRecorder()
+
+	h.SessionInjectorMiddleware(func(w http.ResponseWriter, r *http.Request, p *models.Preference, u *models.User, prov models.Provider) {
+		w.WriteHeader(http.StatusOK)
+	}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 after retry, got %d", rec.Code)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls (fail once, succeed on retry), got %d", calls)
 	}
 }


### PR DESCRIPTION

Notes for Reviewers

Relates to https://github.com/meshery/meshery/issues/20721 (mechanism confirmed via unit test; not marked as a full fix yet — awaiting the reporter's confirmation against their actual DigitalOcean Kubernetes setup)
SessionInjectorMiddleware currently returns a hard 503 on the very first transient failure of provider.GetUserDetails() (e.g. a cold connection to a remote provider like Layer5 Cloud), with no retry — even though the existing code already avoids destroying the session in this case. On a freshly-provisioned cluster, the first outbound call to a remote provider is exactly the kind of request likely to hit a cold-start timeout, which matches the reported "first login attempt fails, immediate retry succeeds" symptom.

This PR adds a small bounded retry (2 attempts, 300ms backoff) around that call before falling through to the existing transient/genuine-error handling. No other behavior changes.

Before:
middlewares_test.go:310: expected 200 after retry, got 503
middlewares_test.go:313: expected 2 calls (fail once, succeed on retry), got 1
--- FAIL

After:
=== RUN TestSessionInjectorMiddleware_RetriesTransientProviderError
--- PASS: TestSessionInjectorMiddleware_RetriesTransientProviderError (0.30s)
PASS
ok github.com/meshery/meshery/server/handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for remote identity-provider lookups by retrying transient connection failures with a bounded backoff before continuing normal error handling.
  * Temporary provider issues are more likely to recover automatically, reducing unnecessary interruptions to the user session.

* **Tests**
  * Added coverage to ensure the session-injection middleware retries transient provider failures and succeeds when the provider recovers on the next attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->