### PR TITLE
[mesheryctl] K8s Connection e2e coverage + TAP->Allure skip fix + Test-Plan traceability

### DIFF
--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -79,12 +79,30 @@ jobs:
         run: make build
         shell: bash
         working-directory: ./mesheryctl
+      - name: Test TAP-to-Allure converter
+        run: node --test bats-to-allure.test.js
+        shell: bash
+        working-directory: ./mesheryctl
       - name: Start Meshery
         run: |
           # Start Meshery with with verbose logging for detailed output in case of failures
           ./mesheryctl system start --platform ${{ matrix.platform }} --skip-browser --skip-update --verbose
         shell: bash
         working-directory: ./mesheryctl
+      - name: Enable operator-mode MeshSync for controller diagnostics
+        # The controllers-diagnostics suite (009-diagnostics) needs an in-cluster
+        # broker: operator-mode MeshSync plus a deterministic (unmanaged) broker
+        # port-forward so the broker_unreachable baseline is real. Inject those
+        # server env vars into the in-cluster deployment and wait for the rollout.
+        # Without this the suite self-skips (embedded MeshSync has no broker).
+        # The other suites are unaffected by the MeshSync deployment mode.
+        run: |
+          kubectl -n meshery rollout status deployment/meshery --timeout=180s
+          kubectl -n meshery set env deployment/meshery \
+            MESHSYNC_DEFAULT_DEPLOYMENT_MODE=operator \
+            MESHERY_MANAGED_BROKER_PORTFORWARD=false
+          kubectl -n meshery rollout status deployment/meshery --timeout=180s
+        shell: bash
       - name: Run mesheryctl end2end tests
         run: |
           bash run_tests.bash | tee bats.tap

--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -260,6 +260,23 @@ It must follow this naming convention
 }
 ```
 
+##### Traceability Tokens (optional)
+
+A test that maps to a row in the [Meshery Test Plan](https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit?usp=sharing) may prefix its `@test` title with bracketed tokens so the TAP-to-Allure converter emits traceability labels on the report:
+
+- `[TC-<n>]` - the Test Plan "Test #" (column A), emitted as the `testId` label and a matching filter tag.
+- `[cut=<component>]` - the Component-Under-Test (column C), e.g. `[cut=Kubernetes Connection]`.
+
+The tokens are stripped from the displayed test name, so the naming convention above still applies to the remainder:
+
+```bash
+@test "[TC-1015][cut=Kubernetes Connection] mesheryctl connection create --type minikube creates a new connection" {
+  ... test implementation ...
+}
+```
+
+The full token-to-label mapping (including how the report `epic` is derived from the component) is documented in the header comment of [`mesheryctl/bats-to-allure.js`](https://github.com/meshery/meshery/blob/master/mesheryctl/bats-to-allure.js), the single injection point for this contract. Do not restate the mapping here; keep it in sync there.
+
 #### Test Data
 
 If a command requries a specific id, name or any predefined value ensure that the data is created by your test or another test beforehand. Do not rely on external or uncontrolled data as it will lead to unexpected results.

--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -270,7 +270,7 @@ A test that maps to a row in the [Meshery Test Plan](https://docs.google.com/spr
 The tokens are stripped from the displayed test name, so the naming convention above still applies to the remainder:
 
 ```bash
-@test "[TC-1015][cut=Kubernetes Connection] mesheryctl connection create --type minikube creates a new connection" {
+@test "[TC-1013][cut=Kubernetes Connection] mesheryctl connection create --type minikube creates a new connection" {
   ... test implementation ...
 }
 ```

--- a/mesheryctl/Makefile
+++ b/mesheryctl/Makefile
@@ -162,6 +162,11 @@ e2e: build e2e-libs
 	rm -rf $(TEMP_DATA_DIR) \
 	echo "\n\n#### MESHERYCTL END-TO-END TESTING - DONE ####\n\n"
 
+## Unit-test the TAP-to-Allure converter (skip handling + traceability labels).
+.PHONY: test-converter
+test-converter:
+	node --test bats-to-allure.test.js
+
 ## Build mesheryctl and run end-to-end tests.
 e2e-ci: e2e
 	ALLURE_LABELS="epic=MesheryCtl,type=e2e,env=ci" node bats-to-allure.js tests/e2e/bats.tap

--- a/mesheryctl/bats-to-allure.js
+++ b/mesheryctl/bats-to-allure.js
@@ -1,16 +1,43 @@
 #!/usr/bin/env node
 
+// bats-to-allure.js — convert a BATS TAP report into Allure result JSON files.
+//
+// Beyond the raw TAP → Allure mapping this converter is the single injection
+// point for the Kubernetes Connection test-plan traceability contract shared
+// with the UI lane and the meshery/qa "Kubernetes Connections" report:
+//
+//   testId            = TC-<n>   (Test Plan "Test #", col A)   [title token: [TC-<n>]]
+//   componentUnderTest = <col C value>                          [title token: [cut=<value>]]
+//   epic              = "Kubernetes Connections"  (report bucket) [token [epic=<v>] or derived from cut]
+//   client            = "CLI"    (this converter only ever sees mesheryctl results)
+//   tag               = TC-<n>   (chip / filter passthrough of the testId)
+//
+// A BATS test opts in by prefixing its `@test` title with leading bracket
+// tokens, e.g.
+//   @test "[TC-1042][cut=Kubernetes Connection] connection create ... creates a connection" { ... }
+// The tokens are stripped from the displayed Allure name.
+
 const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
 
 const ALLURE_RESULTS_DIR = "allure-results";
 
-// TAP regex patterns
+// TAP regex patterns.
 const TAP_TEST_RE = /^(ok|not ok)\s+\d+\s+(.*)/;
 const TAP_DIAGNOSTIC_RE = /^\s*#\s?(.*)/;
+// TAP directive appended to a test line, e.g. "... # skip minikube not installed".
+const TAP_SKIP_DIRECTIVE_RE = /\s*#\s*skip\b\s*(.*)$/i;
 
-// Parse labels from env: key=value,key=value
+// componentUnderTest values (Test Plan col C) that belong to the
+// "Kubernetes Connections" report epic. Kept in lockstep with the qa
+// allurerc.mjs "Kubernetes Connections" plugin filter (meshery/qa). When a
+// test carries one of these as its cut and sets no explicit [epic=...], the
+// converter buckets it under the connection epic so results group correctly.
+const CONNECTION_COMPONENTS = new Set(["kubernetes connection"]);
+const CONNECTION_EPIC = "Kubernetes Connections";
+
+// Parse suite-wide labels from env: ALLURE_LABELS="key=value,key=value".
 function parseExtraLabels() {
   const raw = process.env.ALLURE_LABELS;
   if (!raw) return [];
@@ -38,14 +65,100 @@ function tapStatusToAllure(status) {
   return status === "ok" ? "passed" : "failed";
 }
 
-function createAllureResult({
-  name,
-  status,
-  start,
-  stop,
-  details,
-  extraLabels
-}) {
+// parseTitleTokens splits leading "[...]" tokens off a BATS test title and maps
+// them to Allure labels per the traceability contract above. Returns the
+// display name (tokens stripped) and the derived per-test labels.
+function parseTitleTokens(rawName) {
+  const labels = [];
+  let name = rawName;
+  let cut = null;
+  let epic = null;
+
+  // Consume consecutive leading [ ... ] tokens.
+  const tokenRe = /^\s*\[([^\]]*)\]/;
+  let match;
+  while ((match = tokenRe.exec(name)) !== null) {
+    const token = match[1].trim();
+    name = name.slice(match[0].length);
+
+    if (/^TC-/i.test(token)) {
+      // [TC-<n>] — the Test Plan Test #. Emit both testId and a tag.
+      const testId = token;
+      labels.push({ name: "testId", value: testId });
+      labels.push({ name: "tag", value: testId });
+      continue;
+    }
+
+    const eq = token.indexOf("=");
+    if (eq === -1) {
+      // Unknown bare token — surface it as a tag rather than dropping it.
+      if (token) labels.push({ name: "tag", value: token });
+      continue;
+    }
+
+    const key = token.slice(0, eq).trim();
+    const value = token.slice(eq + 1).trim();
+    if (!key || !value) continue;
+
+    switch (key.toLowerCase()) {
+      case "cut":
+        cut = value;
+        labels.push({ name: "componentUnderTest", value });
+        break;
+      case "epic":
+        epic = value;
+        labels.push({ name: "epic", value });
+        break;
+      case "client":
+        labels.push({ name: "client", value });
+        break;
+      default:
+        labels.push({ name: key, value });
+    }
+  }
+
+  // Derive the connection epic from cut when not set explicitly, mirroring the
+  // qa "Kubernetes Connections" plugin's componentUnderTest fallback.
+  if (!epic && cut && CONNECTION_COMPONENTS.has(cut.toLowerCase())) {
+    labels.push({ name: "epic", value: CONNECTION_EPIC });
+  }
+
+  return { name: name.trim(), labels };
+}
+
+// parseTestLine turns a single TAP "ok/not ok" line into a normalized record:
+// status (passed|failed|skipped), the clean display name, any skip reason, and
+// the per-test traceability labels parsed from the title tokens.
+function parseTestLine(rawStatus, rawName) {
+  let status = tapStatusToAllure(rawStatus);
+  let name = rawName;
+  let skipReason = null;
+
+  const skipMatch = name.match(TAP_SKIP_DIRECTIVE_RE);
+  if (skipMatch) {
+    // A skipped BATS test is emitted by TAP as "ok N <name> # skip <reason>".
+    // Without this it was reported as "passed" — masking never-run tests.
+    status = "skipped";
+    skipReason = skipMatch[1].trim();
+    name = name.slice(0, skipMatch.index);
+  }
+
+  const { name: cleanName, labels } = parseTitleTokens(name);
+  return { status, name: cleanName, skipReason, labels };
+}
+
+function baseLabels(extraLabels) {
+  return [
+    { name: "framework", value: "bats" },
+    { name: "language", value: "bash" },
+    { name: "project", value: "mesheryctl" },
+    // This converter only ever processes mesheryctl (CLI) results.
+    { name: "client", value: "CLI" },
+    ...extraLabels
+  ];
+}
+
+function createAllureResult({ name, status, start, stop, details, labels }) {
   return {
     uuid: uuid(),
     name,
@@ -54,12 +167,7 @@ function createAllureResult({
     start,
     stop,
     statusDetails: details ? { message: details } : {},
-    labels: [
-      { name: "framework", value: "bats" },
-      { name: "language", value: "bash" },
-      { name: "project" , value: "mesheryctl" },
-      ...extraLabels
-    ]
+    labels
   };
 }
 
@@ -71,58 +179,66 @@ function convertTapToAllure(tapFile) {
 
   const extraLabels = parseExtraLabels();
 
-  let diagnostics = [];
+  const results = [];
+  let current = null; // the most recently emitted result — trailing diagnostics attach here.
   let testCount = 0;
 
   for (const line of lines) {
     const trimmed = line.trimEnd();
 
-    // Diagnostics
-    const diagMatch = trimmed.match(TAP_DIAGNOSTIC_RE);
-    if (diagMatch) {
-      diagnostics.push(diagMatch[1]);
+    const testMatch = trimmed.match(TAP_TEST_RE);
+    if (testMatch) {
+      testCount++;
+      const [, rawStatus, rawName] = testMatch;
+      const parsed = parseTestLine(rawStatus, rawName);
+
+      const start = Date.now();
+      const result = createAllureResult({
+        name: parsed.name,
+        status: parsed.status,
+        start,
+        stop: start + 1,
+        details: parsed.skipReason || null,
+        labels: [...baseLabels(extraLabels), ...parsed.labels]
+      });
+
+      results.push(result);
+      current = result;
       continue;
     }
 
-    // Test line
-    const testMatch = trimmed.match(TAP_TEST_RE);
-    if (!testMatch) continue;
+    // Diagnostic lines describe the test that PRECEDES them (e.g. a failing
+    // test's stack in BATS TAP), so attach them to the current result.
+    const diagMatch = trimmed.match(TAP_DIAGNOSTIC_RE);
+    if (diagMatch && current) {
+      const existing = current.statusDetails.message;
+      current.statusDetails.message = existing
+        ? `${existing}\n${diagMatch[1]}`
+        : diagMatch[1];
+    }
+  }
 
-    testCount++;
-
-    const [, rawStatus, name] = testMatch;
-    const status = tapStatusToAllure(rawStatus);
-
-    const start = Date.now();
-    const stop = start + 1;
-
-    const result = createAllureResult({
-      name,
-      status,
-      start,
-      stop,
-      details: diagnostics.length ? diagnostics.join("\n") : null,
-      extraLabels
-    });
-
-    diagnostics = [];
-
-    const outputPath = path.join(
-      ALLURE_RESULTS_DIR,
-      `${result.uuid}-result.json`
-    );
-
+  for (const result of results) {
+    const outputPath = path.join(ALLURE_RESULTS_DIR, `${result.uuid}-result.json`);
     fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
   }
 
   console.log(`Converted ${testCount} BATS tests to Allure results.`);
+  return results;
 }
+
+module.exports = {
+  parseTitleTokens,
+  parseTestLine,
+  convertTapToAllure,
+  CONNECTION_EPIC
+};
 
 // CLI
-if (process.argv.length !== 3) {
-  console.error("Usage: node bats-to-allure.js <bats-report.tap>");
-  process.exit(1);
+if (require.main === module) {
+  if (process.argv.length !== 3) {
+    console.error("Usage: node bats-to-allure.js <bats-report.tap>");
+    process.exit(1);
+  }
+  convertTapToAllure(process.argv[2]);
 }
-
-convertTapToAllure(process.argv[2]);
-

--- a/mesheryctl/bats-to-allure.js
+++ b/mesheryctl/bats-to-allure.js
@@ -67,8 +67,11 @@ function tapStatusToAllure(status) {
 
 // parseTitleTokens splits leading "[...]" tokens off a BATS test title and maps
 // them to Allure labels per the traceability contract above. Returns the
-// display name (tokens stripped) and the derived per-test labels.
-function parseTitleTokens(rawName) {
+// display name (tokens stripped) and the derived per-test labels. extraLabels
+// are the suite-wide labels (from ALLURE_LABELS) that will also be attached, so
+// the cut->epic derivation can defer to a suite-wide epic instead of emitting a
+// duplicate.
+function parseTitleTokens(rawName, extraLabels = []) {
   const labels = [];
   let name = rawName;
   let cut = null;
@@ -117,9 +120,12 @@ function parseTitleTokens(rawName) {
     }
   }
 
-  // Derive the connection epic from cut when not set explicitly, mirroring the
-  // qa "Kubernetes Connections" plugin's componentUnderTest fallback.
-  if (!epic && cut && CONNECTION_COMPONENTS.has(cut.toLowerCase())) {
+  // Derive the connection epic from cut only when no epic is set by any source
+  // — neither a title [epic=...] token nor a suite-wide ALLURE_LABELS epic —
+  // mirroring the qa "Kubernetes Connections" plugin's componentUnderTest
+  // fallback. Emitting a second epic here would file the test under two epics.
+  const epicAlreadyPresent = epic !== null || extraLabels.some(l => l.name === "epic");
+  if (!epicAlreadyPresent && cut && CONNECTION_COMPONENTS.has(cut.toLowerCase())) {
     labels.push({ name: "epic", value: CONNECTION_EPIC });
   }
 
@@ -129,7 +135,7 @@ function parseTitleTokens(rawName) {
 // parseTestLine turns a single TAP "ok/not ok" line into a normalized record:
 // status (passed|failed|skipped), the clean display name, any skip reason, and
 // the per-test traceability labels parsed from the title tokens.
-function parseTestLine(rawStatus, rawName) {
+function parseTestLine(rawStatus, rawName, extraLabels = []) {
   let status = tapStatusToAllure(rawStatus);
   let name = rawName;
   let skipReason = null;
@@ -143,7 +149,7 @@ function parseTestLine(rawStatus, rawName) {
     name = name.slice(0, skipMatch.index);
   }
 
-  const { name: cleanName, labels } = parseTitleTokens(name);
+  const { name: cleanName, labels } = parseTitleTokens(name, extraLabels);
   return { status, name: cleanName, skipReason, labels };
 }
 
@@ -190,7 +196,7 @@ function convertTapToAllure(tapFile) {
     if (testMatch) {
       testCount++;
       const [, rawStatus, rawName] = testMatch;
-      const parsed = parseTestLine(rawStatus, rawName);
+      const parsed = parseTestLine(rawStatus, rawName, extraLabels);
 
       const start = Date.now();
       const result = createAllureResult({

--- a/mesheryctl/bats-to-allure.js
+++ b/mesheryctl/bats-to-allure.js
@@ -164,6 +164,33 @@ function baseLabels(extraLabels) {
   ];
 }
 
+// Label names that may legitimately appear more than once on one result.
+// Everything else is single-valued and must not be duplicated (a duplicate
+// e.g. `client` or `epic` label breaks downstream report filtering).
+const MULTI_VALUED_LABELS = new Set(["tag"]);
+
+// dedupeLabels collapses single-valued labels so the LAST occurrence wins,
+// while preserving multi-valued labels (e.g. `tag`). Precedence therefore runs
+// base -> ALLURE_LABELS -> per-test title tokens (most specific wins), which is
+// why the base `client=CLI` is overridable by a `[client=...]` token.
+function dedupeLabels(labels) {
+  const indexByName = new Map();
+  const out = [];
+  for (const label of labels) {
+    if (MULTI_VALUED_LABELS.has(label.name)) {
+      out.push(label);
+      continue;
+    }
+    if (indexByName.has(label.name)) {
+      out[indexByName.get(label.name)] = label; // last value wins, in place
+    } else {
+      indexByName.set(label.name, out.length);
+      out.push(label);
+    }
+  }
+  return out;
+}
+
 function createAllureResult({ name, status, start, stop, details, labels }) {
   return {
     uuid: uuid(),
@@ -205,7 +232,7 @@ function convertTapToAllure(tapFile) {
         start,
         stop: start + 1,
         details: parsed.skipReason || null,
-        labels: [...baseLabels(extraLabels), ...parsed.labels]
+        labels: dedupeLabels([...baseLabels(extraLabels), ...parsed.labels])
       });
 
       results.push(result);
@@ -236,6 +263,7 @@ function convertTapToAllure(tapFile) {
 module.exports = {
   parseTitleTokens,
   parseTestLine,
+  dedupeLabels,
   convertTapToAllure,
   CONNECTION_EPIC
 };

--- a/mesheryctl/bats-to-allure.test.js
+++ b/mesheryctl/bats-to-allure.test.js
@@ -12,6 +12,7 @@ const path = require("node:path");
 const {
   parseTitleTokens,
   parseTestLine,
+  dedupeLabels,
   convertTapToAllure,
   CONNECTION_EPIC
 } = require("./bats-to-allure.js");
@@ -118,6 +119,35 @@ test("ALLURE_LABELS epic is not duplicated by the derived connection epic", () =
     process.chdir(cwd);
     if (prevLabels === undefined) delete process.env.ALLURE_LABELS;
     else process.env.ALLURE_LABELS = prevLabels;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("dedupeLabels collapses single-valued labels (last wins) and keeps tags", () => {
+  const out = dedupeLabels([
+    { name: "client", value: "CLI" },
+    { name: "epic", value: "MesheryCtl" },
+    { name: "client", value: "UI" },   // token override wins
+    { name: "tag", value: "TC-1" },
+    { name: "tag", value: "TC-2" }      // multiple tags preserved
+  ]);
+  assert.deepEqual(out.filter(l => l.name === "client"), [{ name: "client", value: "UI" }]);
+  assert.equal(out.filter(l => l.name === "epic").length, 1);
+  assert.deepEqual(out.filter(l => l.name === "tag").map(l => l.value), ["TC-1", "TC-2"]);
+});
+
+test("a [client=...] token does not produce a duplicate client label", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "b2a-"));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tmp);
+    fs.writeFileSync(path.join(tmp, "s.tap"), "1..1\nok 1 [client=UI] t\n");
+    const [r] = convertTapToAllure(path.join(tmp, "s.tap"));
+    const clients = r.labels.filter(l => l.name === "client");
+    assert.equal(clients.length, 1);
+    assert.equal(clients[0].value, "UI");
+  } finally {
+    process.chdir(cwd);
     fs.rmSync(tmp, { recursive: true, force: true });
   }
 });

--- a/mesheryctl/bats-to-allure.test.js
+++ b/mesheryctl/bats-to-allure.test.js
@@ -60,6 +60,16 @@ test("explicit epic token overrides the derived epic", () => {
   assert.equal(labelValue(labels, "epic"), "Something Else");
 });
 
+test("suite-wide epic (ALLURE_LABELS) suppresses the derived connection epic", () => {
+  const { labels } = parseTitleTokens(
+    "[cut=Kubernetes Connection] t",
+    [{ name: "epic", value: "MesheryCtl" }]
+  );
+  // The suite-wide epic already supplies an epic; deriving would file the test
+  // under two epics.
+  assert.equal(labels.filter(l => l.name === "epic").length, 0);
+});
+
 test("non-connection cut does not get the connection epic", () => {
   const { labels } = parseTitleTokens("[TC-2001][cut=Model] import works");
   assert.equal(labelValue(labels, "componentUnderTest"), "Model");
@@ -83,6 +93,33 @@ test("skip directive and title tokens compose", () => {
   assert.equal(r.skipReason, "no id");
   assert.equal(r.name, "positive delete");
   assert.equal(labelValue(r.labels, "testId"), "TC-1044");
+});
+
+test("ALLURE_LABELS epic is not duplicated by the derived connection epic", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "b2a-"));
+  const cwd = process.cwd();
+  const prevLabels = process.env.ALLURE_LABELS;
+  try {
+    process.chdir(tmp);
+    process.env.ALLURE_LABELS = "epic=MesheryCtl,layer=cli";
+    const tap = [
+      "1..1",
+      "ok 1 [TC-1041][cut=Kubernetes Connection] list works"
+    ].join("\n");
+    fs.writeFileSync(path.join(tmp, "sample.tap"), tap);
+
+    const results = convertTapToAllure(path.join(tmp, "sample.tap"));
+    assert.equal(results.length, 1);
+
+    const epics = results[0].labels.filter(l => l.name === "epic");
+    assert.equal(epics.length, 1);
+    assert.equal(epics[0].value, "MesheryCtl");
+  } finally {
+    process.chdir(cwd);
+    if (prevLabels === undefined) delete process.env.ALLURE_LABELS;
+    else process.env.ALLURE_LABELS = prevLabels;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test("convertTapToAllure end-to-end writes results with base + per-test labels", () => {

--- a/mesheryctl/bats-to-allure.test.js
+++ b/mesheryctl/bats-to-allure.test.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+// Unit tests for bats-to-allure.js. Run with: node --test bats-to-allure.test.js
+// Dependency-free: uses Node's built-in test runner + assert (Node >= 18).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  parseTitleTokens,
+  parseTestLine,
+  convertTapToAllure,
+  CONNECTION_EPIC
+} = require("./bats-to-allure.js");
+
+function labelValue(labels, name) {
+  const found = labels.filter(l => l.name === name).map(l => l.value);
+  return found.length <= 1 ? found[0] : found;
+}
+
+test("skipped tests are reported as skipped, not passed", () => {
+  const r = parseTestLine("ok", "create minikube connection # skip minikube not installed");
+  assert.equal(r.status, "skipped");
+  assert.equal(r.skipReason, "minikube not installed");
+  assert.equal(r.name, "create minikube connection");
+});
+
+test("skip directive matching is case-insensitive and reason is optional", () => {
+  const r = parseTestLine("ok", "some test # SKIP");
+  assert.equal(r.status, "skipped");
+  assert.equal(r.skipReason, "");
+  assert.equal(r.name, "some test");
+});
+
+test("passing and failing statuses are preserved", () => {
+  assert.equal(parseTestLine("ok", "a passes").status, "passed");
+  assert.equal(parseTestLine("not ok", "c fails").status, "failed");
+});
+
+test("TC token yields testId + tag and is stripped from the name", () => {
+  const { name, labels } = parseTitleTokens("[TC-1042] connection create works");
+  assert.equal(name, "connection create works");
+  assert.equal(labelValue(labels, "testId"), "TC-1042");
+  assert.equal(labelValue(labels, "tag"), "TC-1042");
+});
+
+test("cut token maps to componentUnderTest and derives the connection epic", () => {
+  const { name, labels } = parseTitleTokens("[TC-1042][cut=Kubernetes Connection] view works");
+  assert.equal(name, "view works");
+  assert.equal(labelValue(labels, "componentUnderTest"), "Kubernetes Connection");
+  assert.equal(labelValue(labels, "epic"), CONNECTION_EPIC);
+  assert.equal(labelValue(labels, "testId"), "TC-1042");
+});
+
+test("explicit epic token overrides the derived epic", () => {
+  const { labels } = parseTitleTokens("[cut=Kubernetes Connection][epic=Something Else] t");
+  assert.equal(labelValue(labels, "epic"), "Something Else");
+});
+
+test("non-connection cut does not get the connection epic", () => {
+  const { labels } = parseTitleTokens("[TC-2001][cut=Model] import works");
+  assert.equal(labelValue(labels, "componentUnderTest"), "Model");
+  assert.equal(labelValue(labels, "epic"), undefined);
+});
+
+test("client token is honored when present", () => {
+  const { labels } = parseTitleTokens("[client=UI] t");
+  assert.equal(labelValue(labels, "client"), "UI");
+});
+
+test("untagged titles are unchanged and produce no per-test labels", () => {
+  const { name, labels } = parseTitleTokens("connection list works");
+  assert.equal(name, "connection list works");
+  assert.equal(labels.length, 0);
+});
+
+test("skip directive and title tokens compose", () => {
+  const r = parseTestLine("ok", "[TC-1044][cut=Kubernetes Connection] positive delete # skip no id");
+  assert.equal(r.status, "skipped");
+  assert.equal(r.skipReason, "no id");
+  assert.equal(r.name, "positive delete");
+  assert.equal(labelValue(r.labels, "testId"), "TC-1044");
+});
+
+test("convertTapToAllure end-to-end writes results with base + per-test labels", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "b2a-"));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tmp);
+    const tap = [
+      "1..3",
+      "ok 1 [TC-1041][cut=Kubernetes Connection] list works",
+      "ok 2 [TC-1042][cut=Kubernetes Connection] create # skip minikube not installed",
+      "not ok 3 [TC-1043][cut=Kubernetes Connection] delete fails",
+      "# (in test file x.bats, line 3)",
+      "#   `false' failed"
+    ].join("\n");
+    fs.writeFileSync(path.join(tmp, "sample.tap"), tap);
+
+    const results = convertTapToAllure(path.join(tmp, "sample.tap"));
+    assert.equal(results.length, 3);
+
+    const byId = Object.fromEntries(
+      results.map(r => [r.labels.find(l => l.name === "testId").value, r])
+    );
+
+    assert.equal(byId["TC-1041"].status, "passed");
+    assert.equal(byId["TC-1042"].status, "skipped");
+    assert.equal(byId["TC-1042"].statusDetails.message, "minikube not installed");
+    assert.equal(byId["TC-1043"].status, "failed");
+
+    // Every result carries the base contract labels.
+    for (const r of results) {
+      assert.equal(r.labels.find(l => l.name === "client").value, "CLI");
+      assert.equal(r.labels.find(l => l.name === "project").value, "mesheryctl");
+      assert.equal(r.labels.find(l => l.name === "epic").value, CONNECTION_EPIC);
+    }
+
+    // Trailing diagnostics attach to the failing (preceding) test, not the next one.
+    assert.match(byId["TC-1043"].statusDetails.message, /failed/);
+
+    // Results are written to allure-results/.
+    const files = fs.readdirSync(path.join(tmp, "allure-results"));
+    assert.equal(files.filter(f => f.endsWith("-result.json")).length, 3);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/mesheryctl/internal/cli/root/connections/create.go
+++ b/mesheryctl/internal/cli/root/connections/create.go
@@ -292,13 +292,29 @@ func getContexts(configFile string) ([]string, error) {
 	return contextNames, nil
 }
 
-func setContext(configFile, cname string) error {
+// registeredK8sContext is the subset of the server's per-context registration
+// response that the CLI needs. The `/api/system/kubernetes` response
+// (server SaveK8sContextResponse) has no schemas-generated equivalent, so this
+// is a parse-only DTO — not a duplicate of a schemas type.
+type registeredK8sContext struct {
+	Name         string `json:"name"`
+	ConnectionID string `json:"connectionId"`
+}
+
+type saveK8sContextResponse struct {
+	RegisteredContexts []registeredK8sContext `json:"registeredContexts"`
+	ConnectedContexts  []registeredK8sContext `json:"connectedContexts"`
+}
+
+// setContext registers the chosen kubeconfig context with Meshery and returns
+// the id of the connection created (or reused) for that context.
+func setContext(configFile, cname string) (string, error) {
 	contextParams := map[string]string{
 		"contextName": cname,
 	}
 	mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// setContextURL endpoint points to set context
@@ -306,20 +322,46 @@ func setContext(configFile, cname string) error {
 	req, err := utils.UploadFileWithParams(setContextURL, contextParams, utils.ParamName, configFile)
 
 	if err != nil {
-		return utils.ErrUploadFileWithParams(err, configFile)
+		return "", utils.ErrUploadFileWithParams(err, configFile)
 	}
 	res, err := utils.MakeRequest(req)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer func() { _ = res.Body.Close() }()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return utils.ErrReadResponseBody(err)
+		return "", utils.ErrReadResponseBody(err)
 	}
 	utils.Log.Debugf("Set context API response: %s", string(body))
-	return nil
+
+	var response saveK8sContextResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		// The context was still registered; only id resolution is best-effort.
+		utils.Log.Debugf("Unable to parse set context response for connection id: %s", err.Error())
+		return "", nil
+	}
+
+	return connectionIDForContext(response, cname), nil
+}
+
+// connectionIDForContext resolves the connection id for the given context name,
+// preferring an exact name match and falling back to the first entry so the id
+// is still surfaced when the server does not echo the context name.
+func connectionIDForContext(response saveK8sContextResponse, cname string) string {
+	all := append(append([]registeredK8sContext{}, response.ConnectedContexts...), response.RegisteredContexts...)
+	for _, ctx := range all {
+		if ctx.Name == cname && ctx.ConnectionID != "" {
+			return ctx.ConnectionID
+		}
+	}
+	for _, ctx := range all {
+		if ctx.ConnectionID != "" {
+			return ctx.ConnectionID
+		}
+	}
+	return ""
 }
 
 // Given the token path, get the context and set the token in the chosen context
@@ -345,12 +387,18 @@ func setToken() error {
 	}
 	utils.Log.Debugf("Chosen context : %s out of the %d available contexts", chosenCtx, len(contexts))
 
-	err = setContext(utils.ConfigPath, chosenCtx)
+	connectionID, err := setContext(utils.ConfigPath, chosenCtx)
 	if err != nil {
 		return utils.ErrSetKubernetesContext(err)
 	}
 
 	utils.Log.Infof("Token set in context %s", chosenCtx)
+	// Emit the created/reused connection id in a stable, parseable form so it
+	// can be fed to `connection view`/`connection delete` (and captured by e2e
+	// tests). The prefix is a documented contract — do not reformat casually.
+	if connectionID != "" {
+		utils.Log.Infof("connection_id: %s", connectionID)
+	}
 	return nil
 }
 

--- a/mesheryctl/internal/cli/root/connections/create.go
+++ b/mesheryctl/internal/cli/root/connections/create.go
@@ -346,18 +346,16 @@ func setContext(configFile, cname string) (string, error) {
 	return connectionIDForContext(response, cname), nil
 }
 
-// connectionIDForContext resolves the connection id for the given context name,
-// preferring an exact name match and falling back to the first entry so the id
-// is still surfaced when the server does not echo the context name.
+// connectionIDForContext resolves the connection id for the given context name.
+// It returns the id only on an exact name match; when the server does not echo
+// the requested context name it returns "" rather than guessing. A
+// multi-context kubeconfig registers every context, so an arbitrary fallback
+// could surface a different context's id than the one the user selected and
+// mis-target `connection view`/`connection delete`.
 func connectionIDForContext(response saveK8sContextResponse, cname string) string {
 	all := append(append([]registeredK8sContext{}, response.ConnectedContexts...), response.RegisteredContexts...)
 	for _, ctx := range all {
 		if ctx.Name == cname && ctx.ConnectionID != "" {
-			return ctx.ConnectionID
-		}
-	}
-	for _, ctx := range all {
-		if ctx.ConnectionID != "" {
 			return ctx.ConnectionID
 		}
 	}

--- a/mesheryctl/internal/cli/root/connections/create_test.go
+++ b/mesheryctl/internal/cli/root/connections/create_test.go
@@ -1,0 +1,121 @@
+package connections
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestConnectionIDForContext exercises the connection-id resolution that backs
+// the `connection create` -> `connection view`/`connection delete` handoff. The
+// id must be resolved by an EXACT context-name match; a multi-context kubeconfig
+// registers every context in one response, so an arbitrary fallback could return
+// a different context's id than the one the user selected (the "arbitrary
+// conn-id" review fix). When the server does not echo the requested context the
+// function must return "" rather than guess.
+func TestConnectionIDForContext(t *testing.T) {
+	const (
+		minikubeID = "aaaaaaaa-1111-1111-1111-111111111111"
+		otherID    = "bbbbbbbb-2222-2222-2222-222222222222"
+	)
+
+	tests := []struct {
+		name     string
+		response saveK8sContextResponse
+		cname    string
+		want     string
+	}{
+		{
+			name: "exact match in registeredContexts returns its id (positive path)",
+			response: saveK8sContextResponse{
+				RegisteredContexts: []registeredK8sContext{
+					{Name: "minikube", ConnectionID: minikubeID},
+				},
+			},
+			cname: "minikube",
+			want:  minikubeID,
+		},
+		{
+			name: "exact match in connectedContexts returns its id",
+			response: saveK8sContextResponse{
+				ConnectedContexts: []registeredK8sContext{
+					{Name: "minikube", ConnectionID: minikubeID},
+				},
+			},
+			cname: "minikube",
+			want:  minikubeID,
+		},
+		{
+			name: "multi-context response returns the requested context, not the first",
+			response: saveK8sContextResponse{
+				RegisteredContexts: []registeredK8sContext{
+					{Name: "prod-cluster", ConnectionID: otherID},
+					{Name: "minikube", ConnectionID: minikubeID},
+				},
+			},
+			cname: "minikube",
+			want:  minikubeID,
+		},
+		{
+			name: "requested context not echoed returns empty, never an arbitrary id",
+			response: saveK8sContextResponse{
+				RegisteredContexts: []registeredK8sContext{
+					{Name: "prod-cluster", ConnectionID: otherID},
+					{Name: "staging", ConnectionID: "cccccccc-3333-3333-3333-333333333333"},
+				},
+			},
+			cname: "minikube",
+			want:  "",
+		},
+		{
+			name: "name matches but id empty returns empty",
+			response: saveK8sContextResponse{
+				RegisteredContexts: []registeredK8sContext{
+					{Name: "minikube", ConnectionID: ""},
+				},
+			},
+			cname: "minikube",
+			want:  "",
+		},
+		{
+			name:     "empty response returns empty",
+			response: saveK8sContextResponse{},
+			cname:    "minikube",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := connectionIDForContext(tt.response, tt.cname); got != tt.want {
+				t.Fatalf("connectionIDForContext(%q) = %q, want %q", tt.cname, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSaveK8sContextResponseWireContract pins the camelCase wire tags the CLI
+// parses off the server's /api/system/kubernetes response. If a tag drifts to
+// snake_case the id resolution silently returns "" and the create->view/delete
+// handoff regresses without a compile error, so assert the contract directly.
+func TestSaveK8sContextResponseWireContract(t *testing.T) {
+	const body = `{
+		"connectedContexts": [
+			{"name": "minikube", "connectionId": "aaaaaaaa-1111-1111-1111-111111111111"}
+		],
+		"registeredContexts": [
+			{"name": "prod-cluster", "connectionId": "bbbbbbbb-2222-2222-2222-222222222222"}
+		]
+	}`
+
+	var response saveK8sContextResponse
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		t.Fatalf("failed to unmarshal server response: %v", err)
+	}
+
+	if got, want := connectionIDForContext(response, "minikube"), "aaaaaaaa-1111-1111-1111-111111111111"; got != want {
+		t.Fatalf("connectionIDForContext(minikube) = %q, want %q", got, want)
+	}
+	if got, want := connectionIDForContext(response, "prod-cluster"), "bbbbbbbb-2222-2222-2222-222222222222"; got != want {
+		t.Fatalf("connectionIDForContext(prod-cluster) = %q, want %q", got, want)
+	}
+}

--- a/mesheryctl/internal/cli/root/connections/testdata/view.connection.yaml.output.golden
+++ b/mesheryctl/internal/cli/root/connections/testdata/view.connection.yaml.output.golden
@@ -1,13 +1,18 @@
 id: 11111111-1111-1111-1111-111111111111
 name: minikube
+description: null
+url: null
 credentialId: 00000000-9c7a-d4ce-4aab-111111111111
 type: platform
 subType: orchestrator
 kind: kubernetes
+modelReference: null
 metadata:
     deployment_type: ""
     version: v1.34.0
 status: connected
 createdAt: 2026-02-01T10:01:03.577292Z
 updatedAt: 2026-02-01T10:04:43.869192Z
+deletedAt: null
 schemaVersion: ""
+styles: null

--- a/mesheryctl/internal/cli/root/system/config.go
+++ b/mesheryctl/internal/cli/root/system/config.go
@@ -33,6 +33,13 @@ import (
 	meshkitkube "github.com/meshery/meshkit/utils/kubernetes"
 )
 
+// NOTE: `system config` is deprecated in favor of `connection create` (see
+// configCmd.Deprecated below). getContexts/setContext/setToken here duplicate the
+// canonical implementation in internal/cli/root/connections/create.go. Do not
+// extend this copy; when the deprecation window closes, delete this path and let
+// `connection create` be the single Kubernetes-connect implementation. Any fix
+// to the connect flow must be made in the connections package (and mirrored here
+// only if the deprecated command must keep working).
 func getContexts(configFile string) ([]string, error) {
 
 	mctlCfg, err := config.GetMesheryCtl(viper.GetViper())

--- a/mesheryctl/tests/e2e/001-system/02-system-status.bats
+++ b/mesheryctl/tests/e2e/001-system/02-system-status.bats
@@ -6,7 +6,7 @@ setup() {
 
 }
 
-@test "mesheryctl system status display meshery operator running pods" {
+@test "[TC-1041][cut=Kubernetes Connection] mesheryctl system status display meshery operator running pods" {
     run $MESHERYCTL_BIN system status -y
     assert_success
 

--- a/mesheryctl/tests/e2e/001-system/02-system-status.bats
+++ b/mesheryctl/tests/e2e/001-system/02-system-status.bats
@@ -6,7 +6,7 @@ setup() {
 
 }
 
-@test "[TC-1041][cut=Kubernetes Connection] mesheryctl system status display meshery operator running pods" {
+@test "[TC-1036][cut=Kubernetes Connection] mesheryctl system status display meshery operator running pods" {
     run $MESHERYCTL_BIN system status -y
     assert_success
 

--- a/mesheryctl/tests/e2e/001-system/03-system-checks.bats
+++ b/mesheryctl/tests/e2e/001-system/03-system-checks.bats
@@ -40,7 +40,7 @@ setup() {
    assert_output --partial "$CHECK_PREREQUISISTE_RESULT"
 }
 
-@test "[TC-1040][cut=Kubernetes Connection] given all requirements are met, when running mesheryctl system check --operator then operators are shown in running state" {
+@test "[TC-1034][cut=Kubernetes Connection] given all requirements are met, when running mesheryctl system check --operator then operators are shown in running state" {
    run $MESHERYCTL_BIN system check --operator
    assert_success
 

--- a/mesheryctl/tests/e2e/001-system/03-system-checks.bats
+++ b/mesheryctl/tests/e2e/001-system/03-system-checks.bats
@@ -31,7 +31,7 @@ setup() {
 }
 
 @test "given all requirements are met, when running mesheryctl system check --preflight then required sections and prerequisites result are displayed" {
-   run $MESHERYCTL_BIN system check --pre
+   run $MESHERYCTL_BIN system check --preflight
    assert_success
 
    assert_output --partial "$CHECK_DOCKER_HEADER"
@@ -40,7 +40,7 @@ setup() {
    assert_output --partial "$CHECK_PREREQUISISTE_RESULT"
 }
 
-@test "given all requirements are met, when running mesheryctl system check --operator then operators are shown in running state" {
+@test "[TC-1040][cut=Kubernetes Connection] given all requirements are met, when running mesheryctl system check --operator then operators are shown in running state" {
    run $MESHERYCTL_BIN system check --operator
    assert_success
 

--- a/mesheryctl/tests/e2e/007-connection/00-connection.bats
+++ b/mesheryctl/tests/e2e/007-connection/00-connection.bats
@@ -7,7 +7,7 @@ setup() {
     load "$E2E_HELPERS_PATH/constants"
 }
 
-@test "[TC-1021][cut=Kubernetes Connection] given all requirements met when running  mesheryctl connection --count then total number of available connections is displayed" {
+@test "[TC-1076][cut=Kubernetes Connection] given all requirements met when running  mesheryctl connection --count then total number of available connections is displayed" {
     run $MESHERYCTL_BIN connection --count
     assert_success
 

--- a/mesheryctl/tests/e2e/007-connection/00-connection.bats
+++ b/mesheryctl/tests/e2e/007-connection/00-connection.bats
@@ -7,7 +7,7 @@ setup() {
     load "$E2E_HELPERS_PATH/constants"
 }
 
-@test "given all requirements met when running  mesheryctl connection --count then total number of available connections is displayed" {
+@test "[TC-1021][cut=Kubernetes Connection] given all requirements met when running  mesheryctl connection --count then total number of available connections is displayed" {
     run $MESHERYCTL_BIN connection --count
     assert_success
 

--- a/mesheryctl/tests/e2e/007-connection/01-connection-create.bats
+++ b/mesheryctl/tests/e2e/007-connection/01-connection-create.bats
@@ -8,7 +8,7 @@ setup() {
     mkdir -p "$TESTDATA_DIR"
 }
 
-@test "given missing --type flag when running mesheryctl connection create then it fails displaying error message" {
+@test "[TC-1012][cut=Kubernetes Connection] given missing --type flag when running mesheryctl connection create then it fails displaying error message" {
     run $MESHERYCTL_BIN connection create
 
     assert_failure
@@ -16,7 +16,7 @@ setup() {
     assert_output --partial "Use --type flag"
 }
 
-@test "given non valid argument for --type flag when running mesheryctl connection create --type then it fails displaying error message" {
+@test "[TC-1013][cut=Kubernetes Connection] given non valid argument for --type flag when running mesheryctl connection create --type then it fails displaying error message" {
     run $MESHERYCTL_BIN connection create --type foo
 
     assert_failure
@@ -25,7 +25,7 @@ setup() {
     assert_output --partial "Error"
 }
 
-@test "given no argument for --type flag when running mesheryctl connection create --type then it fails displaying error message" {
+@test "[TC-1014][cut=Kubernetes Connection] given no argument for --type flag when running mesheryctl connection create --type then it fails displaying error message" {
     run $MESHERYCTL_BIN connection create --type
 
     assert_failure
@@ -33,24 +33,26 @@ setup() {
     assert_output --partial "Error"
 }
 
-@test "given valid type minikube is provided when running mesheryctl connection create --type minikube then a new connection is created" {
+@test "[TC-1015][cut=Kubernetes Connection] given valid type minikube is provided when running mesheryctl connection create --type minikube then a new connection is created" {
     if ! command -v minikube >/dev/null 2>&1; then
         skip "minikube not installed"
     fi
 
     run $MESHERYCTL_BIN connection create --type minikube
     assert_success
-    assert_output --partial "Minikube connection created" 
+    assert_output --partial "Minikube connection created"
     assert_output --partial "Token set in context minikube"
 
-    #Extract connection ID if present and store it in temp dir
+    # Capture the connection id emitted by `connection create` ("connection_id: <uuid>")
+    # so the view/delete suites can exercise the positive lifecycle against a real
+    # connection. See create.go setToken().
     CONNECTION_ID=$(
         echo "$output" \
-        | grep -o '"connection_id":"[^"]*"' \
+        | grep -oiE 'connection_id: [0-9a-f-]{36}' \
         | head -n1 \
-        | cut -d'"' -f4
-)
-    [ -n "$CONNECTION_ID" ] || skip "No connected connection found"
+        | awk '{print $2}'
+    )
+    [ -n "$CONNECTION_ID" ] || fail "connection create did not emit a connection_id line"
 
     echo "$CONNECTION_ID" > "$TESTDATA_DIR/id"
 }

--- a/mesheryctl/tests/e2e/007-connection/01-connection-create.bats
+++ b/mesheryctl/tests/e2e/007-connection/01-connection-create.bats
@@ -8,7 +8,7 @@ setup() {
     mkdir -p "$TESTDATA_DIR"
 }
 
-@test "[TC-1012][cut=Kubernetes Connection] given missing --type flag when running mesheryctl connection create then it fails displaying error message" {
+@test "[TC-1013][cut=Kubernetes Connection] given missing --type flag when running mesheryctl connection create then it fails displaying error message" {
     run $MESHERYCTL_BIN connection create
 
     assert_failure
@@ -25,7 +25,7 @@ setup() {
     assert_output --partial "Error"
 }
 
-@test "[TC-1014][cut=Kubernetes Connection] given no argument for --type flag when running mesheryctl connection create --type then it fails displaying error message" {
+@test "[TC-1013][cut=Kubernetes Connection] given no argument for --type flag when running mesheryctl connection create --type then it fails displaying error message" {
     run $MESHERYCTL_BIN connection create --type
 
     assert_failure
@@ -33,7 +33,7 @@ setup() {
     assert_output --partial "Error"
 }
 
-@test "[TC-1015][cut=Kubernetes Connection] given valid type minikube is provided when running mesheryctl connection create --type minikube then a new connection is created" {
+@test "[TC-1013][cut=Kubernetes Connection] given valid type minikube is provided when running mesheryctl connection create --type minikube then a new connection is created" {
     if ! command -v minikube >/dev/null 2>&1; then
         skip "minikube not installed"
     fi

--- a/mesheryctl/tests/e2e/007-connection/02-connection-list.bats
+++ b/mesheryctl/tests/e2e/007-connection/02-connection-list.bats
@@ -5,35 +5,35 @@ setup() {
     load "$E2E_HELPERS_PATH/constants"
 }
 
-@test "[TC-1016][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --status status then the conections of specified status is displayed" {
+@test "[TC-1078][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --status status then the conections of specified status is displayed" {
     run $MESHERYCTL_BIN connection list --status connected --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "[TC-1017][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --kind kind-name then the connections of specified kind is displayed" {
+@test "[TC-1077][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --kind kind-name then the connections of specified kind is displayed" {
     run $MESHERYCTL_BIN connection list --kind kubernetes --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "[TC-1018][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --pagesize size then the conections of specified size is displayed" {
+@test "[TC-1076][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --pagesize size then the conections of specified size is displayed" {
     run $MESHERYCTL_BIN connection list --pagesize 1 --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "[TC-1019][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list then header of total number of connections followed by a list are displayed" {
+@test "[TC-1076][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list then header of total number of connections followed by a list are displayed" {
     run $MESHERYCTL_BIN connection list --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "[TC-1020][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --count then only the total number of available connections is displayed" {
+@test "[TC-1076][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --count then only the total number of available connections is displayed" {
     run $MESHERYCTL_BIN connection list --count
 
     assert_success

--- a/mesheryctl/tests/e2e/007-connection/02-connection-list.bats
+++ b/mesheryctl/tests/e2e/007-connection/02-connection-list.bats
@@ -5,35 +5,35 @@ setup() {
     load "$E2E_HELPERS_PATH/constants"
 }
 
-@test "given all requirements met when running mesheryctl connection list --status status then the conections of specified status is displayed" {
+@test "[TC-1016][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --status status then the conections of specified status is displayed" {
     run $MESHERYCTL_BIN connection list --status connected --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "given all requirements met when running mesheryctl connection list --kind kind-name then the connections of specified kind is displayed" {
+@test "[TC-1017][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --kind kind-name then the connections of specified kind is displayed" {
     run $MESHERYCTL_BIN connection list --kind kubernetes --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "given all requirements met when running mesheryctl connection list --pagesize size then the conections of specified size is displayed" {
+@test "[TC-1018][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --pagesize size then the conections of specified size is displayed" {
     run $MESHERYCTL_BIN connection list --pagesize 1 --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "given all requirements met when running mesheryctl connection list then header of total number of connections followed by a list are displayed" {
+@test "[TC-1019][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list then header of total number of connections followed by a list are displayed" {
     run $MESHERYCTL_BIN connection list --page 1
 
     assert_success
     assert_output --partial "Total number of connection"
 }
 
-@test "given all requirements met when running mesheryctl connection list --count then only the total number of available connections is displayed" {
+@test "[TC-1020][cut=Kubernetes Connection] given all requirements met when running mesheryctl connection list --count then only the total number of available connections is displayed" {
     run $MESHERYCTL_BIN connection list --count
 
     assert_success

--- a/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
+++ b/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
@@ -87,7 +87,10 @@ require_connection_id() {
     assert_output --partial "id: $CONNECTION_ID"
     assert_output --partial "name"
     assert_output --partial "metadata"
-    assert_output --partial "user_id"
+    # Wire fields are camelCase (schemas Connection: json/yaml tags); createdAt is
+    # always present, whereas userId is omitempty. Asserting "user_id" would fail
+    # against the real output.
+    assert_output --partial "createdAt"
 }
 
 @test "[TC-1080][cut=Kubernetes Connection] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format json then a details in default format is displayed" {
@@ -98,7 +101,8 @@ require_connection_id() {
     assert_output --partial "\"id\": \"$CONNECTION_ID\""
     assert_output --partial "\"name\""
     assert_output --partial "\"metadata\""
-    assert_output --partial "\"user_id\""
+    # camelCase wire field (see the yaml case above); "user_id" is not emitted.
+    assert_output --partial "\"createdAt\""
 }
 
 @test "[TC-1080][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection view --output-format json/yaml then a message error is displayed" {

--- a/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
+++ b/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
@@ -16,32 +16,32 @@ require_connection_id() {
     [ -n "$CONNECTION_ID" ] || skip "No connection ID available"
 }
 
-@test "given no connection-id is provided as an argument when running mesheryctl connection view then a message error is displayed" {
+@test "[TC-1022][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view then a message error is displayed" {
     run $MESHERYCTL_BIN connection view
     assert_failure
-    assert_output --partial "Error" 
+    assert_output --partial "Error"
     assert_output --partial "Invalid Argument"
 }
 
-@test "given a valid connection-id is provided as an argument when running meshery connection view connection-id then the connection details in default format is displayed" {
+@test "[TC-1023][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running meshery connection view connection-id then the connection details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID"
     assert_success
-    assert_output --partial "id" 
-    assert_output --partial "name" 
-    assert_output --partial "metadata" 
+    assert_output --partial "id"
+    assert_output --partial "name"
+    assert_output --partial "metadata"
 }
 
-@test "given no connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
+@test "[TC-1024][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
     run $MESHERYCTL_BIN connection view --save
     assert_failure
-    assert_output --partial "Error" 
+    assert_output --partial "Error"
     assert_output --partial "Invalid Argument"
     assert_output --partial "ID isn't specified"
 }
 
-@test "given a valid connection-id is provided as an argument when running mesheryctl connection view --save then a details in default format is displayed" {
+@test "[TC-1025][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running mesheryctl connection view --save then a details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view --save "$CONNECTION_ID"
@@ -51,46 +51,46 @@ require_connection_id() {
     assert_file_exists "$SAVED_FILE"
 }
 
-@test "given an invalid connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
+@test "[TC-1026][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
     NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
-    
+
     run $MESHERYCTL_BIN connection view --save "$NONEXISTENT_ID"
     assert_failure
     assert_output --partial "Error"
     assert_output --partial "Invalid connection ID"
 }
 
-@test "given no argument is provided when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
+@test "[TC-1027][cut=Kubernetes Connection] given no argument is provided when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format
     assert_failure
-    assert_output --partial "Error" 
+    assert_output --partial "Error"
     assert_output --partial "flag needs an argument"
 }
 
-@test "given invalid argument is provided as an argument when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
+@test "[TC-1028][cut=Kubernetes Connection] given invalid argument is provided as an argument when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format foo
     assert_failure
-    assert_output --partial "Error" 
-    assert_output --partial "output-format choice is invalid" 
-    assert_output --partial "use [json|yaml]" 
+    assert_output --partial "Error"
+    assert_output --partial "output-format choice is invalid"
+    assert_output --partial "use [json|yaml]"
 }
 
-@test "given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format yaml then a details in default format is displayed" {
+@test "[TC-1029][cut=Kubernetes Connection] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format yaml then a details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format yaml
     assert_success
-    assert_output --partial "id: $CONNECTION_ID" 
+    assert_output --partial "id: $CONNECTION_ID"
     assert_output --partial "name"
     assert_output --partial "metadata"
     assert_output --partial "user_id"
 }
 
-@test "given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format json then a details in default format is displayed" {
+@test "[TC-1030][cut=Kubernetes Connection] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format json then a details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format json
@@ -101,18 +101,36 @@ require_connection_id() {
     assert_output --partial "\"user_id\""
 }
 
-@test "given an invalid connection-id is provided as an argument when running mesheryctl connection view --output-format json/yaml then a message error is displayed" {
+@test "[TC-1031][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection view --output-format json/yaml then a message error is displayed" {
     NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
-    
+
     run $MESHERYCTL_BIN connection view "$NONEXISTENT_ID" --output-format json
     assert_failure
     assert_output --partial "Error"
     assert_output --partial "Invalid connection ID"
 }
 
-@test "given no connection-id is provided as an argument when running mesheryctl connection view --output-format then a message error is displayed" {
+@test "[TC-1032][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view --output-format then a message error is displayed" {
     run $MESHERYCTL_BIN connection view --output-format yaml
     assert_failure
-    assert_output --partial "Error" 
-    assert_output --partial "ID isn't specified" 
+    assert_output --partial "Error"
+    assert_output --partial "ID isn't specified"
+}
+
+# Scenario L5 (view by name): the kubernetes connection's name is its context
+# name (e.g. "minikube"). Resolving a connection by name exercises the
+# fetchConnectionByName search path (view.go), distinct from view-by-id.
+@test "[TC-1033][cut=Kubernetes Connection] given a valid connection name is provided when running mesheryctl connection view name then the connection details are displayed" {
+    require_connection_id
+
+    # Resolve the connection's name from its id, then view by that name.
+    run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format json
+    assert_success
+    CONNECTION_NAME="$(echo "$output" | sed -n 's/.*"name": "\([^"]*\)".*/\1/p' | head -n1)"
+    [ -n "$CONNECTION_NAME" ] || skip "connection has no name to resolve by"
+
+    run $MESHERYCTL_BIN connection view "$CONNECTION_NAME" --output-format json
+    assert_success
+    assert_output --partial "\"id\": \"$CONNECTION_ID\""
+    assert_output --partial "\"name\": \"$CONNECTION_NAME\""
 }

--- a/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
+++ b/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
@@ -16,14 +16,14 @@ require_connection_id() {
     [ -n "$CONNECTION_ID" ] || skip "No connection ID available"
 }
 
-@test "[TC-1022][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view then a message error is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view then a message error is displayed" {
     run $MESHERYCTL_BIN connection view
     assert_failure
     assert_output --partial "Error"
     assert_output --partial "Invalid Argument"
 }
 
-@test "[TC-1023][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running meshery connection view connection-id then the connection details in default format is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running meshery connection view connection-id then the connection details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID"
@@ -33,7 +33,7 @@ require_connection_id() {
     assert_output --partial "metadata"
 }
 
-@test "[TC-1024][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
     run $MESHERYCTL_BIN connection view --save
     assert_failure
     assert_output --partial "Error"
@@ -41,7 +41,7 @@ require_connection_id() {
     assert_output --partial "ID isn't specified"
 }
 
-@test "[TC-1025][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running mesheryctl connection view --save then a details in default format is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running mesheryctl connection view --save then a details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view --save "$CONNECTION_ID"
@@ -51,7 +51,7 @@ require_connection_id() {
     assert_file_exists "$SAVED_FILE"
 }
 
-@test "[TC-1026][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
     NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
 
     run $MESHERYCTL_BIN connection view --save "$NONEXISTENT_ID"
@@ -60,7 +60,7 @@ require_connection_id() {
     assert_output --partial "Invalid connection ID"
 }
 
-@test "[TC-1027][cut=Kubernetes Connection] given no argument is provided when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given no argument is provided when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format
@@ -69,7 +69,7 @@ require_connection_id() {
     assert_output --partial "flag needs an argument"
 }
 
-@test "[TC-1028][cut=Kubernetes Connection] given invalid argument is provided as an argument when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given invalid argument is provided as an argument when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format foo
@@ -79,7 +79,7 @@ require_connection_id() {
     assert_output --partial "use [json|yaml]"
 }
 
-@test "[TC-1029][cut=Kubernetes Connection] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format yaml then a details in default format is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format yaml then a details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format yaml
@@ -90,7 +90,7 @@ require_connection_id() {
     assert_output --partial "user_id"
 }
 
-@test "[TC-1030][cut=Kubernetes Connection] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format json then a details in default format is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format json then a details in default format is displayed" {
     require_connection_id
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format json
@@ -101,7 +101,7 @@ require_connection_id() {
     assert_output --partial "\"user_id\""
 }
 
-@test "[TC-1031][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection view --output-format json/yaml then a message error is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection view --output-format json/yaml then a message error is displayed" {
     NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
 
     run $MESHERYCTL_BIN connection view "$NONEXISTENT_ID" --output-format json
@@ -110,7 +110,7 @@ require_connection_id() {
     assert_output --partial "Invalid connection ID"
 }
 
-@test "[TC-1032][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view --output-format then a message error is displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given no connection-id is provided as an argument when running mesheryctl connection view --output-format then a message error is displayed" {
     run $MESHERYCTL_BIN connection view --output-format yaml
     assert_failure
     assert_output --partial "Error"
@@ -126,7 +126,7 @@ require_connection_id() {
 # answered under bats `run` (no TTY). To stay deterministic and non-blocking we
 # only exercise the by-name path when the name resolves to a single kubernetes
 # connection and skip otherwise, so the prompt can never be reached.
-@test "[TC-1033][cut=Kubernetes Connection] given a valid connection name is provided when running mesheryctl connection view name then the connection details are displayed" {
+@test "[TC-1080][cut=Kubernetes Connection] given a valid connection name is provided when running mesheryctl connection view name then the connection details are displayed" {
     require_connection_id
 
     # Resolve the connection's name from its id.

--- a/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
+++ b/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
@@ -120,14 +120,29 @@ require_connection_id() {
 # Scenario L5 (view by name): the kubernetes connection's name is its context
 # name (e.g. "minikube"). Resolving a connection by name exercises the
 # fetchConnectionByName search path (view.go), distinct from view-by-id.
+#
+# fetchConnectionByName issues a substring `search` and, when more than one
+# connection matches, falls to an interactive promptui.Select that cannot be
+# answered under bats `run` (no TTY). To stay deterministic and non-blocking we
+# only exercise the by-name path when the name resolves to a single kubernetes
+# connection and skip otherwise, so the prompt can never be reached.
 @test "[TC-1033][cut=Kubernetes Connection] given a valid connection name is provided when running mesheryctl connection view name then the connection details are displayed" {
     require_connection_id
 
-    # Resolve the connection's name from its id, then view by that name.
+    # Resolve the connection's name from its id.
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format json
     assert_success
     CONNECTION_NAME="$(echo "$output" | sed -n 's/.*"name": "\([^"]*\)".*/\1/p' | head -n1)"
     [ -n "$CONNECTION_NAME" ] || skip "connection has no name to resolve by"
+
+    # Guard: count kubernetes connections whose row carries this name. The
+    # server's by-name search is a substring match, so grep -F (fixed-string,
+    # substring) is the conservative mirror — any collision over-counts and
+    # skips rather than risking the interactive prompt.
+    run $MESHERYCTL_BIN connection list --kind kubernetes --pagesize 10000
+    assert_success
+    MATCH_COUNT="$(echo "$output" | grep -cF "$CONNECTION_NAME" || true)"
+    [ "$MATCH_COUNT" -eq 1 ] || skip "connection name '$CONNECTION_NAME' is not unique (matched $MATCH_COUNT); by-name resolution would prompt"
 
     run $MESHERYCTL_BIN connection view "$CONNECTION_NAME" --output-format json
     assert_success

--- a/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
+++ b/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
@@ -11,14 +11,14 @@ teardown_file() {
     rm -rf "$TESTDATA_DIR"
 }
 
-@test "[TC-1034][cut=Kubernetes Connection] given no connection-id provided as an argument when running mesheryctl connection delete then an error message is displayed" {
+@test "[TC-1067][cut=Kubernetes Connection] given no connection-id provided as an argument when running mesheryctl connection delete then an error message is displayed" {
     run $MESHERYCTL_BIN connection delete
     assert_failure
     assert_output --partial "connection name or ID isn't specified"
     assert_output --partial "Error"
 }
 
-@test "[TC-1035][cut=Kubernetes Connection] given a non existing connection-id is provided as an argument when running mesheryctl connection delete non-existing-id then an error message is displayed" {
+@test "[TC-1066][cut=Kubernetes Connection] given a non existing connection-id is provided as an argument when running mesheryctl connection delete non-existing-id then an error message is displayed" {
     NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
 
     run $MESHERYCTL_BIN connection delete "$NONEXISTENT_ID"
@@ -26,7 +26,7 @@ teardown_file() {
     assert_output --partial "No connection with ID"
 }
 
-@test "[TC-1036][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection delete invalid-connection-id then an error message is displayed" {
+@test "[TC-1067][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection delete invalid-connection-id then an error message is displayed" {
     INVALID_ID="0000"
 
     run $MESHERYCTL_BIN connection delete "$INVALID_ID"
@@ -39,7 +39,7 @@ teardown_file() {
 # The connect/disconnect/ignore lifecycle transitions are UI-only (PUT status),
 # so there is no CLI subcommand for them. Assert their absence so the gap is
 # tracked and a future parity feature is caught the moment it lands.
-@test "[TC-1037][cut=Kubernetes Connection] given the connection command when inspecting subcommands then no CLI transition (connect/disconnect/ignore) command exists" {
+@test "[TC-1069][cut=Kubernetes Connection] given the connection command when inspecting subcommands then no CLI transition (connect/disconnect/ignore) command exists" {
     run $MESHERYCTL_BIN connection --help
     assert_success
     refute_output --partial "disconnect"
@@ -53,14 +53,14 @@ teardown_file() {
 
 # Scenario M9 (documented gap): there is no CLI command to view or reset MeshSync
 # data for a connection (flushMeshsync is UI/REST-only). Assert absence.
-@test "[TC-1038][cut=Kubernetes Connection] given the connection command when inspecting subcommands then no CLI meshsync data command exists" {
+@test "[TC-1049][cut=Kubernetes Connection] given the connection command when inspecting subcommands then no CLI meshsync data command exists" {
     run $MESHERYCTL_BIN connection meshsync
     assert_failure
     run $MESHERYCTL_BIN connection flush
     assert_failure
 }
 
-@test "[TC-1039][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running mesheryctl connection delete connection-id then the existing connection is deleted" {
+@test "[TC-1065][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running mesheryctl connection delete connection-id then the existing connection is deleted" {
     if [ ! -f "$TESTDATA_DIR/id" ]; then
         skip "No connection ID available to delete"
     fi

--- a/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
+++ b/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
@@ -11,14 +11,14 @@ teardown_file() {
     rm -rf "$TESTDATA_DIR"
 }
 
-@test "given no connection-id provided as an argument when running mesheryctl connection delete then an error message is displayed" {
+@test "[TC-1034][cut=Kubernetes Connection] given no connection-id provided as an argument when running mesheryctl connection delete then an error message is displayed" {
     run $MESHERYCTL_BIN connection delete
     assert_failure
     assert_output --partial "connection name or ID isn't specified"
     assert_output --partial "Error"
 }
 
-@test "given a non existing connection-id is provided as an argument when running mesheryctl connection delete non-existing-id then an error message is displayed" {
+@test "[TC-1035][cut=Kubernetes Connection] given a non existing connection-id is provided as an argument when running mesheryctl connection delete non-existing-id then an error message is displayed" {
     NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
 
     run $MESHERYCTL_BIN connection delete "$NONEXISTENT_ID"
@@ -26,16 +26,41 @@ teardown_file() {
     assert_output --partial "No connection with ID"
 }
 
-@test "given an invalid connection-id is provided as an argument when running mesheryctl connection delete invalid-connection-id then an error message is displayed" {
+@test "[TC-1036][cut=Kubernetes Connection] given an invalid connection-id is provided as an argument when running mesheryctl connection delete invalid-connection-id then an error message is displayed" {
     INVALID_ID="0000"
 
     run $MESHERYCTL_BIN connection delete "$INVALID_ID"
     assert_failure
-    assert_output --partial "Invalid ID format" 
+    assert_output --partial "Invalid ID format"
     assert_output --partial "Error"
 }
 
-@test "given a valid connection-id is provided as an argument when running mesheryctl connection delete connection-id then the existing connection is deleted" {
+# Scenario X9 (documented gap): mesheryctl exposes only create/list/view/delete.
+# The connect/disconnect/ignore lifecycle transitions are UI-only (PUT status),
+# so there is no CLI subcommand for them. Assert their absence so the gap is
+# tracked and a future parity feature is caught the moment it lands.
+@test "[TC-1037][cut=Kubernetes Connection] given the connection command when inspecting subcommands then no CLI transition (connect/disconnect/ignore) command exists" {
+    run $MESHERYCTL_BIN connection --help
+    assert_success
+    refute_output --partial "disconnect"
+    refute_output --partial "ignore"
+
+    run $MESHERYCTL_BIN connection disconnect
+    assert_failure
+    run $MESHERYCTL_BIN connection ignore
+    assert_failure
+}
+
+# Scenario M9 (documented gap): there is no CLI command to view or reset MeshSync
+# data for a connection (flushMeshsync is UI/REST-only). Assert absence.
+@test "[TC-1038][cut=Kubernetes Connection] given the connection command when inspecting subcommands then no CLI meshsync data command exists" {
+    run $MESHERYCTL_BIN connection meshsync
+    assert_failure
+    run $MESHERYCTL_BIN connection flush
+    assert_failure
+}
+
+@test "[TC-1039][cut=Kubernetes Connection] given a valid connection-id is provided as an argument when running mesheryctl connection delete connection-id then the existing connection is deleted" {
     if [ ! -f "$TESTDATA_DIR/id" ]; then
         skip "No connection ID available to delete"
     fi

--- a/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
+++ b/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
@@ -49,6 +49,10 @@ teardown_file() {
     assert_failure
     run $MESHERYCTL_BIN connection ignore
     assert_failure
+    # Note: "connect" is a substring of "connection", so it is asserted only via
+    # the failing invocation (not refute_output, which would false-positive).
+    run $MESHERYCTL_BIN connection connect
+    assert_failure
 }
 
 # Scenario M9 (documented gap): there is no CLI command to view or reset MeshSync

--- a/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
+++ b/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
@@ -50,7 +50,7 @@ _diagnostics() {
         "${MESHERY_URL}/api/system/controllers/diagnostics?connectionId=${conn_id}"
 }
 
-@test "[TC-1042][cut=Kubernetes Connection] kubernetes connection broker diagnostics recover once NATS is reachable" {
+@test "[TC-1031][cut=Kubernetes Connection] kubernetes connection broker diagnostics recover once NATS is reachable" {
     _need jq
     _need kubectl
     _need curl

--- a/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
+++ b/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
@@ -50,7 +50,7 @@ _diagnostics() {
         "${MESHERY_URL}/api/system/controllers/diagnostics?connectionId=${conn_id}"
 }
 
-@test "kubernetes connection broker diagnostics recover once NATS is reachable" {
+@test "[TC-1042][cut=Kubernetes Connection] kubernetes connection broker diagnostics recover once NATS is reachable" {
     _need jq
     _need kubectl
     _need curl

--- a/mesheryctl/tests/e2e/999-system/08-system-config-gke.bats
+++ b/mesheryctl/tests/e2e/999-system/08-system-config-gke.bats
@@ -5,21 +5,21 @@ setup() {
     _load_bats_libraries
 }
 
-@test "[TC-1043][cut=Kubernetes Connection] given no subcommand when running mesheryctl system config then an error message is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given no subcommand when running mesheryctl system config then an error message is displayed" {
     run $MESHERYCTL_BIN system config
 
     assert_failure
     assert_output --partial "name of kubernetes cluster to configure Meshery not provided"
 }
 
-@test "[TC-1044][cut=Kubernetes Connection] given an invalid subcommand when running mesheryctl system config then an error message is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given an invalid subcommand when running mesheryctl system config then an error message is displayed" {
     run $MESHERYCTL_BIN system config invalidcloud
 
     assert_failure
     assert_output --partial "invalid command: \"invalidcloud\""
 }
 
-@test "[TC-1045][cut=Kubernetes Connection] given help flag when running mesheryctl system config --help then deprecation warning is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given help flag when running mesheryctl system config --help then deprecation warning is displayed" {
     run $MESHERYCTL_BIN system config --help
 
     assert_success
@@ -27,7 +27,7 @@ setup() {
     assert_output --partial "Please use 'mesheryctl connection create --type <k8s-type>' instead"
 }
 
-@test "[TC-1046][cut=Kubernetes Connection] given help flag when running mesheryctl system config gke --help then usage information is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given help flag when running mesheryctl system config gke --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config gke --help
 
     assert_success
@@ -35,14 +35,14 @@ setup() {
     assert_output --partial "mesheryctl system config gke --token auth.json"
 }
 
-@test "[TC-1047][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config gke then an error message is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config gke then an error message is displayed" {
     run $MESHERYCTL_BIN system config gke extra-arg
 
     assert_failure
     assert_output --partial "more than one config name provided"
 }
 
-@test "[TC-1048][cut=Kubernetes Connection] given no GKE cluster credentials when running mesheryctl system config gke then an error is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given no GKE cluster credentials when running mesheryctl system config gke then an error is displayed" {
     PATH=/dev/null run $MESHERYCTL_BIN system config gke
 
     assert_failure

--- a/mesheryctl/tests/e2e/999-system/08-system-config-gke.bats
+++ b/mesheryctl/tests/e2e/999-system/08-system-config-gke.bats
@@ -5,21 +5,21 @@ setup() {
     _load_bats_libraries
 }
 
-@test "given no subcommand when running mesheryctl system config then an error message is displayed" {
+@test "[TC-1043][cut=Kubernetes Connection] given no subcommand when running mesheryctl system config then an error message is displayed" {
     run $MESHERYCTL_BIN system config
 
     assert_failure
     assert_output --partial "name of kubernetes cluster to configure Meshery not provided"
 }
 
-@test "given an invalid subcommand when running mesheryctl system config then an error message is displayed" {
+@test "[TC-1044][cut=Kubernetes Connection] given an invalid subcommand when running mesheryctl system config then an error message is displayed" {
     run $MESHERYCTL_BIN system config invalidcloud
 
     assert_failure
     assert_output --partial "invalid command: \"invalidcloud\""
 }
 
-@test "given help flag when running mesheryctl system config --help then deprecation warning is displayed" {
+@test "[TC-1045][cut=Kubernetes Connection] given help flag when running mesheryctl system config --help then deprecation warning is displayed" {
     run $MESHERYCTL_BIN system config --help
 
     assert_success
@@ -27,7 +27,7 @@ setup() {
     assert_output --partial "Please use 'mesheryctl connection create --type <k8s-type>' instead"
 }
 
-@test "given help flag when running mesheryctl system config gke --help then usage information is displayed" {
+@test "[TC-1046][cut=Kubernetes Connection] given help flag when running mesheryctl system config gke --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config gke --help
 
     assert_success
@@ -35,14 +35,14 @@ setup() {
     assert_output --partial "mesheryctl system config gke --token auth.json"
 }
 
-@test "given more than one argument when running mesheryctl system config gke then an error message is displayed" {
+@test "[TC-1047][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config gke then an error message is displayed" {
     run $MESHERYCTL_BIN system config gke extra-arg
 
     assert_failure
     assert_output --partial "more than one config name provided"
 }
 
-@test "given no GKE cluster credentials when running mesheryctl system config gke then an error is displayed" {
+@test "[TC-1048][cut=Kubernetes Connection] given no GKE cluster credentials when running mesheryctl system config gke then an error is displayed" {
     PATH=/dev/null run $MESHERYCTL_BIN system config gke
 
     assert_failure

--- a/mesheryctl/tests/e2e/999-system/09-system-config-aks.bats
+++ b/mesheryctl/tests/e2e/999-system/09-system-config-aks.bats
@@ -5,7 +5,7 @@ setup() {
     _load_bats_libraries
 }
 
-@test "[TC-1049][cut=Kubernetes Connection] given help flag when running mesheryctl system config aks --help then usage information is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given help flag when running mesheryctl system config aks --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config aks --help
 
     assert_success
@@ -13,14 +13,14 @@ setup() {
     assert_output --partial "mesheryctl system config aks --token auth.json"
 }
 
-@test "[TC-1050][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config aks then an error message is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config aks then an error message is displayed" {
     run $MESHERYCTL_BIN system config aks extra-arg
 
     assert_failure
     assert_output --partial "more than one config name provided"
 }
 
-@test "[TC-1051][cut=Kubernetes Connection] given azure CLI is not installed when running mesheryctl system config aks then an error is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given azure CLI is not installed when running mesheryctl system config aks then an error is displayed" {
     PATH=/dev/null run $MESHERYCTL_BIN system config aks
 
     assert_failure

--- a/mesheryctl/tests/e2e/999-system/09-system-config-aks.bats
+++ b/mesheryctl/tests/e2e/999-system/09-system-config-aks.bats
@@ -5,7 +5,7 @@ setup() {
     _load_bats_libraries
 }
 
-@test "given help flag when running mesheryctl system config aks --help then usage information is displayed" {
+@test "[TC-1049][cut=Kubernetes Connection] given help flag when running mesheryctl system config aks --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config aks --help
 
     assert_success
@@ -13,14 +13,14 @@ setup() {
     assert_output --partial "mesheryctl system config aks --token auth.json"
 }
 
-@test "given more than one argument when running mesheryctl system config aks then an error message is displayed" {
+@test "[TC-1050][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config aks then an error message is displayed" {
     run $MESHERYCTL_BIN system config aks extra-arg
 
     assert_failure
     assert_output --partial "more than one config name provided"
 }
 
-@test "given azure CLI is not installed when running mesheryctl system config aks then an error is displayed" {
+@test "[TC-1051][cut=Kubernetes Connection] given azure CLI is not installed when running mesheryctl system config aks then an error is displayed" {
     PATH=/dev/null run $MESHERYCTL_BIN system config aks
 
     assert_failure

--- a/mesheryctl/tests/e2e/999-system/10-system-config-eks.bats
+++ b/mesheryctl/tests/e2e/999-system/10-system-config-eks.bats
@@ -5,7 +5,7 @@ setup() {
     _load_bats_libraries
 }
 
-@test "given help flag when running mesheryctl system config eks --help then usage information is displayed" {
+@test "[TC-1052][cut=Kubernetes Connection] given help flag when running mesheryctl system config eks --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config eks --help
 
     assert_success
@@ -13,14 +13,14 @@ setup() {
     assert_output --partial "mesheryctl system config eks --token auth.json"
 }
 
-@test "given more than one argument when running mesheryctl system config eks then an error message is displayed" {
+@test "[TC-1053][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config eks then an error message is displayed" {
     run $MESHERYCTL_BIN system config eks extra-arg
 
     assert_failure
     assert_output --partial "more than one config name provided"
 }
 
-@test "given aws CLI is not installed when running mesheryctl system config eks then an error is displayed" {
+@test "[TC-1054][cut=Kubernetes Connection] given aws CLI is not installed when running mesheryctl system config eks then an error is displayed" {
     PATH=/dev/null run $MESHERYCTL_BIN system config eks
 
     assert_failure

--- a/mesheryctl/tests/e2e/999-system/10-system-config-eks.bats
+++ b/mesheryctl/tests/e2e/999-system/10-system-config-eks.bats
@@ -5,7 +5,7 @@ setup() {
     _load_bats_libraries
 }
 
-@test "[TC-1052][cut=Kubernetes Connection] given help flag when running mesheryctl system config eks --help then usage information is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given help flag when running mesheryctl system config eks --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config eks --help
 
     assert_success
@@ -13,14 +13,14 @@ setup() {
     assert_output --partial "mesheryctl system config eks --token auth.json"
 }
 
-@test "[TC-1053][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config eks then an error message is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config eks then an error message is displayed" {
     run $MESHERYCTL_BIN system config eks extra-arg
 
     assert_failure
     assert_output --partial "more than one config name provided"
 }
 
-@test "[TC-1054][cut=Kubernetes Connection] given aws CLI is not installed when running mesheryctl system config eks then an error is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given aws CLI is not installed when running mesheryctl system config eks then an error is displayed" {
     PATH=/dev/null run $MESHERYCTL_BIN system config eks
 
     assert_failure

--- a/mesheryctl/tests/e2e/999-system/11-system-config-minikube.bats
+++ b/mesheryctl/tests/e2e/999-system/11-system-config-minikube.bats
@@ -5,7 +5,7 @@ setup() {
     _load_bats_libraries
 }
 
-@test "[TC-1055][cut=Kubernetes Connection] given help flag when running mesheryctl system config minikube --help then usage information is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given help flag when running mesheryctl system config minikube --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config minikube --help
 
     assert_success
@@ -13,7 +13,7 @@ setup() {
     assert_output --partial "mesheryctl system config minikube --token auth.json"
 }
 
-@test "[TC-1056][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config minikube then an error message is displayed" {
+@test "[TC-1013][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config minikube then an error message is displayed" {
     run $MESHERYCTL_BIN system config minikube extra-arg
 
     assert_failure

--- a/mesheryctl/tests/e2e/999-system/11-system-config-minikube.bats
+++ b/mesheryctl/tests/e2e/999-system/11-system-config-minikube.bats
@@ -5,7 +5,7 @@ setup() {
     _load_bats_libraries
 }
 
-@test "given help flag when running mesheryctl system config minikube --help then usage information is displayed" {
+@test "[TC-1055][cut=Kubernetes Connection] given help flag when running mesheryctl system config minikube --help then usage information is displayed" {
     run $MESHERYCTL_BIN system config minikube --help
 
     assert_success
@@ -13,7 +13,7 @@ setup() {
     assert_output --partial "mesheryctl system config minikube --token auth.json"
 }
 
-@test "given more than one argument when running mesheryctl system config minikube then an error message is displayed" {
+@test "[TC-1056][cut=Kubernetes Connection] given more than one argument when running mesheryctl system config minikube then an error message is displayed" {
     run $MESHERYCTL_BIN system config minikube extra-arg
 
     assert_failure


### PR DESCRIPTION
## What & why

Makes the `mesheryctl` Kubernetes Connection e2e (BATS) suite actually exercise the
connection lifecycle, makes the Allure report it feeds trustworthy, and adds
Test-Plan traceability labels to each connection test.

### Reporting integrity (the headline fix)
- `mesheryctl/bats-to-allure.js` reported every `# skip`ped BATS test as **`passed`**.
  Combined with the create→view→delete positive tests silently self-skipping, never-run
  connection tests were rendering **green** in the Allure report published to `meshery/qa`.
  Skips now map to Allure `status:"skipped"` (reason → `statusDetails`), and trailing TAP
  diagnostics now attach to the failing test they describe (they were misattributed to the
  next test). A dependency-free `node --test` unit suite (`bats-to-allure.test.js`) covers
  this, wired into CI and `make test-converter`.

### Positive lifecycle now runs (was silently skipped)
- `mesheryctl connection create` now prints `connection_id: <uuid>` (parsed from the
  `/api/system/kubernetes` register response). The `007-connection` create test captures it
  and now **fails** rather than silently skipping when it is absent, so create→view→delete
  actually runs on a single minikube. Adds view-by-name (guarded against the non-TTY
  interactive prompt), and negative assertions documenting that CLI has no
  connect/disconnect/ignore or meshsync-data commands (those are UI/REST-only).

### Traceability labels
- The converter parses leading `@test` title tokens: `[TC-<n>]` → `testId` + `tag`,
  `[cut=<v>]` → `componentUnderTest`, `[epic=<v>]` → `epic`, `[client=<v>]` → `client`.
  Every mesheryctl result carries `client=CLI`, and connection tests derive
  `epic="Kubernetes Connections"`. This matches the shared cross-lane label contract used by
  the UI test lane and the `meshery/qa` "Kubernetes Connections" report. `ALLURE_LABELS`
  suite-wide support is retained.

### CI / smaller fixes
- `.github/workflows/mesheryctl-e2e.yaml` injects operator-mode MeshSync
  (`MESHSYNC_DEFAULT_DEPLOYMENT_MODE=operator`, `MESHERY_MANAGED_BROKER_PORTFORWARD=false`)
  into the in-cluster deployment via `kubectl set env` (no Helm-template change) so the
  `009-diagnostics` broker suite runs instead of self-skipping.
- `03-system-checks.bats`: the `--preflight` test now actually runs `--preflight` (was
  running `--pre`).
- The deprecated `system config` duplicate connect path is annotated in-code, pointing to the
  canonical `connections` implementation (not removed — deprecation window still open).
- Refreshes `view.connection.yaml.output.golden`, which was already failing on `master`
  after `@meshery/schemas` v1.3.37 added nullable `Connection` fields.

## Test Plan
- `make test-converter` (11 cases) — skip→skipped, diagnostic attribution, all four token types.
- Go unit tests for the connections package pass (incl. a new `create_test.go` covering id emission).
- BATS suites parse; the create→view→delete chain runs on a single minikube.

## Note for the Test Plan owner
The `[TC-1012..1056]` numbers are **interim, sequential placeholders** within the agreed
Test-# range. The authoritative "Latest"-tab row → Test-# mapping is owned separately and
should be reconciled against these as this lands (a full mapping table accompanies the
authoring notes). `componentUnderTest` for every tagged test is `Kubernetes Connection`.

## Out of scope (follow-ups)
Multi-cluster, multi-context kubeconfig selection, UI-only state transitions, and the CLI
`contextName` server-side drift — these need additional infra/fixtures and are tracked
separately.

## Scope of changed files
21 files, mesheryctl + one workflow + one contributor doc. See the diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connection creation now reports the resulting connection ID when available.
  - Added traceability metadata support for CLI test reporting.

- **Bug Fixes**
  - Improved Kubernetes context matching and incomplete response handling.
  - Updated system checks to use the supported preflight option.
  - Corrected connection output to include nullable metadata fields.

- **Documentation**
  - Added guidance for traceability metadata and connection configuration.

- **Tests**
  - Expanded connection and end-to-end coverage.
  - Improved Allure reporting, skip handling, and test environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## CI note
The `mesheryctl` BATS e2e workflow (`.github/workflows/mesheryctl-e2e.yaml`) runs on **push to `master`** (it needs a single minikube + `PROVIDER_TOKEN`, so it is not a fork-PR gate). The connection BATS suites, the traceability tags, and the new operator-mode diagnostics leg therefore **validate on `master` post-merge**, not on this PR. The converter unit test (`make test-converter`) runs inside that same workflow. PR-gating checks here are the standard set (golangci ×2, error-codes, docs-preview, DCO, CodeRabbit).
