### PR TITLE
[mesheryctl] Add global support for TOON output format (#20973)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -369,6 +369,7 @@ require (
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect
+	github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c // indirect
 	github.com/valyala/fastjson v1.6.5 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -917,6 +917,8 @@ github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Qb2z5hI1UHxSQt4JMyxebFR15KnApw=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
+github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c h1:D8lDFovBMZywze1eh9iwMLcYor5f11mHBocLhO7cBe8=
+github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c/go.mod h1:j/BOnpF2ihnz4lELs99h9mwGJBx/zdleOUCnLLRPCsc=
 github.com/valyala/fastjson v1.6.5 h1:LLabX0wszE1JDH9+IxLK6b+tb4B7gNdTEFTRasd0Ejw=
 github.com/valyala/fastjson v1.6.5/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=

--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1253
+  "next_error_code": 1254
 }

--- a/mesheryctl/internal/cli/pkg/display/error.go
+++ b/mesheryctl/internal/cli/pkg/display/error.go
@@ -28,7 +28,7 @@ func ErrEncodingData(err error, encoder string) error {
 }
 
 func ErrUnsupportedFormat(format string) error {
-	return errors.New(ErrUnsupportedFormatCode, errors.Alert, []string{fmt.Sprintf("The output format '%s' is not supported. ", format)}, []string{fmt.Sprintf("Output format '%s' is not supported. ", format)}, []string{"An unsupported output format was requested. "}, []string{"Specify a supported output format. Choices are 'json' or 'yaml'."})
+	return errors.New(ErrUnsupportedFormatCode, errors.Alert, []string{fmt.Sprintf("The output format '%s' is not supported. ", format)}, []string{fmt.Sprintf("Output format '%s' is not supported. ", format)}, []string{"An unsupported output format was requested. "}, []string{"Specify a supported output format. Choices are 'json', 'yaml', or 'toon'."})
 }
 
 func ErrOutputFileNotSpecified() error {

--- a/mesheryctl/internal/cli/pkg/display/output.go
+++ b/mesheryctl/internal/cli/pkg/display/output.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/toon-format/toon-go"
 
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"gopkg.in/yaml.v3"
@@ -36,6 +37,8 @@ func (o *OutputFormatterFactory[T]) New(format string, data T) (OutputFormatter[
 		return NewJSONOutputFormatter(data), nil
 	case "yaml":
 		return NewYAMLOutputFormatter(data), nil
+	case "toon":
+		return NewTOONOutputFormatter(data), nil
 	default:
 		return nil, ErrUnsupportedFormat(format)
 	}
@@ -55,6 +58,12 @@ func (o *OutputFormatterSaverFactory[T]) New(format string, outputFormatter Outp
 			return nil, ErrUnsupportedFormat(format)
 		}
 		return NewYAMLOutputFormatterSaver(*yamlFormatter), nil
+	case "toon":
+		toonFormatter, ok := outputFormatter.(*TOONOutputFormatter[T])
+		if !ok {
+			return nil, ErrUnsupportedFormat(format)
+		}
+		return NewTOONOutputFormatterSaver(*toonFormatter), nil
 	default:
 		return nil, ErrUnsupportedFormat(format)
 	}
@@ -84,6 +93,16 @@ type YAMLOutputFormatter[T any] struct {
 
 type YAMLOutputFormatterSaver[T any] struct {
 	OutputFormatter YAMLOutputFormatter[T]
+	FilePath        string
+}
+
+type TOONOutputFormatter[T any] struct {
+	Data T
+	Out  io.Writer
+}
+
+type TOONOutputFormatterSaver[T any] struct {
+	OutputFormatter TOONOutputFormatter[T]
 	FilePath        string
 }
 
@@ -205,6 +224,67 @@ func (y *YAMLOutputFormatterSaver[T]) Save() error {
 	return nil
 }
 
+func NewTOONOutputFormatter[T any](data T) OutputFormatter[T] {
+	return &TOONOutputFormatter[T]{
+		Data: data,
+		Out:  nil,
+	}
+}
+
+func NewTOONOutputFormatterSaver[T any](outputFormatter TOONOutputFormatter[T]) OutputFormatterSaver[T] {
+	return &TOONOutputFormatterSaver[T]{
+		OutputFormatter: outputFormatter,
+		FilePath:        "",
+	}
+}
+
+func (t *TOONOutputFormatterSaver[T]) WithFilePath(filePath string) OutputFormatterSaver[T] {
+	t.FilePath = filePath
+	return t
+}
+
+func (t *TOONOutputFormatterSaver[T]) Save() error {
+	if t.FilePath == "" {
+		return ErrOutputFileNotSpecified()
+	}
+
+	var output []byte
+	var err error
+
+	fmt.Println()
+	if output, err = toon.Marshal(t.OutputFormatter.Data); err != nil {
+		return utils.ErrMarshal(errors.Wrap(err, "failed to format output in toon"))
+	}
+
+	err = writeFile(t.FilePath, output)
+	if err != nil {
+		return utils.ErrCreateFile(t.FilePath, errors.Wrap(err, "failed to save output as toon file"))
+	}
+
+	utils.Log.Info("Data saved to file: ", t.FilePath)
+	return nil
+}
+
+func (t *TOONOutputFormatter[T]) WithOutput(out io.Writer) OutputFormatter[T] {
+	t.Out = out
+	return t
+}
+
+func (t *TOONOutputFormatter[T]) Display() error {
+	utils.Log.Debug("\nDebug: Displaying data using TOON output formatter\n")
+	if t.Out == nil {
+		t.Out = os.Stdout
+	}
+
+	output, err := toon.Marshal(t.Data)
+	if err != nil {
+		return ErrEncodingData(err, "toon")
+	}
+
+	_, err = t.Out.Write(output)
+	return err
+}
+
 func writeFile(filePath string, data []byte) error {
 	err := os.WriteFile(filePath, data, 0644)
 	if err != nil {
@@ -234,7 +314,7 @@ func (y *YAMLOutputFormatter[T]) Display() error {
 	return nil
 }
 
-var validOutputFormat = []string{"json", "yaml"}
+var validOutputFormat = []string{"json", "yaml", "toon"}
 
 func ValidateOutputFormat(outputFormat string) error {
 	if !slices.Contains(validOutputFormat, strings.ToLower(outputFormat)) {

--- a/mesheryctl/internal/cli/pkg/display/output.go
+++ b/mesheryctl/internal/cli/pkg/display/output.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/toon-format/toon-go"
+	"gopkg.in/yaml.v3"
 
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
-	"gopkg.in/yaml.v3"
 )
 
 type OutputFormatter[T any] interface {
@@ -96,11 +96,13 @@ type YAMLOutputFormatterSaver[T any] struct {
 	FilePath        string
 }
 
+// TOONOutputFormatter is a formatter for TOON data.
 type TOONOutputFormatter[T any] struct {
 	Data T
 	Out  io.Writer
 }
 
+// TOONOutputFormatterSaver is a saver for TOON data.
 type TOONOutputFormatterSaver[T any] struct {
 	OutputFormatter TOONOutputFormatter[T]
 	FilePath        string

--- a/mesheryctl/internal/cli/pkg/display/output_test.go
+++ b/mesheryctl/internal/cli/pkg/display/output_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
@@ -65,6 +66,10 @@ func Test_Given_OutputFormatter_When_Display_Then_Content_Is_Displayed_Without_E
 			output := tc.buf.String()
 			assert.Contains(t, output, data.Name, "Output should contain name")
 			assert.Contains(t, output, data.Content, "Output should contain content")
+			if strings.Contains(tc.name, "toon data") {
+				assert.Contains(t, output, "name:", "Output should contain field key 'name:'")
+				assert.Contains(t, output, "content:", "Output should contain field key 'content:'")
+			}
 			tc.buf.Reset()
 		})
 	}
@@ -195,7 +200,9 @@ func Test_Given_TOONOutputFormatterSaver_With_Filepath_When_Save_Then_File_Is_Cr
 
 	content, err := os.ReadFile(tmpFilePath)
 	assert.NoError(t, err)
+	assert.Contains(t, string(content), "name:")
 	assert.Contains(t, string(content), data.Name)
+	assert.Contains(t, string(content), "content:")
 	assert.Contains(t, string(content), data.Content)
 }
 

--- a/mesheryctl/internal/cli/pkg/display/output_test.go
+++ b/mesheryctl/internal/cli/pkg/display/output_test.go
@@ -195,7 +195,7 @@ func Test_Given_TOONOutputFormatterSaver_With_Filepath_When_Save_Then_File_Is_Cr
 	}
 
 	saver := NewTOONOutputFormatterSaver(toonFormatter).WithFilePath(tmpFilePath)
-	err := saver.Save()
+	err = saver.Save()
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(tmpFilePath)

--- a/mesheryctl/internal/cli/pkg/display/output_test.go
+++ b/mesheryctl/internal/cli/pkg/display/output_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 type testStruct struct {
-	Name    string `json:"name" yaml:"name"`
-	Content string `json:"content" yaml:"content"`
+	Name    string `json:"name" yaml:"name" toon:"name"`
+	Content string `json:"content" yaml:"content" toon:"content"`
 }
 
 var data = testStruct{
@@ -42,6 +42,13 @@ func Test_Given_OutputFormatter_When_Display_Then_Content_Is_Displayed_Without_E
 			name:        "Given yaml data when encoded then content is displayed without error",
 			input:       data,
 			formatter:   NewYAMLOutputFormatter(data),
+			buf:         &bytes.Buffer{},
+			expectError: false,
+		},
+		{
+			name:        "Given toon data when encoded then content is displayed without error",
+			input:       data,
+			formatter:   NewTOONOutputFormatter(data),
 			buf:         &bytes.Buffer{},
 			expectError: false,
 		},
@@ -165,5 +172,39 @@ func TestYAMLOutputFormatterSaver_Save_WriteError(t *testing.T) {
 
 	saver := NewYAMLOutputFormatterSaver(yamlFormatter).WithFilePath(tmpDir)
 	err = saver.Save()
+	assert.Error(t, err)
+}
+
+func Test_Given_TOONOutputFormatterSaver_With_Filepath_When_Save_Then_File_Is_Created(t *testing.T) {
+	utils.SetupMeshkitLoggerTesting(t, false)
+	tmpFile, err := os.CreateTemp("", "meshery_output_*.toon")
+	assert.NoError(t, err)
+	tmpFilePath := tmpFile.Name()
+	_ = tmpFile.Close()
+	defer func() {
+		assert.NoError(t, os.Remove(tmpFilePath))
+	}()
+
+	toonFormatter := TOONOutputFormatter[testStruct]{
+		Data: data,
+	}
+
+	saver := NewTOONOutputFormatterSaver(toonFormatter).WithFilePath(tmpFilePath)
+	err := saver.Save()
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(tmpFilePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), data.Name)
+	assert.Contains(t, string(content), data.Content)
+}
+
+func Test_Given_TOONOutputFormatterSaver_With_NoFilepath_When_Save_Then_Error_Is_Returned(t *testing.T) {
+	toonFormatter := TOONOutputFormatter[testStruct]{
+		Data: data,
+	}
+
+	saver := NewTOONOutputFormatterSaver(toonFormatter) // no file path set
+	err := saver.Save()
 	assert.Error(t, err)
 }

--- a/mesheryctl/internal/cli/root/components/view.go
+++ b/mesheryctl/internal/cli/root/components/view.go
@@ -29,7 +29,7 @@ import (
 )
 
 type componentViewFlags struct {
-	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml"`
+	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml toon"`
 	Save         bool   `json:"save" validate:"boolean"`
 }
 
@@ -127,8 +127,8 @@ mesheryctl component view [component-name | component-id] -o [json|yaml] --save
 
 func init() {
 	// Add the new components commands to the ComponentsCmd
-	viewComponentCmd.Flags().StringVarP(&cmdComponentViewFlags.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
-	viewComponentCmd.Flags().BoolVarP(&cmdComponentViewFlags.Save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+	viewComponentCmd.Flags().StringVarP(&cmdComponentViewFlags.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
+	viewComponentCmd.Flags().BoolVarP(&cmdComponentViewFlags.Save, "save", "s", false, "(optional) save output as a JSON/YAML/TOON file")
 }
 
 func formatLabel(components []component.ComponentDefinition) []string {

--- a/mesheryctl/internal/cli/root/components/view.go
+++ b/mesheryctl/internal/cli/root/components/view.go
@@ -46,10 +46,10 @@ Find more information at: https://docs.meshery.io/reference/references/mesheryct
 mesheryctl component view [component-name | component-id]
 
 // View details of a specific component in specified format
-mesheryctl component view [component-name | component-id] -o [json|yaml]
+mesheryctl component view [component-name | component-id] -o [json|yaml|toon]
 
 // View details of a specific component in specified format and save it as a file
-mesheryctl component view [component-name | component-id] -o [json|yaml] --save
+mesheryctl component view [component-name | component-id] -o [json|yaml|toon] --save
 	`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return mesheryctlflags.ValidateCmdFlags(cmd, &cmdComponentViewFlags)

--- a/mesheryctl/internal/cli/root/connections/view.go
+++ b/mesheryctl/internal/cli/root/connections/view.go
@@ -187,6 +187,6 @@ func fetchConnectionByName(connectionName string) (*connection.Connection, error
 }
 
 func init() {
-	viewConnectionCmd.Flags().StringVarP(&connectionViewFlagsProvided.outputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
-	viewConnectionCmd.Flags().BoolVarP(&connectionViewFlagsProvided.save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+	viewConnectionCmd.Flags().StringVarP(&connectionViewFlagsProvided.outputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
+	viewConnectionCmd.Flags().BoolVarP(&connectionViewFlagsProvided.save, "save", "s", false, "(optional) save output as a JSON/YAML/TOON file")
 }

--- a/mesheryctl/internal/cli/root/connections/view.go
+++ b/mesheryctl/internal/cli/root/connections/view.go
@@ -46,11 +46,11 @@ Find more information at: https://docs.meshery.io/reference/references/mesheryct
 // View details of a specific connection in default format (yaml)
 mesheryctl connection view [connection-name|connection-id]
 
-// View details of a specific connection in JSON format
-mesheryctl connection view [connection-name|connection-id] --output-format json
+// View details of a specific connection in JSON, YAML or TOON format
+mesheryctl connection view [connection-name|connection-id] --output-format [json|yaml|toon]
 
-// View details of a specific connection in json format and save it to a file
-mesheryctl connection view [connection-name|connection-id] --output-format json --save
+// View details of a specific connection in specified format and save it to a file
+mesheryctl connection view [connection-name|connection-id] --output-format [json|yaml|toon] --save
 	`,
 	Args: func(_ *cobra.Command, args []string) error {
 		if len(args) == 0 {

--- a/mesheryctl/internal/cli/root/design/evaluate.go
+++ b/mesheryctl/internal/cli/root/design/evaluate.go
@@ -42,7 +42,7 @@ import (
 type evaluateDesignFlag struct {
 	File         string `json:"file"          validate:"omitempty,filepath"`
 	OutputFile   string `json:"output"        validate:"required"`
-	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml"`
+	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml toon"`
 }
 
 var evaluateFlags = &evaluateDesignFlag{}
@@ -465,5 +465,5 @@ func init() {
 
 	evaluateCmd.Flags().StringVarP(&evaluateFlags.File, "file", "f", "", "Path to design file")
 	evaluateCmd.Flags().StringVarP(&evaluateFlags.OutputFile, "output", "o", "", "Path to save the evaluated design")
-	evaluateCmd.Flags().StringVar(&evaluateFlags.OutputFormat, "output-format", "yaml", "Output format for the evaluated design [json|yaml]")
+	evaluateCmd.Flags().StringVar(&evaluateFlags.OutputFormat, "output-format", "yaml", "Output format for the evaluated design [json|yaml|toon]")
 }

--- a/mesheryctl/internal/cli/root/design/view.go
+++ b/mesheryctl/internal/cli/root/design/view.go
@@ -141,5 +141,5 @@ func getDesignViewUrlPath(design string, isID bool, viewAll bool) string {
 
 func init() {
 	viewCmd.Flags().BoolVarP(&designViewFlagsProvided.All, "all", "a", false, "(optional) view all designs available")
-	viewCmd.Flags().StringVarP(&designViewFlagsProvided.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
+	viewCmd.Flags().StringVarP(&designViewFlagsProvided.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
 }

--- a/mesheryctl/internal/cli/root/environments/view.go
+++ b/mesheryctl/internal/cli/root/environments/view.go
@@ -120,7 +120,7 @@ mesheryctl environment view --orgId [orgId]
 }
 
 func init() {
-	viewEnvironmentCmd.Flags().StringVarP(&environmentViewFlagsProvided.outputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
-	viewEnvironmentCmd.Flags().BoolVarP(&environmentViewFlagsProvided.save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+	viewEnvironmentCmd.Flags().StringVarP(&environmentViewFlagsProvided.outputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
+	viewEnvironmentCmd.Flags().BoolVarP(&environmentViewFlagsProvided.save, "save", "s", false, "(optional) save output as a JSON/YAML/TOON file")
 	viewEnvironmentCmd.Flags().StringVarP(&environmentViewFlagsProvided.orgId, "orgId", "", "", "Organization ID")
 }

--- a/mesheryctl/internal/cli/root/filter/view.go
+++ b/mesheryctl/internal/cli/root/filter/view.go
@@ -53,11 +53,11 @@ mesheryctl filter view "[filter-name | ID]"
 // View all filter files
 mesheryctl filter view --all
 
-// View all filter files in json
-mesheryctl filter view --all --output-format json
+// View all filter files in a specific format
+mesheryctl filter view --all --output-format [json|yaml|toon]
 
-// View all filter files in json and save it to a file
-mesheryctl filter view --all --output-format json -s
+// View all filter files in a specific format and save it to a file
+mesheryctl filter view --all --output-format [json|yaml|toon] -s
 
 //View multi-word named filter files. Multi-word filter names should be enclosed in quotes
 mesheryctl filter view "filter name"

--- a/mesheryctl/internal/cli/root/filter/view.go
+++ b/mesheryctl/internal/cli/root/filter/view.go
@@ -35,7 +35,7 @@ import (
 
 type filterViewFlags struct {
 	ViewAllFlag  bool   `json:"all" validate:"boolean"`
-	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml"`
+	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml toon"`
 	Save         bool   `json:"save" validate:"boolean"`
 }
 
@@ -195,6 +195,6 @@ func saveToFile(
 
 func init() {
 	viewCmd.Flags().BoolVarP(&filterViewFlagsProvided.ViewAllFlag, "all", "a", false, "(optional) view all filters available")
-	viewCmd.Flags().StringVarP(&filterViewFlagsProvided.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
-	viewCmd.Flags().BoolVarP(&filterViewFlagsProvided.Save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+	viewCmd.Flags().StringVarP(&filterViewFlagsProvided.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
+	viewCmd.Flags().BoolVarP(&filterViewFlagsProvided.Save, "save", "s", false, "(optional) save output as a JSON/YAML/TOON file")
 }

--- a/mesheryctl/internal/cli/root/model/export.go
+++ b/mesheryctl/internal/cli/root/model/export.go
@@ -16,7 +16,7 @@ import (
 type exportModelFlags struct {
 	DiscardComponents    bool   `json:"discard-components" validate:"boolean"`
 	DiscardRelationships bool   `json:"discard-relationships" validate:"boolean"`
-	OutputFormat         string `json:"output-format" validate:"required,oneof=json yaml"`
+	OutputFormat         string `json:"output-format" validate:"required,oneof=json yaml toon"`
 	OutputLocation       string `json:"output-location" validate:"required,dirpath"`
 	OutputType           string `json:"output-type" validate:"required,oneof=oci tar"`
 	Page                 int    `json:"page" validate:"omitempty,min=1"`
@@ -122,7 +122,7 @@ mesheryctl model export [model-name] --version [version (ex: v0.7.3)]
 func init() {
 	exportModelCmd.Flags().BoolVarP(&exportModelFlagsProvided.DiscardComponents, "discard-components", "c", false, "(optional) whether to discard components in the exported model definition (default = false)")
 	exportModelCmd.Flags().BoolVarP(&exportModelFlagsProvided.DiscardRelationships, "discard-relationships", "r", false, "(optional) whether to discard relationships in the exported model definition (default = false)")
-	exportModelCmd.Flags().StringVarP(&exportModelFlagsProvided.OutputFormat, "output-format", "t", "yaml", "(optional) format to display in [json|yaml] (default = yaml)")
+	exportModelCmd.Flags().StringVarP(&exportModelFlagsProvided.OutputFormat, "output-format", "t", "yaml", "(optional) format to display in [json|yaml|toon] (default = yaml)")
 	exportModelCmd.Flags().StringVarP(&exportModelFlagsProvided.OutputLocation, "output-location", "l", "./", "(optional) output location (default = current directory)")
 	exportModelCmd.Flags().StringVarP(&exportModelFlagsProvided.OutputType, "output-type", "o", "oci", "(optional) format to display in [oci|tar] (default = oci)")
 	exportModelCmd.Flags().IntVarP(&exportModelFlagsProvided.Page, "page", "p", 1, "(optional) page number for paginated results (default = 1)")

--- a/mesheryctl/internal/cli/root/model/init.go
+++ b/mesheryctl/internal/cli/root/model/init.go
@@ -21,7 +21,7 @@ import (
 type cmdModelInitFlags struct {
 	Path         string `json:"path" validate:"omitempty,relabspath"`
 	Version      string `json:"version" validate:"semver"`
-	OutputFormat string `json:"output-format" validate:"oneof=json yaml"`
+	OutputFormat string `json:"output-format" validate:"oneof=json yaml toon"`
 }
 
 var modelInitFlags cmdModelInitFlags
@@ -243,7 +243,7 @@ func initModelDeriveDisplayName(modelName string) string {
 func init() {
 	initModelCmd.Flags().StringVarP(&modelInitFlags.Path, "path", "p", ".", "(optional) target directory (default: current dir)")
 	initModelCmd.Flags().StringVarP(&modelInitFlags.Version, "version", "", "v0.1.0", "(optional) model version (default: v0.1.0)")
-	initModelCmd.Flags().StringVarP(&modelInitFlags.OutputFormat, "output-format", "o", "json", "(optional) format to display in [json|yaml]")
+	initModelCmd.Flags().StringVarP(&modelInitFlags.OutputFormat, "output-format", "o", "json", "(optional) format to display in [json|yaml|toon]")
 }
 
 const (

--- a/mesheryctl/internal/cli/root/model/view.go
+++ b/mesheryctl/internal/cli/root/model/view.go
@@ -31,10 +31,10 @@ Find more information at: https://docs.meshery.io/reference/references/mesheryct
 mesheryctl model view [model-name]
 
 // View a specific model in specified format
-mesheryctl model view [model-name] --output-format [json|yaml]
+mesheryctl model view [model-name] --output-format [json|yaml|toon]
 
 // View a specific model in specified format and save it as a file
-mesheryctl model view [model-name] --output-format [json|yaml] --save
+mesheryctl model view [model-name] --output-format [json|yaml|toon] --save
 `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return mesheryctlflags.ValidateCmdFlags(cmd, &modelViewFlags)

--- a/mesheryctl/internal/cli/root/model/view.go
+++ b/mesheryctl/internal/cli/root/model/view.go
@@ -15,7 +15,7 @@ import (
 )
 
 type cmdModelViewFlags struct {
-	OutputFormat string `json:"output-format" validate:"oneof=json yaml"`
+	OutputFormat string `json:"output-format" validate:"oneof=json yaml toon"`
 	Save         bool   `json:"save" validate:"boolean"`
 }
 
@@ -114,6 +114,6 @@ func getModelViewUrlPath(modelNameOrId string) string {
 }
 
 func init() {
-	viewModelCmd.Flags().StringVarP(&modelViewFlags.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
-	viewModelCmd.Flags().BoolVarP(&modelViewFlags.Save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+	viewModelCmd.Flags().StringVarP(&modelViewFlags.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
+	viewModelCmd.Flags().BoolVarP(&modelViewFlags.Save, "save", "s", false, "(optional) save output as a JSON/YAML/TOON file")
 }

--- a/mesheryctl/internal/cli/root/perf/error.go
+++ b/mesheryctl/internal/cli/root/perf/error.go
@@ -90,9 +90,9 @@ func ErrNoProfileFound() error {
 func ErrInvalidOutputChoice() error {
 	return errors.New(ErrInvalidOutputChoiceCode, errors.Alert,
 		[]string{"Invalid output format choice"},
-		[]string{"Output format choice is invalid, use [json|yaml]"},
-		[]string{"Invalid JSON or YAML content"},
-		[]string{"Check the JSON or YAML structure.", formatErrorWithReference()})
+		[]string{"Output format choice is invalid, use [json|yaml|toon]"},
+		[]string{"Invalid JSON, YAML, or TOON content"},
+		[]string{"Check the JSON, YAML, or TOON structure.", formatErrorWithReference()})
 }
 
 func ErrFailUnmarshalFile(err error) error {

--- a/mesheryctl/internal/cli/root/perf/perf.go
+++ b/mesheryctl/internal/cli/root/perf/perf.go
@@ -46,9 +46,10 @@ mesheryctl perf profile sam-test
 // List performance results:
 mesheryctl perf result sam-test
 
-// Display Perf profile in JSON or YAML:
+// Display Perf profile in JSON, YAML, or TOON:
 mesheryctl perf result -o json
 mesheryctl perf result -o yaml
+mesheryctl perf result -o toon
 `,
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/mesheryctl/internal/cli/root/perf/perf.go
+++ b/mesheryctl/internal/cli/root/perf/perf.go
@@ -70,7 +70,7 @@ mesheryctl perf result -o yaml
 
 func init() {
 	PerfCmd.PersistentFlags().StringVarP(&utils.TokenFlag, "token", "t", "", "(required) Path to meshery auth config")
-	PerfCmd.PersistentFlags().StringVarP(&outputFormatFlag, "output-format", "o", "", "(optional) format to display in [json|yaml]")
+	PerfCmd.PersistentFlags().StringVarP(&outputFormatFlag, "output-format", "o", "", "(optional) format to display in [json|yaml|toon]")
 	PerfCmd.PersistentFlags().BoolVarP(&utils.SilentFlag, "yes", "y", false, "(optional) assume yes for user interactive prompts.")
 
 	availableSubcommands = []*cobra.Command{profileCmd, resultCmd, applyCmd}

--- a/mesheryctl/internal/cli/root/relationships/view.go
+++ b/mesheryctl/internal/cli/root/relationships/view.go
@@ -129,6 +129,6 @@ func formatLabel(rows []relationship.RelationshipDefinition) []string {
 }
 
 func init() {
-	viewCmd.Flags().StringVarP(&relationshipViewFlagsProvided.outputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
-	viewCmd.Flags().BoolVarP(&relationshipViewFlagsProvided.save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+	viewCmd.Flags().StringVarP(&relationshipViewFlagsProvided.outputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
+	viewCmd.Flags().BoolVarP(&relationshipViewFlagsProvided.save, "save", "s", false, "(optional) save output as a JSON/YAML/TOON file")
 }

--- a/mesheryctl/internal/cli/root/relationships/view.go
+++ b/mesheryctl/internal/cli/root/relationships/view.go
@@ -41,11 +41,11 @@ var viewCmd = &cobra.Command{
 // View relationships of a model in default format yaml
 mesheryctl relationship view [model-name]
 
-// View relationships of a model in JSON format
-mesheryctl relationship view [model-name] --output-format json
+// View relationships of a model in JSON, YAML, or TOON format
+mesheryctl relationship view [model-name] --output-format [json|yaml|toon]
 
-// View relationships of a model in json format and save it to a file
-mesheryctl relationship view [model-name] --output-format json --save
+// View relationships of a model in a specific format and save it to a file
+mesheryctl relationship view [model-name] --output-format [json|yaml|toon] --save
 	`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {

--- a/mesheryctl/internal/cli/root/workspaces/view.go
+++ b/mesheryctl/internal/cli/root/workspaces/view.go
@@ -15,7 +15,7 @@ import (
 )
 
 type workspaceViewFlags struct {
-	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml"`
+	OutputFormat string `json:"output-format" validate:"required,oneof=json yaml toon"`
 	Save         bool   `json:"save" validate:"boolean"`
 	OrgID        string `json:"orgId" validate:"required,uuid"`
 }
@@ -147,7 +147,7 @@ mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json --
 }
 
 func init() {
-	viewWorkspaceCmd.Flags().StringVarP(&workspaceViewFlagsProvided.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml]")
-	viewWorkspaceCmd.Flags().BoolVarP(&workspaceViewFlagsProvided.Save, "save", "s", false, "(optional) save output as a JSON/YAML file")
+	viewWorkspaceCmd.Flags().StringVarP(&workspaceViewFlagsProvided.OutputFormat, "output-format", "o", "yaml", "(optional) format to display in [json|yaml|toon]")
+	viewWorkspaceCmd.Flags().BoolVarP(&workspaceViewFlagsProvided.Save, "save", "s", false, "(optional) save output as a JSON/YAML/TOON file")
 	viewWorkspaceCmd.Flags().StringVarP(&workspaceViewFlagsProvided.OrgID, "orgId", "", "", "(required) organization ID")
 }

--- a/mesheryctl/internal/cli/root/workspaces/view.go
+++ b/mesheryctl/internal/cli/root/workspaces/view.go
@@ -42,11 +42,11 @@ mesheryctl workspace view [workspace-id] --orgId [orgId]
 // View details of a specific workspace by name
 mesheryctl workspace view [workspace-name] --orgId [orgId]
 
-// View details of a specific workspace in JSON format
-mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json
+// View details of a specific workspace in a specific format
+mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format [json|yaml|toon]
 
-// View details of a specific workspace and save it to a file
-mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json --save
+// View details of a specific workspace in a specific format and save it to a file
+mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format [json|yaml|toon] --save
 	`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return mesheryctlflags.ValidateCmdFlags(cmd, &workspaceViewFlagsProvided)

--- a/mesheryctl/pkg/utils/error.go
+++ b/mesheryctl/pkg/utils/error.go
@@ -573,9 +573,9 @@ func ErrJSONToYAML(err error) error {
 func ErrOutFormatFlag() error {
 	return errors.New(ErrOutFormatFlagCode, errors.Alert,
 		[]string{"Invalid output format choice"},
-		[]string{"Output format choice is invalid, use [json|yaml]"},
-		[]string{"Invalid JSON or YAML content"},
-		[]string{"Check the JSON or YAML structure."})
+		[]string{"Output format choice is invalid, use [json|yaml|toon]"},
+		[]string{"Invalid JSON, YAML, or TOON content"},
+		[]string{"Check the JSON, YAML, or TOON structure."})
 }
 
 func ErrReadConfigFile(err error) error {

--- a/mesheryctl/pkg/utils/format/error.go
+++ b/mesheryctl/pkg/utils/format/error.go
@@ -24,6 +24,7 @@ func ErrOutputToYaml() error {
 		[]string{"Check the Yaml structure you are providing for formatting."})
 }
 
+// ErrOutputToToon is the error for failing to format output in TOON
 func ErrOutputToToon() error {
 	return errors.New(ErrOutputToToonCode, errors.Alert,
 		[]string{"Failed to format output in TOON"},

--- a/mesheryctl/pkg/utils/format/error.go
+++ b/mesheryctl/pkg/utils/format/error.go
@@ -5,6 +5,7 @@ import "github.com/meshery/meshkit/errors"
 var (
 	ErrOutputToJsonCode = "mesheryctl-1147"
 	ErrOutputToYamlCode = "mesheryctl-1158"
+	ErrOutputToToonCode = "mesheryctl-1253"
 )
 
 func ErrOutputToJson() error {
@@ -21,4 +22,12 @@ func ErrOutputToYaml() error {
 		[]string{"Error occurred while formatting to YAML"},
 		[]string{"The content provided for formatting failed."},
 		[]string{"Check the Yaml structure you are providing for formatting."})
+}
+
+func ErrOutputToToon() error {
+	return errors.New(ErrOutputToToonCode, errors.Alert,
+		[]string{"Failed to format output in TOON"},
+		[]string{"Error occurred while formatting to TOON"},
+		[]string{"The content provided for formatting failed."},
+		[]string{"Check the TOON structure you are providing for formatting."})
 }

--- a/mesheryctl/pkg/utils/format/output.go
+++ b/mesheryctl/pkg/utils/format/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/toon-format/toon-go"
 	"gopkg.in/yaml.v2"
 )
 
@@ -46,3 +47,15 @@ func OutputYaml(component interface{}) error {
 	fmt.Print(string(output))
 	return nil
 }
+
+func OutputToon(component interface{}) error {
+	// Marshal the component struct into TOON format.
+	output, err := toon.Marshal(component)
+	if err != nil {
+		return ErrOutputToToon()
+	}
+	// Print the TOON output to standard output.
+	fmt.Print(string(output))
+	return nil
+}
+

--- a/mesheryctl/pkg/utils/format/output.go
+++ b/mesheryctl/pkg/utils/format/output.go
@@ -48,6 +48,8 @@ func OutputYaml(component interface{}) error {
 	return nil
 }
 
+// OutputToon takes a component struct as input, marshals it into a nicely formatted TOON representation,
+// and prints it to standard output.
 func OutputToon(component interface{}) error {
 	// Marshal the component struct into TOON format.
 	output, err := toon.Marshal(component)
@@ -58,4 +60,3 @@ func OutputToon(component interface{}) error {
 	fmt.Print(string(output))
 	return nil
 }
-

--- a/mesheryctl/pkg/utils/format/output_test.go
+++ b/mesheryctl/pkg/utils/format/output_test.go
@@ -1,0 +1,40 @@
+package format
+
+import (
+	"testing"
+)
+
+type sampleData struct {
+	Name string   `json:"name" yaml:"name" toon:"name"`
+	Type string   `json:"type" yaml:"type" toon:"type"`
+	Tags []string `json:"tags" yaml:"tags" toon:"tags"`
+}
+
+func TestOutputFormatters(t *testing.T) {
+	data := sampleData{
+		Name: "test-component",
+		Type: "sample",
+		Tags: []string{"tag1", "tag2"},
+	}
+
+	t.Run("OutputJson", func(t *testing.T) {
+		err := OutputJson(data)
+		if err != nil {
+			t.Fatalf("OutputJson failed: %v", err)
+		}
+	})
+
+	t.Run("OutputYaml", func(t *testing.T) {
+		err := OutputYaml(data)
+		if err != nil {
+			t.Fatalf("OutputYaml failed: %v", err)
+		}
+	})
+
+	t.Run("OutputToon", func(t *testing.T) {
+		err := OutputToon(data)
+		if err != nil {
+			t.Fatalf("OutputToon failed: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20973

Adds **TOON** (Token-Oriented Object Notation) as a first-class, global output format option (`-o toon` / `--output-format toon`) across `mesheryctl` commands alongside existing `json` and `yaml` options.

### Summary of Changes
- **Dependency**: Added `github.com/toon-format/toon-go` to `go.mod`.
- **Serialization Utility**: Added `OutputToon` helper in `mesheryctl/pkg/utils/format/output.go`.
- **Error Handling**: Registered `ErrOutputToToon` with error code `mesheryctl-1253` in `mesheryctl/pkg/utils/format/error.go` and bumped `next_error_code` to `1254`.
- **Display Formatter**: Added `TOONOutputFormatter[T]` and `TOONOutputFormatterSaver[T]` in `mesheryctl/internal/cli/pkg/display/output.go`.
- **CLI Commands**: Updated `--output-format` flag help text (`[json|yaml|toon]`) and struct validation tags (`validate:"required,oneof=json yaml toon"`) across `components`, `connections`, `design`, `environments`, `filter`, `model`, `perf`, `relationships`, and `workspaces`.
- **Tests**: Added unit test coverage for TOON format outputters in `pkg/utils/format` and `display`.

### Automated Tests
Ran:
- `go test -v ./mesheryctl/pkg/utils/format/...`
- `go test -v ./mesheryctl/internal/cli/pkg/display/...`

All tests pass cleanly.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **TOON** as a supported output format across Meshery CLI commands (including rendering and saving to **.toon** files).
- **Documentation**
  - Updated command help/usage text and examples to include `toon` for `--output-format` (and **JSON/YAML/TOON** for save behavior).
- **Bug Fixes**
  - Improved error messaging and validation guidance to recognize `toon` as a valid format.
- **Tests**
  - Added/extended tests to verify TOON serialization, output, and `.toon` file saving (including error when no file path is provided).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->