### PR TITLE
[mesheryctl] Fix panic in generateErrorReferenceDetails

### DIFF
--- a/mesheryctl/internal/cli/pkg/api/meshery.go
+++ b/mesheryctl/internal/cli/pkg/api/meshery.go
@@ -114,6 +114,11 @@ func makeRequest(urlPath string, httpMethod string, body io.Reader, headers map[
 }
 
 func generateErrorReferenceDetails(referenceCodeName, code string) string {
-	codeNumber := strings.Split(code, "-")[1]
+	parts := strings.Split(code, "-")
+	codeNumber := code
+
+	if len(parts) > 1 {
+		codeNumber = parts[1]
+	}
 	return fmt.Sprintf("\nFor additional details see https://docs.meshery.io/reference/error-codes#%s-%s", referenceCodeName, codeNumber)
 }

--- a/mesheryctl/internal/cli/pkg/api/meshery_test.go
+++ b/mesheryctl/internal/cli/pkg/api/meshery_test.go
@@ -76,3 +76,40 @@ func TestMakeRequest_Failures(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateErrorReferenceDetails(t *testing.T) {
+	tests := []struct {
+		name              string
+		referenceCodeName string
+		code              string
+		expected          string
+	}{
+		{
+			name:              "well-formed error code",
+			referenceCodeName: "ErrFailRequestCode",
+			code:              "mesheryctl-1090",
+			expected:          "\nFor additional details see https://docs.meshery.io/reference/error-codes#ErrFailRequestCode-1090",
+		},
+		{
+			name:              "malformed error code without hyphen",
+			referenceCodeName: "ErrNoHyphenCode",
+			code:              "mesheryctl1090",
+			expected:          "\nFor additional details see https://docs.meshery.io/reference/error-codes#ErrNoHyphenCode-mesheryctl1090",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := generateErrorReferenceDetails(tt.referenceCodeName, tt.code)
+			if actual != tt.expected {
+				t.Errorf(
+					"generateErrorReferenceDetails(%q, %q) = %q, want %q",
+					tt.referenceCodeName,
+					tt.code,
+					actual,
+					tt.expected,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20553 

### Summary
- Add a defensive check in `generateErrorReferenceDetails` to avoid panicking on malformed error codes without a hyphen.
- Preserve the existing behavior for well-formed error codes.
- Add a regression test covering both well-formed and malformed inputs.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of error reference links when error codes don’t follow the expected delimiter pattern.
  * Prevented failures when generating and displaying reference links for malformed or incomplete error codes.
* **Tests**
  * Added table-driven test coverage for both well-formed and malformed error code formats to ensure correct link generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->