### PR TITLE
[CI] Split mesheryctl QA results dirs; document Kubernetes Connections tagging contract

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Sync results with qa
         if: ${{ !cancelled() && github.event_name == 'push' }}
         working-directory: qa
-        run: make mesheryctl-results-sync MESHERYCTL_RESULTS_PATH=../mesheryctl-allure-results
+        run: make mesheryctl-unit-results-sync MESHERYCTL_UNIT_RESULTS_PATH=../mesheryctl-allure-results
 
       - name: Pull latest qa changes
         if: ${{ !cancelled() && github.event_name == 'push' }}

--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'push' && matrix.publish_to_qa == true }}
         working-directory: qa
         run: |
-          make mesheryctl-results-sync MESHERYCTL_RESULTS_PATH=../mesheryctl/allure-results
+          make mesheryctl-bats-results-sync MESHERYCTL_BATS_RESULTS_PATH=../mesheryctl/allure-results
 
       - name: Commit & push to qa
         if: ${{ !cancelled() && github.event_name == 'push' && matrix.publish_to_qa == true }}

--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -74,6 +74,30 @@ Collectively, Meshery repositories will generally have CI workflow for commits a
 - Helm charts lint (helm)
 - Helm charts release, tag and push(stefanprodan/helm-gh-pages@master)
 
+### Test result reporting (QA dashboard)
+
+Test results from across the Meshery ecosystem are published as [Allure](https://allurereport.org/) reports on the QA dashboard at [qa.meshery.io](https://qa.meshery.io). CI in each repository converts its test output to Allure results and commits them to the [`meshery/qa`](https://github.com/meshery/qa) repository, which regenerates and deploys the dashboard via GitHub Pages. Each report on the dashboard (Meshery, Mesheryctl, Kubernetes Connections, and extension reports) is a filtered view over one shared pool of results, selected by the **labels** on each result.
+
+Result labels are injected at each test source:
+
+- **UI (Playwright):** global labels via `ALLURE_LABEL_<name>=<value>` (see `ui/package.json`), Playwright `@tag`s (surfaced as `tag` labels), and per-test `allure.label()` from `allure-js-commons`.
+- **CLI / server (Go, BATS):** the `ALLURE_LABELS="key=value,..."` env var consumed by `mesheryctl/bats-to-allure.js` and `server/gotest-to-allure.js`.
+
+#### Kubernetes Connections tagging contract
+
+The **Kubernetes Connections** report aggregates connection tests from both the UI and the CLI. A connection test - identified from the [Meshery Test Plan](https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit) - MUST carry these labels (this is the shared, cross-client contract; use these exact names so both clients group together and the report filter matches):
+
+| Label | Source (Test Plan) | Values | Purpose |
+| --- | --- | --- | --- |
+| `epic` | - | `Kubernetes Connections` (constant) | Report filter key |
+| `componentUnderTest` | column C | e.g. `Kubernetes` | Fallback filter key; component grouping |
+| `testId` | column A ("Test #") | `TC-<n>` | Stable per-behavior id |
+| `client` | - | `UI` or `CLI` | Groups results by which client exercised the behavior |
+
+The report keys on `epic` (falling back to `componentUnderTest`), so tagged tests still appear in their `project` report (Meshery or Mesheryctl); the Connections report is an additional lens, not a relocation.
+
+> The `mesheryctl` BATS e2e results and Go unit results are committed to separate directories (`mesheryctl-bats-results/` and `mesheryctl-unit-results/`) in `meshery/qa` and merged at report-build time, so the two feeders no longer overwrite each other.
+
 ### UI Build System
 
 Meshery UI (`/ui`) and Provider UI (`/provider-ui`) are built using [Next.js](https://nextjs.org/) with [SWC](https://swc.rs/) (Speedy Web Compiler) as the default compiler.


### PR DESCRIPTION
## Intent

Ship the `meshery` half of a two-repo change that adds a dedicated **Kubernetes Connections** report to the QA dashboard ([qa.meshery.io](https://qa.meshery.io) / [`meshery/qa`](https://github.com/meshery/qa)). This PR does two things:

1. **Fix a real results-clobber bug.** The `mesheryctl` BATS e2e workflow (`mesheryctl-e2e.yaml`) and the Go unit workflow (`go-testing-ci.yml`) both synced their Allure results into qa's single `mesheryctl-results/` directory via the `results-sync` make target, which `rm -rf`s its destination. So whichever workflow committed to qa last **wiped the other's results** - and CLI Kubernetes connection results (from BATS) could be erased by a later unit-test sync.
2. **Document the shared connection-tagging contract** so the UI and CLI test lanes (separate PRs implementing the actual per-test label injection) tag connection tests with identical labels and the new report can group/filter them.

## What Changed

- `.github/workflows/mesheryctl-e2e.yaml`: BATS e2e now syncs via `make mesheryctl-bats-results-sync MESHERYCTL_BATS_RESULTS_PATH=...` (was `mesheryctl-results-sync`).
- `.github/workflows/go-testing-ci.yml`: Go unit now syncs via `make mesheryctl-unit-results-sync MESHERYCTL_UNIT_RESULTS_PATH=...` (was `mesheryctl-results-sync`).
- `docs/content/en/project/contributing/build-and-release.md`: new "Test result reporting (QA dashboard)" subsection documenting the Allure label-injection points per client and the **Kubernetes Connections tagging contract** - `epic="Kubernetes Connections"`, `componentUnderTest` (Test Plan col C), `testId=TC-<n>` (Test Plan col A), `client=UI|CLI`.

Source paths written by each converter are unchanged; only the make-target and path-var names changed. Test specs and the `bats-to-allure.js` / `gotest-to-allure.js` converters are intentionally **not** touched here (owned by the sibling UI/CLI lanes). `categories.json` is intentionally not added (Allure applies categories report-wide, so it belongs in a separate deliberate change).

## ⚠️ Depends on meshery/qa#80 - merge order matters

This PR points both workflows at **new** make targets (`mesheryctl-bats-results-sync`, `mesheryctl-unit-results-sync`) that are added in **[meshery/qa#80](https://github.com/meshery/qa/pull/80)**. **meshery/qa#80 MUST be merged before this PR.** If this PR merges first, the next push to `master` runs a make target that does not yet exist in qa's `master`, and the QA-sync step fails. (qa#80 keeps the old `mesheryctl-results-sync` as a back-compat alias, which covers only the old name - it does not protect against this PR landing first.)

## Risk Assessment

✅ Low. Three hunks: two CI workflow one-liners and one docs section. The only material risk is the cross-repo merge-order dependency called out above; sequencing qa#80 first removes it.

## Testing

Validated through the local no-mistakes pipeline: **review, test, document, and lint all passed** at commit `ae82770a`. The review step independently verified the workflow edits are internally consistent (converter output paths still match the sync source paths) and that every docs claim is accurate (`bats-to-allure.js` and `gotest-to-allure.js` both read `ALLURE_LABELS`; `ui/package.json` uses `ALLURE_LABEL_<name>=<value>`). The companion qa#80 change was verified end-to-end by running `make report-build` against synthetic results: the new "Kubernetes Connections" report contained exactly the UI + CLI connection tests grouped by `client`, while those tests still appeared in their own Meshery/Mesheryctl reports and a non-connection test was excluded. No rendered UI surface applies to this PR.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

- ✅ review / test / document / lint passed at `ae82770a`.
- ⚠️ review finding (accepted): the two workflows call make targets that live in meshery/qa#80; sequencing qa#80 first is required (see the merge-order note above). No code change - the coordination is handled by merge order.
- The pipeline's own push/PR/CI steps could not run in this environment (the daemon's push identity lacks upstream access), so this PR was pushed from a fork and opened manually; the change is the exact validated commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for publishing Allure test results to the QA dashboard.
  * Documented labeling requirements for UI, CLI, server, and Kubernetes Connections tests.
  * Clarified separate result locations for BATS and Go unit tests.

* **Bug Fixes**
  * Corrected automated synchronization of mesheryctl BATS and Go unit-test results using their appropriate result paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->