### PR TITLE
[mesheryctl] Surface unsupported schemaVersion in model import error

### DIFF
--- a/mesheryctl/pkg/utils/error.go
+++ b/mesheryctl/pkg/utils/error.go
@@ -678,7 +678,7 @@ func ErrUpdateComponent(err error, modelName, compName string) error {
 }
 
 func ErrInvalidModel() error {
-	return errors.New(ErrInvalidModelCode, errors.Alert, []string{"No valid component or relationship found in the model provided"}, []string{"No valid component or relationship found in the Model provided. A Model can be only imported if it contains at least one valid Component or Relationship."}, []string{"Provided components or relationships might have incorrect format", "Folder structure might be incorrect"}, []string{"Know about Meshery Models and Importing instructions here: https://docs.meshery.io/guides/configuration-management/importing-models"})
+	return errors.New(ErrInvalidModelCode, errors.Alert, []string{"No valid component or relationship found in the model provided"}, []string{"No valid component or relationship found in the Model provided. A Model can be only imported if it contains at least one valid Component or Relationship."}, []string{"Provided components or relationships might have incorrect format", "Folder structure might be incorrect", "Unsupported schemaVersion (e.g., using v1beta3 components with an older server that only supports v1beta1)"}, []string{"Verify that the schemaVersion in your component and relationship definitions is supported by the targeted Meshery Server", "Know about Meshery Models and Importing instructions here: https://docs.meshery.io/guides/configuration-management/importing-models"})
 }
 
 func ErrMissingCommands(err error) error {


### PR DESCRIPTION
Fixes #20901

**Description**
Older Meshery Servers (e.g. `v1.0.62` and prior) only support the `components.meshery.io/v1beta1` schemaVersion and silently reject newer components without returning an actionable error. `mesheryctl model import` then surfaces this as a generic `ErrInvalidModel` ("No valid component or relationship found"). 

This PR updates `ErrInvalidModel` to explicitly mention `schemaVersion` incompatibility as a probable cause, and provides a remediation step directing users to verify the `schemaVersion` in use against their targeted Meshery Server.

**Changes**
* Updated `ErrInvalidModel` in `mesheryctl/pkg/utils/error.go` to surface unsupported `schemaVersion` as a probable cause and remediation.

*(Note: Reverting the model scaffolding back to `v1beta1` was avoided as the project guidelines mandate the use of `v1beta3` and restrict the importation of deprecated `v1beta1` in new code).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model import error messages with clearer guidance for unsupported `schemaVersion` values.
  * Added remediation steps to help verify schema version support on the target Meshery Server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->