### PR TITLE
[Models] Add Artifact Hub and GitHub connection definitions

### DIFF
--- a/docs/content/en/project/contributing/models/connections.md
+++ b/docs/content/en/project/contributing/models/connections.md
@@ -83,16 +83,18 @@ Below is a complete, minimal definition for a hypothetical telemetry backend. It
 These three fields identify the Connection and determine how the wizard treats it:
 
 - **`kind`** - the genre of Connection (e.g. `grafana`, `prometheus`, `kubernetes`). The wizard groups credentials and renders icons by `kind`.
-- **`type`** - a broad classification: `platform`, `telemetry`, `collaboration`, and so on.
-- **`subType`** - a finer classification: `orchestration`, `metrics`, `git`, `chat`, and so on.
+- **`type`** - a broad classification: `platform`, `telemetry`, `source`, `collaboration`, and so on.
+- **`subType`** - a finer classification: `orchestration`, `metrics`, `git`, `registry`, `chat`, and so on.
 
 Together they let the UI target a specific Connection with a [custom wizard extension](#advanced-customizing-the-wizard) when the generic flow is not enough. For reference, the definitions Meshery ships with:
 
-| Connection | `kind`       | `type`      | `subType`       | initial `status` |
-| ---------- | ------------ | ----------- | --------------- | ---------------- |
-| Kubernetes | `kubernetes` | `platform`  | `orchestration` | `discovered`     |
-| Grafana    | `grafana`    | `telemetry` | `metrics`       | `registered`     |
-| Prometheus | `prometheus` | `telemetry` | `metrics`       | `registered`     |
+| Connection   | `kind`        | `type`      | `subType`       | initial `status` |
+| ------------ | ------------- | ----------- | --------------- | ---------------- |
+| Kubernetes   | `kubernetes`  | `platform`  | `orchestration` | `discovered`     |
+| Grafana      | `grafana`     | `telemetry` | `metrics`       | `registered`     |
+| Prometheus   | `prometheus`  | `telemetry` | `metrics`       | `registered`     |
+| Artifact Hub | `artifacthub` | `source`    | `registry`      | `registered`     |
+| GitHub       | `github`      | `source`    | `git`           | `registered`     |
 
 ### Lifecycle: `status` and `transitionMap`
 
@@ -132,7 +134,7 @@ Place the definition as a JSON file in a `connections/` folder inside its Model,
 models/<model>/<version>/connections/<Name>Connection.json
 ```
 
-For example, the shipped definitions live under [`models/meshery-core/.../connections/`](https://github.com/meshery/meshery/tree/master/models) as `KubernetesConnection.json`, `GrafanaConnection.json`, and `PrometheusConnection.json`. A Model may include any number of connection definitions. Use these existing files as templates.
+For example, the shipped definitions live under [`models/meshery-core/.../connections/`](https://github.com/meshery/meshery/tree/master/models) as `KubernetesConnection.json`, `GrafanaConnection.json`, `PrometheusConnection.json`, `ArtifactHubConnection.json`, and `GitHubConnection.json`. A Model may include any number of connection definitions. Use these existing files as templates.
 
 ## How the definition is registered and consumed
 
@@ -147,6 +149,8 @@ For example, the shipped definitions live under [`models/meshery-core/.../connec
    | `DELETE` | `/api/registry/connections/{id}`                | Remove a definition                    |
 
 2. **Consumption.** The [Connection Wizard]({{< ref "guides/infrastructure-management/registering-a-connection.md" >}}) lists every registered definition as a creatable kind and renders its `connectionSchema` and `credentialSchema` as wizard steps. **Register your definition and it appears in the wizard automatically** - no UI changes required.
+
+3. **Lifecycle.** Registration drives the default connection state machine, which implements these transitions: `discovered → registered | ignored`, `registered → connected | ignored`, `connected → disconnected | deleted`, and `disconnected → connected | deleted`. Connecting persists the Connection and its credential. **No server code is required** - add a kind-specific action only when the kind needs a reachability probe before it may advance to `connected` (Grafana and Prometheus verify their endpoint; Kubernetes has a bespoke machine altogether). Keep the [`transitionMap`](#lifecycle-status-and-transitionmap) you author in step with this machine: it is the copy the UI shows for each transition.
 
 {{% alert color="info" title="Verify it appears" %}}
 After registering, open the Connection Wizard (**Connections → Create Connection**) and confirm your kind is listed with its icon, that the Configure and Associate Credential steps render your schemas, and that creating a Connection drives the states you declared in the `transitionMap`.

--- a/models/meshery-core/0.7.2/v1.0.0/connections/ArtifactHubConnection.json
+++ b/models/meshery-core/0.7.2/v1.0.0/connections/ArtifactHubConnection.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "connections.meshery.io/v1beta3",
+  "name": "Artifact Hub",
+  "description": "An Artifact Hub instance that Meshery sources packages from. Find Helm charts and other CNCF artifacts, generate Meshery models and components from the CRDs they carry, and register them into Meshery's registry so they are available on the canvas.",
+  "kind": "artifacthub",
+  "type": "source",
+  "subType": "registry",
+  "status": "registered",
+  "transitionMap": {
+    "discovered": [
+      {
+        "nextState": "registered",
+        "description": "Registers the discovered Artifact Hub instance with Meshery so it can be managed. Meshery does not query it until you connect it."
+      },
+      {
+        "nextState": "ignored",
+        "description": "Ignores the discovered Artifact Hub instance: Meshery takes no further action on it. You can register it again whenever you choose."
+      }
+    ],
+    "registered": [
+      {
+        "nextState": "connected",
+        "description": "Connects to Artifact Hub and makes its packages available to Meshery for model and component generation."
+      },
+      {
+        "nextState": "ignored",
+        "description": "Keeps the Artifact Hub registration but stops Meshery from connecting to or acting on it. You can register it again whenever you choose."
+      }
+    ],
+    "connected": [
+      {
+        "nextState": "disconnected",
+        "description": "Disconnects Artifact Hub: its packages stop being available for model and component generation. Models already generated from it stay registered, and the registration is kept, so you can connect it again later."
+      },
+      {
+        "nextState": "deleted",
+        "description": "Removes the Artifact Hub connection and its associated credential from Meshery and purges the connection record from Meshery's database. Models and components already generated from its packages remain registered. The Artifact Hub instance itself is not modified."
+      }
+    ],
+    "disconnected": [
+      {
+        "nextState": "connected",
+        "description": "Reconnects Artifact Hub and resumes sourcing its packages for model and component generation."
+      },
+      {
+        "nextState": "deleted",
+        "description": "Removes the Artifact Hub connection and its associated credential from Meshery and purges the connection record from Meshery's database. Models and components already generated from its packages remain registered. The Artifact Hub instance itself is not modified."
+      }
+    ]
+  },
+  "connectionSchema": {
+    "type": "object",
+    "title": "Artifact Hub Connection",
+    "required": [
+      "url"
+    ],
+    "properties": {
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "title": "Artifact Hub Endpoint",
+        "description": "Base URL of the Artifact Hub instance (e.g. https://artifacthub.io). Point this at your own deployment to source packages from a self-hosted Artifact Hub."
+      },
+      "name": {
+        "type": "string",
+        "title": "Connection Name",
+        "description": "Optional friendly name for this Artifact Hub connection."
+      }
+    }
+  },
+  "credentialSchema": {
+    "type": "object",
+    "title": "Artifact Hub Credential",
+    "properties": {
+      "apiKeyId": {
+        "type": "string",
+        "title": "API Key ID",
+        "description": "Artifact Hub API key identifier. Leave both key fields empty to use the public, unauthenticated API."
+      },
+      "apiKeySecret": {
+        "type": "string",
+        "format": "password",
+        "title": "API Key Secret",
+        "description": "Secret paired with the API key identifier. Required only when an API key ID is supplied."
+      }
+    }
+  },
+  "styles": {
+    "svgColor": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 360 360\"><defs><style>.cls-1{fill:#fff;}.cls-2{fill:#417598;}</style></defs><path class=\"cls-1\" d=\"M308.81738,81.55659,200.65776,19.84183a42.18579,42.18579,0,0,0-42.05691-.00394L50.33947,81.65a42.11259,42.11259,0,0,0-21.05762,36.41086V241.67857a42.48306,42.48306,0,0,0,21.15369,36.50386l108.15961,61.80512a42.07447,42.07447,0,0,0,42.0591.00177L308.913,278.17892a42.235,42.235,0,0,0,21.05762-36.41085V118.06088A42.48673,42.48673,0,0,0,308.81738,81.55659ZM169.735,320.51965l-108.0587-61.799a19.8167,19.8167,0,0,1-9.84537-17.04208V118.06088a19.76459,19.76459,0,0,1,9.73878-17.03331L169.84425,39.2979a19.718,19.718,0,0,1,9.7945-2.63067,18.77915,18.77915,0,0,1,9.8831,2.55434l108.14294,61.79634a19.81706,19.81706,0,0,1,9.84626,17.043V241.67857a19.76276,19.76276,0,0,1-9.73834,17.03243L189.499,320.53018a19.90962,19.90962,0,0,1-9.905,2.639A19.54838,19.54838,0,0,1,169.735,320.51965Z\"/><path class=\"cls-2\" d=\"M334.46255,118.04816a47.00033,47.00033,0,0,0-23.41238-40.3891L202.8967,15.94738a46.68479,46.68479,0,0,0-46.52951-.00658L48.1058,77.75293a46.61868,46.61868,0,0,0-23.31587,40.30795v123.63a46.99753,46.99753,0,0,0,23.4115,40.38867l108.16268,61.80685a46.56567,46.56567,0,0,0,46.5203.00174l108.26751-61.81476a46.74717,46.74717,0,0,0,23.3106-40.30532Zm-4.49191,123.71991A42.235,42.235,0,0,1,308.913,278.17892L200.65425,339.98929a42.07447,42.07447,0,0,1-42.0591-.00177L50.43554,278.18243a42.48306,42.48306,0,0,1-21.15369-36.50386V118.06088A42.11259,42.11259,0,0,1,50.33947,81.65L158.60085,19.83789a42.18579,42.18579,0,0,1,42.05691.00394L308.81738,81.55659a42.48675,42.48675,0,0,1,21.15326,36.50429Z\"/><path class=\"cls-2\" d=\"M297.77271,258.711a19.76278,19.76278,0,0,0,9.73834-17.03244V118.06088a19.81706,19.81706,0,0,0-9.84626-17.043L189.52184,39.22157a18.77909,18.77909,0,0,0-9.88311-2.55434,19.71793,19.71793,0,0,0-9.79449,2.63067L61.56971,101.02756a19.76459,19.76459,0,0,0-9.73878,17.03331v123.6177a19.81669,19.81669,0,0,0,9.84537,17.0421l108.05872,61.799a19.54833,19.54833,0,0,0,9.859,2.64954,19.90968,19.90968,0,0,0,9.905-2.639Z\"/></svg>",
+    "svgWhite": "<svg id=\"Layer_1\" data-name=\"Layer 1\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 360 360\"><defs><style>.cls-1{fill:#fff;}</style></defs><path class=\"cls-1\" d=\"M169.735,320.51965l-108.0587-61.799a19.8167,19.8167,0,0,1-9.84537-17.04208V118.06088a19.76459,19.76459,0,0,1,9.73878-17.03331L169.84425,39.2979a19.718,19.718,0,0,1,9.7945-2.63067,18.77915,18.77915,0,0,1,9.8831,2.55434l108.14294,61.79634a19.81706,19.81706,0,0,1,9.84626,17.043V241.67857a19.76276,19.76276,0,0,1-9.73834,17.03243L189.499,320.53018a19.90962,19.90962,0,0,1-9.905,2.639A19.54838,19.54838,0,0,1,169.735,320.51965Z\"/><path class=\"cls-1\" d=\"M334.46255,118.04816a47.00033,47.00033,0,0,0-23.41238-40.3891L202.8967,15.94738a46.68479,46.68479,0,0,0-46.52951-.00658L48.1058,77.75293a46.61868,46.61868,0,0,0-23.31587,40.30795v123.63a46.99753,46.99753,0,0,0,23.4115,40.38867l108.16268,61.80685a46.56567,46.56567,0,0,0,46.5203.00174l108.26751-61.81476a46.74717,46.74717,0,0,0,23.3106-40.30532Zm-4.49191,123.71991A42.235,42.235,0,0,1,308.913,278.17892L200.65425,339.98929a42.07447,42.07447,0,0,1-42.0591-.00177L50.43554,278.18243a42.48306,42.48306,0,0,1-21.15369-36.50386V118.06088A42.11259,42.11259,0,0,1,50.33947,81.65L158.60085,19.83789a42.18579,42.18579,0,0,1,42.05691.00394L308.81738,81.55659a42.48675,42.48675,0,0,1,21.15326,36.50429Z\"/><path class=\"cls-1\" d=\"M297.77271,258.711a19.76278,19.76278,0,0,0,9.73834-17.03244V118.06088a19.81706,19.81706,0,0,0-9.84626-17.043L189.52184,39.22157a18.77909,18.77909,0,0,0-9.88311-2.55434,19.71793,19.71793,0,0,0-9.79449,2.63067L61.56971,101.02756a19.76459,19.76459,0,0,0-9.73878,17.03331v123.6177a19.81669,19.81669,0,0,0,9.84537,17.0421l108.05872,61.799a19.54833,19.54833,0,0,0,9.859,2.64954,19.90968,19.90968,0,0,0,9.905-2.639Z\"/></svg>"
+  }
+}

--- a/models/meshery-core/0.7.2/v1.0.0/connections/ArtifactHubConnection.json
+++ b/models/meshery-core/0.7.2/v1.0.0/connections/ArtifactHubConnection.json
@@ -83,6 +83,14 @@
         "title": "API Key Secret",
         "description": "Secret paired with the API key identifier. Required only when an API key ID is supplied."
       }
+    },
+    "dependencies": {
+      "apiKeyId": [
+        "apiKeySecret"
+      ],
+      "apiKeySecret": [
+        "apiKeyId"
+      ]
     }
   },
   "styles": {

--- a/models/meshery-core/0.7.2/v1.0.0/connections/GitHubConnection.json
+++ b/models/meshery-core/0.7.2/v1.0.0/connections/GitHubConnection.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "connections.meshery.io/v1beta3",
+  "name": "GitHub",
+  "description": "A GitHub repository that Meshery sources from. Generate Meshery models and components from the Kubernetes manifests and CRDs the repository holds, and import designs kept under version control alongside the code they describe.",
+  "kind": "github",
+  "type": "source",
+  "subType": "git",
+  "status": "registered",
+  "transitionMap": {
+    "discovered": [
+      {
+        "nextState": "registered",
+        "description": "Registers the discovered repository with Meshery so it can be managed. Meshery does not read from it until you connect it."
+      },
+      {
+        "nextState": "ignored",
+        "description": "Ignores the discovered repository: Meshery takes no further action on it. You can register it again whenever you choose."
+      }
+    ],
+    "registered": [
+      {
+        "nextState": "connected",
+        "description": "Connects to the repository and begins sourcing from it, making its manifests available for model and component generation and its designs available for import."
+      },
+      {
+        "nextState": "ignored",
+        "description": "Keeps the repository registration but stops Meshery from connecting to or reading from it. You can register it again whenever you choose."
+      }
+    ],
+    "connected": [
+      {
+        "nextState": "disconnected",
+        "description": "Stops sourcing from the repository. Models and designs already imported are kept, and the registration is kept, so you can connect it again later without re-registering."
+      },
+      {
+        "nextState": "deleted",
+        "description": "Removes the repository connection and its associated credential from Meshery and purges the connection record from Meshery's database. Models and designs already imported remain in Meshery. The repository itself is not modified."
+      }
+    ],
+    "disconnected": [
+      {
+        "nextState": "connected",
+        "description": "Reconnects the repository and resumes sourcing manifests and designs from it."
+      },
+      {
+        "nextState": "deleted",
+        "description": "Removes the repository connection and its associated credential from Meshery and purges the connection record from Meshery's database. Models and designs already imported remain in Meshery. The repository itself is not modified."
+      }
+    ]
+  },
+  "connectionSchema": {
+    "type": "object",
+    "title": "GitHub Connection",
+    "required": [
+      "url"
+    ],
+    "properties": {
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "title": "Repository URL",
+        "description": "URL of the repository Meshery reads from (e.g. https://github.com/meshery/meshery). GitHub Enterprise Server URLs are accepted."
+      },
+      "branch": {
+        "type": "string",
+        "title": "Branch",
+        "description": "Branch or tag Meshery reads from. Leave empty to use the repository's default branch."
+      },
+      "name": {
+        "type": "string",
+        "title": "Connection Name",
+        "description": "Optional friendly name for this GitHub connection."
+      }
+    }
+  },
+  "credentialSchema": {
+    "type": "object",
+    "title": "GitHub Credential",
+    "properties": {
+      "token": {
+        "type": "string",
+        "format": "password",
+        "title": "Access Token",
+        "description": "Personal access token or GitHub App installation token. Required for private repositories; for public repositories it is optional and raises the API rate limit."
+      }
+    }
+  },
+  "styles": {
+    "svgColor": "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" id=\"Layer_1\" x=\"0\" y=\"0\" version=\"1.1\" viewBox=\"0 0 274.1 267.3\" xml:space=\"preserve\" style=\"enable-background:new 0 0 274.1 267.3\"><path d=\"M137.1,0C61.4,0,0,61.3,0,136.9C0,196,37.8,248.4,93.8,267c6.8,1.3,9.3-3,9.3-6.6c0-3.3-0.1-11.9-0.2-23.3\tc-38.1,8.3-46.1-18.4-46.1-18.4c-6.2-15.8-15.2-20-15.2-20c-12.4-8.5,0.9-8.3,0.9-8.3c13.7,1,21,14.1,21,14.1\tc12.2,20.9,32.1,14.9,39.9,11.4c1.2-8.9,4.8-14.9,8.7-18.3c-30.4-3.5-62.4-15.2-62.4-67.7c-0.2-13.6,4.8-26.8,14.1-36.8\tc-1.4-3.5-6.1-17.4,1.3-36.3c0,0,11.5-3.7,37.7,14c11.2-3.1,22.7-4.6,34.3-4.6c11.6,0.1,23.1,1.6,34.3,4.6\tc26.2-17.7,37.6-14,37.6-14c7.5,18.9,2.8,32.8,1.4,36.3c9.3,10,14.3,23.2,14.1,36.8c0,52.6-32,64.2-62.5,67.6\tc4.9,4.2,9.3,12.6,9.3,25.4c0,18.3-0.2,33.1-0.2,37.6c0,3.7,2.5,7.9,9.4,6.6c71.8-24,110.5-101.7,86.5-173.5\tC248.3,37.7,196,0,137.1,0L137.1,0z\"/></svg>",
+    "svgWhite": "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:svgjs=\"http://svgjs.com/svgjs\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" style=\"enable-background:new 0 0 512 512\" width=\"512\" height=\"512\" x=\"0\" y=\"0\" version=\"1.1\" viewBox=\"0 0 512 512\" xml:space=\"preserve\"><g><path xmlns=\"http://www.w3.org/2000/svg\" fill=\"#fff\" d=\"m512 257c0 120-84.101562 220.5-196 247.5l-30.601562-97.199219h-58.796876l-29.601562 97.199219c-111.898438-27-197-127.5-197-247.5 0-140.699219 115.300781-257 256-257s256 116.300781 256 257zm0 0\" data-original=\"#384949\"/><path xmlns=\"http://www.w3.org/2000/svg\" fill=\"#fff\" d=\"m512 257c0 120-84.101562 220.5-196 247.5l-30.601562-97.199219h-29.398438v-407.300781c140.699219 0 256 116.300781 256 257zm0 0\" data-original=\"#293939\"/><path xmlns=\"http://www.w3.org/2000/svg\" fill=\"#000\" d=\"m181.277344 430.058594c-6.078125 0-12.011719-.867188-17.828125-2.578125-15.128907-4.46875-27.421875-14.546875-36.546875-29.914063-4.160156-7.015625-8.496094-11.878906-13.605469-15.308594-5.027344-3.382812-9.039063-4.671874-13.273437-4.363281l-2.636719-29.882812c11.117187-.953125 21.753906 2.0625 32.59375 9.316406 8.832031 5.902344 16.257812 14.0625 22.71875 24.914063 5.304687 8.921874 11.410156 14.152343 19.25 16.46875 8.804687 2.589843 17.941406 1.507812 29.632812-3.472657l11.808594 27.566407c-11.296875 4.835937-21.929687 7.253906-32.113281 7.253906zm0 0\" data-original=\"#ececf1\"/><path xmlns=\"http://www.w3.org/2000/svg\" fill=\"#000\" d=\"m400.902344 287.300781c-10.503906 27.898438-36.902344 63.300781-103.800782 73.199219 8.699219 12.898438 19.199219 19.800781 18.898438 46.800781v97.199219c-19.199219 4.800781-39.300781 7.5-60 7.5s-39.800781-2.699219-59-7.5v-98.402344c0-26.699218 10.101562-34.199218 17.898438-45.597656-66.898438-9.902344-93.296876-45.300781-103.800782-73.199219-14.097656-37.203125-6.597656-83.402343 18.003906-112.800781.597657-.601562 1.5-2.101562 1.199219-3-11.402343-34.199219 2.398438-62.699219 3-65.699219 12.898438 3.898438 15-3.902343 56.699219 21.597657l7.199219 4.203124c3 1.796876 2.101562.597657 5.101562.597657 17.398438-4.800781 35.699219-7.5 53.699219-7.5 18.300781 0 36.300781 2.699219 54.597656 7.5l2.101563.300781s.597656 0 2.101562-.898438c51.898438-31.503906 50.097657-21.300781 64.195313-25.800781.300781 3 14.101562 31.796875 2.703125 65.699219-1.5 4.5 45 47.097656 19.203125 115.800781zm0 0\" data-original=\"#ececf1\"/><path xmlns=\"http://www.w3.org/2000/svg\" fill=\"#000\" d=\"m400.902344 287.300781c-10.503906 27.898438-36.902344 63.300781-103.800782 73.199219 8.699219 12.898438 19.199219 19.800781 18.898438 46.800781v97.199219c-19.199219 4.800781-39.300781 7.5-60 7.5v-387.300781c18.300781 0 36.300781 2.699219 54.601562 7.5l2.097657.300781s.601562 0 2.101562-.898438c51.898438-31.503906 50.097657-21.300781 64.199219-25.800781.300781 3 14.101562 31.796875 2.699219 65.699219-1.5 4.5 45 47.097656 19.203125 115.800781zm0 0\" data-original=\"#e2e2e7\"/></g></svg>"
+  }
+}

--- a/server/machines/helpers/helpers.go
+++ b/server/machines/helpers/helpers.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/machines/grafana"
@@ -35,35 +34,58 @@ func StatusToEvent(status connections.ConnectionStatus) machines.EventType {
 	}
 	return machines.EventType(machines.DefaultState)
 }
+
+// getMachine builds the lifecycle state machine for a connection kind.
+//
+// Kubernetes has a bespoke machine (extra states, cluster-specific actions).
+// Every other kind runs the default machine, whose transitions mirror the
+// `transitionMap` authored on the kind's connection definition
+// (models/.../connections/*.json): discovered -> registered/ignored,
+// registered -> connected/ignored, connected -> disconnected/deleted,
+// disconnected -> connected/deleted.
+//
+// Kinds differ only in whether the REGISTERED state carries a verification
+// action. Grafana and Prometheus verify their endpoint is reachable before
+// advancing; kinds without a reachability probe (e.g. artifacthub, github)
+// register with no extra action and persist on connect.
+//
+// This deliberately does NOT allowlist kinds. The set of registerable kinds is
+// the set of registered connection definitions - that is what drives the Create
+// Connection wizard (buildConnectionWizardKindConfigs) - so an allowlist here
+// would be a second, silently divergent source of truth: shipping a definition
+// would surface the kind in the wizard and then fail registration with
+// meshery-server-1218.
 func getMachine(initialState machines.StateType, mtype, id string, userID core.Uuid, log logger.Handler, dbHandler *database.Handler) (*machines.StateMachine, error) {
-	switch mtype {
-	case "kubernetes":
+	if mtype == "kubernetes" {
 		return kubernetes.New(id, userID, log)
-	case "grafana":
-		mch, err := machines.New(initialState, id, userID, log, mtype)
-		if err != nil {
-			return mch, err
-		}
-		register := mch.States[machines.REGISTERED]
-		mch.States[machines.REGISTERED] = *register.RegisterAction(&grafana.RegisterAction{})
-
-		connect := mch.States[machines.CONNECTED]
-		mch.States[machines.CONNECTED] = *connect.RegisterAction(&machines.DefaultConnectAction{})
-		return mch, nil
-	case "prometheus":
-		mch, err := machines.New(initialState, id, userID, log, mtype)
-		if err != nil {
-			return mch, err
-		}
-		register := mch.States[machines.REGISTERED]
-		mch.States[machines.REGISTERED] = *register.RegisterAction(&prometheus.RegisterAction{})
-
-		connect := mch.States[machines.CONNECTED]
-		mch.States[machines.CONNECTED] = *connect.RegisterAction(&machines.DefaultConnectAction{})
-
-		return mch, nil
 	}
-	return nil, machines.ErrInvalidType(fmt.Errorf("invlaid type requested"))
+
+	mch, err := machines.New(initialState, id, userID, log, mtype)
+	if err != nil {
+		return mch, err
+	}
+
+	if action := registerActionForKind(mtype); action != nil {
+		register := mch.States[machines.REGISTERED]
+		mch.States[machines.REGISTERED] = *register.RegisterAction(action)
+	}
+
+	connect := mch.States[machines.CONNECTED]
+	mch.States[machines.CONNECTED] = *connect.RegisterAction(&machines.DefaultConnectAction{})
+
+	return mch, nil
+}
+
+// registerActionForKind returns the kind-specific action run on entry to the
+// REGISTERED state, or nil when the kind has no verification step.
+func registerActionForKind(mtype string) machines.Action {
+	switch mtype {
+	case "grafana":
+		return &grafana.RegisterAction{}
+	case "prometheus":
+		return &prometheus.RegisterAction{}
+	}
+	return nil
 }
 
 // HasMachineContext reports whether a state machine instance exists and carries

--- a/server/machines/helpers/helpers_test.go
+++ b/server/machines/helpers/helpers_test.go
@@ -3,8 +3,11 @@ package helpers
 import (
 	"testing"
 
+	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/machines/kubernetes"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/schemas/models/core"
 )
 
 // HasMachineContext gates every site that drives a state machine returned by
@@ -56,6 +59,63 @@ func TestHasMachineContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := HasMachineContext(tt.inst); got != tt.want {
 				t.Fatalf("HasMachineContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// getMachine must not carry a hardcoded allowlist of connection kinds. The
+// registerable set is the set of registered connection definitions
+// (models/.../connections/*.json) — that is what the Create Connection wizard
+// builds its kind list from — so a kind that ships a definition but has no
+// bespoke verify action (artifacthub, github) has to get the default machine
+// rather than meshery-server-1218.
+func TestGetMachineCoversEveryDefinitionKind(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4()).String()
+	userID := core.Uuid(uuid.Must(uuid.NewV4()))
+	log, err := logger.New("test", logger.Options{Format: logger.JsonLogFormat})
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+
+	tests := []struct {
+		kind string
+		// Kinds with a reachability probe run an action on entry to REGISTERED;
+		// the rest register with no extra action.
+		wantRegisterAction bool
+	}{
+		{kind: "kubernetes", wantRegisterAction: true},
+		{kind: "grafana", wantRegisterAction: true},
+		{kind: "prometheus", wantRegisterAction: true},
+		{kind: "artifacthub", wantRegisterAction: false},
+		{kind: "github", wantRegisterAction: false},
+		// Any other definition-backed kind must resolve too, not error.
+		{kind: "some-future-kind", wantRegisterAction: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			mch, err := getMachine(machines.DISCOVERED, tt.kind, connID, userID, log, nil)
+			if err != nil {
+				t.Fatalf("getMachine(%q) error = %v, want nil", tt.kind, err)
+			}
+			if mch == nil {
+				t.Fatalf("getMachine(%q) returned a nil machine", tt.kind)
+			}
+
+			if tt.kind == "kubernetes" {
+				// The bespoke Kubernetes machine owns its own state set.
+				return
+			}
+
+			gotRegisterAction := mch.States[machines.REGISTERED].Action != nil
+			if gotRegisterAction != tt.wantRegisterAction {
+				t.Fatalf("getMachine(%q) REGISTERED action present = %v, want %v", tt.kind, gotRegisterAction, tt.wantRegisterAction)
+			}
+			// Every non-Kubernetes kind persists the connection and its
+			// credential on connect.
+			if mch.States[machines.CONNECTED].Action == nil {
+				t.Fatalf("getMachine(%q) has no CONNECTED action; the connection would never be persisted", tt.kind)
 			}
 		})
 	}

--- a/ui/components/connections/ConnectionStateTransitionModal.test.tsx
+++ b/ui/components/connections/ConnectionStateTransitionModal.test.tsx
@@ -9,18 +9,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import kubernetesDefinition from '../../../models/meshery-core/0.7.2/v1.0.0/connections/KubernetesConnection.json';
 import grafanaDefinition from '../../../models/meshery-core/0.7.2/v1.0.0/connections/GrafanaConnection.json';
 import prometheusDefinition from '../../../models/meshery-core/0.7.2/v1.0.0/connections/PrometheusConnection.json';
+import artifactHubDefinition from '../../../models/meshery-core/0.7.2/v1.0.0/connections/ArtifactHubConnection.json';
+import githubDefinition from '../../../models/meshery-core/0.7.2/v1.0.0/connections/GitHubConnection.json';
 
 // Mutable store state so individual tests can swap in stale/absent definition
 // data. Reset in beforeEach.
 const mockStoreState: {
-  ui: { connectionMetadataState: Record<string, { transitionMap?: unknown }> | null };
+  ui: {
+    connectionMetadataState: Record<string, { name?: string; transitionMap?: unknown }> | null;
+  };
 } = { ui: { connectionMetadataState: null } };
 
-const defaultConnectionMetadataState = () => ({
-  kubernetes: { transitionMap: kubernetesDefinition.transitionMap },
-  grafana: { transitionMap: grafanaDefinition.transitionMap },
-  prometheus: { transitionMap: prometheusDefinition.transitionMap },
-});
+const seed = (definition: { name: string; kind: string; transitionMap: unknown }) => [
+  definition.kind,
+  { name: definition.name, transitionMap: definition.transitionMap },
+];
+
+const defaultConnectionMetadataState = () =>
+  Object.fromEntries(
+    [
+      kubernetesDefinition,
+      grafanaDefinition,
+      prometheusDefinition,
+      artifactHubDefinition,
+      githubDefinition,
+    ].map(seed),
+  );
 
 vi.mock('react-redux', () => ({
   useSelector: (selector: (state: unknown) => unknown) => selector(mockStoreState),
@@ -150,6 +164,8 @@ describe('shouldShowTransitionDescription', () => {
     ['KubernetesConnection.json', kubernetesDefinition],
     ['GrafanaConnection.json', grafanaDefinition],
     ['PrometheusConnection.json', prometheusDefinition],
+    ['ArtifactHubConnection.json', artifactHubDefinition],
+    ['GitHubConnection.json', githubDefinition],
   ])('every authored description in %s is displayable (no prompt-style copy)', (_name, def) => {
     Object.entries(def.transitionMap).forEach(([currentStatus, transitions]) => {
       (transitions as { nextState: string; description?: string }[]).forEach((transition) => {
@@ -206,6 +222,55 @@ describe('ConnectionStateTransitionModal', () => {
     await userEvent.click(confirm);
     expect(resolved).toBe(true);
     expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+
+  // Title casing the kind slug yields "Github"/"Artifacthub". The definition's
+  // authored `name` is the display label, so the dialog must use it.
+  it.each([
+    ['github', 'Delete GitHub connection?', 'repository itself is not modified'],
+    [
+      'artifacthub',
+      'Delete Artifact Hub connection?',
+      'Artifact Hub instance itself is not modified',
+    ],
+  ])(
+    'titles a %s transition with the definition-authored display name',
+    async (kind, expectedTitle, expectedCopy) => {
+      const ref = setup();
+
+      act(() => {
+        ref.current.show({
+          targetStatus: 'deleted',
+          currentStatus: 'connected',
+          kind,
+          connections: [{ id: 'c1', name: 'meshery/meshery' }],
+        });
+      });
+
+      expect(await screen.findByText(expectedTitle)).toBeInTheDocument();
+      expect(screen.getByTestId('connection-transition-description')).toHaveTextContent(
+        expectedCopy,
+      );
+      expect(screen.queryByTestId('connection-transition-fallback')).not.toBeInTheDocument();
+    },
+  );
+
+  it('falls back to title-cased kind when the definition carries no display name', async () => {
+    mockStoreState.ui.connectionMetadataState = {
+      github: { transitionMap: githubDefinition.transitionMap },
+    };
+    const ref = setup();
+
+    act(() => {
+      ref.current.show({
+        targetStatus: 'deleted',
+        currentStatus: 'connected',
+        kind: 'github',
+        connections: [{ id: 'c1', name: 'meshery/meshery' }],
+      });
+    });
+
+    expect(await screen.findByText('Delete Github connection?')).toBeInTheDocument();
   });
 
   it('falls back to the generic line when the current state is unknown', async () => {

--- a/ui/components/connections/ConnectionStateTransitionModal.tsx
+++ b/ui/components/connections/ConnectionStateTransitionModal.tsx
@@ -38,7 +38,7 @@ export const KUBERNETES_CONNECTION_LIFECYCLE_DOCS_URL =
 // transition means; this modal only resolves and renders it.
 type ConnectionMetadataState = Record<
   string,
-  { transitionMap?: ConnectionTransitionMap } | undefined
+  { name?: string; transitionMap?: ConnectionTransitionMap } | undefined
 > | null;
 
 const getDocsTooltipMarkdown = (kind: string | undefined): string =>
@@ -188,14 +188,23 @@ export const getTransitionActionLabel = (targetStatus: string): string => {
 export const buildTransitionTitle = ({
   targetStatus,
   kind,
+  kindName,
   count,
 }: {
   targetStatus: string;
   kind?: string;
+  /**
+   * The kind's authored display name from its connection definition. Preferred
+   * over title-casing the kind slug, which cannot recover the intended casing
+   * for multi-word or camel-cased kinds ("artifacthub" -> "Artifacthub",
+   * "github" -> "Github").
+   */
+  kindName?: string;
   count: number;
 }): string => {
   const plural = count > 1;
-  const kindLabel = kind ? `${formatToTitleCase(kind)} ` : '';
+  const label = kindName?.trim() || (kind ? formatToTitleCase(kind) : '');
+  const kindLabel = label ? `${label} ` : '';
   const connectionWord = `connection${plural ? 's' : ''}`;
   const countLabel = plural ? `${count} ` : '';
 
@@ -301,7 +310,8 @@ const ConnectionStateTransitionModal = forwardRef<ConnectionStateTransitionModal
     // connection definition. Bulk selections resolve per connection; the copy
     // is shown only when every selected connection lands on the same one
     // (mixed current states get the generic fallback line instead).
-    const transitionMap = kind ? connectionMetadataState?.[kind]?.transitionMap : undefined;
+    const kindMetadata = kind ? connectionMetadataState?.[kind] : undefined;
+    const transitionMap = kindMetadata?.transitionMap;
     const resolvedDescriptions = new Set(
       connections.map((connection) =>
         getTransitionDescription(transitionMap, connection.status ?? currentStatus, targetStatus),
@@ -316,7 +326,12 @@ const ConnectionStateTransitionModal = forwardRef<ConnectionStateTransitionModal
       ? definitionDescription
       : undefined;
     const actionLabel = getTransitionActionLabel(targetStatus);
-    const title = buildTransitionTitle({ targetStatus, kind, count });
+    const title = buildTransitionTitle({
+      targetStatus,
+      kind,
+      kindName: kindMetadata?.name,
+      count,
+    });
     const connectionPhrase = (
       <>
         {plural ? `${count} connections` : 'the connection'}

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -214,6 +214,9 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
       (res?.connectionDefinitions || []).forEach((definition) => {
         if (definition?.kind) {
           connectionDef[definition.kind] = {
+            // The definition's authored display name ("Artifact Hub", "GitHub"),
+            // which title-casing the kind slug cannot reproduce.
+            name: definition.name,
             transitionMap: definition.transitionMap,
             icon: definition.styles?.svgColor,
           };
@@ -224,8 +227,8 @@ const MesheryApp = ({ Component, pageProps, relayEnvironment, emotionCache }) =>
     }
 
     // Fall back to the legacy `<Kind>Connection` component for kinds without a
-    // first-class connection definition yet (e.g. meshery, github), and to
-    // backfill the flat `transitions` list / icon the definition did not provide.
+    // first-class connection definition yet (e.g. meshery), and to backfill the
+    // flat `transitions` list / icon the definition did not provide.
     const promises = CONNECTION_KINDS_DEF.map(async (kind) => {
       try {
         const res = await getMeshModelComponentByName(formatToTitleCase(kind).concat('Connection'));


### PR DESCRIPTION
**Notes for Reviewers**

Adds connection definitions for **Artifact Hub** and **GitHub**, modelled on `KubernetesConnection.json`.

Both are already first-class registrants in Meshery - models and components are generated from Artifact Hub packages (`MeshModelGenerationHandler`) and from GitHub-hosted manifests (meshkit `generators/github`) - but neither had a connection definition. So both kinds surfaced with no icon, no description, no connection or credential schema, and no `transitionMap` ("No transitions Available" in the status dropdown, exactly as the fallback note in `ui/pages/_app.tsx` called out).

### What's added

| | `kind` | `type` | `subType` | initial `status` |
|---|---|---|---|---|
| Artifact Hub | `artifacthub` | `source` | `registry` | `registered` |
| GitHub | `github` | `source` | `git` | `registered` |

- **`ArtifactHubConnection.json`** - `connectionSchema` takes the Artifact Hub endpoint (so a self-hosted instance works, not just artifacthub.io); `credentialSchema` takes the optional API key id/secret pair, since the public API needs no auth.
- **`GitHubConnection.json`** - `connectionSchema` takes the repository URL plus an optional branch; `credentialSchema` takes an optional access token (required only for private repos).
- Both use the icons **already in this repo** under `docs/static/v0.9/extensions/models/{artifact-hub,github}/icons/{color,white}/`.
- `transitionMap` on both matches the default connection state machine exactly: `discovered → registered | ignored`, `registered → connected | ignored`, `connected → disconnected | deleted`, `disconnected → connected | deleted`. Copy is written as consequence statements (the modal title owns the "Are you sure" framing), consistent with the Grafana/Prometheus definitions.

### Decision worth a reviewer's eye: `type: "source"`

`connection.yaml`'s docstring lists `platform, telemetry, collaboration` for `type` and `cloud, identity, metrics, chat, git, orchestration` for `subType` - neither list covers "a thing Meshery sources models from". Meshery Cloud already persists `ConnectionType: "source"` / `SubType: "git"` for GitHub connections (`server/handlers/github.go`), so these definitions match that rather than inventing a second wire identity for the same kind. `subType: "registry"` extends the set for Artifact Hub, mirroring the `Type: "registry"` already used for registrant connections in `server/models/meshmodel/core/register.go`. The contributor docs table is updated to reflect both. Happy to change if we'd rather force these into `collaboration`.

### Two supporting fixes, so the definitions aren't dead on arrival

Out of scope of "add two JSON files", but shipping without them would ship a known break:

1. **`server/machines/helpers/helpers.go`** - `getMachine` hardcoded an allowlist of `kubernetes`/`grafana`/`prometheus` and returned `meshery-server-1218` ("invlaid type requested") for anything else. The Create Connection wizard is registry-driven (`buildConnectionWizardKindConfigs` lists *every* registered definition), so simply shipping a definition surfaced the kind in the wizard and then 500'd on register. Kinds now fall through to the default machine; only the `REGISTERED`-state verification action stays kind-specific (Grafana/Prometheus probe their endpoint; Kubernetes keeps its bespoke machine). This deletes a second, silently divergent source of truth for which kinds exist.
   - Note: `machines.ErrInvalidType` is left in place but is now unreferenced. I did not remove it to avoid error-code/doc-export churn in this PR - say the word if you'd rather it go.
2. **`ui/components/connections/ConnectionStateTransitionModal.tsx`** - the modal titled its dialog by title-casing the kind slug, which reads **"Github"** and **"Artifacthub"**. The definition's authored `name` is now seeded onto `connectionMetadataState` (`ui/pages/_app.tsx`) and preferred; the title-cased slug remains the fallback for kinds without a definition. Titles now read "Delete GitHub connection?" / "Delete Artifact Hub connection?".

### Docs

`docs/content/en/project/contributing/models/connections.md`: identity table and shipped-definitions list updated for both kinds; `type`/`subType` example lists extended; a new "Lifecycle" step documents that the default state machine needs **no server code** and which transitions it implements.

### Testing

All run locally:

- `npx vitest run components/connections utils/__tests__` → **38 files, 535 tests passed**. The definition-copy drift guard (`it.each` over the shipped JSONs) now covers both new files; new cases assert the display-name title and its fallback.
- `go test ./server/machines/... ./server/handlers/...` → **pass**. New `TestGetMachineCoversEveryDefinitionKind` asserts every definition-backed kind resolves to a machine with a `CONNECTED` action, and that only Grafana/Prometheus carry a `REGISTERED` action.
- `golangci-lint run ./server/machines/...` → **0 issues**. `npx eslint` on touched UI files → clean.
- Icons rendered to PNG and eyeballed on both light and dark backgrounds.

Not run: an end-to-end wizard pass against a live server (no cluster/provider in this environment). Worth a reviewer confirming both kinds appear in **Connections → Create Connection** with their icons and that registering one lands a `connected` row.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Artifact Hub and GitHub connection definitions, including configuration, credentials, lifecycle states, and UI branding.
  - Transition dialogs now display connection-authored names (with fallback to a readable default when no name is provided).

- **Documentation**
  - Updated connection contributing guidance to expand “Identity” examples, list additional shipped connection kinds, and document the full definition lifecycle with default state transitions.

- **Bug Fixes**
  - Improved connection lifecycle handling to cover newly added (and future) connection kinds consistently.
  - Fixed transition and delete dialog titles/descriptions for Artifact Hub and GitHub to match authored labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->