### PR TITLE
[Docs] Homepage: list model categories with parenthetical counts

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -153,6 +153,7 @@ linkTitle: Documentation
         </p>
       </summary>
       <ul class="section-title">
+        {{< model-categories >}}
         <li>See all <a href="{{< ref "extensions/models/_index.md" >}}">{{< model-count >}} models</a></li>
       </ul>
     </details>

--- a/docs/layouts/shortcodes/model-categories.html
+++ b/docs/layouts/shortcodes/model-categories.html
@@ -1,0 +1,21 @@
+{{- /*
+  Renders a bulleted list of model category names, each with a parenthetical
+  count of the models in that category (e.g. "Provisioning (69)"). Counts are
+  derived from the `integrations-category` param on each model page, so they
+  stay accurate as models are added, removed, or recategorized. Categories are
+  ordered by count (descending) so the largest are surfaced first.
+*/ -}}
+{{- $models := where site.RegularPages ".File.Dir" "like" `^extensions/models/` -}}
+{{- $groups := $models.GroupByParam "integrations-category" -}}
+{{- $modelsPage := site.GetPage "/extensions/models" -}}
+{{- $modelsURL := cond (ne $modelsPage nil) $modelsPage.RelPermalink "/extensions/models/" -}}
+{{- $categories := slice -}}
+{{- range $groups -}}
+  {{- if .Key -}}
+    {{- $categories = $categories | append (dict "name" .Key "count" (len .Pages)) -}}
+  {{- end -}}
+{{- end -}}
+{{- $categories = sort $categories "count" "desc" -}}
+{{- range $categories }}
+<li><a href="{{ $modelsURL }}">{{ .name }}</a> ({{ .count }})</li>
+{{- end }}

--- a/docs/layouts/shortcodes/model-categories.html
+++ b/docs/layouts/shortcodes/model-categories.html
@@ -1,14 +1,17 @@
 {{- /*
-  Renders a bulleted list of model category names, each with a parenthetical
-  count of the models in that category (e.g. "Provisioning (69)"). Counts are
-  derived from the `integrations-category` param on each model page, so they
-  stay accurate as models are added, removed, or recategorized. Categories are
+  Renders a list of model category names, each with a parenthetical count of
+  the models in that category (e.g. "Provisioning (69)"). Counts are derived
+  from the `integrations-category` param on each model page, so they stay
+  accurate as models are added, removed, or recategorized. Categories are
   ordered by count (descending) so the largest are surfaced first.
+
+  Category names are plain labels, not links: the models index is a single
+  alphabetized page with no per-category filtering, so a category link would
+  resolve to the same unfiltered page for every category. The "See all models"
+  link in the parent list provides navigation to that index.
 */ -}}
 {{- $models := where site.RegularPages ".File.Dir" "like" `^extensions/models/` -}}
 {{- $groups := $models.GroupByParam "integrations-category" -}}
-{{- $modelsPage := site.GetPage "/extensions/models" -}}
-{{- $modelsURL := cond (ne $modelsPage nil) $modelsPage.RelPermalink "/extensions/models/" -}}
 {{- $categories := slice -}}
 {{- range $groups -}}
   {{- if .Key -}}
@@ -16,6 +19,6 @@
   {{- end -}}
 {{- end -}}
 {{- $categories = sort $categories "count" "desc" -}}
-{{- range $categories }}
-<li><a href="{{ $modelsURL }}">{{ .name }}</a> ({{ .count }})</li>
-{{- end }}
+{{- range $categories -}}
+<li>{{ .name }} ({{ .count }})</li>
+{{- end -}}


### PR DESCRIPTION
## Description

On the [docs homepage](https://docs.meshery.io/), the **Integrations & Extensions → Models** section only linked to "See all N models". This adds a bulleted list of model **category names, each with a parenthetical count** of the models in that category (e.g. `App Definition and Development (84)`), rendered above the existing "See all models" link.

## Changes

- **`docs/layouts/shortcodes/model-categories.html`** (new) — groups model pages by their `integrations-category` frontmatter param, renders a `<li>` per category with its count, ordered by count (largest first). Counts are derived from page params, so they stay accurate as models are added, removed, or recategorized - nothing is hardcoded. Mirrors the existing `model-count` shortcode's page-selection logic.
- **`docs/content/en/_index.md`** — invokes `{{< model-categories >}}` inside the existing Models `<ul class="section-title">`, above the "See all models" link.

## Testing

Validated with an isolated Hugo 0.164 build using representative model pages: confirmed correct grouping, accurate counts, descending sort, that pages without an `integrations-category` are skipped, and that category links resolve to the models index.

Fixes #18249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model category navigation list to the Models documentation.
  * Categories are displayed within the Models integration section and include an integrations count.
  * Categories are automatically ordered by the number of available integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->