### PR TITLE
[UI] Add permission keys to Telemetry sidebar icons and connection buttons

### DIFF
--- a/ui/components/layout/Navigator/navigatorComponents.test.tsx
+++ b/ui/components/layout/Navigator/navigatorComponents.test.tsx
@@ -198,4 +198,24 @@ describe('navigatorComponents', () => {
     // Just sanity-check that a React element was provided as an icon
     expect(React.isValidElement(catalog?.icon)).toBe(true);
   });
+
+  it('attaches ViewMetrics permission to Charts child', () => {
+    const items = getNavigatorComponents(
+      fakeProviderUiAccessControl({ TELEMETRY: true, GRAFANA: true }),
+      theme,
+    );
+    const telemetry = items.find((i: any) => i.id === 'TELEMETRY');
+    const charts = telemetry?.children?.find((c: any) => c.id === 'GRAFANA');
+    expect(charts?.permissionKey).toEqual(Keys.MesherySystemViewMetrics);
+  });
+
+  it('attaches ViewMetrics permission to Metrics child', () => {
+    const items = getNavigatorComponents(
+      fakeProviderUiAccessControl({ TELEMETRY: true, PROMETHEUS: true }),
+      theme,
+    );
+    const telemetry = items.find((i: any) => i.id === 'TELEMETRY');
+    const metrics = telemetry?.children?.find((c: any) => c.id === 'PROMETHEUS');
+    expect(metrics?.permissionKey).toEqual(Keys.MesherySystemViewMetrics);
+  });
 });

--- a/ui/components/layout/Navigator/navigatorComponents.tsx
+++ b/ui/components/layout/Navigator/navigatorComponents.tsx
@@ -177,6 +177,7 @@ export const getNavigatorComponents = (
         title: 'Charts',
         show: providerUiAccessControl.isNavigatorComponentEnabled([TELEMETRY, GRAFANA]),
         link: true,
+        permissionKey: Keys.MesherySystemViewMetrics,
       },
       {
         id: PROMETHEUS,
@@ -185,6 +186,7 @@ export const getNavigatorComponents = (
         title: 'Metrics',
         show: providerUiAccessControl.isNavigatorComponentEnabled([TELEMETRY, PROMETHEUS]),
         link: true,
+        permissionKey: Keys.MesherySystemViewMetrics,
       },
     ],
   },

--- a/ui/components/telemetry/dashboards/index.tsx
+++ b/ui/components/telemetry/dashboards/index.tsx
@@ -17,6 +17,7 @@ import {
   useUpdatePinnedBoardsMutation,
 } from '@/rtk-query/telemetryGrafana';
 import { CoreConnectionKinds } from '@/utils/Enum';
+import { Keys } from '@meshery/schemas/permissions';
 import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
 import ConnectionPicker, { TelemetryConnection } from '../common/ConnectionPicker';
 import PingStatus from '../common/PingStatus';
@@ -163,6 +164,7 @@ const TelemetryDashboards: React.FC = () => {
               skipKindSelection: true,
             })
           }
+          permissionKey={Keys.MesherySystemConnectMetrics}
         >
           Add a Grafana connection
         </Button>

--- a/ui/components/telemetry/metrics/index.tsx
+++ b/ui/components/telemetry/metrics/index.tsx
@@ -17,6 +17,7 @@ import {
   useUpdatePrometheusPanelsMutation,
 } from '@/rtk-query/telemetryPrometheus';
 import { CoreConnectionKinds } from '@/utils/Enum';
+import { Keys } from '@meshery/schemas/permissions';
 import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
 import ConnectionPicker, { TelemetryConnection } from '../common/ConnectionPicker';
 import PingStatus from '../common/PingStatus';
@@ -175,6 +176,7 @@ const TelemetryMetrics: React.FC = () => {
               skipKindSelection: true,
             })
           }
+          permissionKey={Keys.MesherySystemConnectMetrics}
         >
           Add a Prometheus connection
         </Button>


### PR DESCRIPTION
## Description

Adds missing `permissionKey` props to the Telemetry section so the permission shield renders consistently with every other sidebar item.

### Changes

- **Sidebar icons**: Added `Keys.MesherySystemViewMetrics` to the Charts (Grafana) and Metrics (Prometheus) children in `navigatorComponents.tsx` — these were the only sidebar items missing a `permissionKey`.
- **"Add a Grafana connection" button** (`telemetry/dashboards/index.tsx`): Added `Keys.MesherySystemConnectMetrics`.
- **"Add a Prometheus connection" button** (`telemetry/metrics/index.tsx`): Added `Keys.MesherySystemConnectMetrics`.
- **Tests**: Added 2 test cases in `navigatorComponents.test.tsx` verifying the new permission keys on both telemetry children.

### Key mapping rationale

| Element | Key | Why |
|---|---|---|
| Sidebar icons (view pages) | `MesherySystemViewMetrics` | "View already configured metrics", read-only navigation |
| Add connection buttons (mutating action) | `MesherySystemConnectMetrics` | "Configure and connect to metrics like Grafana and Prometheus" |

Fixes #21006 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added permission controls for Telemetry navigation entries, including Charts and Metrics.
  - Added permission checks when creating Grafana or Prometheus connections from empty-state screens.

- **Tests**
  - Added coverage verifying the correct permissions are assigned to Telemetry navigation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->