### PR TITLE
fix: filter annotation components before validation

### DIFF
--- a/server/handlers/design_engine_handler.go
+++ b/server/handlers/design_engine_handler.go
@@ -268,6 +268,7 @@ func _processPattern(opts *patterncore.ProcessPatternOptions) (map[string]interf
 			Add(stages.Format()).
 			// Add(stages.ServiceIdentifierAndMutator(sip, sap)).
 			Add(stages.Filler(opts.SkipPrintLogs)).
+			Add(stages.FilterAnnotations()).
 			// Calling this stage `The Validation stage` is a bit deceiving considering
 			// that the validation stage also formats the `data` (chain function parameter) that the
 			// subsequent stages depend on.

--- a/server/models/pattern/stages/dry_run.go
+++ b/server/models/pattern/stages/dry_run.go
@@ -17,7 +17,6 @@ func DryRun(_ ServiceInfoProvider, act ServiceActionProvider) ChainStageFunction
 			act.Terminate(err)
 			return
 		}
-		processAnnotations(data.Pattern)
 
 		resp, err := act.DryRun(data.Pattern.Components)
 		if err != nil {

--- a/server/models/pattern/stages/provision.go
+++ b/server/models/pattern/stages/provision.go
@@ -29,8 +29,6 @@ func Provision(prov ServiceInfoProvider, act ServiceActionProvider, log logger.H
 			return
 		}
 
-		processAnnotations(data.Pattern)
-
 		// Create provision plan
 		plan, err := planner.CreatePlan(*data.Pattern, prov.IsDelete())
 		if err != nil {
@@ -87,6 +85,23 @@ func Provision(prov ServiceInfoProvider, act ServiceActionProvider, log logger.H
 
 		if next != nil {
 			next(data, mergeErrors(errs))
+		}
+	}
+}
+
+func FilterAnnotations() ChainStageFunction {
+	return func(data *Data, err error, next ChainStageNextFunction) {
+		if err != nil {
+			if next != nil {
+				next(data, err)
+			}
+			return
+		}
+
+		processAnnotations(data.Pattern)
+
+		if next != nil {
+			next(data, nil)
 		}
 	}
 }

--- a/server/models/pattern/stages/provision_test.go
+++ b/server/models/pattern/stages/provision_test.go
@@ -1,0 +1,47 @@
+package stages
+
+import (
+	"testing"
+
+	"github.com/meshery/schemas/models/v1beta2/component"
+	pattern "github.com/meshery/schemas/models/v1beta3/design"
+)
+
+func TestFilterAnnotations(t *testing.T) {
+	annotation := &component.ComponentDefinition{}
+	annotation.Metadata.IsAnnotation = true
+
+	regular := &component.ComponentDefinition{}
+	regular.Metadata.IsAnnotation = false
+
+	data := &Data{
+		Pattern: &pattern.PatternFile{
+			Components: []*component.ComponentDefinition{
+				annotation,
+				regular,
+			},
+		},
+	}
+
+	called := false
+
+	FilterAnnotations()(data, nil, func(data *Data, err error) {
+		called = true
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(data.Pattern.Components) != 1 {
+			t.Fatalf("expected 1 component after filtering, got %d", len(data.Pattern.Components))
+		}
+
+		if data.Pattern.Components[0] != regular {
+			t.Fatal("expected regular component to remain after filtering")
+		}
+	})
+
+	if !called {
+		t.Fatal("expected next stage to be called")
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

This PR moves annotation filtering before the validation stage so annotation components don't reach validation with an empty apiVersion

It adds a FilterAnnotations stage before `Validator` and removes the duplicate filtering from DryRun and Provision

Also added a test to make sure annotation components are filtered while regular components are kept.


- This PR fixes #20855 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern processing by filtering annotation components before validation, dry-run, and provisioning operations.
  * Prevented annotation components from affecting dry-run and provisioning results.
  * Added coverage to verify annotations are removed while regular components remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->