### PR TITLE
[UI] Reposition toolbar below Connections/MeshSync tabs

### DIFF
--- a/ui/components/connections/ConnectionTable.test.tsx
+++ b/ui/components/connections/ConnectionTable.test.tsx
@@ -48,20 +48,17 @@ vi.mock('@sistent/sistent', () => ({
     search,
     filter,
     columnVisibility,
-    tabs,
   }: {
     primaryActions?: React.ReactNode;
     search?: React.ReactNode;
     filter?: React.ReactNode;
     columnVisibility?: React.ReactNode;
-    tabs?: React.ReactNode;
   }) => (
     <div data-testid="data-table-toolbar">
       {primaryActions}
       {search}
       {filter}
       {columnVisibility}
-      {tabs}
     </div>
   ),
   ResponsiveDataTable: (props) => {
@@ -758,19 +755,24 @@ describe('ConnectionTable', () => {
       ).toBe(true);
     });
   });
-  // Regression coverage for the review feedback on PR #20695: the
-  // Connections/MeshSync tab switcher must be passed down through the
-  // toolbar (rendered between the toolbar and the data table), not dropped.
-  it('renders the tabs prop inside the toolbar, ahead of the data table', () => {
+  // Regression coverage: the Connections/MeshSync tab switcher must render
+  // above the toolbar (not inside it), ahead of the data table (#20791).
+  it('renders the tabs prop above the toolbar, ahead of the data table', () => {
     render(<ConnectionTable tabs={<div data-testid="connection-tabs">tabs</div>} />);
 
+    // Tabs should NOT be inside the toolbar — they are a sibling rendered before it.
     const toolbar = screen.getByTestId('data-table-toolbar');
-    expect(toolbar).toContainElement(screen.getByTestId('connection-tabs'));
+    const tabs = screen.getByTestId('connection-tabs');
+    expect(toolbar).not.toContainElement(tabs);
 
-    const positions = screen
-      .getByTestId('connection-tabs')
-      .compareDocumentPosition(screen.getByTestId('responsive-data-table'));
+    // Tabs should appear before the toolbar in DOM order.
+    const tabsBeforeToolbar = tabs.compareDocumentPosition(toolbar);
+    expect(tabsBeforeToolbar & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
-    expect(positions & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Tabs should appear before the data table in DOM order.
+    const tabsBeforeTable = tabs.compareDocumentPosition(
+      screen.getByTestId('responsive-data-table'),
+    );
+    expect(tabsBeforeTable & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/ui/components/connections/ConnectionTable.tsx
+++ b/ui/components/connections/ConnectionTable.tsx
@@ -663,6 +663,8 @@ const ConnectionTable = ({
 
   return (
     <>
+      {tabs}
+
       <ConnectionTableToolbar
         isSearchExpanded={isSearchExpanded}
         setIsSearchExpanded={setIsSearchExpanded}
@@ -674,7 +676,6 @@ const ConnectionTable = ({
         columns={columns}
         columnVisibility={columnVisibility}
         setColumnVisibility={setColumnVisibilityByUser}
-        tabs={tabs}
       />
 
       <ResponsiveDataTable

--- a/ui/components/connections/ConnectionTableToolbar.tsx
+++ b/ui/components/connections/ConnectionTableToolbar.tsx
@@ -21,7 +21,6 @@ type ConnectionTableToolbarProps = {
   columns: Array<{ name: string; label?: string; options?: { display?: boolean } }>;
   columnVisibility: Record<string, boolean | undefined>;
   setColumnVisibility: (visibility: Record<string, boolean | undefined>) => void;
-  tabs?: React.ReactNode;
 };
 
 export const ConnectionTableToolbar = ({
@@ -35,7 +34,6 @@ export const ConnectionTableToolbar = ({
   columns,
   columnVisibility,
   setColumnVisibility,
-  tabs,
 }: ConnectionTableToolbarProps) => {
   return (
     <DataTableToolbar
@@ -74,7 +72,6 @@ export const ConnectionTableToolbar = ({
           }}
         />
       }
-      tabs={tabs}
     />
   );
 };

--- a/ui/components/connections/index.tsx
+++ b/ui/components/connections/index.tsx
@@ -178,10 +178,10 @@ function Connections() {
   );
 
   // Rendered by whichever table is active (ConnectionTable or MeshSyncTable) so
-  // the tab switcher stays visible - and functional - on both tabs, between
-  // that table's own toolbar and its data grid. Memoized so the unstable JSX
-  // identity doesn't cascade into the tables' props on every render (this page
-  // has previously hit React error #185 from exactly this kind of churn).
+  // the tab switcher stays visible - and functional - on both tabs, above
+  // that table's own toolbar. Memoized so the unstable JSX identity doesn't
+  // cascade into the tables' props on every render (this page has previously
+  // hit React error #185 from exactly this kind of churn).
   const tabs = useMemo(
     () => (
       <AppBar position="static" color="default" style={{ marginBottom: '3rem' }}>

--- a/ui/components/connections/meshSync/index.test.tsx
+++ b/ui/components/connections/meshSync/index.test.tsx
@@ -37,6 +37,13 @@ vi.mock('@sistent/sistent', () => ({
     return StyledComponent;
   },
   accentGrey: 'gray',
+  DataTableToolbar: ({ search, filter, columnVisibility }) => (
+    <div data-testid="datatable-toolbar">
+      {search}
+      {filter}
+      {columnVisibility}
+    </div>
+  ),
 }));
 
 vi.mock('../../../utils/hooks/useNotification', () => ({
@@ -98,10 +105,6 @@ vi.mock('../styles', () => ({
   ContentContainer: ({ children }) => <div>{children}</div>,
   ConnectionStyledSelect: ({ children }) => <div>{children}</div>,
   InnerTableContainer: ({ children }) => <div>{children}</div>,
-}));
-
-vi.mock('@/assets/styles/general/tool.styles', () => ({
-  ToolWrapper: ({ children }) => <div>{children}</div>,
 }));
 
 vi.mock('@/store/slices/mesheryUi', () => ({

--- a/ui/components/connections/meshSync/index.tsx
+++ b/ui/components/connections/meshSync/index.tsx
@@ -4,6 +4,7 @@ import { useNotification } from '../../../utils/hooks/useNotification';
 import { EVENT_TYPES } from '../../../lib/event-types';
 import {
   CustomColumnVisibilityControl,
+  DataTableToolbar,
   ResponsiveDataTable,
   SearchBar,
   UniversalFilter,
@@ -13,7 +14,6 @@ import {
 import { MeshSyncDataFormatter } from '../metadata';
 import { getK8sClusterIdsFromCtxId } from '../../../utils/multi-ctx';
 import { DefaultTableCell, SortableTableCell } from '../common';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
 import {
   JsonParse,
   camelcaseToSnakecase,
@@ -689,41 +689,39 @@ export default function MeshSyncTable(props) {
 
   return (
     <>
-      <ToolWrapper style={{ marginBottom: '5px', marginTop: '-30px' }}>
-        <div
-          style={{
-            display: 'flex',
-            borderRadius: '0.5rem 0.5rem 0 0',
-            width: '100%',
-            justifyContent: 'end',
-          }}
-        >
-          <SearchBar
-            onSearch={(value) => {
-              setSearch(value);
-            }}
-            expanded={isSearchExpanded}
-            setExpanded={setIsSearchExpanded}
-            placeholder="Search Connections..."
-          />
+      {tabs}
 
+      <DataTableToolbar
+        search={
+          <div data-testid="MeshSyncTable-search">
+            <SearchBar
+              onSearch={(value) => {
+                setSearch(value);
+              }}
+              expanded={isSearchExpanded}
+              setExpanded={setIsSearchExpanded}
+              placeholder="Search MeshSync Resources..."
+            />
+          </div>
+        }
+        filter={
           <UniversalFilter
-            id="ref"
+            id="meshsync-table-filter"
             filters={filters}
             selectedFilters={selectedFilters}
             setSelectedFilters={setSelectedFilters}
             handleApplyFilter={handleApplyFilter}
           />
-
+        }
+        columnVisibility={
           <CustomColumnVisibilityControl
-            id="ref"
+            style={{ zIndex: 1300 }}
+            id="meshsync-table-column-visibility"
             columns={getVisibilityColums(columns)}
             customToolsProps={{ columnVisibility, setColumnVisibility }}
           />
-        </div>
-      </ToolWrapper>
-
-      {tabs}
+        }
+      />
 
       {!meshSyncResources || meshSyncResources.length === 0 ? (
         <MeshSyncEmptyState />


### PR DESCRIPTION
## Description

Moves the CONNECTIONS / MESHSYNC tab switcher above the action toolbar on the Connections page.

**Before:** Toolbar (Create Connection, search, filters, column visibility) rendered above the tab switcher.  
**After:** Tab switcher renders first; toolbar sits directly below it, above the data table.

Fixes #20741 

## Changes

- **ConnectionTable.tsx** – Render `{tabs}` above `<ConnectionTableToolbar>` instead of passing it through.
- **ConnectionTableToolbar.tsx** – Remove `tabs` prop; stop forwarding it to `<DataTableToolbar>`.
- **meshSync/index.tsx** – Replace custom `ToolWrapper` with `<DataTableToolbar>` from sistent, render `{tabs}` above it, fix search placeholder from "Search Connections..." → "Search MeshSync Resources...".
- **index.tsx** – Update comment to reflect new tab position.
- **Tests** – Update mocks to match (add `DataTableToolbar` mock to MeshSync test, remove `tabs` from ConnectionTable toolbar mock, remove stale `ToolWrapper` mock).

<img width="1543" height="358" alt="Screenshot 2026-07-30 at 7 35 28 PM" src="https://github.com/user-attachments/assets/12c3ada3-8545-432e-be38-729b108f9155" />
<img width="1530" height="348" alt="Screenshot 2026-07-30 at 7 35 17 PM" src="https://github.com/user-attachments/assets/9c82751b-56dd-45b7-a364-5910342b8498" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Positioned the Connections and MeshSync tab switcher above the table toolbar for clearer navigation.
  - Standardized the MeshSync table toolbar with consistent search, filtering, and column visibility controls.
  - Updated the MeshSync search placeholder to “Search MeshSync Resources...” and refreshed control identifiers.

- **Bug Fixes**
  - Improved table layout behavior to prevent rendering issues when switching between connection views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->