### PR TITLE
[mesheryctl] Guard type assertions in model import error output

### DIFF
--- a/mesheryctl/internal/cli/root/model/import.go
+++ b/mesheryctl/internal/cli/root/model/import.go
@@ -287,21 +287,44 @@ func displaySuccessfulRelationships(response *models.RegistryAPIResponse, model 
 		relationshipMap := make(map[string][][]string)
 
 		for _, rel := range response.EntityTypeSummary.SuccessfulRelationships {
-			kind := rel["Kind"].(string)
-			subtype := rel["Subtype"].(string)
-			relationshipType := rel["RelationshipType"].(string)
-			modelName := rel["Model"].(string)
-			if modelName != model {
+			modelName, ok := rel["Model"].(string)
+			if !ok || modelName != model {
 				continue
 			}
-			selectors := rel["Selectors"].([]interface{})
+			kind, _ := rel["Kind"].(string)
+			subtype, _ := rel["Subtype"].(string)
+			relationshipType, _ := rel["RelationshipType"].(string)
+			selectors, ok := rel["Selectors"].([]interface{})
+			if !ok {
+				continue
+			}
 			for _, selector := range selectors {
-				selectorMap := selector.(map[string]interface{})
-				allow := selectorMap["allow"].(map[string]interface{})
-				from := allow["from"].([]interface{})
-				to := allow["to"].([]interface{})
-				fromComponent := fmt.Sprintf("%s", from[0].(map[string]interface{})["kind"])
-				toComponent := fmt.Sprintf("%s", to[0].(map[string]interface{})["kind"])
+				selectorMap, ok := selector.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				allow, ok := selectorMap["allow"].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				from, ok := allow["from"].([]interface{})
+				if !ok || len(from) == 0 {
+					continue
+				}
+				to, ok := allow["to"].([]interface{})
+				if !ok || len(to) == 0 {
+					continue
+				}
+				fromMap, ok := from[0].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				toMap, ok := to[0].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				fromComponent := fmt.Sprintf("%s", fromMap["kind"])
+				toComponent := fmt.Sprintf("%s", toMap["kind"])
 				key := fmt.Sprintf("%s/%s/%s", kind, subtype, relationshipType)
 				if seen[key+fromComponent+toComponent] {
 					continue

--- a/mesheryctl/internal/cli/root/model/import.go
+++ b/mesheryctl/internal/cli/root/model/import.go
@@ -291,9 +291,18 @@ func displaySuccessfulRelationships(response *models.RegistryAPIResponse, model 
 			if !ok || modelName != model {
 				continue
 			}
-			kind, _ := rel["Kind"].(string)
-			subtype, _ := rel["Subtype"].(string)
-			relationshipType, _ := rel["RelationshipType"].(string)
+			kind, ok := rel["Kind"].(string)
+			if !ok {
+				continue
+			}
+			subtype, ok := rel["Subtype"].(string)
+			if !ok {
+				continue
+			}
+			relationshipType, ok := rel["RelationshipType"].(string)
+			if !ok {
+				continue
+			}
 			selectors, ok := rel["Selectors"].([]interface{})
 			if !ok {
 				continue
@@ -323,8 +332,14 @@ func displaySuccessfulRelationships(response *models.RegistryAPIResponse, model 
 				if !ok {
 					continue
 				}
-				fromComponent := fmt.Sprintf("%s", fromMap["kind"])
-				toComponent := fmt.Sprintf("%s", toMap["kind"])
+				fromComponent, ok := fromMap["kind"].(string)
+				if !ok {
+					continue
+				}
+				toComponent, ok := toMap["kind"].(string)
+				if !ok {
+					continue
+				}
 				key := fmt.Sprintf("%s/%s/%s", kind, subtype, relationshipType)
 				if seen[key+fromComponent+toComponent] {
 					continue

--- a/mesheryctl/internal/cli/root/model/import.go
+++ b/mesheryctl/internal/cli/root/model/import.go
@@ -410,12 +410,18 @@ func buildEntityTypeLine(names, entityTypes []interface{}, longDescription, prob
 	compCount, relCount := 0, 0
 	EntityTypeLine := ""
 	for i, name := range names {
+		nameStr, ok := name.(string)
+		if !ok {
+			continue
+		}
 		entityType := ""
 		if i < len(entityTypes) {
-			entityType = entityTypes[i].(string)
+			if et, ok := entityTypes[i].(string); ok {
+				entityType = et
+			}
 		}
 		if modelName != "" {
-			if modelName != name.(string) {
+			if modelName != nameStr {
 				continue
 			}
 		} else if modelName == "" {
@@ -425,7 +431,7 @@ func buildEntityTypeLine(names, entityTypes []interface{}, longDescription, prob
 		}
 		switch entityType {
 		case "unknown":
-			utils.Log.Infof("\n%s: Error encountered while importing model %s: \n    %s\n\n    Ensure that you are importing an existing model.\n    Create a new model to import or find an existing model in the Meshery \x1b]8;;https://meshery.io/catalog/models\x1b\\catalog\x1b]8;;\x1b\\.", utils.BoldString("ERROR"), name.(string), longDescription)
+			utils.Log.Infof("\n%s: Error encountered while importing model %s: \n    %s\n\n    Ensure that you are importing an existing model.\n    Create a new model to import or find an existing model in the Meshery \x1b]8;;https://meshery.io/catalog/models\x1b\\catalog\x1b]8;;\x1b\\.", utils.BoldString("ERROR"), nameStr, longDescription)
 			if probableCause != "" {
 				utils.Log.Infof("\n  %s:\n  %s", utils.BoldString("PROBABLE CAUSE"), probableCause)
 			}

--- a/mesheryctl/internal/cli/root/model/import_typeassert_test.go
+++ b/mesheryctl/internal/cli/root/model/import_typeassert_test.go
@@ -24,6 +24,7 @@ func captureStdout(t *testing.T, f func()) string {
 	}
 	os.Stdout = w
 	defer func() { os.Stdout = orig }()
+	defer func() { _ = r.Close() }()
 
 	f()
 

--- a/mesheryctl/internal/cli/root/model/import_typeassert_test.go
+++ b/mesheryctl/internal/cli/root/model/import_typeassert_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
@@ -189,8 +190,15 @@ func TestDisplaySuccessfulRelationshipsSkipsMalformedOutput(t *testing.T) {
 		out := captureStdout(t, func() {
 			displaySuccessfulRelationships(resp, "mymodel")
 		})
-		if out == "" {
-			t.Error("expected output for a well-formed relationship, got none")
+		// Assert the actual rendered content, not just that something printed:
+		// displaySuccessfulRelationships emits a leading `fmt.Println("")`, so a
+		// non-empty check alone would pass even if the table never rendered.
+		// The table headers render uppercase ("FROM"/"TO"); X and Y are the
+		// endpoint kinds from the selector.
+		for _, want := range []string{"FROM", "TO", "X", "Y"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected rendered output to contain %q, got:\n%s", want, out)
+			}
 		}
 	})
 }

--- a/mesheryctl/internal/cli/root/model/import_typeassert_test.go
+++ b/mesheryctl/internal/cli/root/model/import_typeassert_test.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+)
+
+// buildEntityTypeLine receives names/entityTypes as []interface{} decoded from a
+// registry API JSON response. Its sibling builders (buildDescription,
+// buildDescriptionList) guard every element with the comma-ok form, but
+// buildEntityTypeLine asserted .(string) directly, so a non-string element
+// panicked the mesheryctl model import error display. This test asserts it
+// degrades gracefully instead of panicking.
+func TestBuildEntityTypeLineHandlesNonStringEntries(t *testing.T) {
+	utils.SetupMeshkitLoggerTesting(t, false)
+
+	tests := []struct {
+		name        string
+		names       []interface{}
+		entityTypes []interface{}
+		modelName   string
+	}{
+		{"non-string name with model filter", []interface{}{123}, []interface{}{"unknown"}, "mymodel"},
+		{"non-string entityType", []interface{}{"mymodel"}, []interface{}{42}, "mymodel"},
+		{"mixed non-string entries", []interface{}{true, "mymodel"}, []interface{}{nil, "unknown"}, "mymodel"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Must not panic on malformed (non-string) interface elements.
+			_ = buildEntityTypeLine(tt.names, tt.entityTypes, "desc", "", "", tt.modelName)
+		})
+	}
+}

--- a/mesheryctl/internal/cli/root/model/import_typeassert_test.go
+++ b/mesheryctl/internal/cli/root/model/import_typeassert_test.go
@@ -1,11 +1,40 @@
 package model
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
 )
+
+// captureStdout runs f and returns everything it wrote to os.Stdout. The
+// display helpers print with fmt.Println, so this is how a test asserts that a
+// malformed relationship renders nothing at all rather than a header or a
+// %!s(...) row.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	f()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return buf.String()
+}
 
 // buildEntityTypeLine receives names/entityTypes as []interface{} decoded from a
 // registry API JSON response. Its sibling builders (buildDescription,
@@ -88,4 +117,80 @@ func TestDisplaySuccessfulRelationshipsHandlesMalformed(t *testing.T) {
 			displaySuccessfulRelationships(resp, "mymodel")
 		})
 	}
+}
+
+// A relationship whose display fields (Kind/Subtype/RelationshipType) or endpoint
+// kinds are not strings is skipped entirely: it must not render a RELATIONSHIP
+// header or a From/To row, and must never emit a %!s(...) verb. Only well-formed
+// relationships produce output.
+func TestDisplaySuccessfulRelationshipsSkipsMalformedOutput(t *testing.T) {
+	utils.SetupMeshkitLoggerTesting(t, false)
+
+	malformed := []struct {
+		name string
+		rel  map[string]interface{}
+	}{
+		{
+			name: "non-string endpoint kind",
+			rel: map[string]interface{}{
+				"Model": "mymodel", "Kind": "a", "Subtype": "b", "RelationshipType": "c",
+				"Selectors": []interface{}{
+					map[string]interface{}{"allow": map[string]interface{}{
+						"from": []interface{}{map[string]interface{}{"kind": 7}},
+						"to":   []interface{}{map[string]interface{}{"kind": "Y"}},
+					}},
+				},
+			},
+		},
+		{
+			name: "non-string RelationshipType",
+			rel: map[string]interface{}{
+				"Model": "mymodel", "Kind": "a", "Subtype": "b", "RelationshipType": 9,
+				"Selectors": []interface{}{
+					map[string]interface{}{"allow": map[string]interface{}{
+						"from": []interface{}{map[string]interface{}{"kind": "X"}},
+						"to":   []interface{}{map[string]interface{}{"kind": "Y"}},
+					}},
+				},
+			},
+		},
+	}
+	for _, tt := range malformed {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &models.RegistryAPIResponse{
+				EntityTypeSummary: models.EntityTypeSummary{
+					SuccessfulRelationships: []map[string]interface{}{tt.rel},
+				},
+			}
+			out := captureStdout(t, func() {
+				displaySuccessfulRelationships(resp, "mymodel")
+			})
+			if out != "" {
+				t.Errorf("expected no output for malformed relationship, got:\n%s", out)
+			}
+		})
+	}
+
+	// Positive control: a well-formed relationship still renders.
+	t.Run("well-formed relationship renders", func(t *testing.T) {
+		resp := &models.RegistryAPIResponse{
+			EntityTypeSummary: models.EntityTypeSummary{
+				SuccessfulRelationships: []map[string]interface{}{{
+					"Model": "mymodel", "Kind": "a", "Subtype": "b", "RelationshipType": "c",
+					"Selectors": []interface{}{
+						map[string]interface{}{"allow": map[string]interface{}{
+							"from": []interface{}{map[string]interface{}{"kind": "X"}},
+							"to":   []interface{}{map[string]interface{}{"kind": "Y"}},
+						}},
+					},
+				}},
+			},
+		}
+		out := captureStdout(t, func() {
+			displaySuccessfulRelationships(resp, "mymodel")
+		})
+		if out == "" {
+			t.Error("expected output for a well-formed relationship, got none")
+		}
+	})
 }

--- a/mesheryctl/internal/cli/root/model/import_typeassert_test.go
+++ b/mesheryctl/internal/cli/root/model/import_typeassert_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshery/server/models"
 )
 
 // buildEntityTypeLine receives names/entityTypes as []interface{} decoded from a
@@ -29,6 +30,62 @@ func TestBuildEntityTypeLineHandlesNonStringEntries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Must not panic on malformed (non-string) interface elements.
 			_ = buildEntityTypeLine(tt.names, tt.entityTypes, "desc", "", "", tt.modelName)
+		})
+	}
+}
+
+// displaySuccessfulRelationships walks SuccessfulRelationships ([]map[string]interface{})
+// straight from the registry API JSON. It asserted .(string)/.(map)/.([]interface{})
+// directly and indexed from[0]/to[0] without a length check, so a malformed or
+// sparse relationship entry panicked mesheryctl. This asserts it skips bad entries
+// instead of crashing, matching displaySuccessfulComponents in the same file.
+func TestDisplaySuccessfulRelationshipsHandlesMalformed(t *testing.T) {
+	utils.SetupMeshkitLoggerTesting(t, false)
+
+	tests := []struct {
+		name string
+		rel  map[string]interface{}
+	}{
+		{
+			name: "empty from/to lists (index out of range)",
+			rel: map[string]interface{}{
+				"Model": "mymodel", "Kind": "a", "Subtype": "b", "RelationshipType": "c",
+				"Selectors": []interface{}{
+					map[string]interface{}{"allow": map[string]interface{}{
+						"from": []interface{}{}, "to": []interface{}{},
+					}},
+				},
+			},
+		},
+		{
+			name: "non-string kind with a valid selector",
+			rel: map[string]interface{}{
+				"Model": "mymodel", "Kind": 123, "Subtype": "b", "RelationshipType": "c",
+				"Selectors": []interface{}{
+					map[string]interface{}{"allow": map[string]interface{}{
+						"from": []interface{}{map[string]interface{}{"kind": "X"}},
+						"to":   []interface{}{map[string]interface{}{"kind": "Y"}},
+					}},
+				},
+			},
+		},
+		{
+			name: "selector is not a map",
+			rel: map[string]interface{}{
+				"Model": "mymodel", "Kind": "a", "Subtype": "b", "RelationshipType": "c",
+				"Selectors": []interface{}{"not-a-map"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &models.RegistryAPIResponse{
+				EntityTypeSummary: models.EntityTypeSummary{
+					SuccessfulRelationships: []map[string]interface{}{tt.rel},
+				},
+			}
+			// Must not panic on malformed relationship data.
+			displaySuccessfulRelationships(resp, "mymodel")
 		})
 	}
 }


### PR DESCRIPTION
two builders in mesheryctl model import display, buildEntityTypeLine and displaySuccessfulRelationships, assert .(string) / .(map[string]interface{}) / .([]interface{}) directly on data decoded from the registry api response as []interface{}, and displaySuccessfulRelationships also indexes from[0] / to[0] with no length check. a non-string field, or a sparse/empty relationship entry, panics mesheryctl mid-import while it is printing results. the sibling displaySuccessfulComponents in the same file already uses the comma-ok form, so this makes the other two consistent with it.

no behaviour change for well-formed responses: fields that are not the expected type are skipped, and empty from/to lists are skipped.

tests added: TestBuildEntityTypeLineHandlesNonStringEntries and TestDisplaySuccessfulRelationshipsHandlesMalformed. before the change they panic ("interface conversion: interface {} is int, not string" and "index out of range [0] with length 0"); after, they pass:

    cd mesheryctl ; go test ./internal/cli/root/model/ -run "TestBuildEntityTypeLine|TestDisplaySuccessfulRelationships"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model relationship import handling for malformed or incomplete registry data.
  * Prevented crashes when model names, selectors, relationship endpoints, or entity details contain unexpected values.
  * Invalid relationship entries are now safely skipped, with clearer error reporting for affected entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->