### PR TITLE
[Server] Re-run initFunc on cache hit when cached

### DIFF
--- a/server/machines/helpers/helpers.go
+++ b/server/machines/helpers/helpers.go
@@ -140,6 +140,15 @@ func InitializeMachineWithContext(
 ) (*machines.StateMachine, error) {
 	inst, ok := smInstanceTracker.Get(ID)
 	if ok {
+
+		if initFunc == nil || HasMachineContext(inst) {
+			return inst, nil
+		}
+
+		_, err := inst.Start(ctx, machineCtx, log, initFunc) 
+		if err != nil {
+			return nil, err 
+		}
 		return inst, nil
 	}
 

--- a/server/machines/helpers/helpers.go
+++ b/server/machines/helpers/helpers.go
@@ -145,9 +145,9 @@ func InitializeMachineWithContext(
 			return inst, nil
 		}
 
-		_, err := inst.Start(ctx, machineCtx, log, initFunc) 
+		_, err := inst.Start(ctx, machineCtx, log, initFunc)
 		if err != nil {
-			return nil, err 
+			return nil, err
 		}
 		return inst, nil
 	}

--- a/server/machines/helpers/helpers_test.go
+++ b/server/machines/helpers/helpers_test.go
@@ -1,12 +1,17 @@
 package helpers
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/machines/kubernetes"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/meshkit/models/events"
 	"github.com/meshery/schemas/models/core"
 )
 
@@ -119,4 +124,168 @@ func TestGetMachineCoversEveryDefinitionKind(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeProvider satisfies models.Provider via a nil embedded interface, and
+// overrides only the one method InitializeMachineWithContext's cache-miss
+// path actually calls. Any other Provider method being invoked would panic
+// on the nil embedded interface — which is fine, since none of these tests
+// exercise those paths.
+type fakeProvider struct {
+	models.Provider
+}
+
+func (fakeProvider) GetGenericPersister() *database.Handler {
+	return nil
+}
+
+func newHelpersTestLogger(t *testing.T) logger.Handler {
+	t.Helper()
+	l, err := logger.New("test", logger.Options{Format: logger.JsonLogFormat})
+	if err != nil {
+		t.Fatalf("logger.New() error = %v", err)
+	}
+	return l
+}
+
+func newEmptyTracker() *machines.ConnectionToStateMachineInstanceTracker {
+	return &machines.ConnectionToStateMachineInstanceTracker{
+		ConnectToInstanceMap: map[core.Uuid]*machines.StateMachine{},
+	}
+}
+
+// TestInitializeMachineWithContext covers meshery#20820: a cache hit must
+// respect what the CALLER's initFunc requires, not silently hand back a
+// machine initialized for a different purpose.
+func TestInitializeMachineWithContext(t *testing.T) {
+	t.Run("cache hit, nil initFunc: returns cached instance untouched", func(t *testing.T) {
+		id := core.Uuid(uuid.Must(uuid.NewV4()))
+		userID := core.Uuid(uuid.Must(uuid.NewV4()))
+		tracker := newEmptyTracker()
+		cached := &machines.StateMachine{ID: id, Context: nil}
+		tracker.Add(id, cached)
+
+		// initFunc == nil mirrors the non-kubernetes registration callers
+		// (auto_register.go, connections_handlers.go:67) — they never require
+		// a Context, so a nil-Context cache hit is exactly what they expect.
+		got, err := InitializeMachineWithContext(nil, context.Background(), id, userID, tracker, newHelpersTestLogger(t), fakeProvider{}, machines.DISCOVERED, "artifacthub", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != cached {
+			t.Fatalf("expected the cached instance to be returned as-is")
+		}
+	})
+
+	t.Run("cache hit, instance already has a context: initFunc is NOT re-run", func(t *testing.T) {
+		id := core.Uuid(uuid.Must(uuid.NewV4()))
+		userID := core.Uuid(uuid.Must(uuid.NewV4()))
+		tracker := newEmptyTracker()
+		existingCtx := &struct{ marker string }{marker: "already-set"}
+		cached := &machines.StateMachine{ID: id, Context: existingCtx}
+		tracker.Add(id, cached)
+
+		called := false
+		spyInit := func(ctx context.Context, machineCtx interface{}, log logger.Handler) (interface{}, *events.Event, error) {
+			called = true
+			return &struct{ marker string }{marker: "should-never-be-used"}, nil, nil
+		}
+
+		got, err := InitializeMachineWithContext(nil, context.Background(), id, userID, tracker, newHelpersTestLogger(t), fakeProvider{}, machines.DISCOVERED, "artifacthub", spyInit)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if called {
+			t.Fatalf("initFunc must not run again when the cached instance already has a context — unnecessary re-init")
+		}
+		if got.Context != existingCtx {
+			t.Fatalf("expected the existing context to be preserved untouched, got %#v", got.Context)
+		}
+	})
+
+	// This is the exact scenario from the issue: a connection first cached by
+	// a nil-initFunc caller (or one whose Start failed) must NOT stay stuck
+	// forever once a caller that actually needs a Context comes along.
+	t.Run("cache hit, instance lacks context: initFunc re-runs and Context gets assigned", func(t *testing.T) {
+		id := core.Uuid(uuid.Must(uuid.NewV4()))
+		userID := core.Uuid(uuid.Must(uuid.NewV4()))
+		tracker := newEmptyTracker()
+		cached := &machines.StateMachine{ID: id, Context: nil}
+		tracker.Add(id, cached)
+
+		newCtx := &struct{ marker string }{marker: "freshly-initialized"}
+		called := false
+		initFn := func(ctx context.Context, machineCtx interface{}, log logger.Handler) (interface{}, *events.Event, error) {
+			called = true
+			return newCtx, nil, nil
+		}
+
+		got, err := InitializeMachineWithContext(nil, context.Background(), id, userID, tracker, newHelpersTestLogger(t), fakeProvider{}, machines.DISCOVERED, "artifacthub", initFn)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatalf("expected initFunc to be re-run for a cached instance missing its context")
+		}
+		if got != cached {
+			t.Fatalf("expected the SAME *StateMachine to be reused (mutated in place), not a new instance")
+		}
+		if got.Context != newCtx {
+			t.Fatalf("expected Context to be updated to the freshly-initialized value, got %#v", got.Context)
+		}
+
+		// The tracker must reflect the update too — no stale second copy.
+		trackedInst, ok := tracker.Get(id)
+		if !ok || trackedInst.Context != newCtx {
+			t.Fatalf("tracker entry was not updated in place")
+		}
+	})
+
+	t.Run("cache hit, instance lacks context: re-init failure surfaces the error", func(t *testing.T) {
+		id := core.Uuid(uuid.Must(uuid.NewV4()))
+		userID := core.Uuid(uuid.Must(uuid.NewV4()))
+		tracker := newEmptyTracker()
+		cached := &machines.StateMachine{ID: id, Context: nil}
+		tracker.Add(id, cached)
+
+		wantErr := errors.New("cluster unreachable")
+		initFn := func(ctx context.Context, machineCtx interface{}, log logger.Handler) (interface{}, *events.Event, error) {
+			return nil, nil, wantErr
+		}
+
+		got, err := InitializeMachineWithContext(nil, context.Background(), id, userID, tracker, newHelpersTestLogger(t), fakeProvider{}, machines.DISCOVERED, "artifacthub", initFn)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want %v", err, wantErr)
+		}
+		if got != nil {
+			t.Fatalf("expected a nil instance on re-init failure, got %#v", got)
+		}
+	})
+
+	t.Run("cache miss: builds, initializes, and caches a new instance", func(t *testing.T) {
+		id := core.Uuid(uuid.Must(uuid.NewV4()))
+		userID := core.Uuid(uuid.Must(uuid.NewV4()))
+		tracker := newEmptyTracker()
+
+		newCtx := &struct{ marker string }{marker: "built-fresh"}
+		initFn := func(ctx context.Context, machineCtx interface{}, log logger.Handler) (interface{}, *events.Event, error) {
+			return newCtx, nil, nil
+		}
+
+		got, err := InitializeMachineWithContext(nil, context.Background(), id, userID, tracker, newHelpersTestLogger(t), fakeProvider{}, machines.DISCOVERED, "artifacthub", initFn)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatalf("expected a non-nil instance")
+		}
+		if got.Context != newCtx {
+			t.Fatalf("expected Context to be set from initFunc, got %#v", got.Context)
+		}
+
+		trackedInst, ok := tracker.Get(id)
+		if !ok || trackedInst != got {
+			t.Fatalf("expected the new instance to be cached under ID")
+		}
+	})
 }


### PR DESCRIPTION
**Notes for Reviewers**

Fixes #20820

Description
cache hit was returning the cached instance no matter what even if the caller's initFunc needed a context and the cached one didn't have it now it reruns Start in that case else returns as-is like before

added tests for both cases Build/vet/lint clean

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine initialization to correctly reuse cached instances without unnecessary re-initialization.
  * Prevented re-running initialization when no initializer is provided or when the cached machine already has context.
  * Ensured cached machines missing context are initialized in place, with errors properly propagated and results omitted when initialization fails.
  * Kept cache-miss flows creating, initializing, and registering machines consistently.

* **Tests**
  * Added coverage for cache hit/miss behavior and initialization success/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->