### PR TITLE
[mesheryctl] Exit instead of hanging when the dashboard port-forward drops

### DIFF
--- a/mesheryctl/internal/cli/root/system/dashboard.go
+++ b/mesheryctl/internal/cli/root/system/dashboard.go
@@ -160,11 +160,13 @@ Note: Meshery's web-based user interface is embedded in Meshery Server and is av
 				// ticker for keeping connection alive with pod each 10 seconds
 				ticker := time.NewTicker(10 * time.Second)
 				go func() {
+					defer ticker.Stop()
 					for {
 						select {
 						case <-signals:
 							portforward.Stop()
-							ticker.Stop()
+							return
+						case <-portforward.GetStop():
 							return
 						case <-ticker.C:
 							keepConnectionAlive(mesheryURL)
@@ -180,6 +182,11 @@ Note: Meshery's web-based user interface is embedded in Meshery Server and is av
 				}
 
 				<-portforward.GetStop()
+				if err := portforward.Err(); err != nil {
+					err = ErrRunPortForward(err)
+					utils.Log.Error(err)
+					return err
+				}
 				return nil
 			}
 

--- a/mesheryctl/pkg/utils/portforward.go
+++ b/mesheryctl/pkg/utils/portforward.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
 
 	meshkitkube "github.com/meshery/meshkit/utils/kubernetes"
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,9 @@ type PortForward struct {
 	emitLogs   bool
 	stopCh     chan struct{}
 	readyCh    chan struct{}
+	stopOnce   sync.Once
+	errMx      sync.Mutex
+	err        error
 	config     *rest.Config
 }
 
@@ -145,20 +149,38 @@ func (pf *PortForward) run() error {
 // Init creates and runs a port-forward connection.
 // This function blocks until the connection is established, in which case it returns nil.
 // It's the caller's responsibility to call Stop() to finish the connection.
+// If the tunnel drops on its own after this returns, the channel from GetStop() is
+// closed and Err() reports why.
 func (pf *PortForward) Init() error {
+	return pf.start(pf.run)
+}
+
+// start runs the forwarder in the background and waits for it to either become
+// ready or fail. The forwarder is a parameter so that tests can exercise the
+// lifecycle without a live cluster.
+func (pf *PortForward) start(run func() error) error {
 	log.Debugf("Starting port forward to %s %d:%d", pf.url, pf.localPort, pf.remotePort)
 
-	failure := make(chan error)
+	// Buffered so the goroutine can always hand off the error and exit, even once
+	// nobody is receiving here anymore (i.e. the tunnel dropped after we returned).
+	failure := make(chan error, 1)
 
 	go func() {
-		if err := pf.run(); err != nil {
+		if err := run(); err != nil {
+			pf.setErr(err)
 			failure <- err
 		}
+		// run() has returned, so the tunnel is gone either way. Closing stopCh
+		// releases everyone waiting on GetStop().
+		pf.Stop()
 	}()
 
-	// The `select` statement below depends on one of two outcomes from `pf.run()`:
+	// `pf.run()` has three possible outcomes:
 	// 1) Succeed and block, causing a receive on `<-pf.readyCh`
-	// 2) Return an err, causing a receive `<-failure`
+	// 2) Return an err before the tunnel is ready, causing a receive on `<-failure`
+	// 3) Succeed, then return an err once the tunnel drops. client-go closes
+	//    `Ready` before it starts waiting on the connection, so this lands after
+	//    we've already returned nil; the goroutine above records it and stops us.
 	select {
 	case <-pf.readyCh:
 		log.Debug("Port forward initialized")
@@ -171,9 +193,26 @@ func (pf *PortForward) Init() error {
 }
 
 // Stop terminates the port-forward connection.
-// It is the caller's responsibility to call Stop even in case of errors
+// It is the caller's responsibility to call Stop even in case of errors.
+// Stop is idempotent and safe to call concurrently.
 func (pf *PortForward) Stop() {
-	close(pf.stopCh)
+	pf.stopOnce.Do(func() {
+		close(pf.stopCh)
+	})
+}
+
+// Err returns the error that brought the port-forward connection down, or nil if
+// it was stopped cleanly. It is only meaningful once GetStop() has been closed.
+func (pf *PortForward) Err() error {
+	pf.errMx.Lock()
+	defer pf.errMx.Unlock()
+	return pf.err
+}
+
+func (pf *PortForward) setErr(err error) {
+	pf.errMx.Lock()
+	defer pf.errMx.Unlock()
+	pf.err = err
 }
 
 // GetStop returns the stopCh.

--- a/mesheryctl/pkg/utils/portforward_test.go
+++ b/mesheryctl/pkg/utils/portforward_test.go
@@ -1,0 +1,123 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// waitForStop waits for the port-forward to report that it has stopped, failing
+// the test if it never does. A hang here is the bug this file guards against.
+func waitForStop(t *testing.T, pf *PortForward) {
+	t.Helper()
+
+	select {
+	case <-pf.GetStop():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the port-forward to stop")
+	}
+}
+
+func newTestPortForward() *PortForward {
+	return &PortForward{
+		host:       "localhost",
+		namespace:  "meshery",
+		podName:    "meshery-0",
+		localPort:  9081,
+		remotePort: 8080,
+		stopCh:     make(chan struct{}, 1),
+		readyCh:    make(chan struct{}),
+	}
+}
+
+// The forwarder fails before it ever signals readiness, so Init reports the
+// error to its caller.
+func TestPortForwardInitFailsBeforeReady(t *testing.T) {
+	pf := newTestPortForward()
+	wantErr := errors.New("error upgrading connection: dial tcp: connection refused")
+
+	err := pf.start(func() error {
+		return wantErr
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("start() = %v, want %v", err, wantErr)
+	}
+
+	waitForStop(t, pf)
+
+	if !errors.Is(pf.Err(), wantErr) {
+		t.Fatalf("Err() = %v, want %v", pf.Err(), wantErr)
+	}
+}
+
+// client-go closes Ready and only then waits on the connection, so a dropped
+// tunnel surfaces after Init has already returned nil. The caller learns about
+// it through GetStop() and Err() rather than blocking forever.
+func TestPortForwardReportsTunnelDropAfterReady(t *testing.T) {
+	pf := newTestPortForward()
+	wantErr := errors.New("lost connection to pod")
+	dropTunnel := make(chan struct{})
+
+	err := pf.start(func() error {
+		close(pf.readyCh)
+		<-dropTunnel
+		return wantErr
+	})
+	if err != nil {
+		t.Fatalf("start() = %v, want nil once the tunnel is ready", err)
+	}
+
+	select {
+	case <-pf.GetStop():
+		t.Fatal("port-forward reported a stop while the tunnel was still up")
+	default:
+	}
+
+	close(dropTunnel)
+	waitForStop(t, pf)
+
+	if !errors.Is(pf.Err(), wantErr) {
+		t.Fatalf("Err() = %v, want %v", pf.Err(), wantErr)
+	}
+}
+
+// A tunnel torn down by Stop() is not a failure, so Err() stays nil.
+func TestPortForwardStopIsNotAnError(t *testing.T) {
+	pf := newTestPortForward()
+
+	err := pf.start(func() error {
+		close(pf.readyCh)
+		<-pf.stopCh
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("start() = %v, want nil", err)
+	}
+
+	pf.Stop()
+	waitForStop(t, pf)
+
+	if pf.Err() != nil {
+		t.Fatalf("Err() = %v, want nil after a clean stop", pf.Err())
+	}
+}
+
+// Stop() races with the forwarder goroutine closing the same channel, and
+// callers are told to call it even after an error, so it has to be repeatable.
+func TestPortForwardStopIsIdempotent(t *testing.T) {
+	pf := newTestPortForward()
+
+	err := pf.start(func() error {
+		return errors.New("unable to listen on any of the requested ports")
+	})
+	if err == nil {
+		t.Fatal("start() = nil, want an error")
+	}
+
+	waitForStop(t, pf)
+
+	// The forwarder goroutine has already closed stopCh; these must not panic.
+	pf.Stop()
+	pf.Stop()
+}


### PR DESCRIPTION


**Notes for Reviewers**

- This PR fixes #21020 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard port-forward lifecycle handling.
  - Port-forward failures and unexpected tunnel drops are now reported clearly.
  - Stopping port forwarding is safe to repeat and no longer causes shutdown errors.

- **Tests**
  - Added coverage for startup failures, tunnel interruptions, clean shutdowns, and repeated stop requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->