### PR TITLE
[Server] Guard nil filter and nil filter.Type in getAvailableAddons

### DIFF
--- a/server/internal/graphql/resolver/addons.go
+++ b/server/internal/graphql/resolver/addons.go
@@ -9,12 +9,12 @@ import (
 
 func (r *Resolver) getAvailableAddons(ctx context.Context, provider models.Provider, filter *model.ServiceMeshFilter) ([]*model.AddonList, error) {
 	var cids []string
-	if len(filter.K8sClusterIDs) != 0 {
+	if filter != nil && len(filter.K8sClusterIDs) != 0 {
 		cids = filter.K8sClusterIDs
 	}
 
 	selectors := make([]model.MeshType, 0)
-	if filter == nil || *filter.Type == model.MeshTypeAllMesh {
+	if filter == nil || filter.Type == nil || *filter.Type == model.MeshTypeAllMesh {
 		selectors = append(selectors, model.AllMeshType...)
 	} else {
 		selectors = append(selectors, *filter.Type)


### PR DESCRIPTION
Fixes #20988.

### What It Does

`getAvailableAddons` had two nil-safety gaps:

1. It read `filter.K8sClusterIDs` **before** its own `filter == nil` check, so that check could never protect anything.
2. It dereferenced `*filter.Type` without checking whether `Type` was set. `ServiceMeshFilter.Type` is an optional `*MeshType` (`json:"type,omitempty"`, `models_gen.go:303`), so a valid query that omits `type` — e.g. `getAvailableAddons(filter: {k8sClusterIDs: [...]})` — panicked.

This checks `filter` before reading `K8sClusterIDs`, and treats a nil `Type` as "all mesh types".

### Consistency

`getControlPlanes` (`control-plane.go`) and `getDataPlanes` (`data-plane.go`) already do exactly this — `getAvailableAddons` was the only one of the three missing the check. This brings it in line with its siblings.

### Notes for Reviewers

Two lines, defensive only; no behaviour change for a filter that already supplies `type`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause available add-ons queries to fail when no filter was provided.
  * Add-on retrieval now handles omitted filters safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->