### PR TITLE
[Server] Surface Plugin details in Notification Center

### DIFF
--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -269,7 +269,7 @@ func (h *Handler) ProviderComponentsHandler(
 			event := eventBuilder.
 				WithSeverity(events.Error).
 				WithDescription(fmt.Sprintf(
-					"Failed to load extension %s (version %s).",
+					"Failed to load extension %s (%s).",
 					providerProps.ProviderName,
 					providerProps.PackageVersion,
 				)).
@@ -286,7 +286,7 @@ func (h *Handler) ProviderComponentsHandler(
 		event := eventBuilder.
 			WithSeverity(events.Informational).
 			WithDescription(fmt.Sprintf(
-				"Extension %s (version %s) loaded successfully.",
+				"Extension %s (%s) loaded successfully.",
 				providerProps.ProviderName,
 				providerProps.PackageVersion,
 			)).

--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/meshery/meshkit/models/events"
+
 	models "github.com/meshery/meshery/server/models"
 )
 
@@ -232,13 +234,67 @@ func (h *Handler) ProviderComponentsHandler(
 	if strings.HasPrefix(r.URL.Path, serverReqBasePath) {
 		h.ExtensionsEndpointHandler(w, r, prefObj, user, provider)
 	} else if r.URL.Path == loadReqBasePath {
+		token, _ := r.Context().Value(models.TokenCtxKey).(string)
+		if token == "" {
+			if ck, err := r.Cookie(models.TokenCookieName); err == nil {
+				token = ck.Value
+			}
+		}
+		providerProps := provider.GetProviderProperties()
+		metadata := map[string]interface{}{
+			"providerName":   providerProps.ProviderName,
+			"packageVersion": providerProps.PackageVersion,
+			"packageURL":     providerProps.PackageURL,
+		}
+
+		if len(providerProps.Extensions.GraphQL) > 0 {
+			gql := providerProps.Extensions.GraphQL[0]
+
+			metadata["component"] = gql.Component
+			metadata["path"] = gql.Path
+			metadata["type"] = gql.Type
+		}
+		eventBuilder := events.NewEvent().
+			ActedUpon(user.ID).
+			FromOwner(user.ID).
+			FromSystem(*h.SystemID).
+			WithCategory("extension").
+			WithAction("load")
 		err := h.LoadExtensionFromPackage(w, r, provider)
 		if err != nil {
-			// failed to load extensions from package
-			h.log.Error(ErrFailToLoadExtensions(err))
-			writeMeshkitError(w, ErrFailToLoadExtensions(err), http.StatusInternalServerError)
+			_err := ErrFailToLoadExtensions(err)
+
+			metadata["error"] = _err
+
+			event := eventBuilder.
+				WithSeverity(events.Error).
+				WithDescription(fmt.Sprintf(
+					"Failed to load extension %s (version %s).",
+					providerProps.ProviderName,
+					providerProps.PackageVersion,
+				)).
+				WithMetadata(metadata).
+				Build()
+
+			_ = provider.PersistEvent(*event, token)
+			go h.config.EventBroadcaster.Publish(user.ID, event)
+
+			h.log.Error(_err)
+			writeMeshkitError(w, _err, http.StatusInternalServerError)
 			return
 		}
+		event := eventBuilder.
+			WithSeverity(events.Informational).
+			WithDescription(fmt.Sprintf(
+				"Extension %s (version %s) loaded successfully.",
+				providerProps.ProviderName,
+				providerProps.PackageVersion,
+			)).
+			WithMetadata(metadata).
+			Build()
+
+		_ = provider.PersistEvent(*event, token)
+		go h.config.EventBroadcaster.Publish(user.ID, event)
 		writeJSONEmptyObject(w, http.StatusOK)
 	} else {
 		ServeReactComponentFromPackage(w, r, uiReqBasePath, provider)


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #10509 
- Adds Notification Center events for successful and failed extension loading in the server.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

### After
<img width="1171" height="692" alt="Screenshot 2026-07-31 at 4 59 02 PM" src="https://github.com/user-attachments/assets/97c7fc9d-3003-4e8e-aa7c-8c9b1944555a" />

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added event tracking for extension package loading, capturing relevant provider, package, user, and component details when available.
  - Loading activity is now recorded for both successful and unsuccessful attempts, improving operational visibility.

- **Bug Fixes**
  - Improved error reporting when extension package loading fails.
  - Preserved the existing successful response behavior for completed package loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->