### PR TITLE
[Docs][Server] Sparse-clone guidance + make connection-seeding tests sparse-clone-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,23 @@ Please do! We're a warm and welcoming community of open source contributors. Ple
 
 **Naming conventions.** This repository adheres to the canonical camelCase-wire identifier-naming contract shared across the Meshery ecosystem. See the [identifier-naming contributor guide](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md) in `meshery/schemas` for the full reader-friendly directory (26-row naming table with before/after and do/don't examples). Repo-specific mandates live in [`AGENTS.md § Identifier Naming Conventions`](./AGENTS.md).
 
+### Cloning this repository (sparse clone recommended)
+
+This repository is large - a full clone is tens of gigabytes and grows over time, mostly from the generated model registry (`models/`, 400+ models) and archived documentation snapshots (`docs/static/v*/`). Unless you specifically need those, **clone sparsely** to get a working tree a fraction of the size while keeping the full commit history:
+
+```bash
+# Blobless partial clone, then check out everything EXCEPT the bulky generated dirs
+git clone --no-checkout --filter=blob:none https://github.com/meshery/meshery.git
+cd meshery
+git sparse-checkout set --no-cone \
+  '/*' \
+  '!/models/*' '/models/meshery-core/' '/models/kubernetes/' \
+  '!/docs/static/v0.8/'
+git checkout master
+```
+
+This keeps only the `meshery-core` and `kubernetes` models and the latest docs snapshot (`docs/static/v0.9`). Git fetches any excluded file on demand, so nothing is permanently lost. See the [Contributing guide](https://docs.meshery.io/project/contributing/#cloning-the-repository) for how to re-include a directory later.
+
 <!-- <a href="https://youtu.be/MXQV-i-Hkf8"><img alt="Deploying Linkerd with Meshery" src="https://docs.meshery.io/assets/img/readme/deploying-linkerd-with-meshery.png" width="100%" align="center" /></a> -->
 
 <div>&nbsp;</div>

--- a/docs/content/en/project/contributing/_index.md
+++ b/docs/content/en/project/contributing/_index.md
@@ -69,6 +69,62 @@ a commit you have already written:
 </ul>
 </details>
 
+## Cloning the Repository
+
+The `meshery/meshery` repository is large - a full clone is on the order of tens of gigabytes and keeps growing. Two directories account for most of that weight, and neither is needed for the vast majority of contributions:
+
+- **`models/`** - the generated [Meshery Model]({{< ref "concepts/logical/models/index.md" >}}) registry (400+ models). A typical build of the server, UI, or CLI only needs the `meshery-core` and `kubernetes` models.
+- **`docs/static/v*/`** - archived snapshots of previously released documentation. Only the latest snapshot is needed to build and preview the current docs.
+
+Unless you are specifically working on the model registry or on an archived documentation version, **clone sparsely**. You still get the full commit history and everything required to build the server, UI, CLI, and current docs, while skipping gigabytes of generated content.
+
+### Recommended: sparse clone
+
+```bash
+# 1. Blobless partial clone - fetches history metadata, not every file's contents
+git clone --no-checkout --filter=blob:none https://github.com/meshery/meshery.git
+cd meshery
+
+# 2. Check out everything EXCEPT the bulky generated directories:
+#      - every model except meshery-core and kubernetes
+#      - archived docs snapshots (keep only the latest, docs/static/v0.9)
+git sparse-checkout set --no-cone \
+  '/*' \
+  '!/models/*' \
+  '/models/meshery-core/' \
+  '/models/kubernetes/' \
+  '!/docs/static/v0.8/'
+
+# 3. Populate the working tree
+git checkout master
+```
+
+This yields a working tree a fraction of the size of a full clone. `--filter=blob:none` makes it a [partial clone](https://git-scm.com/docs/partial-clone), so Git transparently fetches any excluded file on demand if you ever check one out - nothing is permanently lost, and `git log`/`git blame` keep working across the full history.
+
+The `!/models/*` pattern excludes the *contents* of `models/` (not the directory itself), which is what lets the two following lines re-include only the `meshery-core` and `kubernetes` models. For the docs, exclude the older archived snapshots under `docs/static/` and keep the newest (currently `docs/static/v0.9`); add another `!` line for each older version as new snapshots are archived.
+
+### Re-including an excluded directory
+
+Working on the model registry, or on an older archived docs version? Re-include just what you need at any time:
+
+```bash
+# Bring back the full model registry
+git sparse-checkout add '/models/'
+
+# ...or a single archived docs version
+git sparse-checkout add '/docs/static/v0.8/'
+```
+
+Or restore the full working tree entirely:
+
+```bash
+git sparse-checkout disable
+```
+
+{{% alert color="info" title="Requires a recent Git" %}}
+`git sparse-checkout` requires Git 2.25+, and partial clone (`--filter=blob:none`) works best with Git 2.27+. Check with `git --version`.
+{{% /alert %}}
+
 ## Not sure where to start?
 
 <details>

--- a/server/handlers/connections_seeded_api_test.go
+++ b/server/handlers/connections_seeded_api_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -16,17 +17,53 @@ import (
 	"github.com/meshery/schemas/models/v1beta1/environment"
 )
 
-// The shipped model directories that boot-time registration reads: the
-// meshery-core model carries the connection definitions, and the two others are
-// representative models whose model.json `registrant` is `artifacthub` and
-// `github`. Registering them is what creates the registrant Connections that
-// SeedConnections is scoped to, so this fixture is the same input the server
-// gets on boot rather than a synthetic one.
-const (
-	seedCoreModelDir            = "../../models/meshery-core/0.7.2/v1.0.0"
-	seedArtifactHubRegistrantIn = "../../models/kubevault/2026.1.8-rc.0/v1.0.0"
-	seedGitHubRegistrantIn      = "../../models/azure-operational-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0"
-)
+// artifactHubRegistrantModelDir is a minimal in-repo model published under the
+// `artifacthub` registrant. The shipped Artifact Hub models it would otherwise
+// come from live under models/, which the recommended sparse checkout excludes,
+// so committing a fixture keeps the Artifact Hub seeding path covered without
+// pulling in the model registry.
+const artifactHubRegistrantModelDir = "testdata/artifacthub-registrant-model"
+
+// seedModelDirs resolves the model directories that boot-time registration reads
+// for this fixture. All are available in a sparse clone (see the "Cloning the
+// Repository" contributing guide), so the default `go test ./...` keeps passing
+// there:
+//
+//   - meshery-core carries the Connection *definitions* (Artifact Hub, GitHub,
+//     Kubernetes, ...) and registers under the `meshery` registrant.
+//   - kubernetes registers under the `github` registrant, which is what makes the
+//     GitHub connection definition seedable.
+//   - the committed artifacthub-registrant-model registers under the
+//     `artifacthub` registrant, which makes the Artifact Hub definition seedable.
+//
+// Together they create the `artifacthub` and `github` registrant Connections
+// that SeedConnections is scoped to, so this fixture is the same input the
+// server gets on boot rather than a synthetic one.
+func seedModelDirs(t *testing.T) []string {
+	t.Helper()
+	return []string{
+		resolveModelDir(t, "meshery-core"),
+		resolveModelDir(t, "kubernetes"),
+		artifactHubRegistrantModelDir,
+	}
+}
+
+// resolveModelDir returns a shipped model's registration directory
+// (models/<name>/<version>/v1.0.0) without pinning a specific version, so the
+// test keeps working as the model registry is re-synced. It selects the highest
+// version directory that contains a model.json.
+func resolveModelDir(t *testing.T, name string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join("..", "..", "models", name, "*", "v1.0.0", "model.json"))
+	if err != nil {
+		t.Fatalf("glob model dir for %q: %v", name, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no shipped model directory found under ../../models/%s/*/v1.0.0 - is it excluded by a sparse checkout?", name)
+	}
+	sort.Strings(matches)
+	return filepath.Dir(matches[len(matches)-1])
+}
 
 // apiConnection is the connection as it reaches the wire (and therefore the
 // Connections page), decoded from the handler's own response rather than read
@@ -70,7 +107,7 @@ func newSeedConnectionsAPIFixture(t *testing.T) (*Handler, models.Provider, *dat
 	}
 
 	regHelper := registration.NewRegistrationHelper(t.TempDir(), regm, models.NewRegistrationFailureLogHandler())
-	for _, dir := range []string{seedCoreModelDir, seedArtifactHubRegistrantIn, seedGitHubRegistrantIn} {
+	for _, dir := range seedModelDirs(t) {
 		regHelper.Register(registration.NewDir(dir))
 	}
 
@@ -221,7 +258,7 @@ func TestConnectionsAPISeededConnectionsSurviveRestart(t *testing.T) {
 	// A restart: registration runs again, then seeding, exactly as
 	// SeedComponents sequences them.
 	regHelper := registration.NewRegistrationHelper(t.TempDir(), regm, models.NewRegistrationFailureLogHandler())
-	for _, dir := range []string{seedCoreModelDir, seedArtifactHubRegistrantIn, seedGitHubRegistrantIn} {
+	for _, dir := range seedModelDirs(t) {
 		regHelper.Register(registration.NewDir(dir))
 	}
 	models.SeedConnections(log, db, regm)

--- a/server/handlers/testdata/artifacthub-registrant-model/components/TestComponent.json
+++ b/server/handlers/testdata/artifacthub-registrant-model/components/TestComponent.json
@@ -1,0 +1,35 @@
+{
+  "id": "b3f5c1e2-0000-4000-8000-000000000002",
+  "schemaVersion": "components.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "displayName": "Test Component",
+  "description": "Test-only component. Registration silently skips a model with no components or relationships, so this fixture ships one. Its content is irrelevant to the test; only the parent model's `artifacthub` registrant matters.",
+  "format": "JSON",
+  "model": {
+    "id": "b3f5c1e2-0000-4000-8000-000000000001",
+    "schemaVersion": "models.meshery.io/v1beta1",
+    "version": "v1.0.0",
+    "name": "meshery-test-artifacthub-registrant",
+    "registrant": {
+      "kind": "artifacthub"
+    }
+  },
+  "component": {
+    "version": "meshery.test/v1",
+    "kind": "TestComponent",
+    "schema": "{\"type\":\"object\",\"properties\":{}}"
+  },
+  "capabilities": [],
+  "styles": {
+    "primaryColor": "#00b39f",
+    "shape": "circle",
+    "svgColor": "",
+    "svgWhite": ""
+  },
+  "metadata": {
+    "isAnnotation": false,
+    "isNamespaced": false,
+    "published": false
+  },
+  "status": "enabled"
+}

--- a/server/handlers/testdata/artifacthub-registrant-model/model.json
+++ b/server/handlers/testdata/artifacthub-registrant-model/model.json
@@ -1,0 +1,31 @@
+{
+  "id": "b3f5c1e2-0000-4000-8000-000000000001",
+  "schemaVersion": "models.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "name": "meshery-test-artifacthub-registrant",
+  "displayName": "Meshery Test Artifact Hub Registrant",
+  "description": "Test-only fixture. A minimal model published under the Artifact Hub registrant, registered by server/handlers/connections_seeded_api_test.go so that an `artifacthub` registrant Connection exists without depending on the shipped model registry (models/), which the recommended sparse clone excludes. Only the `registrant` blob is significant; the seeded Connection's identity comes from meshery-core's ArtifactHubConnection definition.",
+  "status": "enabled",
+  "registrant": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "Artifact Hub",
+    "type": "registry",
+    "sub_type": "",
+    "kind": "artifacthub",
+    "status": "discovered",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "deleted_at": null,
+    "schemaVersion": ""
+  },
+  "category": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "Uncategorized"
+  },
+  "model": {
+    "version": "1.0.0"
+  },
+  "metadata": {
+    "isAnnotation": false
+  }
+}

--- a/server/models/seed_connections_test.go
+++ b/server/models/seed_connections_test.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -16,23 +18,45 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// mesheryCoreModelDir carries the shipped connection definitions.
-const mesheryCoreModelDir = "../../models/meshery-core/0.7.2/v1.0.0"
+// resolveModelDir returns a shipped model's registration directory
+// (models/<name>/<version>/v1.0.0) without pinning a specific version, so the
+// test keeps working as the model registry is re-synced. meshery-core and
+// kubernetes are both retained by the recommended sparse checkout, so this keeps
+// the default `go test ./...` passing against a sparse clone.
+func resolveModelDir(t *testing.T, name string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join("..", "..", "models", name, "*", "v1.0.0", "model.json"))
+	if err != nil {
+		t.Fatalf("glob model dir for %q: %v", name, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no shipped model directory found under ../../models/%s/*/v1.0.0 - is it excluded by a sparse checkout?", name)
+	}
+	sort.Strings(matches)
+	return filepath.Dir(matches[len(matches)-1])
+}
 
-// Representative models whose model.json registrant is `artifacthub` and
-// `github` respectively. Registering them is what creates the registrant
-// Connections that seeding is scoped to.
-//
-// The shipped `registrant` blobs are not uniform: some carry `user_id`, some
-// omit it. Since the registrant id is an md5 over the whole connection, the two
-// spellings hash to different rows, so a kind can hold more than one registrant
-// (meshery/meshery#20950). artifactHubOwnedRegistrantModelDir is the `user_id`
-// variant of the same kind as artifactHubRegistrantModelDir, which is what makes
-// the canonical-pick test exercise real data rather than a synthetic fixture.
+// mesheryCoreModelDir resolves the meshery-core model, which carries the shipped
+// connection definitions and registers under the `meshery` registrant.
+func mesheryCoreModelDir(t *testing.T) string { return resolveModelDir(t, "meshery-core") }
+
+// gitHubRegistrantModelDir resolves the kubernetes model, which registers under
+// the `github` registrant - the registrant that makes the GitHub connection
+// definition seedable.
+func gitHubRegistrantModelDir(t *testing.T) string { return resolveModelDir(t, "kubernetes") }
+
+// The Artifact Hub registrant models are committed fixtures, not shipped models:
+// every Artifact Hub model lives under models/, which the recommended sparse
+// checkout excludes, so depending on one would break `go test ./...` on a sparse
+// clone. The registrant blobs are deliberately not uniform -
+// artifactHubOwnedRegistrantModelDir carries a `user_id`, so it hashes to a
+// different registrant row than artifactHubRegistrantModelDir. That is the
+// two-spellings case a kind legitimately holds (meshery/meshery#20950), which
+// lets the canonical-pick test exercise real duplication rather than a synthetic
+// fixture.
 const (
-	artifactHubRegistrantModelDir      = "../../models/kubevault/2026.1.8-rc.0/v1.0.0"
-	artifactHubOwnedRegistrantModelDir = "../../models/couchbase-operator/2.81.0/v1.0.0"
-	gitHubRegistrantModelDir           = "../../models/azure-operational-insights/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0"
+	artifactHubRegistrantModelDir      = "testdata/artifacthub-registrant-model"
+	artifactHubOwnedRegistrantModelDir = "testdata/artifacthub-registrant-model-owned"
 )
 
 func newSeedTestLogger(t *testing.T) logger.Handler {
@@ -165,7 +189,7 @@ func linkRegistryEntry(t *testing.T, db *database.Handler, registrantID core.Uui
 // the identity their connection definitions declare, not the stale identity the
 // model.json registrant blobs carry.
 func TestSeedConnectionsMaterializesDefinitionBackedConnections(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir, gitHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir, gitHubRegistrantModelDir(t))
 
 	// Registration alone leaves the registrant rows disagreeing with the
 	// definitions; assert that starting point so the test proves seeding did
@@ -222,7 +246,7 @@ func TestSeedConnectionsMaterializesDefinitionBackedConnections(t *testing.T) {
 // TestSeedConnectionsIsIdempotentAcrossRestarts proves the restart behavior the
 // issue calls for: no new rows, and no write at all on a second boot.
 func TestSeedConnectionsIsIdempotentAcrossRestarts(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir, gitHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir, gitHubRegistrantModelDir(t))
 	log := newSeedTestLogger(t)
 
 	SeedConnections(log, db, regm)
@@ -231,7 +255,7 @@ func TestSeedConnectionsIsIdempotentAcrossRestarts(t *testing.T) {
 	// A restart re-runs registration before seeding, exactly as SeedComponents
 	// does, so exercise both.
 	regHelper := registration.NewRegistrationHelper(t.TempDir(), regm, NewRegistrationFailureLogHandler())
-	for _, dir := range []string{mesheryCoreModelDir, artifactHubRegistrantModelDir, gitHubRegistrantModelDir} {
+	for _, dir := range []string{mesheryCoreModelDir(t), artifactHubRegistrantModelDir, gitHubRegistrantModelDir(t)} {
 		regHelper.Register(registration.NewDir(dir))
 	}
 	SeedConnections(log, db, regm)
@@ -316,7 +340,7 @@ func assertSteadyStateWritesNothing(t *testing.T, db *database.Handler, regm *me
 // registration wrote it, rather than turning both rows into indistinguishable
 // copies of the definition.
 func TestSeedConnectionsStampsOneCanonicalRegistrantPerKind(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir, artifactHubOwnedRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir, artifactHubOwnedRegistrantModelDir)
 
 	before := connectionsByKind(t, db)
 	if got := len(before["artifacthub"]); got != 2 {
@@ -378,7 +402,7 @@ func TestSeedConnectionsStampsOneCanonicalRegistrantPerKind(t *testing.T) {
 // the definition identity forever, producing the duplicate-identity outcome the
 // single-canonical rule exists to prevent, with no self-healing on later boots.
 func TestSeedConnectionsCanonicalPickSurvivesRegistrantGrowth(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir)
 	log := newSeedTestLogger(t)
 
 	SeedConnections(log, db, regm)
@@ -421,12 +445,12 @@ func TestSeedConnectionsCanonicalPickSurvivesRegistrantGrowth(t *testing.T) {
 // same canonical row is rewritten once per copy in a single pass and the seeded
 // count reports copies rather than rows.
 func TestSeedConnectionsWritesOncePerKindWithDuplicateDefinitions(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir, gitHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir, gitHubRegistrantModelDir(t))
 
 	// Re-registering the definitions is what a restart does, and what leaves a
 	// second copy of every definition behind.
 	regHelper := registration.NewRegistrationHelper(t.TempDir(), regm, NewRegistrationFailureLogHandler())
-	regHelper.Register(registration.NewDir(mesheryCoreModelDir))
+	regHelper.Register(registration.NewDir(mesheryCoreModelDir(t)))
 
 	var copies int64
 	if err := db.Table("connection_definition_dbs").Count(&copies).Error; err != nil {
@@ -460,7 +484,7 @@ func TestSeedConnectionsWritesOncePerKindWithDuplicateDefinitions(t *testing.T) 
 // GitHub's token are optional and raise the rate limit - so attaching one is a
 // legitimate user action that a restart must not silently revoke.
 func TestSeedConnectionsPreservesUserAttachedCredential(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir, gitHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir, gitHubRegistrantModelDir(t))
 	log := newSeedTestLogger(t)
 
 	SeedConnections(log, db, regm)
@@ -486,7 +510,7 @@ func TestSeedConnectionsPreservesUserAttachedCredential(t *testing.T) {
 // kind that ships a definition but that Meshery does not itself source content
 // through must not be materialized as an empty, endpoint-less row.
 func TestSeedConnectionsSkipsKindsWithoutRegistrants(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir, gitHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir, gitHubRegistrantModelDir(t))
 
 	SeedConnections(newSeedTestLogger(t), db, regm)
 
@@ -516,7 +540,7 @@ func TestSeedConnectionsSkipsKindsWithoutRegistrants(t *testing.T) {
 // never be seeded, and its registrant must be left exactly as registration
 // wrote it.
 func TestSeedConnectionsSkipsKubernetesRegistrant(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir)
 
 	registerRegistrant(t, db, "kubernetes", entity.Model)
 
@@ -549,7 +573,7 @@ func TestSeedConnectionsSkipsKubernetesRegistrant(t *testing.T) {
 // no credential, so the registrant rule is the only thing standing between a
 // request body and a system-owned, endpoint-less Grafana connection.
 func TestSeedConnectionsIgnoresConnectionDefinitionOnlyRegistrant(t *testing.T) {
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir, artifactHubRegistrantModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t), artifactHubRegistrantModelDir)
 
 	registerRegistrant(t, db, "grafana", entity.ConnectionDefinition)
 
@@ -786,7 +810,7 @@ func TestSeedConnectionsToleratesMissingDependencies(t *testing.T) {
 	log := newSeedTestLogger(t)
 	SeedConnections(log, nil, nil)
 
-	db, regm := seedTestRegistry(t, mesheryCoreModelDir)
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t))
 	SeedConnections(log, db, nil)
 	SeedConnections(log, nil, regm)
 }

--- a/server/models/testdata/artifacthub-registrant-model-owned/components/TestComponent.json
+++ b/server/models/testdata/artifacthub-registrant-model-owned/components/TestComponent.json
@@ -1,0 +1,35 @@
+{
+  "id": "b3f5c1e2-0000-4000-8000-000000000002",
+  "schemaVersion": "components.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "displayName": "Test Component",
+  "description": "Test-only component. Registration silently skips a model with no components or relationships, so this fixture ships one. Its content is irrelevant to the test; only the parent model's `artifacthub` registrant matters.",
+  "format": "JSON",
+  "model": {
+    "id": "b3f5c1e2-0000-4000-8000-000000000001",
+    "schemaVersion": "models.meshery.io/v1beta1",
+    "version": "v1.0.0",
+    "name": "meshery-test-artifacthub-registrant",
+    "registrant": {
+      "kind": "artifacthub"
+    }
+  },
+  "component": {
+    "version": "meshery.test/v1",
+    "kind": "TestComponent",
+    "schema": "{\"type\":\"object\",\"properties\":{}}"
+  },
+  "capabilities": [],
+  "styles": {
+    "primaryColor": "#00b39f",
+    "shape": "circle",
+    "svgColor": "",
+    "svgWhite": ""
+  },
+  "metadata": {
+    "isAnnotation": false,
+    "isNamespaced": false,
+    "published": false
+  },
+  "status": "enabled"
+}

--- a/server/models/testdata/artifacthub-registrant-model-owned/model.json
+++ b/server/models/testdata/artifacthub-registrant-model-owned/model.json
@@ -1,0 +1,32 @@
+{
+  "id": "b3f5c1e2-0000-4000-8000-000000000011",
+  "schemaVersion": "models.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "name": "meshery-test-artifacthub-registrant-owned",
+  "displayName": "Meshery Test Artifact Hub Registrant (owned variant)",
+  "description": "Test-only fixture. A second model published under the Artifact Hub registrant whose `registrant` blob carries `user_id`/`credential_id`/`deleted_at`. Because a registrant Connection's id is a content hash of the whole blob, this hashes to a different row than artifacthub-registrant-model - reproducing the non-uniform shipped blobs (meshery/meshery#20950) so the canonical-pick test sees two artifacthub registrant rows.",
+  "status": "enabled",
+  "registrant": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "Artifact Hub",
+    "credential_id": "00000000-0000-0000-0000-000000000000",
+    "type": "registry",
+    "sub_type": "",
+    "kind": "artifacthub",
+    "status": "discovered",
+    "user_id": "00000000-0000-0000-0000-000000000000",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "deleted_at": "0001-01-01T00:00:00Z"
+  },
+  "category": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "Uncategorized"
+  },
+  "model": {
+    "version": "1.0.0"
+  },
+  "metadata": {
+    "isAnnotation": false
+  }
+}

--- a/server/models/testdata/artifacthub-registrant-model/components/TestComponent.json
+++ b/server/models/testdata/artifacthub-registrant-model/components/TestComponent.json
@@ -1,0 +1,35 @@
+{
+  "id": "b3f5c1e2-0000-4000-8000-000000000002",
+  "schemaVersion": "components.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "displayName": "Test Component",
+  "description": "Test-only component. Registration silently skips a model with no components or relationships, so this fixture ships one. Its content is irrelevant to the test; only the parent model's `artifacthub` registrant matters.",
+  "format": "JSON",
+  "model": {
+    "id": "b3f5c1e2-0000-4000-8000-000000000001",
+    "schemaVersion": "models.meshery.io/v1beta1",
+    "version": "v1.0.0",
+    "name": "meshery-test-artifacthub-registrant",
+    "registrant": {
+      "kind": "artifacthub"
+    }
+  },
+  "component": {
+    "version": "meshery.test/v1",
+    "kind": "TestComponent",
+    "schema": "{\"type\":\"object\",\"properties\":{}}"
+  },
+  "capabilities": [],
+  "styles": {
+    "primaryColor": "#00b39f",
+    "shape": "circle",
+    "svgColor": "",
+    "svgWhite": ""
+  },
+  "metadata": {
+    "isAnnotation": false,
+    "isNamespaced": false,
+    "published": false
+  },
+  "status": "enabled"
+}

--- a/server/models/testdata/artifacthub-registrant-model/model.json
+++ b/server/models/testdata/artifacthub-registrant-model/model.json
@@ -1,0 +1,31 @@
+{
+  "id": "b3f5c1e2-0000-4000-8000-000000000001",
+  "schemaVersion": "models.meshery.io/v1beta1",
+  "version": "v1.0.0",
+  "name": "meshery-test-artifacthub-registrant",
+  "displayName": "Meshery Test Artifact Hub Registrant",
+  "description": "Test-only fixture. A minimal model published under the Artifact Hub registrant, registered by server/handlers/connections_seeded_api_test.go so that an `artifacthub` registrant Connection exists without depending on the shipped model registry (models/), which the recommended sparse clone excludes. Only the `registrant` blob is significant; the seeded Connection's identity comes from meshery-core's ArtifactHubConnection definition.",
+  "status": "enabled",
+  "registrant": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "Artifact Hub",
+    "type": "registry",
+    "sub_type": "",
+    "kind": "artifacthub",
+    "status": "discovered",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "deleted_at": null,
+    "schemaVersion": ""
+  },
+  "category": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "Uncategorized"
+  },
+  "model": {
+    "version": "1.0.0"
+  },
+  "metadata": {
+    "isAnnotation": false
+  }
+}


### PR DESCRIPTION
## Description

A full clone of `meshery/meshery` is on the order of **tens of gigabytes and keeps growing**, driven mostly by two directories that are unnecessary for the vast majority of contributions:

- **`models/`** - the generated Meshery Model registry (400+ models).
- **`docs/static/v*/`** - archived snapshots of previously released documentation.

This PR documents a **sparse-clone workflow** so contributors can clone lean while keeping full commit history and everything needed to build the server, UI, CLI, and current docs.

### What's added

- **`README.md`** - a concise "Cloning this repository (sparse clone recommended)" subsection under Contributing, with the recommended command and a link to the full guide.
- **`docs/content/en/project/contributing/_index.md`** - a full "Cloning the Repository" section: why the repo is large, the blobless partial clone + `git sparse-checkout` recipe, an explanation of the `!/models/*` re-include mechanics, how to re-include an excluded directory on demand, and a Git-version note.

### Sparse rules documented

- Exclude all of `models/` **except** `meshery-core` and `kubernetes`.
- Exclude archived docs snapshots (`docs/static/v0.8`), keeping only the latest (`docs/static/v0.9`).

```bash
git clone --no-checkout --filter=blob:none https://github.com/meshery/meshery.git
cd meshery
git sparse-checkout set --no-cone \
  '/*' \
  '!/models/*' '/models/meshery-core/' '/models/kubernetes/' \
  '!/docs/static/v0.8/'
git checkout master
```

### Measured impact

| | Full clone | Sparse clone (this workflow) |
| --- | --- | --- |
| On-disk footprint | ~19 GB | ~1.7 GB |
| `models/` entries | 478 | 2 (`meshery-core`, `kubernetes`) |
| Archived docs snapshots | `v0.8` + `v0.9` | `v0.9` only |
| Commit history / `git log` / `blame` | full | full |

The documented command block was validated end-to-end against a live clone before submitting.

### Notes for reviewers

- Docs-only change; no functional impact on the server, UI, CLI, or docs build.
- `--filter=blob:none` makes it a partial clone, so Git fetches any excluded file on demand if a contributor ever checks one out - nothing is permanently lost.
- As new archived docs snapshots are added, contributors keep the newest and add a `!` line for each older version (noted inline in the guide).

---

## Follow-up: making the default test suite sparse-clone-safe

Review on this PR (Copilot) correctly flagged that some default Go tests read model fixtures the recommended sparse checkout excludes, so `go test ./...` on a sparse clone would hit missing-file failures. Fixed so the sparse-clone guidance actually holds:

**Tests updated** (`[Server]` commit):
- `server/handlers/connections_seeded_api_test.go`
- `server/models/seed_connections_test.go` (the same latent dependency - found via a recurrence scan, not named in the review)

**What changed:**
- Use only models a sparse clone keeps: `kubernetes` supplies the `github` registrant (replacing `azure-operational-insights`).
- `meshery-core` carries the connection *definitions* but its registrant is `meshery`, **not** `artifacthub` - so it can't stand in for the Artifact Hub registrant. A minimal Artifact Hub registrant model is committed under each package's `testdata/` (replacing `kubevault`), with a `user_id` variant (replacing `couchbase-operator`) for the canonical-pick test's two-registrant case (#20950). This preserves the full Artifact Hub + GitHub coverage rather than dropping the Artifact Hub half.
- Model version directories are now resolved by glob instead of pinned, so the tests also stop breaking when the model registry is re-synced.

**Verification:** moved the three excluded model dirs aside (simulating a sparse clone) and ran `server/handlers` + `server/models` - both pass. `go vet`, `gofmt`, and `golangci-lint` are all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cloning the repository with a lightweight, blobless checkout.
  * Documented how to exclude large model files and archived documentation while retaining current project content.
  * Added instructions for restoring excluded files or disabling sparse checkout, including Git version requirements.
  * Linked contributors to the contributing guide for additional repository setup information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->