### PR TITLE
[mesheryctl] Replace log.Fatal with proper error handling in auth.go

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -168,7 +168,7 @@ func GetCurrentAuthToken() (string, error) {
 	// get config.yaml struct
 	mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 	// Get token of current-context
 	token, err := mctlCfg.GetTokenForContext(mctlCfg.CurrentContext)


### PR DESCRIPTION
Fixes #21040

**Notes for Reviewers**
Removed `log.Fatal(err)` inside `GetCurrentAuthToken()` in `pkg/utils/auth.go` and returned the error properly (`return "", err`). This prevents the CLI from crashing abruptly during token retrieval and aligns with the guideline to return errors for proper handling and logging via MeshKit.

- This PR fixes #21040

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication configuration errors are now returned for proper handling instead of abruptly terminating the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->