### PR TITLE
[Server] Surface datastore errors from registry read handlers as 500

### DIFF
--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -186,8 +186,9 @@ func (h *Handler) GetMeshmodelModels(rw http.ResponseWriter, r *http.Request) {
 
 	entities, count, _, err := h.registryManager.GetEntities(filter)
 	if err != nil {
-		h.log.Error(ErrGetMeshModels(err))
-		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		wrappedErr := ErrGetMeshModels(err)
+		h.log.Error(wrappedErr)
+		writeMeshkitError(rw, wrappedErr, http.StatusInternalServerError)
 		return
 	}
 	var modelDefs []_model.ModelDefinition
@@ -597,8 +598,9 @@ func (h *Handler) GetMeshmodelComponentByModel(rw http.ResponseWriter, r *http.R
 	}
 	entities, count, _, err := h.registryManager.GetEntities(filter)
 	if err != nil {
-		h.log.Error(ErrGetMeshModels(err))
-		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		wrappedErr := ErrGetMeshModels(err)
+		h.log.Error(wrappedErr)
+		writeMeshkitError(rw, wrappedErr, http.StatusInternalServerError)
 		return
 	}
 	comps := processComponentDefinitions(entities)
@@ -750,8 +752,9 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 	}
 	entities, count, _, err := h.registryManager.GetEntities(filter)
 	if err != nil {
-		h.log.Error(ErrGetMeshModels(err))
-		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		wrappedErr := ErrGetMeshModels(err)
+		h.log.Error(wrappedErr)
+		writeMeshkitError(rw, wrappedErr, http.StatusInternalServerError)
 		return
 	}
 	comps := processComponentDefinitions(entities)

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -184,7 +184,12 @@ func (h *Handler) GetMeshmodelModels(rw http.ResponseWriter, r *http.Request) {
 		filter.Greedy = true
 	}
 
-	entities, count, _, _ := h.registryManager.GetEntities(filter)
+	entities, count, _, err := h.registryManager.GetEntities(filter)
+	if err != nil {
+		h.log.Error(ErrGetMeshModels(err))
+		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		return
+	}
 	var modelDefs []_model.ModelDefinition
 	for _, model := range entities {
 		model, ok := model.(*_model.ModelDefinition)
@@ -590,7 +595,12 @@ func (h *Handler) GetMeshmodelComponentByModel(rw http.ResponseWriter, r *http.R
 		filter.Greedy = true
 		filter.DisplayName = search
 	}
-	entities, count, _, _ := h.registryManager.GetEntities(filter)
+	entities, count, _, err := h.registryManager.GetEntities(filter)
+	if err != nil {
+		h.log.Error(ErrGetMeshModels(err))
+		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		return
+	}
 	comps := processComponentDefinitions(entities)
 
 	var pgSize int64
@@ -738,7 +748,12 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 		filter.Greedy = true
 		filter.DisplayName = search
 	}
-	entities, count, _, _ := h.registryManager.GetEntities(filter)
+	entities, count, _, err := h.registryManager.GetEntities(filter)
+	if err != nil {
+		h.log.Error(ErrGetMeshModels(err))
+		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		return
+	}
 	comps := processComponentDefinitions(entities)
 
 	var pgSize int64

--- a/server/handlers/registry_read_error_test.go
+++ b/server/handlers/registry_read_error_test.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRegistryReadHandlers_DatastoreErrorReturns500(t *testing.T) {
 	rm, db := newTestRegistryManager(t)
-	require.NoError(t, db.DBClose())
+	if err := db.DBClose(); err != nil {
+		t.Fatalf("close registry database: %v", err)
+	}
 	h := &Handler{registryManager: rm, log: newTestLogger(t)}
 
 	cases := []struct {
@@ -30,6 +31,9 @@ func TestRegistryReadHandlers_DatastoreErrorReturns500(t *testing.T) {
 		{"components", "/api/registry/components", nil, h.GetAllMeshmodelComponents},
 		{"components by model", "/api/registry/models/kubernetes/components", map[string]string{"model": "kubernetes"}, h.GetMeshmodelComponentByModel},
 		{"relationships", "/api/registry/relationships", nil, h.GetAllMeshmodelRelationships},
+		// GetAllMeshmodelRelationships also serves the model-scoped route, so
+		// exercise that entry point too.
+		{"relationships by model", "/api/registry/models/kubernetes/relationships", map[string]string{"model": "kubernetes"}, h.GetAllMeshmodelRelationships},
 	}
 
 	for _, tc := range cases {
@@ -42,8 +46,9 @@ func TestRegistryReadHandlers_DatastoreErrorReturns500(t *testing.T) {
 
 			tc.fn(rec, req)
 
-			require.Equal(t, http.StatusInternalServerError, rec.Code,
-				"a datastore failure must be reported as 500, not masked as an empty 200; body: %s", rec.Body.String())
+			if rec.Code != http.StatusInternalServerError {
+				t.Errorf("a datastore failure must be reported as 500, not masked as an empty 200; got %d, body: %s", rec.Code, rec.Body.String())
+			}
 		})
 	}
 }

--- a/server/handlers/registry_read_error_test.go
+++ b/server/handlers/registry_read_error_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+// When the registry datastore fails, the read handlers must surface a 500 so a
+// client can tell a real failure apart from a genuinely empty result, instead
+// of the earlier behaviour of encoding an empty 200. The datastore is forced to
+// fail by closing the in-memory database before the request runs, which makes
+// every subsequent query return an error.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryReadHandlers_DatastoreErrorReturns500(t *testing.T) {
+	rm, db := newTestRegistryManager(t)
+	require.NoError(t, db.DBClose())
+	h := &Handler{registryManager: rm, log: newTestLogger(t)}
+
+	cases := []struct {
+		name string
+		url  string
+		vars map[string]string
+		fn   http.HandlerFunc
+	}{
+		{"models", "/api/registry/models", nil, h.GetMeshmodelModels},
+		{"components", "/api/registry/components", nil, h.GetAllMeshmodelComponents},
+		{"components by model", "/api/registry/models/kubernetes/components", map[string]string{"model": "kubernetes"}, h.GetMeshmodelComponentByModel},
+		{"relationships", "/api/registry/relationships", nil, h.GetAllMeshmodelRelationships},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			if tc.vars != nil {
+				req = mux.SetURLVars(req, tc.vars)
+			}
+			rec := httptest.NewRecorder()
+
+			tc.fn(rec, req)
+
+			require.Equal(t, http.StatusInternalServerError, rec.Code,
+				"a datastore failure must be reported as 500, not masked as an empty 200; body: %s", rec.Body.String())
+		})
+	}
+}

--- a/server/handlers/relationship_handlers.go
+++ b/server/handlers/relationship_handlers.go
@@ -77,8 +77,9 @@ func (h *Handler) GetAllMeshmodelRelationships(rw http.ResponseWriter, r *http.R
 		RelationshipType: r.URL.Query().Get("type"),
 	})
 	if err != nil {
-		h.log.Error(ErrGetMeshModels(err))
-		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		wrappedErr := ErrGetMeshModels(err)
+		h.log.Error(wrappedErr)
+		writeMeshkitError(rw, wrappedErr, http.StatusInternalServerError)
 		return
 	}
 

--- a/server/handlers/relationship_handlers.go
+++ b/server/handlers/relationship_handlers.go
@@ -64,7 +64,7 @@ func (h *Handler) GetAllMeshmodelRelationships(rw http.ResponseWriter, r *http.R
 	page, offset, limit, _, order, sort, _ := getPaginationParams(r)
 	typ := mux.Vars(r)["model"]
 
-	entities, count, _, _ := h.registryManager.GetEntities(&regv1alpha3.RelationshipFilter{
+	entities, count, _, err := h.registryManager.GetEntities(&regv1alpha3.RelationshipFilter{
 		Id:               r.URL.Query().Get("id"),
 		Version:          r.URL.Query().Get("version"),
 		ModelName:        typ,
@@ -76,6 +76,11 @@ func (h *Handler) GetAllMeshmodelRelationships(rw http.ResponseWriter, r *http.R
 		SubType:          r.URL.Query().Get("subType"),
 		RelationshipType: r.URL.Query().Get("type"),
 	})
+	if err != nil {
+		h.log.Error(ErrGetMeshModels(err))
+		writeMeshkitError(rw, ErrGetMeshModels(err), http.StatusInternalServerError)
+		return
+	}
 
 	var pgSize int64
 	if limit == 0 {


### PR DESCRIPTION
**Notes for Reviewers**

The MeshModel registry list/search read handlers dropped the error from `registryManager.GetEntities` (`entities, count, _, _ :=`) and always returned `200`, so a datastore failure looked the same as an empty result. This returns `500` instead, matching the pattern `GetMeshmodelRegistrants` and `connection_definition_handler.go` already use.

Handlers changed, in `server/handlers/component_handler.go` and `server/handlers/relationship_handlers.go`:

- `GetMeshmodelModels` — `/api/registry/models`
- `GetAllMeshmodelComponents` — `/api/registry/components`
- `GetMeshmodelComponentByModel` — `/api/registry/models/{model}/components`
- `GetAllMeshmodelRelationships` — `/api/registry/relationships` and `/api/registry/models/{model}/relationships`

Each now captures the error, logs it, and returns `ErrGetMeshModels` with `http.StatusInternalServerError`. This reuses the existing error, so there is no new error code and no wire or schema change. The only behavior change is that a failed query returns `500` instead of an empty `200`.

Test: `server/handlers/registry_read_error_test.go` closes the in-memory registry database and asserts each handler returns `500`.

Two things intentionally left out to keep this reviewable and can follow up:

- `GetMeshmodelCategories` has the same symptom, but the error is swallowed inside `CategoryFilter.Get` in meshkit (it returns a nil error on a failed query), so a handler-level fix has no effect. That one needs a change in `meshery/meshkit`.
- The nested exact-name lookup variants (`GetMeshmodelComponentsByNameByModelByCategory` and the other `...ByName...` handlers) share the same handler pattern.

Fixes #21031

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registry read endpoints now return a clear HTTP 500 error when the underlying data store is unavailable.
  * Prevented failed registry queries from being returned as empty or misleading successful responses.

* **Tests**
  * Added coverage verifying consistent error responses across model, component, and relationship endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->