### PR TITLE
[UI] Fix Filters table filter reset and URL apply lag

### DIFF
--- a/ui/components/filters/Filters.filters.test.tsx
+++ b/ui/components/filters/Filters.filters.test.tsx
@@ -1,0 +1,337 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const can = vi.fn(() => true);
+const useGetFiltersQuery = vi.fn();
+const useGetProviderCapabilitiesQuery = vi.fn();
+const getMeshModels = vi.fn();
+const routerReplace = vi.fn();
+
+const router = {
+  query: {} as Record<string, unknown>,
+  pathname: '/configuration/filters',
+  push: vi.fn(),
+  replace: (...args: unknown[]) => {
+    const [{ query }] = args as [{ query: Record<string, string> }];
+    if (query) {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) params.set(key, value);
+      }
+      const qs = params.toString();
+      window.history.replaceState({}, '', qs ? `${router.pathname}?${qs}` : router.pathname);
+    }
+    routerReplace(...args);
+  },
+};
+
+vi.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+vi.mock('@/utils/can', () => ({
+  default: (...args: unknown[]) => can(...args),
+}));
+
+vi.mock('@meshery/schemas/permissions', () => ({
+  Keys: new Proxy({}, { get: () => ({ id: 'id', function: 'fn' }) }),
+}));
+
+vi.mock('@/rtk-query/filter', () => ({
+  useGetFiltersQuery: (...args: unknown[]) => useGetFiltersQuery(...args),
+  useCloneFilterMutation: () => [vi.fn()],
+  usePublishFilterMutation: () => [vi.fn()],
+  useUnpublishFilterMutation: () => [vi.fn()],
+  useDeleteFilterMutation: () => [vi.fn()],
+  useUpdateFilterFileMutation: () => [vi.fn()],
+  useUploadFilterFileMutation: () => [vi.fn()],
+}));
+
+vi.mock('@/rtk-query/user', () => ({
+  useGetProviderCapabilitiesQuery: (...args: unknown[]) => useGetProviderCapabilitiesQuery(...args),
+}));
+
+vi.mock('../../api/meshmodel', () => ({
+  getMeshModels: (...args: unknown[]) => getMeshModels(...args),
+}));
+
+vi.mock('@/graphql/queries/CatalogFilterQuery', () => ({
+  default: () => ({
+    subscribe: ({ next }: any) => {
+      next({ catalogFilters: [] });
+      return { unsubscribe: vi.fn() };
+    },
+  }),
+}));
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector: any) =>
+    selector({
+      ui: {
+        user: { id: 'user-1' },
+        catalogVisibility: false,
+      },
+    }),
+}));
+
+vi.mock('../../utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify: vi.fn() }),
+}));
+
+vi.mock('../../utils/dimension', () => ({
+  useWindowDimensions: () => ({ width: 1200 }),
+}));
+
+vi.mock('@/utils/hooks/useColumnVisibilityPreference', () => ({
+  useColumnVisibilityPreference: () => ({
+    columnVisibility: {},
+    setColumnVisibilityByUser: vi.fn(),
+    setColumnVisibilityByResponsive: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/slices/mesheryUi', () => ({
+  updateProgress: vi.fn(),
+}));
+
+vi.mock('../../utils/utils', () => ({
+  modifyRJSFSchema: (schema: any) => schema,
+}));
+
+vi.mock('../../utils/Enum', () => ({
+  MesheryFiltersCatalog: 'meshery-filters-catalog',
+  VISIBILITY: { PUBLISHED: 'published', PUBLIC: 'public', PRIVATE: 'private' },
+}));
+
+vi.mock('../../lib/event-types', () => ({
+  EVENT_TYPES: { ERROR: 'ERROR', SUCCESS: 'SUCCESS' },
+}));
+
+vi.mock('../general/ViewSwitch', () => ({
+  default: () => <div data-testid="view-switch" />,
+}));
+
+vi.mock('./FiltersGrid', () => ({
+  default: () => <div data-testid="filters-grid" />,
+}));
+
+vi.mock('./YAMLEditor', () => ({
+  default: () => null,
+}));
+
+vi.mock('./ImportModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('./PublishModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../shared/Modal/Information/InfoModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../general/PromptComponent', () => ({
+  default: React.forwardRef(() => null),
+}));
+
+vi.mock('../shared/LoadingState/LoadingComponent', () => ({
+  default: () => <div data-testid="loading" />,
+}));
+
+vi.mock('../general/error-404/index', () => ({
+  default: () => <div data-testid="error-404" />,
+}));
+
+vi.mock('../../css/icons.styles', () => ({
+  iconMedium: {},
+}));
+
+vi.mock('@/assets/styles/general/tool.styles', () => ({
+  ToolWrapper: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('./Filters.styled', () => ({
+  CreateButton: ({ children }: any) => <div>{children}</div>,
+  ViewSwitchButton: ({ children }: any) => <div>{children}</div>,
+  BtnText: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('@/assets/icons', () => ({
+  Publish: () => <svg data-testid="publish-icon" />,
+}));
+
+vi.mock('./Filters.columns', () => ({
+  buildFiltersColumns: () => [{ name: 'name' }, { name: 'Actions' }],
+}));
+
+vi.mock('./Filters.tableOptions', () => ({
+  buildFiltersTableOptions: () => ({
+    serverSide: true,
+    count: 0,
+    page: 0,
+    rowsPerPage: 10,
+  }),
+}));
+
+vi.mock('./Filters.fileActions', () => ({
+  createDeleteFilter: () => vi.fn(),
+  createHandleClone: () => vi.fn(),
+  createHandleDownload: () => vi.fn(),
+  createHandleImportFilter: () => vi.fn(),
+  createHandlePublish: () => vi.fn(),
+  createHandleSubmit: () => vi.fn(),
+  createHandleUnpublishModal: () => vi.fn(),
+  createUploadHandler: () => vi.fn(),
+}));
+
+vi.mock('@sistent/sistent', () => {
+  const styled = (_Component: any) => (_factory?: any) => {
+    const Styled = ({ children, ...props }: any) => <div {...props}>{children}</div>;
+    Styled.displayName = 'StyledMock';
+    return Styled;
+  };
+  return {
+    NoSsr: ({ children }: any) => <>{children}</>,
+    CustomColumnVisibilityControl: () => <div data-testid="column-visibility" />,
+    ResponsiveDataTable: () => <div data-testid="filters-table" />,
+    SearchBar: () => <div data-testid="search-bar" />,
+    UniversalFilter: ({ handleApplyFilter, setSelectedFilters }: any) => (
+      <div data-testid="universal-filter">
+        <button
+          type="button"
+          data-testid="apply-public"
+          onClick={() => {
+            const next = { visibility: 'public' };
+            setSelectedFilters(next);
+            handleApplyFilter(next);
+          }}
+        >
+          Apply Public
+        </button>
+        <button
+          type="button"
+          data-testid="apply-private"
+          onClick={() => {
+            const next = { visibility: 'private' };
+            setSelectedFilters(next);
+            handleApplyFilter(next);
+          }}
+        >
+          Apply Private
+        </button>
+        <button
+          type="button"
+          data-testid="apply-all"
+          onClick={() => {
+            const next = { visibility: 'All' };
+            setSelectedFilters(next);
+            handleApplyFilter(next);
+          }}
+        >
+          Apply All
+        </button>
+      </div>
+    ),
+    Button: ({ children, onClick }: any) => (
+      <button type="button" onClick={onClick}>
+        {children}
+      </button>
+    ),
+    publishCatalogItemSchema: {},
+    publishCatalogItemUiSchema: {},
+    PROMPT_VARIANTS: { DANGER: 'danger' },
+    styled,
+  };
+});
+
+import MesheryFilters from './Filters';
+
+const filtersData = [
+  { id: '1', name: 'public-filter', visibility: 'public', userId: 'user-1' },
+  { id: '2', name: 'private-filter', visibility: 'private', userId: 'user-1' },
+];
+
+describe('Filters visibility filter apply', () => {
+  beforeEach(() => {
+    can.mockReset();
+    can.mockReturnValue(true);
+    router.query = {};
+    routerReplace.mockReset();
+    window.history.replaceState({}, '', '/configuration/filters');
+    useGetFiltersQuery.mockReset();
+    useGetProviderCapabilitiesQuery.mockReset();
+    getMeshModels.mockReset();
+
+    useGetFiltersQuery.mockReturnValue({
+      data: { filters: filtersData, totalCount: filtersData.length },
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+    useGetProviderCapabilitiesQuery.mockReturnValue({
+      data: { capabilities: [], providerType: 'remote' },
+    });
+    getMeshModels.mockResolvedValue({ models: [] });
+  });
+
+  const renderComponent = () => render(<MesheryFilters />);
+
+  it('writes fil_vis to the URL on the first Apply click', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByTestId('apply-public'));
+
+    await waitFor(() => {
+      expect(routerReplace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathname: '/configuration/filters',
+          query: expect.objectContaining({ fil_vis: 'public' }),
+        }),
+        undefined,
+        { shallow: true },
+      );
+    });
+  });
+
+  it('uses the current Apply payload instead of the previous filter value', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.click(screen.getByTestId('apply-public'));
+    router.query = { fil_vis: 'public' };
+
+    await user.click(screen.getByTestId('apply-private'));
+
+    await waitFor(() => {
+      expect(routerReplace).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({ fil_vis: 'private' }),
+        }),
+        undefined,
+        { shallow: true },
+      );
+    });
+  });
+
+  it('clears fil_vis from the URL when visibility is reset to All', async () => {
+    const user = userEvent.setup();
+    router.query = { fil_vis: 'public' };
+    window.history.replaceState({}, '', '/configuration/filters?fil_vis=public');
+    renderComponent();
+
+    await user.click(screen.getByTestId('apply-all'));
+
+    await waitFor(() => {
+      expect(routerReplace).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          query: expect.not.objectContaining({ fil_vis: expect.anything() }),
+        }),
+        undefined,
+        { shallow: true },
+      );
+    });
+  });
+});

--- a/ui/components/filters/Filters.tsx
+++ b/ui/components/filters/Filters.tsx
@@ -89,7 +89,8 @@ function MesheryFilters() {
     [updateTableState],
   );
 
-  const visibilityFilter = tableState.filters.vis || null;
+  const visibilityFilter =
+    tableState.filters.vis && tableState.filters.vis !== 'All' ? tableState.filters.vis : null;
 
   const [count, setCount] = useState(0);
   const modalRef = useRef<{ show: (_args: any) => Promise<string> } | null>(null);
@@ -131,6 +132,10 @@ function MesheryFilters() {
   const [selectedFilters, setSelectedFilters] = useState<{ visibility: string }>(() => ({
     visibility: tableState.filters.vis || 'All',
   }));
+
+  useEffect(() => {
+    setSelectedFilters({ visibility: tableState.filters.vis || 'All' });
+  }, [tableState.filters.vis]);
 
   const {
     data: filtersData,
@@ -215,9 +220,10 @@ function MesheryFilters() {
     });
   };
 
-  const handleApplyFilter = () => {
+  const handleApplyFilter = (filters?: { visibility: string }) => {
+    const next = filters ?? selectedFilters;
     updateTableState({
-      filters: { vis: selectedFilters.visibility === 'All' ? '' : selectedFilters.visibility },
+      filters: { vis: !next.visibility || next.visibility === 'All' ? '' : next.visibility },
       page: 0,
     });
   };
@@ -285,9 +291,8 @@ function MesheryFilters() {
       });
       setCount(filtersData.totalCount || 0);
       handleSetFilters(filteredWasmFilters);
-      setFilters(filtersData.filters || []);
     }
-  }, [filtersData]);
+  }, [filtersData, visibilityFilter]);
 
   /**
    * Checking whether users are signed in under a provider that doesn't have
@@ -323,9 +328,17 @@ function MesheryFilters() {
     fetchSchemaData();
   }, [capabilitiesData]);
 
+  const prevViewType = useRef<TypeView | null>(null);
   useEffect(() => {
-    if (viewType === 'grid') setSearch('');
-  }, [viewType]);
+    if (prevViewType.current === null) {
+      prevViewType.current = viewType;
+      return;
+    }
+    if (prevViewType.current !== viewType) {
+      if (viewType === 'grid') setSearch('');
+      prevViewType.current = viewType;
+    }
+  }, [viewType, setSearch]);
 
   useEffect(() => {
     catalogVisibilityRef.current = catalogVisibility;

--- a/ui/utils/hooks/useTableUrlState.test.ts
+++ b/ui/utils/hooks/useTableUrlState.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTableUrlState } from './useTableUrlState';
+
+const routerReplace = vi.fn();
+const router = {
+  query: {} as Record<string, unknown>,
+  pathname: '/configuration/filters',
+  replace: (...args: unknown[]) => routerReplace(...args),
+};
+
+vi.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+vi.mock('./useNotification', () => ({
+  useNotification: () => ({ notify: vi.fn() }),
+}));
+
+describe('useTableUrlState', () => {
+  beforeEach(() => {
+    router.query = {};
+    routerReplace.mockReset();
+    window.history.replaceState({}, '', '/configuration/filters');
+  });
+
+  it('preserves filter params when a stale router.query races a later update', () => {
+    const { result } = renderHook(() =>
+      useTableUrlState({
+        tableKey: 'fil',
+        defaults: {
+          page: 0,
+          pageSize: 10,
+          sortOrder: '',
+          search: '',
+          filters: { vis: '' },
+        },
+      }),
+    );
+
+    act(() => {
+      result.current.updateTableState({
+        filters: { vis: 'public' },
+        page: 0,
+      });
+    });
+
+    window.history.replaceState({}, '', '/configuration/filters?fil_vis=public');
+
+    act(() => {
+      result.current.updateTableState({ search: '', page: 0 });
+    });
+
+    expect(routerReplace).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ fil_vis: 'public' }),
+      }),
+      undefined,
+      { shallow: true },
+    );
+  });
+});

--- a/ui/utils/hooks/useTableUrlState.ts
+++ b/ui/utils/hooks/useTableUrlState.ts
@@ -58,6 +58,23 @@ function decodeParam(value: string | string[] | undefined): string {
   return typeof value === 'string' ? decodeURIComponent(value) : '';
 }
 
+/** Merge router.query with the live URL bar (router.query can lag after shallow replace). */
+function getCurrentQueryParams(
+  routerQuery: Record<string, string | string[] | undefined>,
+): Record<string, string | undefined> {
+  const next: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(routerQuery)) {
+    if (value === undefined) continue;
+    next[key] = Array.isArray(value) ? value[0] : String(value);
+  }
+  if (typeof window !== 'undefined') {
+    for (const [key, value] of new URLSearchParams(window.location.search)) {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
 export function useTableUrlState<F extends Record<string, string> = Record<string, string>>(
   options: UseTableUrlStateOptions<F>,
 ) {
@@ -94,11 +111,9 @@ export function useTableUrlState<F extends Record<string, string> = Record<strin
 
   const updateTableState = useCallback(
     (updates: Partial<TableUrlState<F>>) => {
-      const { query: currentQuery } = routerRef.current;
-      const next: Record<string, string | undefined> = { ...currentQuery } as Record<
-        string,
-        string | undefined
-      >;
+      const next: Record<string, string | undefined> = getCurrentQueryParams(
+        routerRef.current.query as Record<string, string | string[] | undefined>,
+      );
 
       if (updates.page !== undefined) {
         if (updates.page === 0) delete next[`${prefix}page`];


### PR DESCRIPTION
## Summary

Draft PR for **#20906**: stale Apply state on Configuration → Filters, including cases where the URL (`fil_vis`) did not update on the first Apply.

### Observed behavior

1. **Stale Apply (same pattern as Connections / MeshSync)**  
   Selecting a visibility filter and clicking Apply could apply the *previous* value. Resetting to **All** often failed to restore the full list.

2. **URL lag (Filters-specific)**  
   After addressing the stale closure in `handleApplyFilter`, Apply still sometimes did **not** write `fil_vis` on the first click. A second Apply would update the URL, often with the previous selection. This matched a race where `router.query` lagged behind the address bar after shallow `replace` (static-export / Next.js), so a follow-up table-state update could overwrite or drop `fil_vis`.

### Root cause

- `UniversalFilter` calls `setSelectedFilters(next)` then `handleApplyFilter(next)` in the same tick. Reading React `selectedFilters` in `handleApplyFilter` used a stale value.
- Separately, `useTableUrlState` merged updates from `router.query` only. Under lag, that could lose a filter param that was already visible in `window.location.search`.

### Changes

- Prefer UniversalFilter’s Apply payload in `handleApplyFilter`; map `"All"` → clear `fil_vis`
- Treat `"All"` as unset for the visibility query
- Sync `selectedFilters` from URL when `fil_vis` changes
- Merge live URL search params in `useTableUrlState` when updating table state
- Avoid clearing search on initial grid mount (which could race filter Apply)
- Add regression tests for Apply / reset / URL race

Fixes #20906

## Test plan

- [ ] `cd ui && npm test -- --run components/filters/Filters.filters.test.tsx utils/hooks/useTableUrlState.test.ts`
- [ ] Open `http://localhost:3000/configuration/filters` (`make ui` + `make server`)
- [ ] Public → Apply → `?fil_vis=public` appears on the **first** click
- [ ] Private → Apply → URL shows the **current** value, not the previous one
- [ ] All → Apply → `fil_vis` removed and full list restored

**Notes for Reviewers**

- This PR fixes #20906
- Same stale-closure pattern as #20804 / #20908 / #20909
- Unit tests pass. I am **not fully confident** the URL race is fully resolved in the browser after the Apply-payload fix alone; please help verify first-click `fil_vis` updates on `:3000`
- Core files: `ui/components/filters/Filters.tsx`, `ui/utils/hooks/useTableUrlState.ts`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.