### PR TITLE
fix(server): resolve connection tracker leak in contexts handler

### DIFF
--- a/server/handlers/contexts_handler.go
+++ b/server/handlers/contexts_handler.go
@@ -131,14 +131,14 @@ func (h *Handler) DeleteContext(w http.ResponseWriter, req *http.Request, _ *mod
 		smInstanceTracker.Remove(connectionUUID)
 	} else {
 		go func(inst *machines.StateMachine) {
+			defer smInstanceTracker.Remove(connectionUUID)
+
 			event, err := inst.SendEvent(req.Context(), machines.Delete, nil)
 			if err != nil {
 				h.log.Error(err)
 				h.log.Debug(event)
 				return
 			}
-
-			smInstanceTracker.Remove(connectionUUID)
 		}(inst)
 	}
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes a resource leak in `server/handlers/contexts_handler.go`. 

When deleting a context, `smInstanceTracker.Remove(connectionUUID)` was located at the end of the `DeleteContext` goroutine. If `inst.SendEvent()` returned an error (which can happen due to network timeouts or unreachable clusters), the goroutine would `return` early. This skipped the removal entirely, causing the connection UUID to leak permanently in the active instance tracker. 

This is fixed by using `defer` to guarantee that `smInstanceTracker.Remove(connectionUUID)` executes regardless of whether `SendEvent` succeeds or fails.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when deleting Kubernetes connections.
  * Prevented stale connection state from remaining when deletion events fail to dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->