### PR TITLE
[Docs] Fix broken image references in sistent.md

### DIFF
--- a/docs/content/en/project/contributing/ui/sistent.md
+++ b/docs/content/en/project/contributing/ui/sistent.md
@@ -19,8 +19,8 @@ Sistent leverages Material UI libraries and provides a custom theme on top of it
 
 - This `Modal` is a Sistent Standard Modal used in validation of design.
 
-<a href="images/sistent-modal.png">
-<img style= "width: 600px;" src="images/sistent-modal.png" />
+<a href="../images/sistent-modal.png">
+<img style= "width: 600px;" src="../images/sistent-modal.png" />
 </a>
 
 ### How to use Sistent in Meshery UI


### PR DESCRIPTION
**Notes for Reviewers**
- This PR fixes # <!-- add issue number if applicable -->

Fixed a broken image reference on the [Sistent UI contributing guide](https://docs.meshery.io/project/contributing/ui/sistent/), where `sistent-modal.png` was not rendering due to an incorrect image path. Updated the path so the image now loads correctly on the documentation page.

**Before:**
`sistent-modal.png` failed to load / broken image link on the Sistent contributing docs page.

<img width="736" height="805" alt="image" src="https://github.com/user-attachments/assets/4eb2fb7d-d52e-41dd-b001-916b9ac7149e" />


**After:**
`sistent-modal.png` renders correctly.

<img width="687" height="643" alt="image" src="https://github.com/user-attachments/assets/25f83498-7f17-4fb3-a3e7-94e8582f1993" />

[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)
- [x] Yes, I signed my commits.
