### PR TITLE
[UI] Consume @meshery/schemas MeshKit detail arrays; drop raw-body stopgap

### DIFF
--- a/ui/components/environments/index.test.tsx
+++ b/ui/components/environments/index.test.tsx
@@ -162,9 +162,10 @@ const EVENT_SUCCESS = 'success';
 
 // Shape the real chain produces for a provider-rejected create: `data` is the
 // verbatim server envelope (camelCase, per server/models/httputil/httputil.go)
-// and `meshkit` is what the @meshery/schemas baseQuery wrapper attaches - which
-// today is message/code/severity only, because that wrapper reads the
-// snake_case spellings the server does not emit (meshery/schemas#1081).
+// and `meshkit` is what the @meshery/schemas baseQuery wrapper attaches -
+// since v1.3.37 (meshery/schemas#1081) it carries the full envelope, reading
+// the server's camelCase detail arrays with a snake_case fallback, so the
+// probable cause and remediation list arrive populated.
 // `utils/helpers/__tests__/meshkitErrorChain.test.ts` pins that transform
 // against the real client; this fixture mirrors its output.
 const REJECTED_CREATE = {
@@ -180,6 +181,8 @@ const REJECTED_CREATE = {
     message: 'Unable to create the environment',
     code: 'meshery-server-1448',
     severity: 'ALERT',
+    probableCause: ['Your account does not have permission.'],
+    suggestedRemediation: ['Ask an organization owner to grant the Environment role.'],
   },
 };
 

--- a/ui/components/workspaces/index.test.tsx
+++ b/ui/components/workspaces/index.test.tsx
@@ -171,9 +171,11 @@ describe('Workspaces create flow notifications', () => {
   it('surfaces the failure when the provider rejects the create', async () => {
     // `data` is the verbatim server envelope (camelCase, per
     // server/models/httputil/httputil.go); `meshkit` is what the
-    // @meshery/schemas baseQuery wrapper actually attaches - message/code/
-    // severity only, because it reads snake_case spellings the server does not
-    // emit (meshery/schemas#1081). The real transform is pinned in
+    // @meshery/schemas baseQuery wrapper attaches - since v1.3.37
+    // (meshery/schemas#1081) it carries the full envelope, reading the
+    // server's camelCase detail arrays with a snake_case fallback, so the
+    // probable cause and remediation list arrive populated. The real
+    // transform is pinned in
     // `utils/helpers/__tests__/meshkitErrorChain.test.ts`.
     createWorkspace.mockReturnValue({
       unwrap: () =>
@@ -190,6 +192,8 @@ describe('Workspaces create flow notifications', () => {
             message: 'Unable to create the workspace',
             code: 'meshery-server-1454',
             severity: 'ALERT',
+            probableCause: ['Your account does not have permission to create workspaces.'],
+            suggestedRemediation: ['Ask an organization owner to grant the Workspace role.'],
           },
         }),
     });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@meshery/schemas": "^1.3.35",
+        "@meshery/schemas": "^1.3.38",
         "@microlink/react-json-view": "^1.31.20",
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.2",
@@ -2068,9 +2068,9 @@
       "license": "MIT"
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.35",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.35.tgz",
-      "integrity": "sha512-YDYETnh/p8kqhiY2PGrmISmXahmGfXGYDSuZcXZt1Np2/24kBcZJ5kPm9HZAMcysRVVBdSjYkA7BO29To++2gQ==",
+      "version": "1.3.38",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.38.tgz",
+      "integrity": "sha512-9dfN8t/T8ZTYo2SHWfzNJGPM5NXk4OF5ajIMaH5sjPPwCY4mj/D63WWZPD8YWP01hPnen5zh/u0aelnv889eNA==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",
@@ -3062,9 +3062,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3082,9 +3079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3102,9 +3096,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3122,9 +3113,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3142,9 +3130,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3162,9 +3147,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@meshery/schemas": "^1.3.35",
+    "@meshery/schemas": "^1.3.38",
     "@microlink/react-json-view": "^1.31.20",
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.2",

--- a/ui/utils/helpers/__tests__/meshkitError.test.ts
+++ b/ui/utils/helpers/__tests__/meshkitError.test.ts
@@ -87,21 +87,22 @@ describe('formatApiError', () => {
     expect(result.message).toContain('`meshery-server-1014`');
   });
 
-  // The schemas baseQuery wrapper drops the detail arrays (meshery/schemas#1081),
-  // so `formatApiError` recovers them from the raw response body. The real
-  // transform is exercised in `meshkitErrorChain.test.ts`; these pin the merge
-  // rules in isolation.
-  it('recovers camelCase detail arrays from the raw body', () => {
+  // Since @meshery/schemas v1.3.37 (meshery/schemas#1081) the baseQuery wrapper
+  // populates the MeshKit detail arrays on `error.meshkit` directly - camelCase,
+  // with a snake_case fallback - so `formatApiError` reads them straight off the
+  // envelope. The real transform is exercised end-to-end in
+  // `meshkitErrorChain.test.ts`; these pin the rendering in isolation.
+  it('surfaces every detail array carried on the envelope', () => {
     const result = formatApiError({
       status: 403,
-      data: {
-        error: 'Unable to create the environment',
+      data: { error: 'Unable to create the environment' },
+      meshkit: {
+        message: 'Unable to create the environment',
         code: 'meshery-server-1448',
         probableCause: ['Missing permission.'],
         suggestedRemediation: ['Ask an owner for the Environment role.'],
         longDescription: ['The provider rejected the request.'],
       },
-      meshkit: { message: 'Unable to create the environment', code: 'meshery-server-1448' },
     });
 
     expect(result.message).toContain('*Try:*');
@@ -110,44 +111,10 @@ describe('formatApiError', () => {
     expect(result.meshkit?.longDescription).toEqual(['The provider rejected the request.']);
   });
 
-  it('recovers snake_case detail arrays from the raw body', () => {
-    const result = formatApiError({
-      status: 409,
-      data: { error: 'duplicate', suggested_remediation: ['Pick a different name.'] },
-      meshkit: { message: 'duplicate' },
-    });
-
-    expect(result.message).toContain('- Pick a different name.');
-  });
-
-  it('prefers camelCase over snake_case when the body carries both', () => {
-    const result = formatApiError({
-      status: 409,
-      data: {
-        error: 'duplicate',
-        suggestedRemediation: ['camel wins'],
-        suggested_remediation: ['snake loses'],
-      },
-      meshkit: { message: 'duplicate' },
-    });
-
-    expect(result.meshkit?.suggestedRemediation).toEqual(['camel wins']);
-  });
-
-  it('keeps the envelope values when meshkit already carries the details', () => {
-    const result = formatApiError({
-      status: 409,
-      data: { error: 'duplicate', suggestedRemediation: ['from body'] },
-      meshkit: { message: 'duplicate', suggestedRemediation: ['from envelope'] },
-    });
-
-    expect(result.meshkit?.suggestedRemediation).toEqual(['from envelope']);
-  });
-
-  it('ignores blank and non-string detail entries on the raw body', () => {
+  it('renders no Try: section when the envelope carries no remediations', () => {
     const result = formatApiError({
       status: 500,
-      data: { error: 'boom', suggestedRemediation: ['', '   ', 42] },
+      data: { error: 'boom' },
       meshkit: { message: 'boom' },
     });
 

--- a/ui/utils/helpers/__tests__/meshkitErrorChain.test.ts
+++ b/ui/utils/helpers/__tests__/meshkitErrorChain.test.ts
@@ -14,19 +14,18 @@ const { mesheryApi } = await import('@meshery/schemas/mesheryApi');
 // End-to-end coverage for the error chain the app actually runs:
 //
 //   server JSON envelope
-//     -> real `@meshery/schemas` baseQuery (`withMeshkitError`)
+//     -> real `@meshery/schemas` baseQuery (`withMeshkitErrorTransform`)
 //       -> real `mesheryApi.endpoints.*`
 //         -> `formatApiError`
 //           -> snackbar markdown
 //
-// Deliberately NOT hand-constructing `error.meshkit`: that is exactly the gap
-// that let the casing mismatch ship. The schemas wrapper reads the snake_case
-// spellings (`probable_cause`, ...) while the server emits camelCase
-// (`probableCause`, ...), so a hand-built envelope passes while production
-// silently drops the probable cause and the remediation list.
-//
-// See meshery/schemas#1081 and the `MESHKIT_DETAIL_ALIASES` comment in
-// `utils/helpers/meshkitError.ts`.
+// Deliberately NOT hand-constructing `error.meshkit`: driving the real wrapper
+// is what catches a casing regression. The server emits camelCase
+// (`probableCause`, ...); a casing mismatch in the wrapper once dropped the
+// probable cause and the remediation list on the floor (meshery/schemas#1081,
+// fixed in @meshery/schemas v1.3.37). The wrapper now reads camelCase with a
+// snake_case fallback, and these tests guard that end-to-end so the gap cannot
+// silently reopen on a future schemas bump.
 // ---------------------------------------------------------------------------
 
 /**
@@ -47,6 +46,21 @@ const CREATE_ENVIRONMENT_403 = {
     'The environment was NOT created - retry after resolving the cause.',
   ],
   longDescription: ['The remote provider rejected the create request.'],
+};
+
+/**
+ * The same envelope emitted with the legacy snake_case detail keys. Some
+ * producers still send these; `withMeshkitErrorTransform` reads camelCase
+ * first and falls back to snake_case, so this MUST yield a MeshKit envelope
+ * identical to the camelCase case above.
+ */
+const CREATE_ENVIRONMENT_403_SNAKE = {
+  error: CREATE_ENVIRONMENT_403.error,
+  code: CREATE_ENVIRONMENT_403.code,
+  severity: CREATE_ENVIRONMENT_403.severity,
+  probable_cause: CREATE_ENVIRONMENT_403.probableCause,
+  suggested_remediation: CREATE_ENVIRONMENT_403.suggestedRemediation,
+  long_description: CREATE_ENVIRONMENT_403.longDescription,
 };
 
 const makeStore = () =>
@@ -84,7 +98,7 @@ afterEach(() => {
 });
 
 describe('MeshKit error chain (real schemas client)', () => {
-  it('surfaces the schemas transform gap this helper compensates for', async () => {
+  it('populates the whole MeshKit envelope from a real camelCase 403', async () => {
     respondWith(403, CREATE_ENVIRONMENT_403);
 
     const error = (await createEnvironmentError()) as {
@@ -92,16 +106,42 @@ describe('MeshKit error chain (real schemas client)', () => {
       meshkit?: Record<string, unknown>;
     };
 
-    // The wrapper does attach an envelope, and it does carry message/code...
+    // The wrapper attaches the full envelope: message, code and - since
+    // @meshery/schemas v1.3.37 (meshery/schemas#1081) - the detail arrays,
+    // read from the server's camelCase spellings. If a future schemas bump
+    // reintroduces the casing mismatch, these assertions fail here rather than
+    // silently dropping the probable cause and remediation list in production.
     expect(error?.status).toBe(403);
     expect(error?.meshkit?.message).toBe('Unable to create the environment');
     expect(error?.meshkit?.code).toBe('meshery-server-1448');
-    // ...but the detail arrays are dropped, because the wrapper reads
-    // `probable_cause`/`suggested_remediation` and the server sends camelCase.
-    // Delete this assertion (and the fallback it justifies) once
-    // meshery/schemas#1081 ships and the dependency is bumped.
-    expect(error?.meshkit?.suggestedRemediation).toBeUndefined();
-    expect(error?.meshkit?.probableCause).toBeUndefined();
+    expect(error?.meshkit?.suggestedRemediation).toEqual(
+      CREATE_ENVIRONMENT_403.suggestedRemediation,
+    );
+    expect(error?.meshkit?.probableCause).toEqual(CREATE_ENVIRONMENT_403.probableCause);
+    expect(error?.meshkit?.longDescription).toEqual(CREATE_ENVIRONMENT_403.longDescription);
+  });
+
+  it('populates the whole MeshKit envelope from a real snake_case 403', async () => {
+    respondWith(403, CREATE_ENVIRONMENT_403_SNAKE);
+
+    const error = (await createEnvironmentError()) as {
+      status?: number;
+      meshkit?: Record<string, unknown>;
+    };
+
+    // The wrapper reads camelCase first and falls back to the legacy
+    // snake_case spellings, so a producer still emitting `probable_cause` /
+    // `suggested_remediation` / `long_description` must yield the SAME complete
+    // envelope as the camelCase case. Guards the fallback so a schemas
+    // regression can't silently drop the detail arrays for such producers.
+    expect(error?.status).toBe(403);
+    expect(error?.meshkit?.message).toBe('Unable to create the environment');
+    expect(error?.meshkit?.code).toBe('meshery-server-1448');
+    expect(error?.meshkit?.suggestedRemediation).toEqual(
+      CREATE_ENVIRONMENT_403.suggestedRemediation,
+    );
+    expect(error?.meshkit?.probableCause).toEqual(CREATE_ENVIRONMENT_403.probableCause);
+    expect(error?.meshkit?.longDescription).toEqual(CREATE_ENVIRONMENT_403.longDescription);
   });
 
   it('renders the title, every remediation bullet and the code from a real 403', async () => {

--- a/ui/utils/helpers/meshkitError.ts
+++ b/ui/utils/helpers/meshkitError.ts
@@ -16,10 +16,14 @@ export interface FormattedApiError {
 
 /**
  * Type-guard that narrows an unknown RTK Query error to one carrying a
- * MeshKit envelope. The schemas package's `transformErrorResponse` wrapper
- * (v1.2.2+) sets `error.meshkit` on every non-2xx JSON response that matches
- * the MeshKit shape, so this guard can be used directly on the `error`
- * returned by mutation/query hooks without manual casting.
+ * MeshKit envelope. The schemas package's `withMeshkitErrorTransform`
+ * baseQuery wrapper sets `error.meshkit` — message, code, severity and the
+ * `probableCause`/`suggestedRemediation`/`longDescription` detail arrays — on
+ * every non-2xx JSON response that matches the MeshKit shape. Since
+ * @meshery/schemas v1.3.37 (meshery/schemas#1081) the wrapper reads the
+ * server's camelCase spellings with a snake_case fallback, so the detail
+ * arrays arrive fully populated. Callers can therefore read `error.meshkit`
+ * directly, without manual casting or re-parsing the raw response body.
  */
 export const hasMeshkitError = (
   error: unknown,
@@ -74,67 +78,6 @@ export const formatMeshkitErrorMarkdown = (
   return lines.join('\n');
 };
 
-type MeshkitDetailKey = 'probableCause' | 'suggestedRemediation' | 'longDescription';
-
-/**
- * Wire aliases for each MeshKit detail array, most-preferred spelling first.
- *
- * The Meshery server emits camelCase - see the `errorResponse` struct in
- * `server/models/httputil/httputil.go` and the identifier-naming contract in
- * AGENTS.md - but the `withMeshkitError` baseQuery wrapper in
- * `@meshery/schemas` reads the snake_case spellings (`probable_cause`,
- * `suggested_remediation`, `long_description`) instead. The result is an
- * `error.meshkit` carrying only message/code/severity, so the "*Try:*" section
- * below never renders even though the server sent remediations.
- *
- * Tracked upstream as meshery/schemas#1081
- * (https://github.com/meshery/schemas/issues/1081). The defect is present in
- * the pinned 1.3.x line and in 1.4.0. Once it is fixed upstream and this
- * repo's dependency is bumped past it, the raw-body fallback in
- * `resolveMeshkitError` becomes redundant and can be deleted.
- */
-const MESHKIT_DETAIL_ALIASES: Record<MeshkitDetailKey, readonly string[]> = {
-  probableCause: ['probableCause', 'probable_cause'],
-  suggestedRemediation: ['suggestedRemediation', 'suggested_remediation'],
-  longDescription: ['longDescription', 'long_description'],
-};
-
-/** Narrow an unknown value to a non-empty array of non-blank strings. */
-const toStringArray = (value: unknown): string[] | undefined => {
-  if (!Array.isArray(value)) return undefined;
-  const entries = value.filter(
-    (entry): entry is string => typeof entry === 'string' && entry.trim().length > 0,
-  );
-  return entries.length > 0 ? entries : undefined;
-};
-
-/**
- * Merge the MeshKit envelope attached by the schemas baseQuery with the detail
- * arrays still present on the raw response body at `error.data`. Values already
- * on `meshkit` win; within the body camelCase wins over snake_case, so a future
- * producer emitting either spelling keeps working.
- */
-const resolveMeshkitError = (error: { meshkit: MeshkitError; data?: unknown }): MeshkitError => {
-  const body =
-    error.data && typeof error.data === 'object' && !Array.isArray(error.data)
-      ? (error.data as Record<string, unknown>)
-      : undefined;
-  if (!body) return error.meshkit;
-
-  const resolved: MeshkitError = { ...error.meshkit };
-  for (const key of Object.keys(MESHKIT_DETAIL_ALIASES) as MeshkitDetailKey[]) {
-    if (toStringArray(resolved[key])) continue;
-    for (const alias of MESHKIT_DETAIL_ALIASES[key]) {
-      const fromBody = toStringArray(body[alias]);
-      if (fromBody) {
-        resolved[key] = fromBody;
-        break;
-      }
-    }
-  }
-  return resolved;
-};
-
 /**
  * Extract a single best-effort string from a non-MeshKit RTK Query error or
  * any thrown value. Mirrors the legacy `error?.data` / `error?.message`
@@ -177,7 +120,7 @@ const extractFallbackMessage = (error: unknown): string | undefined => {
  */
 export const formatApiError = (error: unknown, fallbackTitle?: string): FormattedApiError => {
   if (hasMeshkitError(error)) {
-    const meshkit = resolveMeshkitError(error);
+    const { meshkit } = error;
     return {
       message: formatMeshkitErrorMarkdown(meshkit, fallbackTitle),
       meshkit,

--- a/ui/utils/hooks/useNotification.tsx
+++ b/ui/utils/hooks/useNotification.tsx
@@ -213,9 +213,9 @@ export const useNotificationHandlers = () => {
 
   /**
    * Surface an RTK Query error in a toast, automatically consuming the
-   * structured `meshkit` envelope set by `@meshery/schemas` v1.2.2's
-   * `transformErrorResponse` wrapper. When MeshKit metadata is present the
-   * toast renders:
+   * structured `meshkit` envelope set by `@meshery/schemas`'s
+   * `withMeshkitErrorTransform` baseQuery wrapper. When MeshKit metadata is
+   * present the toast renders:
    *   - `meshkit.message` as a bold title,
    *   - `meshkit.suggestedRemediation` as a bullet list (one entry per line),
    *   - `meshkit.code` as a muted reference for support tickets.


### PR DESCRIPTION
**Notes for Reviewers**

Removes the `ui/utils/helpers/meshkitError.ts` stopgap now that its upstream cause is fixed and released.

**Symptom** - The `*Try:*` remediation bullet list in error snackbars silently didn't render even when the server sent remediations.

**Root cause** - `@meshery/schemas`' RTK `baseQuery` wrapper read the MeshKit detail arrays from the **snake_case** wire keys (`probable_cause`, `suggested_remediation`, `long_description`), but the Meshery server emits **camelCase** (per the identifier-naming contract). The result was an `error.meshkit` carrying only `message`/`code`/`severity`, so `probableCause`/`suggestedRemediation`/`longDescription` arrived `undefined`. Tracked as [meshery/schemas#1081](https://github.com/meshery/schemas/issues/1081).

**Fix (upstream)** - Fixed in `@meshery/schemas` **v1.3.37** ([meshery/schemas#1087](https://github.com/meshery/schemas/pull/1087)): `withMeshkitErrorTransform` now reads camelCase with a snake_case fallback, so `error.meshkit.*` is populated correctly.

**This PR**
- Bumps `@meshery/schemas` to `^1.3.38` (lockfile resolves **1.3.38**, which carries the v1.3.37 transform fix). `go.mod` already pins `v1.3.37`, so Go and UI now align on the same schemas release.
- Deletes the now-redundant `resolveMeshkitError` + `MESHKIT_DETAIL_ALIASES` (and the `toStringArray`/`MeshkitDetailKey` helpers that only served them). `formatApiError` reads `error.meshkit` directly.
- Refreshes stale comments that referenced schemas#1081 as an open defect and the old wrapper name (`meshkitError.ts`, `useNotification.tsx`, and the chain test header).
- Updates the unit tests to assert detail arrays surface straight off the envelope, and flips the **real-client** end-to-end chain test from asserting the bug to guarding the fix - so a future casing regression fails loudly there.

**Why it's safe** - Pure dead-code cleanup. The stopgap already preferred values on `error.meshkit`; removing it changes nothing behaviorally now that those fields are populated upstream.

**Verification**
- `tsc --noEmit`: clean on the touched files.
- `eslint`: clean on all touched files.
- `vitest`: all 41 tests in `utils/helpers` pass, including `meshkitErrorChain.test.ts`, which drives a real 403 through the real `@meshery/schemas` v1.3.38 client and asserts the `*Try:*` bullet list renders end-to-end (`server JSON -> withMeshkitErrorTransform -> mesheryApi endpoint -> formatApiError -> snackbar markdown`).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MeshKit API error rendering so probable causes and suggested remediations are consistently sourced from the full server error envelope.
  * Notifications and formatted error markdown now include the remediation “Try” section only when remediations are available.
  * Maintains compatibility with both camelCase and legacy snake_case MeshKit error detail fields.
* **Chores**
  * Updated the `@meshery/schemas` dependency to the latest compatible version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->