### PR TITLE
[UI] Fix Dashboard resources filter reset to All

### DIFF
--- a/ui/components/dashboard/resources/resources-table.test.tsx
+++ b/ui/components/dashboard/resources/resources-table.test.tsx
@@ -1,22 +1,34 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const fetchMeshSyncResources = vi.fn();
+const getClusterIds = vi.fn();
 
 // Mock the leaf dependencies that the SUT pulls in. The SUT itself is NOT
 // mocked — we import it and exercise its real exports below.
 vi.mock('@/rtk-query/meshsync', () => ({
   useLazyGetMeshSyncResourcesQuery: () => [
-    vi.fn().mockResolvedValue({ resources: [], total_count: 0 }),
+    (...args: unknown[]) => fetchMeshSyncResources(...args),
     { data: undefined, isFetching: false },
   ],
-  useGetMeshSyncResourceKindsQuery: () => ({ data: { kinds: [] } }),
+  useGetMeshSyncResourceKindsQuery: () => ({
+    data: { kinds: [], namespaces: ['default', 'kube-system'] },
+  }),
 }));
 
 vi.mock('react-redux', () => ({
   useSelector: () => ({}),
 }));
 
-const routerState = { isReady: false, query: {}, push: vi.fn(), replace: vi.fn() };
+const routerState = {
+  isReady: false,
+  query: {} as Record<string, unknown>,
+  pathname: '/dashboard',
+  push: vi.fn(),
+  replace: vi.fn(),
+};
 vi.mock('next/router', () => ({
   useRouter: () => routerState,
 }));
@@ -30,11 +42,11 @@ vi.mock('../../../utils/hooks/useNotification', () => ({
 }));
 
 vi.mock('../../../utils/multi-ctx', () => ({
-  getK8sClusterIdsFromCtxId: () => [],
+  getK8sClusterIdsFromCtxId: (...args: unknown[]) => getClusterIds(...args),
 }));
 
 vi.mock('../../../utils/responsive-column', () => ({
-  updateVisibleColumns: vi.fn(),
+  updateVisibleColumns: () => ({}),
 }));
 
 vi.mock('../../../utils/dimension', () => ({
@@ -60,15 +72,60 @@ vi.mock('@sistent/sistent', () => ({
   SearchBar: () => <div data-testid="search-bar" />,
   Slide: ({ children, in: visible }: any) =>
     visible ? <div data-testid="slide">{children}</div> : null,
-  UniversalFilter: () => <div data-testid="universal-filter" />,
+  UniversalFilter: ({ handleApplyFilter, setSelectedFilters }: any) => (
+    <div data-testid="universal-filter">
+      <button
+        type="button"
+        data-testid="apply-namespace"
+        onClick={() => {
+          const next = { namespace: 'kube-system' };
+          setSelectedFilters(next);
+          handleApplyFilter(next);
+        }}
+      >
+        Apply Namespace
+      </button>
+      <button
+        type="button"
+        data-testid="apply-all"
+        onClick={() => {
+          const next = { namespace: 'All' };
+          setSelectedFilters(next);
+          handleApplyFilter(next);
+        }}
+      >
+        Apply All
+      </button>
+    </div>
+  ),
 }));
 
-// Now import the real SUT.
 import ResourcesTable, { ACTION_TYPES } from './resources-table';
+
+const baseProps = {
+  updateProgress: vi.fn(),
+  k8sConfig: {},
+  useResourceConfig: () => ({
+    name: 'Pod',
+    columns: [{ name: 'name' }],
+    colViews: [],
+    options: {},
+  }),
+  submenu: false,
+  workloadType: 'pods',
+  selectedK8sContexts: ['all'],
+};
 
 describe('resources-table module', () => {
   beforeEach(() => {
     routerState.isReady = false;
+    routerState.query = {};
+    fetchMeshSyncResources.mockReset();
+    getClusterIds.mockReset();
+    getClusterIds.mockReturnValue(['cluster-a']);
+    fetchMeshSyncResources.mockReturnValue({
+      unwrap: () => Promise.resolve({ resources: [], page: 0, totalCount: 0, pageSize: 10 }),
+    });
   });
 
   it('exports the FETCH_MESHSYNC_RESOURCES action type', () => {
@@ -81,31 +138,49 @@ describe('resources-table module', () => {
 
   it('renders nothing while next/router is not yet ready', () => {
     routerState.isReady = false;
-    const { container } = render(
-      <ResourcesTable
-        updateProgress={vi.fn()}
-        k8sConfig={{}}
-        useResourceConfig={() => ({ columns: [], options: {} })}
-        submenu={false}
-        workloadType="pods"
-        selectedK8sContexts={[]}
-      />,
-    );
+    const { container } = render(<ResourcesTable {...baseProps} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('mounts the inner table once next/router becomes ready', () => {
     routerState.isReady = true;
-    render(
-      <ResourcesTable
-        updateProgress={vi.fn()}
-        k8sConfig={{}}
-        useResourceConfig={() => ({ columns: [], options: {} })}
-        submenu={false}
-        workloadType="pods"
-        selectedK8sContexts={[]}
-      />,
-    );
+    render(<ResourcesTable {...baseProps} />);
     expect(screen.getByTestId('responsive-data-table')).toBeInTheDocument();
+  });
+
+  it('applies the namespace from the Apply payload on first click', async () => {
+    const user = userEvent.setup();
+    routerState.isReady = true;
+    render(<ResourcesTable {...baseProps} />);
+
+    await user.click(screen.getByTestId('apply-namespace'));
+
+    await waitFor(() => {
+      expect(fetchMeshSyncResources).toHaveBeenCalledWith(
+        expect.objectContaining({ namespace: 'kube-system' }),
+      );
+    });
+  });
+
+  it('clears the namespace filter when Apply resets to All', async () => {
+    const user = userEvent.setup();
+    routerState.isReady = true;
+    render(<ResourcesTable {...baseProps} />);
+
+    await user.click(screen.getByTestId('apply-namespace'));
+    await waitFor(() => {
+      expect(fetchMeshSyncResources).toHaveBeenCalledWith(
+        expect.objectContaining({ namespace: 'kube-system' }),
+      );
+    });
+
+    fetchMeshSyncResources.mockClear();
+    await user.click(screen.getByTestId('apply-all'));
+
+    await waitFor(() => {
+      expect(fetchMeshSyncResources).toHaveBeenCalled();
+      const lastCall = fetchMeshSyncResources.mock.calls.at(-1)?.[0];
+      expect(lastCall).not.toHaveProperty('namespace');
+    });
   });
 });

--- a/ui/components/dashboard/resources/resources-table.tsx
+++ b/ui/components/dashboard/resources/resources-table.tsx
@@ -76,8 +76,9 @@ const ResourcesTableInner = (props: ResourcesTableProps) => {
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
   const { width } = useWindowDimensions();
   const { connectionMetadataState } = useSelector((state) => state.ui);
-  const handleApplyFilter = () => {
-    const namespaceFilter = selectedFilters.namespace === 'All' ? null : selectedFilters.namespace;
+  const handleApplyFilter = (filters?: { namespace: string }) => {
+    const next = filters ?? selectedFilters;
+    const namespaceFilter = next.namespace === 'All' ? null : next.namespace;
     setNamespaceFilter(namespaceFilter);
   };
   const clusterIds = getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig);


### PR DESCRIPTION
## Summary

Fixes resetting Dashboard resources table filters to **All** so the resource list is restored correctly instead of staying on the previous namespace (stale Apply state).

### Root cause

`UniversalFilter` calls `setSelectedFilters(next)` then `handleApplyFilter(next)` in the same tick. `handleApplyFilter` ignored the argument and read React `selectedFilters`, which was still the old value.

### Changes

- Use the filters payload from `UniversalFilter` on Apply
- Treat `"All"` as unset (`null`) for namespace
- Keep existing `selectedFilters` / `namespaceFilter` naming
- Add regression tests for apply + reset to All

Fixes #20907

## Test plan

- [ ] `cd ui && npm test -- --run components/dashboard/resources/resources-table.test.tsx`
- [ ] Manual: Dashboard → resource tab → filter by namespace → Apply → set back to **All** → Apply → full list restored
- [ ] Confirm a non-All namespace filter still narrows results

**Notes for Reviewers**

- Core fix is only in `handleApplyFilter` in `resources-table.tsx`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace filtering in the resources table.
  * Selecting a specific namespace now applies it correctly to resource results.
  * Selecting **All** now clears the namespace filter and returns unfiltered results.
  * Improved loading behavior while the routing context is initializing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->