### PR TITLE
fix(server): handle missing pagination defaults in GetEnvironmentConnections

### DIFF
--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -281,6 +281,15 @@ func (ep *EnvironmentPersister) GetEnvironmentConnections(environmentID core.Uui
 	query.Count(&count)
 
 	var connectionsFetched []*connections.Connection
+
+	if page == "" {
+		page = "0"
+	}
+
+	if pageSize == "" {
+		pageSize = "10"
+	}
+
 	pageUint, err := strconv.ParseUint(page, 10, 32)
 	if err != nil {
 		return nil, err

--- a/server/models/environment_persister_test.go
+++ b/server/models/environment_persister_test.go
@@ -1,0 +1,76 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/schemas/models/v1beta3/environment"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newEnvironmentTestDB(t *testing.T) *database.Handler {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create in-memory database: %v", err)
+	}
+
+	handler := &database.Handler{
+		DB: db,
+	}
+
+	if err := handler.AutoMigrate(
+		&environment.Environment{},
+		&environment.EnvironmentConnectionMapping{},
+		&connections.Connection{},
+	); err != nil {
+		t.Fatalf("failed to auto-migrate environment models: %v", err)
+	}
+
+	return handler
+}
+
+// Regression test for #21011.
+// Empty page/pageSize parameters previously caused strconv.ParseUint("")
+// to fail before default pagination values were applied.
+func TestGetEnvironmentConnections_UsesDefaultPaginationWhenParamsAreEmpty(t *testing.T) {
+	dbHandler := newEnvironmentTestDB(t)
+
+	ep := &EnvironmentPersister{
+		DB: dbHandler,
+	}
+
+	envID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("failed to generate environment ID: %v", err)
+	}
+
+	result, err := ep.GetEnvironmentConnections(
+		envID,
+		"", // search
+		"", // order
+		"", // page
+		"", // pageSize
+		"", // filter
+	)
+	if err != nil {
+		t.Fatalf("expected empty pagination params to use defaults, got error: %v", err)
+	}
+
+	var page connections.ConnectionPage
+
+	if err := json.Unmarshal(result, &page); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if page.Page != 0 {
+		t.Fatalf("expected page to default to 0, got %d", page.Page)
+	}
+
+}


### PR DESCRIPTION


**Notes for Reviewers**

- This PR fixes #21007 
- It fixes a server-side error that occurred when retrieving an environment's assigned connections if pagination parameters were omitted.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

### Before
<img width="1510" height="905" alt="Screenshot 2026-07-29 at 5 07 16 PM" src="https://github.com/user-attachments/assets/f1d981cd-e7a7-4cd9-97c2-f10359d7e633" />

### After
<img width="1512" height="905" alt="Screenshot 2026-07-30 at 2 07 22 AM" src="https://github.com/user-attachments/assets/de5d0d00-4ba8-43f4-80b8-77996aeb31d1" />

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent default pagination when page or page size parameters are omitted.
  * Results now default to the first page with 10 items per page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->