### PR TITLE
ci: add checkout action to deploy docs preview workflow

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -49,6 +49,8 @@ jobs:
     needs: read-metadata
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
getting below error
`026-07-28T02:09:29.0635641Z Deploying using Deploy Token… 🔑
2026-07-28T02:09:29.0636467Z Configuring git…
2026-07-28T02:09:29.0674416Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/meshery/meshery
2026-07-28T02:09:29.0755052Z [command]/usr/bin/git config user.name <username>
2026-07-28T02:09:29.0782325Z fatal: not in a git directory`

I believe we need to check out the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation preview deployments by ensuring repository content is checked out before artifacts are downloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->