### PR TITLE
[Docs] Fix broken image paths on contributing pages

### DIFF
--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -216,7 +216,7 @@ To filter and view only CLI-related test cases using the Sheet Views feature:
 1. In the top menu bar, click Data → Change view
 2. Choose the pre-defined view labeled "CLI"
 
-![Meshery Test Plan Screenshot](../images/meshery-test-plan-v0.8.0-ui.png)
+![Meshery Test Plan Screenshot](../../images/meshery-test-plan-v0.8.0-ui.png)
 
 ## Development
 

--- a/docs/content/en/project/contributing/ui/tests.md
+++ b/docs/content/en/project/contributing/ui/tests.md
@@ -191,4 +191,4 @@ To filter and view only UI-related tests using the Sheet Views feature:
 1. In the top menu bar, click Data → Change view
 2. Choose the pre-defined view labeled "UI"
 
-![Meshery Test Plan Screenshot](../images/meshery-test-plan-v0.8.0-ui.png)
+![Meshery Test Plan Screenshot](../../images/meshery-test-plan-v0.8.0-ui.png)

--- a/docs/content/en/project/contributing/ui/ui.md
+++ b/docs/content/en/project/contributing/ui/ui.md
@@ -105,8 +105,9 @@ Now, Meshery will run on the default port `http://localhost:9081`.
 
 **Please note**: If you see "Meshery Development Incompatible" while trying to sign into Meshery Server, then follow these steps:
 
-<a href="../images/meshery-development-incompatible-error.png">
-  <img style= "width: 600px;" src="../images/meshery-development-incompatible-error.png" />
+<a href="../../images/meshery-development-incompatible-error.png">
+  <img style="width: 600px;" src="../../images/meshery-development-incompatible-error.png"
+       alt="Meshery Development Incompatible error dialog" />
 </a>
 
 Potential Solution:


### PR DESCRIPTION
**Notes for Reviewers**

Fixes broken image paths on three documentation pages caused by Hugo's
directory-depth mismatch: since Hugo renders `foo/bar.md` at the URL
`/foo/bar/`, a relative path of `../images/` from these pages resolves one
level too shallow and points at a non-existent directory. Updated the
references to `../../images/` so they correctly resolve to
`docs/content/en/project/contributing/images/`.

- `docs/content/en/project/contributing/ui/ui.md` (lines 108-109) — also added
  missing `alt` text to satisfy markdownlint's MD045 rule
- `docs/content/en/project/contributing/ui/tests.md` (line 194)
- `docs/content/en/project/contributing/cli/tests.md` (line 219)

Verified locally with `make docs-docker` (Hugo dev server) on:
- http://localhost:1313/project/contributing/ui/ui/
- http://localhost:1313/project/contributing/ui/tests/
- http://localhost:1313/project/contributing/cli/tests/

Before:
meshery-development-incompatible-error.png failed to load / broken image link
on the UI contributing docs page (`ui/ui.md`).
meshery-test-plan-v0.8.0-ui.png failed to load / broken image link on the UI
tests contributing docs page (`ui/tests.md`).
meshery-test-plan-v0.8.0-ui.png failed to load / broken image link on the CLI
tests contributing docs page (`cli/tests.md`).

<img width="1374" height="532" alt="スクリーンショット 2026-07-30 18 43 14" src="https://github.com/user-attachments/assets/bda8ecbd-52ed-4f2b-9aa0-c5f12da1ce12" />
<img width="662" height="251" alt="スクリーンショット 2026-07-30 18 44 15" src="https://github.com/user-attachments/assets/3695c2d6-cf4a-4d82-8b12-6ae78f27c1b1" />
<img width="718" height="256" alt="スクリーンショット 2026-07-30 18 45 03" src="https://github.com/user-attachments/assets/215b092b-e111-4667-8fda-c80add20c36d" />

After:
All three images render correctly.

<img width="1364" height="737" alt="スクリーンショット 2026-07-30 18 43 34" src="https://github.com/user-attachments/assets/d619c423-02c6-482d-a141-92da52b211c5" />
<img width="1414" height="876" alt="スクリーンショット 2026-07-30 18 44 30" src="https://github.com/user-attachments/assets/f7f03d29-8681-416b-9340-dcaa403bd8e8" />
<img width="1401" height="868" alt="スクリーンショット 2026-07-30 18 45 09" src="https://github.com/user-attachments/assets/120e2aeb-5491-4a6d-9499-7e030d806e30" />

- This PR fixes #21018

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed broken screenshot links in the CLI testing, UI testing, and UI development guides.
  * Reformatted one image embed while preserving its displayed content and accessibility text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->