### PR TITLE
[Server] Return correct HTTP status codes for encoding errors and wrong method

### DIFF
--- a/server/handlers/extensions.go
+++ b/server/handlers/extensions.go
@@ -79,10 +79,10 @@ func (h *Handler) ExtensionsVersionHandler(w http.ResponseWriter, _ *http.Reques
 	if provider.GetProviderType() == models.LocalProviderType {
 		err := json.NewEncoder(w).Encode("extension not available for current provider")
 		if err != nil {
-			h.log.Error(models.ErrEncoding(err, "extension version"))
-			writeMeshkitError(w, models.ErrEncoding(err, "extension version"), http.StatusNotFound)
-		}
-		return
+		h.log.Error(models.ErrEncoding(err, "extension version"))
+		writeMeshkitError(w, models.ErrEncoding(err, "extension version"), http.StatusInternalServerError)
+	}
+	return
 	}
 
 	// gets the extension version from provider properties
@@ -96,7 +96,7 @@ func (h *Handler) ExtensionsVersionHandler(w http.ResponseWriter, _ *http.Reques
 	err := json.NewEncoder(w).Encode(extensionVersion)
 	if err != nil {
 		h.log.Error(models.ErrEncoding(err, "extension version"))
-		writeMeshkitError(w, models.ErrEncoding(err, "extension version"), http.StatusNotFound)
+		writeMeshkitError(w, models.ErrEncoding(err, "extension version"), http.StatusInternalServerError)
 	}
 }
 

--- a/server/handlers/mesh_ops_handlers.go
+++ b/server/handlers/mesh_ops_handlers.go
@@ -37,7 +37,7 @@ func (h *Handler) AvailableAdaptersHandler(w http.ResponseWriter, _ *http.Reques
 // AdaptersHandler is used to fetch all the adapters
 func (h *Handler) AdaptersHandler(w http.ResponseWriter, req *http.Request, prefObj *models.Preference, user *models.User, provider models.Provider) {
 	if req.Method != http.MethodGet {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
 

--- a/server/handlers/server_spec_handler.go
+++ b/server/handlers/server_spec_handler.go
@@ -46,7 +46,7 @@ func (h *Handler) ServerVersionHandler(w http.ResponseWriter, _ *http.Request) {
 	err = json.NewEncoder(w).Encode(version)
 	if err != nil {
 		h.log.Error(models.ErrEncoding(err, "server-version"))
-		writeMeshkitError(w, models.ErrEncoding(err, "server-version"), http.StatusNotFound)
+		writeMeshkitError(w, models.ErrEncoding(err, "server-version"), http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
**Notes for Reviewers**

Corrects three incorrect HTTP status codes:
- `ExtensionsVersionHandler`: returns 404 on JSON encode failure — changed to 500 (server error)
- `GetServerVersion`: returns 404 on JSON encode failure — changed to 500 (server error)
- `AdaptersHandler`: returns 404 for non-GET requests — changed to 405 Method Not Allowed

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error responses when extension or server version data cannot be encoded, returning **500 Internal Server Error**.
  * Updated adapter endpoint responses for unsupported HTTP methods to return **405 Method Not Allowed** instead of **404 Not Found**.
  * Improved HTTP status accuracy for clearer API error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->