### PR TITLE
fix(server): resolve resource leak in design engine loop by closing c…

### DIFF
--- a/server/handlers/design_engine_handler.go
+++ b/server/handlers/design_engine_handler.go
@@ -568,9 +568,6 @@ func (sap *serviceActionProvider) Provision(ccp stages.CompConfigPair) ([]patter
 		if err != nil {
 			return nil, fmt.Errorf("error creating a mesh client: %v", err)
 		}
-		defer func() {
-			_ = mClient.Close()
-		}()
 
 		// Else it is an  adapter call
 		//TODO: Accommodate gRPC calls to use context mapping with kubeconfig
@@ -581,6 +578,7 @@ func (sap *serviceActionProvider) Provision(ccp stages.CompConfigPair) ([]patter
 		compStr, err := utils.Marshal(ccp.Component)
 		if err != nil {
 			err = errors.Wrapf(err, "error marshalling component \"%s\" of type : %s", ccp.Component.DisplayName, ccp.Component.Component.Kind)
+			_ = mClient.Close()
 			return nil, err
 		}
 		resp, err := mClient.MClient.Provision(context.TODO(), &meshes.ProvisionRequest{
@@ -589,6 +587,7 @@ func (sap *serviceActionProvider) Provision(ccp stages.CompConfigPair) ([]patter
 			KubeConfigs:  kconfigs,
 			Declarations: []string{compStr},
 		})
+		_ = mClient.Close()
 		success := err == nil
 		msgs = append(msgs, patterns.DeploymentMessagePerContext{
 			SystemName: hostName,


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes a resource leak in `server/handlers/design_engine_handler.go`. 
- `meshes.CreateClient()` was being called inside a loop over `ccp.Hosts` and cleaned up using `defer`. Because `defer` executes when the surrounding function returns (rather than at the end of each loop iteration), this would cause memory and mesh client connections to remain open until the entire function finished, leading to resource leaks for multi-host deployments.
- Fixed by removing the `defer func() { _ = mClient.Close() }()` block and adding explicit `_ = mClient.Close()` calls where the client finishes its work inside the loop.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during service provisioning.
  * Ensured connections are closed properly when provisioning or component processing encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->