### PR TITLE
fix(ui): inherit theme color for fullscreen icon

### DIFF
--- a/ui/components/designs/patterns/Cards.styles.tsx
+++ b/ui/components/designs/patterns/Cards.styles.tsx
@@ -18,8 +18,9 @@ export const CardBackGrid = styled(Grid)(() => ({
 
 export const YamlDialogTitleGrid = styled(Grid)(() => ({
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'flex-end',
   justifyContent: 'space-between',
+  width: '100%',
 }));
 
 export const CardHeaderRight = styled('div')(() => ({

--- a/ui/components/designs/patterns/MesheryPatternCard.tsx
+++ b/ui/components/designs/patterns/MesheryPatternCard.tsx
@@ -369,7 +369,11 @@ function MesheryPatternCard_({
                       })
                     }
                   >
-                    {fullScreen ? <FullScreenExitIcon /> : <FullScreenIcon />}
+                    {fullScreen ? (
+                      <FullScreenExitIcon fill="currentColor" />
+                    ) : (
+                      <FullScreenIcon fill="currentColor" />
+                    )}
                   </IconButton>
                 </CustomTooltip>
               </CardHeaderRight>

--- a/ui/components/designs/patterns/YAMLEditor.tsx
+++ b/ui/components/designs/patterns/YAMLEditor.tsx
@@ -56,7 +56,11 @@ function YAMLEditor({ pattern, onClose, onSubmit, isReadOnly = false }) {
             title={fullScreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
             onClick={toggleFullScreen}
           >
-            {fullScreen ? <FullScreenExitIcon /> : <FullScreenIcon />}
+            {fullScreen ? (
+              <FullScreenExitIcon fill="currentColor" />
+            ) : (
+              <FullScreenIcon fill="currentColor" />
+            )}
           </CustomTooltip>
           <CustomTooltip placement="top" title="Exit" onClick={onClose}>
             <CloseIcon />

--- a/ui/components/filters/YAMLEditor.tsx
+++ b/ui/components/filters/YAMLEditor.tsx
@@ -68,9 +68,9 @@ function YAMLEditor({ filter, onClose, onSubmit }: YAMLEditorProps) {
             onClick={toggleFullScreen}
           >
             {fullScreen ? (
-              <FullScreenExitIcon style={iconMedium} />
+              <FullScreenExitIcon fill="currentColor" style={iconMedium} />
             ) : (
-              <FullScreenIcon style={iconMedium} />
+              <FullScreenIcon fill="currentColor" style={iconMedium} />
             )}
           </TooltipIcon>
           <TooltipIcon title="Exit" onClick={onClose}>

--- a/ui/components/general/YamlDialog.tsx
+++ b/ui/components/general/YamlDialog.tsx
@@ -4,8 +4,8 @@ import {
   DialogActions,
   DialogContent,
   Divider,
-  FullScreenExitIcon,
   FullScreenIcon,
+  FullScreenExitIcon,
   IconButton,
   SaveIcon,
   Tooltip,
@@ -36,7 +36,11 @@ const YAMLDialog = ({
         <YamlDialogTitleText variant="h6">{name}</YamlDialogTitleText>
         <Tooltip title="Exit Fullscreen" arrow placement="bottom">
           <IconButton onClick={toggleFullScreen} size="large">
-            {fullScreen ? <FullScreenExitIcon /> : <FullScreenIcon />}
+            {fullScreen ? (
+              <FullScreenExitIcon fill="currentColor" />
+            ) : (
+              <FullScreenIcon fill="currentColor" />
+            )}
           </IconButton>
         </Tooltip>
       </StyledDialog>


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20920 
This PR fixes the fullscreen/maximize icon in the YAML editor so that it correctly inherits the active theme color in dark mode.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

**Before**
<img width="1151" height="687" alt="Screenshot 2026-07-24 at 12 05 08 AM" src="https://github.com/user-attachments/assets/d9f4592a-d79d-466c-8e46-cb13ad68f125" />

**After**
<img width="1164" height="690" alt="Screenshot 2026-07-24 at 12 03 18 AM" src="https://github.com/user-attachments/assets/a5a886d5-56c9-4423-b874-bb35cabccd8c" />

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated fullscreen toggle and tooltip icons across YAML editor and dialog/card headers to explicitly inherit the current text color for consistent visual styling.
  * Adjusted the YAML dialog title grid layout to align content to the bottom and span the full available width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->