### PR TITLE
fix(ui): resolve TypeError on dashboard connection status

### DIFF
--- a/ui/components/dashboard/view.tsx
+++ b/ui/components/dashboard/view.tsx
@@ -92,7 +92,7 @@ const View = ({ setView, resource, k8sConfig }: DashboardViewProps) => {
   if (!resource) return null;
 
   const context = getK8sContextFromClusterId(resource.cluster_id, k8sConfig);
-  const connection = connections?.connections.find((conn) => conn.id === context?.connectionId);
+  const connection = connections?.connections?.find((conn: any) => conn.id === context?.connectionId);
   const connectionStatus = connection?.status || CONNECTION_STATES.DISCONNECTED;
   const iconSrc = normalizeStaticImagePath(resource.component_metadata?.styles?.svgColor);
 

--- a/ui/components/dashboard/view.tsx
+++ b/ui/components/dashboard/view.tsx
@@ -92,7 +92,9 @@ const View = ({ setView, resource, k8sConfig }: DashboardViewProps) => {
   if (!resource) return null;
 
   const context = getK8sContextFromClusterId(resource.cluster_id, k8sConfig);
-  const connection = connections?.connections?.find((conn: any) => conn.id === context?.connectionId);
+  const connection = connections?.connections?.find(
+    (conn: any) => conn.id === context?.connectionId,
+  );
   const connectionStatus = connection?.status || CONNECTION_STATES.DISCONNECTED;
   const iconSrc = normalizeStaticImagePath(resource.component_metadata?.styles?.svgColor);
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes a bug causing a white screen crash: `[UI] TypeError: Cannot read properties of undefined (reading 'find') in dashboard detail view`.

In `ui/components/dashboard/view.tsx`, `useGetConnectionsQuery` can default to returning an empty array `[]` before the data fully loads. The code attempted to call `connections?.connections.find(...)`. Because `[].connections` is `undefined`, the `.find()` method call threw a TypeError and crashed the dashboard.

This is fixed by adding optional chaining (`connections?.connections?.find`), which gracefully allows the component to fall back to `CONNECTION_STATES.DISCONNECTED` instead of crashing.

- This PR fixes #20899

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
