### PR TITLE
[mesheryctl] Fix design export collision rename dropping the extension

### DIFF
--- a/mesheryctl/internal/cli/root/design/export.go
+++ b/mesheryctl/internal/cli/root/design/export.go
@@ -337,7 +337,8 @@ func selectPatternPrompt(patterns []models.MesheryPattern, baseURL string) (mode
 }
 
 func getUniqueFilename(filename string) string {
-	base, ext := filepath.Split(strings.TrimSuffix(filename, filepath.Ext(filename)))
+	ext := filepath.Ext(filename)
+	base := strings.TrimSuffix(filename, ext)
 	for i := 1; ; i++ {
 		if _, err := os.Stat(filename); os.IsNotExist(err) {
 			break

--- a/mesheryctl/internal/cli/root/design/export_test.go
+++ b/mesheryctl/internal/cli/root/design/export_test.go
@@ -1,0 +1,45 @@
+package design
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_getUniqueFilename(t *testing.T) {
+	dir := t.TempDir()
+
+	seed := func(t *testing.T, names ...string) {
+		t.Helper()
+		for _, name := range names {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+				t.Fatalf("failed to seed %q: %v", name, err)
+			}
+		}
+	}
+
+	t.Run("returns the original path when no collision exists", func(t *testing.T) {
+		want := filepath.Join(dir, "report.yaml")
+		if got := getUniqueFilename(want); got != want {
+			t.Errorf("getUniqueFilename() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("appends counter before the extension on collision", func(t *testing.T) {
+		seed(t, "collision.yaml")
+
+		want := filepath.Join(dir, "collision(1).yaml")
+		if got := getUniqueFilename(filepath.Join(dir, "collision.yaml")); got != want {
+			t.Errorf("getUniqueFilename() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("increments the counter until a free name is found", func(t *testing.T) {
+		seed(t, "multi.yaml", "multi(1).yaml", "multi(2).yaml")
+
+		want := filepath.Join(dir, "multi(3).yaml")
+		if got := getUniqueFilename(filepath.Join(dir, "multi.yaml")); got != want {
+			t.Errorf("getUniqueFilename() = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20889 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exported design filename handling, including correct extensions and duplicate-name numbering.
  * Prevented exported files from overwriting existing files by selecting the next available filename.

* **Tests**
  * Added coverage for unique filenames, including no-collision, single-collision, and multiple-collision scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->