### PR TITLE
feat(mesheryctl): add --model filter to component search (#20995)

### DIFF
--- a/mesheryctl/internal/cli/root/components/fixtures/components.model.filter.api.response.golden
+++ b/mesheryctl/internal/cli/root/components/fixtures/components.model.filter.api.response.golden
@@ -1,0 +1,84 @@
+{
+  "page": 1,
+  "page_size": 1,
+  "total_count": 1,
+  "components": [
+    {
+      "id": "fda1c4e7-14ae-4435-8236-adfb9cea0395",
+      "schemaVersion": "components.meshery.io/v1beta1",
+      "version": "v1.0.0",
+      "displayName": "Test",
+      "description": "",
+      "format": "JSON",
+      "model": {
+        "id": "fda1c4e7-14ae-4435-8236-adfb9cea0395",
+        "schemaVersion": "models.meshery.io/v1beta1",
+        "version": "v1.0.0",
+        "name": "component-test-0",
+        "displayName": "Component test",
+        "status": "enabled",
+        "registrant": {
+          "id": "fda1c4e7-14ae-4435-8236-adfb9cea0395",
+          "name": "Artifact Hub",
+          "credentialId": "00000000-0000-0000-0000-000000000000",
+          "type": "registry",
+          "subType": "",
+          "kind": "artifacthub",
+          "status": "registered",
+          "user_id": "00000000-0000-0000-0000-000000000000",
+          "created_at": "2025-03-30T19:59:46.350667005Z",
+          "updated_at": "2025-03-30T19:59:46.350667005Z",
+          "deleted_at": {"Time": "0001-01-01T00:00:00Z", "Valid": false}
+        },
+        "connection_id": "fd01c4e7-14ae-4435-8236-adfb9cea0395",
+        "category": {
+          "id": "fda1c4e7-14ae-4435-8236-adfb9cea0395",
+          "name": "category"
+        },
+        "subCategory": "sub-category",
+        "metadata": {
+          "isAnnotation": false,
+          "primaryColor": "#ff9900",
+          "secondaryColor": "#F4BC79",
+          "shape": "circle",
+          "styleOverrides": "",
+          "svgColor": "ui/public/static/img/meshmodels/kubeform-provider-aws/color/kubeform-provider-aws-color.svg",
+          "svgComplete": "",
+          "svgWhite": "ui/public/static/img/meshmodels/kubeform-provider-aws/white/kubeform-provider-aws-white.svg"
+        },
+        "model": {
+          "version": "2023.11.1"
+        },
+        "components_count": 0,
+        "relationships_count": 0,
+        "components": null,
+        "relationships": null
+      },
+      "styles": {
+        "primaryColor": "#ff9900",
+        "secondaryColor": "#F4BC79",
+        "shape": "circle",
+        "svgColor": "ui/public/static/img/meshmodels/kubeform-provider-aws/color/acl-color.svg",
+        "svgComplete": "",
+        "svgWhite": "ui/public/static/img/meshmodels/kubeform-provider-aws/white/acl-white.svg"
+      },
+      "capabilities": [],
+      "status": "enabled",
+      "metadata": {
+        "configurationUISchema": "",
+        "genealogy": "",
+        "instanceDetails": null,
+        "isAnnotation": false,
+        "isNamespaced": false,
+        "published": false
+      },
+      "configuration": null,
+      "component": {
+        "version": "memorydb.aws.kubeform.com/v1alpha1",
+        "kind": "Test",
+        "schema": ""
+      },
+      "duplicates": 0
+    }
+  ]
+}

--- a/mesheryctl/internal/cli/root/components/search.go
+++ b/mesheryctl/internal/cli/root/components/search.go
@@ -25,8 +25,9 @@ import (
 )
 
 type cmdComponentSearchFlags struct {
-	Page     int `json:"page" validate:"omitempty,gte=1"`
-	PageSize int `json:"page-size" validate:"omitempty,gte=1"`
+	Page     int    `json:"page" validate:"omitempty,gte=1"`
+	PageSize int    `json:"page-size" validate:"omitempty,gte=1"`
+	Model    string `json:"model"`
 }
 
 var componentSearchFlags cmdComponentSearchFlags
@@ -46,6 +47,9 @@ mesheryctl component search "Component name"
 
 // Search list of components of specified page [int]
 mesheryctl component search [query-text] [--page 1]
+
+// Search components belonging to a specific model
+mesheryctl component search [query-text] [--model model-name]
 	`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return mesheryctlflags.ValidateCmdFlags(cmd, &componentSearchFlags)
@@ -59,6 +63,9 @@ mesheryctl component search [query-text] [--page 1]
 	RunE: func(cmd *cobra.Command, args []string) error {
 		searchValue := url.Values{}
 		searchValue.Add("search", args[0])
+		if componentSearchFlags.Model != "" {
+			searchValue.Add("model", componentSearchFlags.Model)
+		}
 
 		modelData := display.DisplayDataAsync{
 			UrlPath:  fmt.Sprintf("%s?%s", componentApiPath, searchValue.Encode()),
@@ -80,4 +87,5 @@ mesheryctl component search [query-text] [--page 1]
 func init() {
 	searchComponentsCmd.Flags().IntVarP(&componentSearchFlags.Page, "page", "p", 1, "(optional) List next set of components with --page (default = 1)")
 	searchComponentsCmd.Flags().IntVarP(&componentSearchFlags.PageSize, "pagesize", "s", 10, "(optional) List next set of components with --pagesize (default = 10)")
+	searchComponentsCmd.Flags().StringVarP(&componentSearchFlags.Model, "model", "m", "", "(optional) Filter components by model name")
 }

--- a/mesheryctl/internal/cli/root/components/search_test.go
+++ b/mesheryctl/internal/cli/root/components/search_test.go
@@ -62,8 +62,8 @@ func TestSearchComponent(t *testing.T) {
 			Name:             "given valid name and model flag provided when component search then display matching results",
 			Args:             []string{"search", "Test", "--model", "component-test-0"},
 			URL:              fmt.Sprintf("/%s?model=component-test-0&search=Test&page=0&pagesize=10", componentApiPath),
-			Fixture:          "components.api.response.golden",
-			ExpectedResponse: "components.search.success.output.golden",
+			Fixture:          "components.model.filter.api.response.golden",
+			ExpectedResponse: "components.model.filter.search.output.golden",
 			ExpectError:      false,
 		},
 	}

--- a/mesheryctl/internal/cli/root/components/search_test.go
+++ b/mesheryctl/internal/cli/root/components/search_test.go
@@ -58,6 +58,14 @@ func TestSearchComponent(t *testing.T) {
 			ExpectedResponse: "components.search.output.golden",
 			ExpectError:      false,
 		},
+		{
+			Name:             "given valid name and model flag provided when component search then display matching results",
+			Args:             []string{"search", "Test", "--model", "component-test-0"},
+			URL:              fmt.Sprintf("/%s?model=component-test-0&search=Test&page=0&pagesize=10", componentApiPath),
+			Fixture:          "components.api.response.golden",
+			ExpectedResponse: "components.search.success.output.golden",
+			ExpectError:      false,
+		},
 	}
 
 	mesheryctlflags.InitValidators(ComponentCmd)

--- a/mesheryctl/internal/cli/root/components/testdata/components.model.filter.search.output.golden
+++ b/mesheryctl/internal/cli/root/components/testdata/components.model.filter.search.output.golden
@@ -1,0 +1,4 @@
+Total number of components: 1
+Page: 1
+ID                                    NAME  MODEL             VERSION                             
+fda1c4e7-14ae-4435-8236-adfb9cea0395  Test  component-test-0  memorydb.aws.kubeform.com/v1alpha1  

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -728,6 +728,7 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 		Version:     v,
 		Trim:        queryParams.Get("trim") == queryParamTrue,
 		APIVersion:  queryParams.Get("apiVersion"),
+		ModelName:   queryParams.Get("model"),
 		Limit:       limit,
 		Offset:      offset,
 		OrderOn:     order,


### PR DESCRIPTION
## Description

This PR addresses the component search filtering gap identified in #20995 by exposing the `--model` (`-m`) filter flag in `mesheryctl component search` and wiring it to the backend `ComponentFilter`.

### Changes Included:
1. **Server Handler (`server/handlers/component_handler.go`)**:
   - Updated `GetAllMeshmodelComponents` to parse `queryParams.Get("model")` into `regv1beta1.ComponentFilter{ ModelName: ... }`.
2. **CLI (`mesheryctl/internal/cli/root/components/search.go`)**:
   - Added `--model` / `-m` flag to `mesheryctl component search`.
   - Updated query parameter encoding to pass `model` in API calls.
   - Updated command help text with example usage (`mesheryctl component search [query-text] [--model model-name]`).
3. **Unit Tests (`mesheryctl/internal/cli/root/components/search_test.go`)**:
   - Added test scenario for `mesheryctl component search Test --model component-test-0`.

---

## Related Issue

Contributes to #20995

---

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition/update

---

## Screenshots / CLI Output

```bash
# Example usage:
$ mesheryctl component search "Deployment" --model "kubernetes"

# Help text output:
$ mesheryctl component search --help
Search components registered in Meshery Server based on kind
Find more information at: https://docs.meshery.io/reference/references/mesheryctl/component/search

Usage:
  mesheryctl component search [query-text] [flags]

Examples:
// Search for components using a query
mesheryctl component search [query-text]

// Search for multi-word component names (must be quoted)
mesheryctl component search "Component name"

// Search list of components of specified page [int]
mesheryctl component search [query-text] [--page 1]

// Search components belonging to a specific model
mesheryctl component search [query-text] [--model model-name]

Flags:
  -h, --help              help for search
  -m, --model string      (optional) Filter components by model name
  -p, --page int          (optional) List next set of components with --page (default = 1) (default 1)
  -s, --pagesize int      (optional) List next set of components with --pagesize (default = 10) (default 10)
  
  
  
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-based filtering to component searches.
  * Added `--model` (`-m`) support to the component search command.
  * Search results now display components matching the selected model.

* **Tests**
  * Added coverage for model-filtered searches and validated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->