### PR TITLE
[mesheryctl] fix: return error on non-200 spreadsheet fetch response

### DIFF
--- a/mesheryctl/internal/cli/root/registry/generate.go
+++ b/mesheryctl/internal/cli/root/registry/generate.go
@@ -58,11 +58,15 @@ var (
 )
 
 // checkSpreadsheetFetch validates the result of a spreadsheet fetch and
-// returns an explicit, non-nil error for network failures or non-200
-// HTTP responses, so callers never mistake a failed fetch for success.
+// returns an explicit, non-nil error for network failures, a nil response,
+// or non-200 HTTP responses, so callers never mistake a failed fetch for
+// success or dereference a nil response.
 func checkSpreadsheetFetch(resp *sheets.Spreadsheet, err error, location string) error {
 	if err != nil {
 		return ErrUpdateRegistry(err, location)
+	}
+	if resp == nil {
+		return ErrUpdateRegistry(fmt.Errorf("received nil response fetching spreadsheet"), location)
 	}
 	if resp.HTTPStatusCode != 200 {
 		return ErrUpdateRegistry(fmt.Errorf("unexpected HTTP status %d fetching spreadsheet", resp.HTTPStatusCode), location)

--- a/mesheryctl/internal/cli/root/registry/generate.go
+++ b/mesheryctl/internal/cli/root/registry/generate.go
@@ -56,6 +56,20 @@ var (
 	// Whether to generate only the latest version of each model
 	latestVersionOnly bool
 )
+
+// checkSpreadsheetFetch validates the result of a spreadsheet fetch and
+// returns an explicit, non-nil error for network failures or non-200
+// HTTP responses, so callers never mistake a failed fetch for success.
+func checkSpreadsheetFetch(resp *sheets.Spreadsheet, err error, location string) error {
+	if err != nil {
+		return ErrUpdateRegistry(err, location)
+	}
+	if resp.HTTPStatusCode != 200 {
+		return ErrUpdateRegistry(fmt.Errorf("unexpected HTTP status %d fetching spreadsheet", resp.HTTPStatusCode), location)
+	}
+	return nil
+}
+
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate Models",
@@ -194,9 +208,9 @@ mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tu
 			}
 
 			resp, err := srv.Spreadsheets.Get(spreadsheeetID).Fields().Do()
-			if err != nil || resp.HTTPStatusCode != 200 {
-				utils.Log.Error(ErrUpdateRegistry(err, outputLocation))
-				return err
+			if fetchErr := checkSpreadsheetFetch(resp, err, outputLocation); fetchErr != nil {
+				utils.Log.Error(fetchErr)
+				return fetchErr
 			}
 			fmt.Println("✅ Connected to spreadsheet successfully")
 

--- a/mesheryctl/internal/cli/root/registry/spreadsheet_fetch_test.go
+++ b/mesheryctl/internal/cli/root/registry/spreadsheet_fetch_test.go
@@ -1,67 +1,74 @@
 package registry
 
 import (
-"errors"
-"testing"
+	"errors"
+	"testing"
 
-"github.com/stretchr/testify/assert"
-"google.golang.org/api/googleapi"
-"google.golang.org/api/sheets/v4"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/sheets/v4"
 )
 
 func TestCheckSpreadsheetFetch(t *testing.T) {
-tests := []struct {
-name        string
-resp        *sheets.Spreadsheet
-err         error
-expectError bool
-errorMsg    string
-}{
-{
-name:        "network error is propagated",
-resp:        nil,
-err:         errors.New("network failure"),
-expectError: true,
-errorMsg:    "network failure",
-},
-{
-name: "non-200 status with nil err is reported as an error",
-resp: &sheets.Spreadsheet{
-ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 403},
-},
-err:         nil,
-expectError: true,
-errorMsg:    "unexpected HTTP status 403",
-},
-{
-name: "429 rate limit is reported as an error",
-resp: &sheets.Spreadsheet{
-ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 429},
-},
-err:         nil,
-expectError: true,
-errorMsg:    "unexpected HTTP status 429",
-},
-{
-name: "200 status returns no error",
-resp: &sheets.Spreadsheet{
-ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 200},
-},
-err:         nil,
-expectError: false,
-},
-}
+	tests := []struct {
+		name        string
+		resp        *sheets.Spreadsheet
+		err         error
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "network error is propagated",
+			resp:        nil,
+			err:         errors.New("network failure"),
+			expectError: true,
+			errorMsg:    "network failure",
+		},
+		{
+			name:        "nil response with nil error is treated as failure",
+			resp:        nil,
+			err:         nil,
+			expectError: true,
+			errorMsg:    "nil response",
+		},
+		{
+			name: "non-200 status with nil err is reported as an error",
+			resp: &sheets.Spreadsheet{
+				ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 403},
+			},
+			err:         nil,
+			expectError: true,
+			errorMsg:    "unexpected HTTP status 403",
+		},
+		{
+			name: "429 rate limit is reported as an error",
+			resp: &sheets.Spreadsheet{
+				ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 429},
+			},
+			err:         nil,
+			expectError: true,
+			errorMsg:    "unexpected HTTP status 429",
+		},
+		{
+			name: "200 status returns no error",
+			resp: &sheets.Spreadsheet{
+				ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 200},
+			},
+			err:         nil,
+			expectError: false,
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-err := checkSpreadsheetFetch(tt.resp, tt.err, "./models")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkSpreadsheetFetch(tt.resp, tt.err, "./models")
 
-if tt.expectError {
-assert.Error(t, err)
-assert.Contains(t, err.Error(), tt.errorMsg)
-} else {
-assert.NoError(t, err)
-}
-})
-}
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/mesheryctl/internal/cli/root/registry/spreadsheet_fetch_test.go
+++ b/mesheryctl/internal/cli/root/registry/spreadsheet_fetch_test.go
@@ -1,0 +1,67 @@
+package registry
+
+import (
+"errors"
+"testing"
+
+"github.com/stretchr/testify/assert"
+"google.golang.org/api/googleapi"
+"google.golang.org/api/sheets/v4"
+)
+
+func TestCheckSpreadsheetFetch(t *testing.T) {
+tests := []struct {
+name        string
+resp        *sheets.Spreadsheet
+err         error
+expectError bool
+errorMsg    string
+}{
+{
+name:        "network error is propagated",
+resp:        nil,
+err:         errors.New("network failure"),
+expectError: true,
+errorMsg:    "network failure",
+},
+{
+name: "non-200 status with nil err is reported as an error",
+resp: &sheets.Spreadsheet{
+ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 403},
+},
+err:         nil,
+expectError: true,
+errorMsg:    "unexpected HTTP status 403",
+},
+{
+name: "429 rate limit is reported as an error",
+resp: &sheets.Spreadsheet{
+ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 429},
+},
+err:         nil,
+expectError: true,
+errorMsg:    "unexpected HTTP status 429",
+},
+{
+name: "200 status returns no error",
+resp: &sheets.Spreadsheet{
+ServerResponse: googleapi.ServerResponse{HTTPStatusCode: 200},
+},
+err:         nil,
+expectError: false,
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+err := checkSpreadsheetFetch(tt.resp, tt.err, "./models")
+
+if tt.expectError {
+assert.Error(t, err)
+assert.Contains(t, err.Error(), tt.errorMsg)
+} else {
+assert.NoError(t, err)
+}
+})
+}
+}

--- a/mesheryctl/internal/cli/root/registry/update.go
+++ b/mesheryctl/internal/cli/root/registry/update.go
@@ -139,7 +139,7 @@ func InvokeCompUpdate() error {
 	if err != nil {
 		err = ErrUpdateRegistry(err, modelLocation)
 		utils.Log.Error(err)
-		return nil
+		return err
 	}
 
 	utils.Log.Info("Total Registrants: ", len(componentCSVHelper.Components))

--- a/mesheryctl/internal/cli/root/registry/update.go
+++ b/mesheryctl/internal/cli/root/registry/update.go
@@ -86,9 +86,9 @@ mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdw
 			return err
 		}
 		resp, err := srv.Spreadsheets.Get(spreadsheeetID).Fields().Do()
-		if err != nil || resp.HTTPStatusCode != 200 {
-			utils.Log.Error(ErrUpdateRegistry(err, outputLocation))
-			return err
+		if fetchErr := checkSpreadsheetFetch(resp, err, modelLocation); fetchErr != nil {
+			utils.Log.Error(fetchErr)
+			return fetchErr
 		}
 
 		sheetGID = GetSheetIDFromTitle(resp, "Components")
@@ -96,7 +96,7 @@ mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdw
 		err = InvokeCompUpdate()
 		if err != nil {
 			utils.Log.Error(err)
-			return nil
+			return err
 		}
 
 		return nil


### PR DESCRIPTION
## Description

`mesheryctl registry generate` and `mesheryctl registry update` fetch the
integration spreadsheet before generating/updating models. Previously,
when the fetch returned a non-200 HTTP status (e.g. 403, 404, 429) with
a nil `error`, both commands logged a confusing error with a nil cause
and then returned `nil`/`err` (which was itself nil) — exiting 0 as if
the operation succeeded, even though no models were actually
generated or updated.

## Changes

- Extracted the fetch-validation logic into a shared `checkSpreadsheetFetch`
  helper (in `generate.go`, used by both `generate.go` and `update.go`)
  that returns an explicit, non-nil error for both network failures and
  non-200 HTTP responses, including the actual status code in the message.
- Added `spreadsheet_fetch_test.go` with unit tests covering: a network
  error, a 403 response, a 429 response, and a 200 (success) response.
- In `update.go`, `RunE` no longer swallows the error returned by
  `InvokeCompUpdate()` — it now propagates it instead of returning `nil`,
  so update failures also result in a non-zero exit code.

## Testing

- `go build ./...` and `go vet ./...` pass cleanly.
- Existing test suite in `internal/cli/root/registry/` passes (two
  pre-existing, Windows-environment-only failures in `purge_test.go`
  are unrelated to this change — confirmed present on `master` prior
  to this PR).
- New `TestCheckSpreadsheetFetch` covers all 4 scenarios described above.

Fixes #20902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spreadsheet download validation for registry generation and updates.
  - Added clear error messages for network failures and unexpected HTTP responses, including rate limiting (HTTP 429).
  - Registry update failures are now properly reported instead of being silently treated as successful.
  - Component processing errors are now surfaced during registry updates.
  - Successful spreadsheet requests continue through the normal generation and update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->