### PR TITLE
[UI] Kubernetes Connection e2e: rewrite against wizard + Test-Plan traceability

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -86,7 +86,12 @@ jobs:
         env:
           MESHERY_SERVER_URL: 'http://localhost:9081'
           REMOTE_PROVIDER_URL: "https://cloud.meshery.io"
-          MESHERY_REMOTE_PROVIDER_TOKEN: ${{ secrets.REMOTE_PROVIDER_TOKEN }}
+          # The Playwright suite reads PROVIDER_TOKEN (ui/tests/e2e/env.js); the
+          # secret itself is named REMOTE_PROVIDER_TOKEN. The env var name must
+          # match what env.js consumes, otherwise remote.setup.js falls back to
+          # (unset) email/password auth and the Meshery-provider project never
+          # authenticates.
+          PROVIDER_TOKEN: ${{ secrets.REMOTE_PROVIDER_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             make ui-test-e2e-full

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ ui-provider-build:
 
 ## Run Meshery End-to-End Integration Tests against your local Meshery UI (runs in non-interactive mode).
 ui-integration-tests: ui-setup
-	cd ui; npm run ci-test-integration; cd ..
+	cd ui; npm run test:e2e:ci:local; cd ..
 
 #-----------------------------------------------------------------------------
 # Meshery Docs

--- a/docs/content/en/project/contributing/ui/tests.md
+++ b/docs/content/en/project/contributing/ui/tests.md
@@ -215,10 +215,10 @@ connections suite that map is
 {{< code code=`import { annotateConnCase, connTags } from './connections.testmap';
 
 test(
-  'Open the Kubernetes connection wizard and show kubeconfig upload',
-  { tag: connTags('wizardOpen') },
+  'Register and connect a Kubernetes cluster via kubeconfig upload',
+  { tag: connTags('kubeconfigConnect') },
   async ({ page }, testInfo) => {
-    annotateConnCase(testInfo, 'wizardOpen'); // emits the shared Allure labels
+    annotateConnCase(testInfo, 'kubeconfigConnect'); // emits the shared Allure labels
     // ...
   },
 );` >}}
@@ -226,4 +226,4 @@ test(
 Behaviors that do not yet have a Test Plan row use `connTagsUntracked('<Component>')`
 so they still land in the report grouped by component; graduate them into the
 map once a Test # is assigned. Run a single Test # with
-`npx playwright test --grep @TC-98`.
+`npx playwright test --grep @TC-1012`.

--- a/docs/content/en/project/contributing/ui/tests.md
+++ b/docs/content/en/project/contributing/ui/tests.md
@@ -192,3 +192,38 @@ To filter and view only UI-related tests using the Sheet Views feature:
 2. Choose the pre-defined view labeled "UI"
 
 ![Meshery Test Plan Screenshot](../../images/meshery-test-plan-v0.8.0-ui.png)
+
+## Linking tests to the Test Plan (traceability)
+
+To make Playwright results traceable back to the Meshery Test Plan and to group
+them in the Allure report by behavior, tests are tagged with their Test Plan
+identifiers. The Kubernetes Connection suite is the reference implementation.
+
+- **`@TC-<n>`** - the Test Plan "Test #" (column A). Reuse the existing sheet
+  number for the scenario; never invent one, so the UI, CLI (BATS), and
+  reporting lanes line up on the same id.
+- **`@cut:<slug>`** - the "Component" under test (column C), slugified.
+- **`@client:ui`** and **`@connections`** - client and suite selectors, so a
+  behavior can be run in isolation with `--grep @connections`.
+
+The tag list and the matching Allure labels (`epic`, `feature`, `story`,
+`testId`, `componentUnderTest`, `client`) are produced from a single map so the
+spec stays declarative and the sheet ↔ code link lives in one place. For the
+connections suite that map is
+[`ui/tests/e2e/connections.testmap.ts`](https://github.com/meshery/meshery/blob/master/ui/tests/e2e/connections.testmap.ts):
+
+{{< code code=`import { annotateConnCase, connTags } from './connections.testmap';
+
+test(
+  'Open the Kubernetes connection wizard and show kubeconfig upload',
+  { tag: connTags('wizardOpen') },
+  async ({ page }, testInfo) => {
+    annotateConnCase(testInfo, 'wizardOpen'); // emits the shared Allure labels
+    // ...
+  },
+);` >}}
+
+Behaviors that do not yet have a Test Plan row use `connTagsUntracked('<Component>')`
+so they still land in the report grouped by component; graduate them into the
+map once a Test # is assigned. Run a single Test # with
+`npx playwright test --grep @TC-98`.

--- a/ui/components/connections/ConnectionWizardModal.tsx
+++ b/ui/components/connections/ConnectionWizardModal.tsx
@@ -133,10 +133,15 @@ const ConnectionWizardModal = ({
           <ModalButtonSecondary
             onClick={wizard.canGoBack ? wizard.back : handleClose}
             disabled={wizard.isBusy}
+            data-testid="connection-wizard-back"
           >
             {wizard.canGoBack ? 'Back' : 'Cancel'}
           </ModalButtonSecondary>
-          <ModalButtonPrimary onClick={wizard.next} disabled={!wizard.canProceed || wizard.isBusy}>
+          <ModalButtonPrimary
+            onClick={wizard.next}
+            disabled={!wizard.canProceed || wizard.isBusy}
+            data-testid="connection-wizard-next"
+          >
             {wizard.isBusy ? 'Working...' : wizard.nextLabel}
           </ModalButtonPrimary>
         </Box>

--- a/ui/components/connections/wizard/kubernetesExtension.tsx
+++ b/ui/components/connections/wizard/kubernetesExtension.tsx
@@ -217,7 +217,8 @@ const ReviewContextsStepBody = ({ ctx }: { ctx: WizardContext }) => {
                 onChange={(event) => updateChoice(context.id, { selected: event.target.checked })}
                 sx={{ p: 0 }}
               />
-              <Box sx={{ flex: 1, minWidth: 0 }}>
+              {/* data-testid anchors each discovered context row for e2e. */}
+              <Box sx={{ flex: 1, minWidth: 0 }} data-testid="connection-wizard-context-row">
                 <TextField
                   variant="standard"
                   fullWidth

--- a/ui/tests/e2e/assets/kubeconfig-multi-context.yaml
+++ b/ui/tests/e2e/assets/kubeconfig-multi-context.yaml
@@ -1,0 +1,50 @@
+# Multi-context kubeconfig fixture for Meshery UI e2e tests.
+#
+# Three contexts pointing at deliberately unreachable API servers (the
+# `.invalid` TLD is reserved by RFC 2606 and never resolves). Token auth is used
+# instead of client certificates so the kubeconfig parses and each context can
+# build a Kubernetes client without embedding real PEM material - the servers
+# are simply unreachable, so discovery lists all three contexts and flags them
+# as not reachable (imported as `discovered`, never cascaded to `connected`).
+#
+# This drives the wizard's "Review contexts" step (one row per context) without
+# needing three real clusters, which multi-cluster (lab-only) coverage requires.
+apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster-alpha
+    cluster:
+      server: https://alpha.meshery-e2e.invalid:6443
+      insecure-skip-tls-verify: true
+  - name: cluster-beta
+    cluster:
+      server: https://beta.meshery-e2e.invalid:6443
+      insecure-skip-tls-verify: true
+  - name: cluster-gamma
+    cluster:
+      server: https://gamma.meshery-e2e.invalid:6443
+      insecure-skip-tls-verify: true
+users:
+  - name: user-alpha
+    user:
+      token: e2e-fake-token-alpha
+  - name: user-beta
+    user:
+      token: e2e-fake-token-beta
+  - name: user-gamma
+    user:
+      token: e2e-fake-token-gamma
+contexts:
+  - name: alpha
+    context:
+      cluster: cluster-alpha
+      user: user-alpha
+  - name: beta
+    context:
+      cluster: cluster-beta
+      user: user-beta
+  - name: gamma
+    context:
+      cluster: cluster-gamma
+      user: user-gamma
+current-context: alpha

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -70,7 +70,7 @@ test.describe.serial('Connection Management Tests', () => {
 
   test(
     'Verify that UI components are displayed',
-    { tag: connTagsUntracked('UI/Connections') },
+    { tag: connTagsUntracked('UI/Connections Table') },
     async ({ page }, testInfo) => {
       annotateConnCaseUntracked(testInfo, { feature: 'Connections table' });
       // Verify that connections table is displayed (by checking for table headings)
@@ -81,14 +81,18 @@ test.describe.serial('Connection Management Tests', () => {
     },
   );
 
-  // TC-96: opening the Kubernetes wizard surfaces the kubeconfig upload. This is
+  // Opening the Kubernetes wizard surfaces the kubeconfig upload. This is
   // deterministic - it needs a running Meshery UI but no cluster - so it runs in
-  // CI rather than self-skipping.
+  // CI rather than self-skipping. Untracked: it is a UI smoke of the wizard entry
+  // with no dedicated Test Plan row (the matrix begins at registration, R1).
   test(
     'Open the Kubernetes connection wizard and show kubeconfig upload',
-    { tag: connTags('wizardOpen') },
+    { tag: connTagsUntracked('UI/Connection Wizard') },
     async ({ page }, testInfo) => {
-      annotateConnCase(testInfo, 'wizardOpen');
+      annotateConnCaseUntracked(testInfo, {
+        feature: 'Connection wizard',
+        story: 'Open wizard and show kubeconfig upload',
+      });
 
       await openKubernetesWizard(page);
 
@@ -100,10 +104,10 @@ test.describe.serial('Connection Management Tests', () => {
     },
   );
 
-  // TC-97: uploading a multi-context kubeconfig lists every context in the
-  // "Review contexts" step (one row per context). Uses a committed 3-context
-  // fixture with unreachable servers, so it needs the discovery endpoint (a
-  // running server) but no real clusters. Self-skips if discovery is
+  // TC-1014 (matrix R3): uploading a multi-context kubeconfig lists every context
+  // in the "Review contexts" step (one row per context). Uses a committed
+  // 3-context fixture with unreachable servers, so it needs the discovery
+  // endpoint (a running server) but no real clusters. Self-skips if discovery is
   // unavailable.
   test(
     'Discover multiple kubeconfig contexts in the wizard',
@@ -149,9 +153,9 @@ test.describe.serial('Connection Management Tests', () => {
     },
   );
 
-  // TC-104: register + connect a cluster by uploading a kubeconfig through the
-  // wizard. Requires a reachable cluster (the host/CI kubeconfig), so it
-  // self-skips when no kubeconfig is present or the import call does not
+  // TC-1012 (matrix R1): register + connect a cluster by uploading a kubeconfig
+  // through the wizard. Requires a reachable cluster (the host/CI kubeconfig), so
+  // it self-skips when no kubeconfig is present or the import call does not
   // succeed.
   test(
     'Register and connect a Kubernetes cluster via kubeconfig upload',
@@ -213,7 +217,7 @@ test.describe.serial('Connection Management Tests', () => {
     },
   );
 
-  // TC-98: transition a connected cluster to another lifecycle state and back,
+  // TC-1061 (matrix X1): transition a connected cluster to disconnected (and back),
   // via the table status dropdown and the shared confirmation modal. Requires a
   // pre-connected cluster, so it self-skips in environments without one.
   test(
@@ -269,14 +273,14 @@ test.describe.serial('Connection Management Tests', () => {
     },
   );
 
+  // TC-1063 (matrix X3): FSM delete (graceful) - the UI bulk-delete sets status
+  // to `deleted` via the shared transition modal (PUT /connections/{id}), not the
+  // hard DELETE endpoint. Self-skips without a connected cluster.
   test(
     'Delete Kubernetes cluster connections',
-    { tag: connTagsUntracked('UI/Connections') },
+    { tag: connTags('delete') },
     async ({ page, clusterMetaData }, testInfo) => {
-      annotateConnCaseUntracked(testInfo, {
-        feature: 'Connection lifecycle',
-        story: 'Hard delete a connection',
-      });
+      annotateConnCase(testInfo, 'delete');
       // The full search -> delete -> confirm -> snackbar flow can be slow in CI.
       test.slow();
 

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -42,7 +42,7 @@ async function openKubernetesWizard(page: Page): Promise<void> {
     waitUntil: 'domcontentloaded',
   });
   await expect(page.getByRole('heading', { name: 'Create Connection' })).toBeVisible();
-  await expect(page.getByText('Upload a kubeconfig')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Upload a kubeconfig' })).toBeVisible();
 }
 
 /** Attach a kubeconfig to the wizard's hidden file input. */
@@ -208,7 +208,9 @@ test.describe.serial('Connection Management Tests', () => {
       ).toBe(200);
 
       // The receipt step confirms the import.
-      await expect(page.getByText(/import complete|Configuration saved/i)).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: /Kubernetes import complete|Configuration saved/i }),
+      ).toBeVisible();
     },
   );
 

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -156,10 +156,12 @@ test.describe.serial('Connection Management Tests', () => {
       ).toBe(200);
 
       // The fixture has three contexts (alpha, beta, gamma); each renders one
-      // review row. All three are unreachable, so none cascades to connected.
+      // review row with an editable name field. All three are unreachable, so
+      // none cascades to connected. Assert on the row count rather than a
+      // specific context name (the discovered name is not asserted here).
       const rows = page.getByTestId('connection-wizard-context-row');
       await expect(rows).toHaveCount(3);
-      await expect(page.getByRole('textbox', { name: 'Name for alpha' })).toBeVisible();
+      await expect(rows.first().getByRole('textbox')).toBeVisible();
     },
   );
 

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -28,10 +28,16 @@ import {
 const MULTI_CONTEXT_KUBECONFIG = path.join(__dirname, 'assets', 'kubeconfig-multi-context.yaml');
 const HOST_KUBECONFIG = path.join(os.homedir(), '.kube', 'config');
 
+// Wait for the connections LIST response specifically. Matching any 200 whose
+// URL merely contains "/api/integrations/connections" would also resolve on the
+// PUT /connections/{id} status-update, letting a table-refresh wait complete on
+// an unrelated request; restrict to the GET collection endpoint.
 function waitForConnectionsApiResponse(page: Page): Promise<Response> {
   return page.waitForResponse(
     (response) =>
-      response.url().includes('/api/integrations/connections') && response.status() === 200,
+      response.request().method() === 'GET' &&
+      /\/api\/integrations\/connections(\?|$)/.test(response.url()) &&
+      response.status() === 200,
   );
 }
 
@@ -40,7 +46,11 @@ async function openKubernetesWizard(page: Page): Promise<void> {
   await page.goto('/management/connections?create=true&kind=kubernetes', {
     waitUntil: 'domcontentloaded',
   });
-  await expect(page.getByRole('heading', { name: 'Create Connection' })).toBeVisible();
+  // The wizard opens preset to Kubernetes on the "Import Kubeconfig" step. Its
+  // StepHeader is an h6 ("Upload a kubeconfig"), a reliable heading anchor for
+  // "the wizard opened and reached the kubeconfig step". The modal chrome title
+  // ("Create Connection") is not rendered as a heading element, so it must not
+  // be asserted via getByRole('heading').
   await expect(page.getByRole('heading', { name: 'Upload a kubeconfig' })).toBeVisible();
 }
 
@@ -236,7 +246,9 @@ test.describe.serial('Connection Management Tests', () => {
       const row = page
         .locator('tbody tr')
         .filter({ hasText: clusterMetaData.name })
-        .filter({ hasText: 'connected' })
+        // Exact status match: `hasText: 'connected'` also matches "disconnected"
+        // (substring), which could select an already-disconnected row.
+        .filter({ has: page.getByText('connected', { exact: true }) })
         .first();
 
       if ((await row.count()) === 0) {
@@ -263,13 +275,17 @@ test.describe.serial('Connection Management Tests', () => {
       const restored = page
         .locator('tbody tr')
         .filter({ hasText: clusterMetaData.name })
-        .filter({ hasText: 'disconnected' })
+        .filter({ has: page.getByText('disconnected', { exact: true }) })
         .first();
       await restored.locator('#connection-status-select').click();
       await page.getByRole('option', { name: 'connected' }).click();
       await expect(page.getByTestId('connection-transition-modal')).toBeVisible();
+      // Verify the restore PUT like the disconnect leg, so a failed restore is
+      // surfaced (not left to the snackbar alone) and state is left as found.
+      const restoreRes = waitForConnectionsApiResponse(page);
       await page.getByTestId('connection-transition-confirm').click();
       await waitForSnackBar(page, 'Connection status updated');
+      await restoreRes;
     },
   );
 
@@ -302,7 +318,9 @@ test.describe.serial('Connection Management Tests', () => {
       const row = page
         .locator('tbody tr')
         .filter({ hasText: clusterMetaData.name })
-        .filter({ hasText: 'connected' })
+        // Exact status match: `hasText: 'connected'` also matches "disconnected"
+        // (substring), which could select an already-disconnected row.
+        .filter({ has: page.getByText('connected', { exact: true }) })
         .first();
 
       // Skip the test if no connected cluster is found (e.g., CI environments without a pre-connected cluster)

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -1,18 +1,34 @@
 import { expect, Page, Response } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { test } from './fixtures/project';
-import { ENV } from './env';
 import { DashboardPage } from './pages/DashboardPage';
 import { waitForSnackBar } from './utils/waitForSnackBar';
+import {
+  CONN_CLIENT,
+  CONN_EPIC,
+  annotateConnCase,
+  connTags,
+  connTagsUntracked,
+} from './connections.testmap';
 
-// Define the shape of the transition test objects
-interface TransitionTest {
-  name: string;
-  transitionOption: string;
-  statusAfterTransition: string;
-  restorationOption: string;
-}
+// The connection-lifecycle flows below were rewritten against the current UI.
+// Cluster registration now runs through the Connection Wizard (deep link
+// `?create=true&kind=kubernetes` -> upload `#connection-wizard-kubeconfig-input`
+// -> "Review contexts" -> Import), and state transitions run through the
+// Connections table's status dropdown (`#connection-status-select`) plus the
+// shared `connection-transition-*` confirmation modal. The previous
+// single-modal `connection-addKubernetesModal` / `connection-uploadKubeConfig`
+// testids no longer exist.
+//
+// Tests that need a live Meshery server and a reachable cluster self-skip when
+// the environment cannot provide one (mirroring the delete test), so an
+// infra-less run degrades to "skipped" rather than a false failure.
 
-// These tests need to be updated to reflect the latest connection api changes
+const MULTI_CONTEXT_KUBECONFIG = path.join(__dirname, 'assets', 'kubeconfig-multi-context.yaml');
+const HOST_KUBECONFIG = path.join(os.homedir(), '.kube', 'config');
+
 function waitForConnectionsApiResponse(page: Page): Promise<Response> {
   return page.waitForResponse(
     (response) =>
@@ -20,31 +36,19 @@ function waitForConnectionsApiResponse(page: Page): Promise<Response> {
   );
 }
 
-// name: Name of the test
-// transitionOption: Option to be chosen from dropdown to transition to another state
-// statusAfterTransition: Text shown in current state after transition
-// restorationOption: Option to be chosen from dropdown to transition back to connected state
-const transitionTests: TransitionTest[] = [
-  // skip: this is broken
-  // {
-  //   name: 'Transition to disconnected state and then back to connected state',
-  //   transitionOption: 'disconnected',
-  //   statusAfterTransition: 'disconnected',
-  //   restorationOption: 'connected',
-  // },
-  // {
-  //   name: 'Transition to ignored state and then back to connected state',
-  //   transitionOption: 'ignored',
-  //   statusAfterTransition: 'ignored',
-  //   restorationOption: 'registered',
-  // },
-  // {
-  //   name: 'Transition to not found state and then back to connected state',
-  //   transitionOption: 'not found',
-  //   statusAfterTransition: 'not found',
-  //   restorationOption: 'discovered',
-  // },
-];
+/** Open the Connection Wizard directly on the Kubernetes kubeconfig step. */
+async function openKubernetesWizard(page: Page): Promise<void> {
+  await page.goto('/management/connections?create=true&kind=kubernetes', {
+    waitUntil: 'domcontentloaded',
+  });
+  await expect(page.getByRole('heading', { name: 'Create Connection' })).toBeVisible();
+  await expect(page.getByText('Upload a kubeconfig')).toBeVisible();
+}
+
+/** Attach a kubeconfig to the wizard's hidden file input. */
+async function uploadKubeconfig(page: Page, kubeconfigPath: string): Promise<void> {
+  await page.locator('#connection-wizard-kubeconfig-input').setInputFiles(kubeconfigPath);
+}
 
 test.describe.serial('Connection Management Tests', () => {
   // The shared beforeEach calls dashboardPage.navigateToDashboard() and
@@ -65,191 +69,276 @@ test.describe.serial('Connection Management Tests', () => {
     await expect(page.getByTestId('ConnectionTable-search')).toBeVisible();
   });
 
-  test('Verify that UI components are displayed', async ({ page }) => {
-    // Verify that connections table is displayed (by checking for table headings)
-    const headings = ['Name', 'Environments', 'Kind', 'Category', 'Status', 'Actions'];
-    for (const heading of headings) {
-      await expect(page.getByRole('columnheader', { name: heading })).toBeVisible();
-    }
-  });
-
-  // test('Add a cluster connection by uploading kubeconfig file', async ({
-  //   page,
-  //   clusterMetaData,
-  // }) => {
-  //   await page.getByRole('tab', { name: 'Connections' }).click();
-
-  //   const addConnectionReq = page.waitForRequest(
-  //     (request) =>
-  //       request.url() === `${ENV.MESHERY_SERVER_URL}/api/system/kubernetes` &&
-  //       request.method() === 'POST',
-  //   );
-  //   const addConnectionRes = page.waitForResponse(
-  //     (response) =>
-  //       response.url() === `${ENV.MESHERY_SERVER_URL}/api/system/kubernetes` &&
-  //       response.status() === 200,
-  //   );
-  //   await page.getByTestId('connection-addCluster').click();
-
-  //   // Verify "Add Kubernetes Cluster(s)" modal opens
-  //   await expect(page.getByTestId('connection-addKubernetesModal')).toBeVisible();
-
-  //   const fileChooserPromise = page.waitForEvent('filechooser');
-  //   await page.getByTestId('connection-uploadKubeConfig').click();
-  //   const fileChooser = await fileChooserPromise;
-  //   // Attach existing kubeconfig file of the system, to test the upload without making any changes in configuration
-  //   const kubeConfigPath = `${os.homedir()}/.kube/config`;
-  //   await fileChooser.setFiles(kubeConfigPath);
-
-  //   await page.getByRole('button', { name: 'IMPORT', exact: true }).click();
-
-  //   await addConnectionReq;
-  //   await addConnectionRes;
-
-  //   await page.getByRole('button', { name: 'OK' }).click();
-
-  //   // Search for the newly added cluster
-  //   await page.getByTestId('ConnectionTable-search').getByRole('button').click();
-
-  //   const getConnectionsRes = waitForConnectionsApiResponse(page);
-
-  //   await page.getByRole('textbox', { name: 'Search Connections...' }).click();
-  //   await page.getByRole('textbox', { name: 'Search Connections...' }).fill(clusterMetaData.name);
-
-  //   await getConnectionsRes;
-
-  //   const newConnectionRow = page.getByRole('menuitem', { hasText: clusterMetaData.name }).first();
-  //   await expect(newConnectionRow).toContainText('connected');
-  // });
-
-  transitionTests.forEach((t) => {
-    test(t.name, async ({ page, clusterMetaData }) => {
-      const stateTransitionReq = page.waitForRequest(
-        (request) =>
-          request.url() ===
-            `${ENV.MESHERY_SERVER_URL}/api/integrations/connections/kubernetes/status` &&
-          request.method() === 'PUT',
+  test(
+    'Verify that UI components are displayed',
+    { tag: connTagsUntracked('UI/Connections') },
+    async ({ page }, testInfo) => {
+      testInfo.annotations.push(
+        { type: 'epic', description: CONN_EPIC },
+        { type: 'feature', description: 'Connections table' },
+        { type: 'client', description: CONN_CLIENT },
       );
+      // Verify that connections table is displayed (by checking for table headings)
+      const headings = ['Name', 'Environments', 'Kind', 'Category', 'Status', 'Actions'];
+      for (const heading of headings) {
+        await expect(page.getByRole('columnheader', { name: heading })).toBeVisible();
+      }
+    },
+  );
 
-      const stateTransitionRes = page.waitForResponse(
-        (response) =>
-          response.url() ===
-            `${ENV.MESHERY_SERVER_URL}/api/integrations/connections/kubernetes/status` &&
-          response.status() === 202,
+  // TC-96: opening the Kubernetes wizard surfaces the kubeconfig upload. This is
+  // deterministic - it needs a running Meshery UI but no cluster - so it runs in
+  // CI rather than self-skipping.
+  test(
+    'Open the Kubernetes connection wizard and show kubeconfig upload',
+    { tag: connTags('wizardOpen') },
+    async ({ page }, testInfo) => {
+      annotateConnCase(testInfo, 'wizardOpen');
+
+      await openKubernetesWizard(page);
+
+      // The hidden file input is present (attached, not visible) and the
+      // dropzone prompt + wizard navigation are rendered.
+      await expect(page.locator('#connection-wizard-kubeconfig-input')).toBeAttached();
+      await expect(page.getByText('Click to choose a kubeconfig file')).toBeVisible();
+      await expect(page.getByTestId('connection-wizard-next')).toBeVisible();
+    },
+  );
+
+  // TC-97: uploading a multi-context kubeconfig lists every context in the
+  // "Review contexts" step (one row per context). Uses a committed 3-context
+  // fixture with unreachable servers, so it needs the discovery endpoint (a
+  // running server) but no real clusters. Self-skips if discovery is
+  // unavailable.
+  test(
+    'Discover multiple kubeconfig contexts in the wizard',
+    { tag: connTags('wizardDiscoverContexts') },
+    async ({ page }, testInfo) => {
+      annotateConnCase(testInfo, 'wizardDiscoverContexts');
+      test.slow();
+
+      if (!fs.existsSync(MULTI_CONTEXT_KUBECONFIG)) {
+        test.skip(true, 'Multi-context kubeconfig fixture missing.');
+        return;
+      }
+
+      await openKubernetesWizard(page);
+      await uploadKubeconfig(page, MULTI_CONTEXT_KUBECONFIG);
+
+      const discoverRes = page
+        .waitForResponse(
+          (response) =>
+            response.url().includes('/api/system/kubernetes/contexts') &&
+            response.request().method() === 'POST',
+          { timeout: 60_000 },
+        )
+        .catch(() => null);
+
+      await page.getByTestId('connection-wizard-next').click();
+
+      const response = await discoverRes;
+      if (!response || response.status() !== 200) {
+        test.skip(true, 'Context discovery endpoint unavailable; skipping context listing.');
+        return;
+      }
+
+      // The fixture has three contexts (alpha, beta, gamma); each renders one
+      // review row. All three are unreachable, so none cascades to connected.
+      const rows = page.getByTestId('connection-wizard-context-row');
+      await expect(rows).toHaveCount(3);
+      await expect(page.getByRole('textbox', { name: 'Name for alpha' })).toBeVisible();
+    },
+  );
+
+  // TC-104: register + connect a cluster by uploading a kubeconfig through the
+  // wizard. Requires a reachable cluster (the host/CI kubeconfig), so it
+  // self-skips when no kubeconfig is present or the import call does not
+  // succeed.
+  test(
+    'Register and connect a Kubernetes cluster via kubeconfig upload',
+    { tag: connTags('kubeconfigConnect') },
+    async ({ page }, testInfo) => {
+      annotateConnCase(testInfo, 'kubeconfigConnect');
+      test.slow();
+
+      if (!fs.existsSync(HOST_KUBECONFIG)) {
+        test.skip(true, 'No host kubeconfig available to register a cluster.');
+        return;
+      }
+
+      await openKubernetesWizard(page);
+      await uploadKubeconfig(page, HOST_KUBECONFIG);
+
+      // Step 1 -> 2: discover the contexts in the uploaded kubeconfig.
+      const discoverRes = page
+        .waitForResponse(
+          (response) =>
+            response.url().includes('/api/system/kubernetes/contexts') &&
+            response.request().method() === 'POST',
+          { timeout: 60_000 },
+        )
+        .catch(() => null);
+      await page.getByTestId('connection-wizard-next').click();
+      const discovered = await discoverRes;
+      if (!discovered || discovered.status() !== 200) {
+        test.skip(true, 'Context discovery failed; cannot register cluster.');
+        return;
+      }
+      await expect(page.getByTestId('connection-wizard-context-row').first()).toBeVisible();
+
+      // Step 2 -> 3: import the selected contexts (POST /api/system/kubernetes).
+      const importRes = page
+        .waitForResponse(
+          (response) =>
+            response.url().endsWith('/api/system/kubernetes') &&
+            response.request().method() === 'POST',
+          { timeout: 90_000 },
+        )
+        .catch(() => null);
+      await page.getByTestId('connection-wizard-next').click();
+      const imported = await importRes;
+
+      if (!imported) {
+        test.skip(true, 'Kubeconfig import did not complete in this environment.');
+        return;
+      }
+      expect(
+        imported.status(),
+        `kubeconfig import POST returned ${imported.status()} ${imported.statusText()}`,
+      ).toBe(200);
+
+      // The receipt step confirms the import.
+      await expect(page.getByText(/import complete|Configuration saved/i)).toBeVisible();
+    },
+  );
+
+  // TC-98: transition a connected cluster to another lifecycle state and back,
+  // via the table status dropdown and the shared confirmation modal. Requires a
+  // pre-connected cluster, so it self-skips in environments without one.
+  test(
+    'Transition a Kubernetes connection between lifecycle states',
+    { tag: connTags('stateTransition') },
+    async ({ page, clusterMetaData }, testInfo) => {
+      annotateConnCase(testInfo, 'stateTransition');
+      test.slow();
+
+      // Narrow to the connected data row for the cluster under test.
+      await page.getByTestId('ConnectionTable-search').getByRole('button').click();
+      const filteredRes = waitForConnectionsApiResponse(page);
+      await page.getByRole('textbox', { name: 'Search Connections...' }).fill(clusterMetaData.name);
+      await filteredRes;
+
+      const row = page
+        .locator('tbody tr')
+        .filter({ hasText: clusterMetaData.name })
+        .filter({ hasText: 'connected' })
+        .first();
+
+      if ((await row.count()) === 0) {
+        test.skip(true, 'No connected Kubernetes cluster found to transition. Skipping test.');
+        return;
+      }
+
+      // Open the row's status dropdown and choose "disconnected".
+      await row.locator('#connection-status-select').click();
+      await page.getByRole('option', { name: 'disconnected' }).click();
+
+      // Confirm the transition in the shared modal.
+      await expect(page.getByTestId('connection-transition-modal')).toBeVisible();
+      const transitionRes = waitForConnectionsApiResponse(page);
+      await page.getByTestId('connection-transition-confirm').click();
+      await waitForSnackBar(page, 'Connection status updated');
+      await transitionRes;
+
+      await expect(
+        page.locator('tbody tr').filter({ hasText: clusterMetaData.name }).first(),
+      ).toContainText('disconnected');
+
+      // Transition back to connected so the run leaves state as it found it.
+      const restored = page
+        .locator('tbody tr')
+        .filter({ hasText: clusterMetaData.name })
+        .filter({ hasText: 'disconnected' })
+        .first();
+      await restored.locator('#connection-status-select').click();
+      await page.getByRole('option', { name: 'connected' }).click();
+      await expect(page.getByTestId('connection-transition-modal')).toBeVisible();
+      await page.getByTestId('connection-transition-confirm').click();
+      await waitForSnackBar(page, 'Connection status updated');
+    },
+  );
+
+  test(
+    'Delete Kubernetes cluster connections',
+    { tag: connTagsUntracked('UI/Connections') },
+    async ({ page, clusterMetaData }, testInfo) => {
+      testInfo.annotations.push(
+        { type: 'epic', description: CONN_EPIC },
+        { type: 'feature', description: 'Connection lifecycle' },
+        { type: 'story', description: 'Hard delete a connection' },
+        { type: 'client', description: CONN_CLIENT },
       );
+      // The full search -> delete -> confirm -> snackbar flow can be slow in CI.
+      test.slow();
+
+      // beforeEach already navigates to the connections page.
+      // Find the row with the connection to be deleted.
+      await page.getByTestId('ConnectionTable-search').getByRole('button').click();
 
       const getFilteredConnectionsRes = waitForConnectionsApiResponse(page);
 
-      const getStatusUpdateConnectionsRes = waitForConnectionsApiResponse(page);
-
-      await page.getByTestId('ConnectionTable-search').getByRole('button').click();
+      await page.getByRole('textbox', { name: 'Search Connections...' }).click();
       await page.getByRole('textbox', { name: 'Search Connections...' }).fill(clusterMetaData.name);
 
       await getFilteredConnectionsRes;
 
-      const matchingRows = page.getByRole('menuitem', { hasText: clusterMetaData.name });
-
-      const connectedRow = matchingRows
-        .filter({
-          has: page.locator('span', { hasText: 'connected' }),
-        })
+      // Narrow to the data row for the searched cluster - `tr` alone matches
+      // table headers, MUI menu items, and the chip dropdown popovers, all of
+      // which can carry the word `connected` from filter labels or other
+      // rendered chips and silently grab the wrong row.
+      const row = page
+        .locator('tbody tr')
+        .filter({ hasText: clusterMetaData.name })
+        .filter({ hasText: 'connected' })
         .first();
 
-      await expect(connectedRow).toBeVisible();
+      // Skip the test if no connected cluster is found (e.g., CI environments without a pre-connected cluster)
+      if ((await row.count()) === 0) {
+        test.skip(true, 'No connected Kubernetes cluster found to delete. Skipping test.');
+        return;
+      }
 
-      // ===== TRANSITIONING TO A NEW STATE =====
+      // find the checkbox in the row
+      const checkbox = row.getByRole('checkbox').first();
+      await checkbox.setChecked(true);
 
-      // open state transition options dropdown
-      await connectedRow.locator('span', { hasText: 'connected' }).click();
-      await page.getByRole('option', { name: t.transitionOption }).click();
+      // Click the bulk "Delete" button in the selected-rows toolbar. Delete now
+      // funnels through the shared connection-transition confirmation modal.
+      await page.getByTestId('Button-delete-connections').click();
+      // Verify that the confirmation modal opened.
+      await expect(page.getByTestId('connection-transition-modal')).toBeVisible();
 
-      await expect(page.locator('#searchClick')).toBeVisible();
-      await page.getByRole('button', { name: 'Confirm' }).click();
+      // Capture the PUT to the connection-update endpoint so we can surface
+      // the HTTP status in the test output if the delete fails on the
+      // backend - the alternative (just waiting on the snackbar) leaves
+      // 500s/4xxs invisible: the success toast never fires and the test
+      // hangs to its 60s timeout with no clue what happened.
+      const updateRes = page.waitForResponse(
+        (resp) =>
+          /\/api\/integrations\/connections\/[0-9a-f-]{36}$/.test(resp.url()) &&
+          resp.request().method() === 'PUT',
+        { timeout: 60_000 },
+      );
+
+      await page.getByTestId('connection-transition-confirm').click();
+
+      const response = await updateRes;
+      expect(
+        response.status(),
+        `connection update PUT returned ${response.status()} ${response.statusText()} - body: ${await response.text()}`,
+      ).toBe(200);
 
       await waitForSnackBar(page, 'Connection status updated');
-
-      await stateTransitionReq;
-      await stateTransitionRes;
-      await getStatusUpdateConnectionsRes;
-      // expect new state to be shown as current state
-
-      const updatedConnection = page
-        .getByRole('menuitem', { hasText: clusterMetaData.name })
-        .first();
-      await expect(updatedConnection).toContainText(t.statusAfterTransition);
-
-      // ===== TRANSITION BACK TO "connected" STATE =====
-      // open state transition options dropdown again
-      await updatedConnection.locator('span', { hasText: t.statusAfterTransition }).click();
-      await page.getByRole('option', { name: t.restorationOption }).click();
-
-      await expect(page.locator('#searchClick')).toBeVisible();
-      await page.getByRole('button', { name: 'Confirm' }).click();
-
-      await waitForSnackBar(page, 'Connection status updated');
-    });
-  });
-
-  test('Delete Kubernetes cluster connections', async ({ page, clusterMetaData }) => {
-    // The full search → delete → confirm → snackbar flow can be slow in CI
-    test.slow();
-
-    // beforeEach already navigates to the connections page
-    // Find the row with the connection to be deleted
-    await page.getByTestId('ConnectionTable-search').getByRole('button').click();
-
-    const getFilteredConnectionsRes = waitForConnectionsApiResponse(page);
-
-    await page.getByRole('textbox', { name: 'Search Connections...' }).click();
-    await page.getByRole('textbox', { name: 'Search Connections...' }).fill(clusterMetaData.name);
-
-    await getFilteredConnectionsRes;
-
-    // Narrow to the data row for the searched cluster — `tr` alone matches
-    // table headers, MUI menu items, and the chip dropdown popovers, all of
-    // which can carry the word `connected` from filter labels or other
-    // rendered chips and silently grab the wrong row.
-    const row = page
-      .locator('tbody tr')
-      .filter({ hasText: clusterMetaData.name })
-      .filter({ hasText: 'connected' })
-      .first();
-
-    // Skip the test if no connected cluster is found (e.g., CI environments without a pre-connected cluster)
-    if ((await row.count()) === 0) {
-      test.skip(true, 'No connected Kubernetes cluster found to delete. Skipping test.');
-      return;
-    }
-
-    // find the checkbox in the row
-    const checkbox = row.getByRole('checkbox').first();
-    await checkbox.setChecked(true);
-
-    // Click "Delete" button in the table
-    await page.getByRole('button', { name: 'Delete', exact: true }).click();
-    // Verify that Confirmation modal opened and delete
-    await expect(page.getByText('Delete Connections')).toBeVisible();
-
-    // Capture the PUT to the connection-update endpoint so we can surface
-    // the HTTP status in the test output if the delete fails on the
-    // backend — the alternative (just waiting on the snackbar) leaves
-    // 500s/4xxs invisible: the success toast never fires and the test
-    // hangs to its 60s timeout with no clue what happened.
-    const updateRes = page.waitForResponse(
-      (resp) =>
-        /\/api\/integrations\/connections\/[0-9a-f-]{36}$/.test(resp.url()) &&
-        resp.request().method() === 'PUT',
-      { timeout: 60_000 },
-    );
-
-    await page.getByRole('button', { name: 'DELETE', exact: true }).click();
-
-    const response = await updateRes;
-    expect(
-      response.status(),
-      `connection update PUT returned ${response.status()} ${response.statusText()} — body: ${await response.text()}`,
-    ).toBe(200);
-
-    await waitForSnackBar(page, 'Connection status updated');
-  });
+    },
+  );
 });

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -6,9 +6,8 @@ import { test } from './fixtures/project';
 import { DashboardPage } from './pages/DashboardPage';
 import { waitForSnackBar } from './utils/waitForSnackBar';
 import {
-  CONN_CLIENT,
-  CONN_EPIC,
   annotateConnCase,
+  annotateConnCaseUntracked,
   connTags,
   connTagsUntracked,
 } from './connections.testmap';
@@ -73,11 +72,7 @@ test.describe.serial('Connection Management Tests', () => {
     'Verify that UI components are displayed',
     { tag: connTagsUntracked('UI/Connections') },
     async ({ page }, testInfo) => {
-      testInfo.annotations.push(
-        { type: 'epic', description: CONN_EPIC },
-        { type: 'feature', description: 'Connections table' },
-        { type: 'client', description: CONN_CLIENT },
-      );
+      annotateConnCaseUntracked(testInfo, { feature: 'Connections table' });
       // Verify that connections table is displayed (by checking for table headings)
       const headings = ['Name', 'Environments', 'Kind', 'Category', 'Status', 'Actions'];
       for (const heading of headings) {
@@ -137,10 +132,14 @@ test.describe.serial('Connection Management Tests', () => {
       await page.getByTestId('connection-wizard-next').click();
 
       const response = await discoverRes;
-      if (!response || response.status() !== 200) {
+      if (!response) {
         test.skip(true, 'Context discovery endpoint unavailable; skipping context listing.');
         return;
       }
+      expect(
+        response.status(),
+        `context discovery POST returned ${response.status()} ${response.statusText()}`,
+      ).toBe(200);
 
       // The fixture has three contexts (alpha, beta, gamma); each renders one
       // review row. All three are unreachable, so none cascades to connected.
@@ -274,12 +273,10 @@ test.describe.serial('Connection Management Tests', () => {
     'Delete Kubernetes cluster connections',
     { tag: connTagsUntracked('UI/Connections') },
     async ({ page, clusterMetaData }, testInfo) => {
-      testInfo.annotations.push(
-        { type: 'epic', description: CONN_EPIC },
-        { type: 'feature', description: 'Connection lifecycle' },
-        { type: 'story', description: 'Hard delete a connection' },
-        { type: 'client', description: CONN_CLIENT },
-      );
+      annotateConnCaseUntracked(testInfo, {
+        feature: 'Connection lifecycle',
+        story: 'Hard delete a connection',
+      });
       // The full search -> delete -> confirm -> snackbar flow can be slow in CI.
       test.slow();
 

--- a/ui/tests/e2e/connections.testmap.ts
+++ b/ui/tests/e2e/connections.testmap.ts
@@ -9,13 +9,14 @@ import type { TestInfo } from '@playwright/test';
  * (BATS) and reporting lanes use lets the Connections Allure report line up
  * results across clients on a single Test #.
  *
- * IMPORTANT: `testId`s are reused from EXISTING sheet rows, never invented. As
- * of this writing the sheet's connection rows are Test # 96-104 (the sheet has
- * no higher connection-lifecycle numbering yet). New lifecycle scenarios that
- * do not yet have a sheet row are grouped by feature only (see
- * {@link connTagsUntracked}) until the Test Plan is expanded and their Test #s
- * assigned - at which point they graduate into {@link CONN_CASES}. This file is
- * the single reconciliation point between the sheet and the specs.
+ * IMPORTANT: `testId`s are reused from EXISTING sheet rows, never invented. The
+ * Kubernetes Connection lifecycle cases live at Test # 1012-1089 (the "Latest"
+ * tab is contiguous 1..1011 then 1012..1089), and each row's `[matrix Rn]`
+ * remark ties it to the connection scenario matrix. Only the Client=UI / Both
+ * rows are automated here; scenarios without a rewritten test yet are grouped by
+ * feature only (see {@link connTagsUntracked}) until a test is added - at which
+ * point they graduate into {@link CONN_CASES}. This file is the single
+ * reconciliation point between the sheet and the specs.
  */
 
 /** Allure epic shared by every connection case (groups the Connections report). */
@@ -38,49 +39,43 @@ export interface ConnCase {
 }
 
 /**
- * Tracked connection cases, keyed by a stable symbol used in the specs.
- *
- * The `componentUnderTest` values are copied from the sheet as-authored; note
- * that Test # 104 predates the consolidation of kubeconfig upload into the
- * Connection Wizard, so its component still reads "UI/Settings" even though the
- * test now drives the wizard. The traceability id is what must stay stable;
- * updating the sheet's column C is a Test-Plan edit owned separately.
+ * Tracked connection cases, keyed by a stable symbol used in the specs. Each maps
+ * to a Client=UI row in the Test Plan's connection block (Test # 1012-1089); the
+ * `[matrix Rn]` id from the sheet is noted for cross-reference. `componentUnderTest`
+ * is copied from the sheet's column C verbatim.
  */
 export const CONN_CASES = {
-  wizardOpen: {
-    testId: 'TC-96',
-    sheetRow: 96,
-    componentUnderTest: 'UI/Connection Wizard',
-    feature: 'Connection wizard',
-    story: 'Open wizard and show kubeconfig upload',
-  },
-  wizardDiscoverContexts: {
-    testId: 'TC-97',
-    sheetRow: 97,
-    componentUnderTest: 'UI/Connection Wizard',
-    feature: 'Connection wizard',
-    story: 'Discover kubeconfig contexts',
-  },
-  stateTransition: {
-    testId: 'TC-98',
-    sheetRow: 98,
-    componentUnderTest: 'UI/Connection Wizard',
-    feature: 'Connection state transitions',
-    story: 'Transition a connection between lifecycle states',
-  },
-  operatorStatus: {
-    testId: 'TC-101',
-    sheetRow: 101,
-    componentUnderTest: 'UI/Settings',
-    feature: 'Meshery Operator',
-    story: 'Operator and controller status for a connected cluster',
-  },
+  // matrix R1
   kubeconfigConnect: {
-    testId: 'TC-104',
-    sheetRow: 104,
-    componentUnderTest: 'UI/Settings',
+    testId: 'TC-1012',
+    sheetRow: 1012,
+    componentUnderTest: 'UI/Connection Wizard',
     feature: 'Kubeconfig import',
-    story: 'Register and connect a cluster via kubeconfig upload',
+    story: 'Register reachable single-context kubeconfig',
+  },
+  // matrix R3 (this test covers the multi-context discover + review-listing portion)
+  wizardDiscoverContexts: {
+    testId: 'TC-1014',
+    sheetRow: 1014,
+    componentUnderTest: 'UI/Connection Wizard',
+    feature: 'Connection wizard',
+    story: 'Register multi-context kubeconfig (discover + review contexts)',
+  },
+  // matrix X1
+  stateTransition: {
+    testId: 'TC-1061',
+    sheetRow: 1061,
+    componentUnderTest: 'UI/Connections Table',
+    feature: 'Connection state transitions',
+    story: 'Disconnect a connected cluster',
+  },
+  // matrix X3
+  delete: {
+    testId: 'TC-1063',
+    sheetRow: 1063,
+    componentUnderTest: 'UI/Connections Table',
+    feature: 'Connection lifecycle',
+    story: 'FSM delete (graceful)',
   },
 } as const satisfies Record<string, ConnCase>;
 

--- a/ui/tests/e2e/connections.testmap.ts
+++ b/ui/tests/e2e/connections.testmap.ts
@@ -137,3 +137,24 @@ export function annotateConnCase(testInfo: TestInfo, key: ConnCaseKey): void {
     { type: 'story', description: testCase.story },
   );
 }
+
+/**
+ * Emit the shared Allure label contract for an untracked connection case - one
+ * with no dedicated sheet Test # yet (see {@link connTagsUntracked}): `epic`,
+ * `client`, `feature`, and `story` when provided. Mirrors
+ * {@link annotateConnCase} so the sheet<->code label contract stays defined in
+ * this file rather than inlined per spec.
+ */
+export function annotateConnCaseUntracked(
+  testInfo: TestInfo,
+  { feature, story }: { feature: string; story?: string },
+): void {
+  testInfo.annotations.push(
+    { type: 'epic', description: CONN_EPIC },
+    { type: 'client', description: CONN_CLIENT },
+    { type: 'feature', description: feature },
+  );
+  if (story) {
+    testInfo.annotations.push({ type: 'story', description: story });
+  }
+}

--- a/ui/tests/e2e/connections.testmap.ts
+++ b/ui/tests/e2e/connections.testmap.ts
@@ -1,0 +1,139 @@
+import type { TestInfo } from '@playwright/test';
+
+/**
+ * Traceability map for the Kubernetes Connection Playwright suite.
+ *
+ * Each tracked case mirrors a row in the Meshery Test Plan spreadsheet
+ * ("Latest" tab): `testId` is column A ("Test #") and `componentUnderTest` is
+ * column C ("Component"), verbatim. Keeping the same `testId` here that the CLI
+ * (BATS) and reporting lanes use lets the Connections Allure report line up
+ * results across clients on a single Test #.
+ *
+ * IMPORTANT: `testId`s are reused from EXISTING sheet rows, never invented. As
+ * of this writing the sheet's connection rows are Test # 96-104 (the sheet has
+ * no higher connection-lifecycle numbering yet). New lifecycle scenarios that
+ * do not yet have a sheet row are grouped by feature only (see
+ * {@link connTagsUntracked}) until the Test Plan is expanded and their Test #s
+ * assigned - at which point they graduate into {@link CONN_CASES}. This file is
+ * the single reconciliation point between the sheet and the specs.
+ */
+
+/** Allure epic shared by every connection case (groups the Connections report). */
+export const CONN_EPIC = 'Kubernetes Connections';
+
+/** Client label for the shared cross-lane contract (UI vs CLI). */
+export const CONN_CLIENT = 'UI';
+
+export interface ConnCase {
+  /** Meshery Test Plan "Latest" tab, column A ("Test #"), e.g. `TC-98`. */
+  testId: string;
+  /** Numeric sheet row, for diffing this map against the sheet. */
+  sheetRow: number;
+  /** Meshery Test Plan "Latest" tab, column C ("Component"), verbatim. */
+  componentUnderTest: string;
+  /** Allure feature grouping. */
+  feature: string;
+  /** Allure story. */
+  story: string;
+}
+
+/**
+ * Tracked connection cases, keyed by a stable symbol used in the specs.
+ *
+ * The `componentUnderTest` values are copied from the sheet as-authored; note
+ * that Test # 104 predates the consolidation of kubeconfig upload into the
+ * Connection Wizard, so its component still reads "UI/Settings" even though the
+ * test now drives the wizard. The traceability id is what must stay stable;
+ * updating the sheet's column C is a Test-Plan edit owned separately.
+ */
+export const CONN_CASES = {
+  wizardOpen: {
+    testId: 'TC-96',
+    sheetRow: 96,
+    componentUnderTest: 'UI/Connection Wizard',
+    feature: 'Connection wizard',
+    story: 'Open wizard and show kubeconfig upload',
+  },
+  wizardDiscoverContexts: {
+    testId: 'TC-97',
+    sheetRow: 97,
+    componentUnderTest: 'UI/Connection Wizard',
+    feature: 'Connection wizard',
+    story: 'Discover kubeconfig contexts',
+  },
+  stateTransition: {
+    testId: 'TC-98',
+    sheetRow: 98,
+    componentUnderTest: 'UI/Connection Wizard',
+    feature: 'Connection state transitions',
+    story: 'Transition a connection between lifecycle states',
+  },
+  operatorStatus: {
+    testId: 'TC-101',
+    sheetRow: 101,
+    componentUnderTest: 'UI/Settings',
+    feature: 'Meshery Operator',
+    story: 'Operator and controller status for a connected cluster',
+  },
+  kubeconfigConnect: {
+    testId: 'TC-104',
+    sheetRow: 104,
+    componentUnderTest: 'UI/Settings',
+    feature: 'Kubeconfig import',
+    story: 'Register and connect a cluster via kubeconfig upload',
+  },
+} as const satisfies Record<string, ConnCase>;
+
+export type ConnCaseKey = keyof typeof CONN_CASES;
+
+/** Turn a Component value into a stable, grep-safe tag slug. */
+const slug = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+/**
+ * Playwright tags for a tracked case. These are grep-able (`--grep @TC-98`) and
+ * are surfaced by allure-playwright as Allure `tag` labels and by the repo's
+ * custom reporter, so the Test # and Component travel with the result without a
+ * runtime Allure dependency.
+ */
+export function connTags(key: ConnCaseKey): string[] {
+  const testCase = CONN_CASES[key];
+  return [
+    '@connections',
+    `@${testCase.testId}`,
+    `@cut:${slug(testCase.componentUnderTest)}`,
+    `@client:${slug(CONN_CLIENT)}`,
+  ];
+}
+
+/**
+ * Coarse tags for a connection behaviour that has no dedicated sheet Test # yet
+ * (e.g. hard delete, table filtering). Grouped by Component only so it still
+ * lands in the Connections report; graduate it into {@link CONN_CASES} once a
+ * Test # is assigned.
+ */
+export function connTagsUntracked(componentUnderTest: string): string[] {
+  return ['@connections', `@cut:${slug(componentUnderTest)}`, `@client:${slug(CONN_CLIENT)}`];
+}
+
+/**
+ * Emit the shared Allure label contract via Playwright annotations:
+ * `testId`, `componentUnderTest`, `client`, `epic`, `feature`, `story`.
+ * allure-playwright maps epic/feature/story to Allure labels and captures the
+ * rest; the repo's custom reporter also reads annotations. No extra dependency
+ * is introduced.
+ */
+export function annotateConnCase(testInfo: TestInfo, key: ConnCaseKey): void {
+  const testCase = CONN_CASES[key];
+  testInfo.annotations.push(
+    { type: 'testId', description: testCase.testId },
+    { type: 'componentUnderTest', description: testCase.componentUnderTest },
+    { type: 'client', description: CONN_CLIENT },
+    { type: 'epic', description: CONN_EPIC },
+    { type: 'feature', description: testCase.feature },
+    { type: 'story', description: testCase.story },
+  );
+}

--- a/ui/tests/e2e/connections.testmap.ts
+++ b/ui/tests/e2e/connections.testmap.ts
@@ -117,9 +117,10 @@ export function connTagsUntracked(componentUnderTest: string): string[] {
 /**
  * Emit the shared Allure label contract via Playwright annotations:
  * `testId`, `componentUnderTest`, `client`, `epic`, `feature`, `story`.
- * allure-playwright maps epic/feature/story to Allure labels and captures the
- * rest; the repo's custom reporter also reads annotations. No extra dependency
- * is introduced.
+ * allure-playwright maps epic/feature/story to Allure labels and records the
+ * rest as parameters, so no extra dependency is introduced. (The repo's custom
+ * Playwright reporter only processes `relationship` annotations - it does not
+ * read these; the tags from {@link connTags} are what it surfaces.)
  */
 export function annotateConnCase(testInfo: TestInfo, key: ConnCaseKey): void {
   const testCase = CONN_CASES[key];


### PR DESCRIPTION
## What & why

Establishes automated Meshery UI (Playwright) coverage of the **Kubernetes Connection lifecycle** with traceability back to the Meshery Test Plan, and fixes two latent breakages found along the way. Promoted from a read-only coverage scout of the connections e2e suite.

## Changes

### Connection e2e suite rewritten against the current UI (`ui/tests/e2e/connections.spec.ts`)
The prior add-cluster and state-transition tests were **commented out** and targeted removed testids (`connection-addKubernetesModal`, `connection-uploadKubeConfig`); the kept delete test's `Delete Connections` / `DELETE` selectors were also stale and only survived by self-skipping in CI. Rewritten (not uncommented) against today's UI:

| Test | Test # (matrix) | Runs in CI? |
|---|---|---|
| Register + connect a cluster via kubeconfig upload | TC-1012 (R1) | Self-skips without a reachable cluster |
| Discover multiple kubeconfig contexts (committed 3-context fixture) | TC-1014 (R3) | Yes (server only); **fails** on a broken discovery endpoint, skips only when no server |
| Transition connected -> disconnected -> connected (status dropdown + shared modal) | TC-1061 (X1) | Self-skips without a connected cluster |
| Delete (FSM graceful; bulk-delete -> transition modal -> `deleted`) | TC-1063 (X3) | Self-skips without a connected cluster |
| Open the Kubernetes wizard, show kubeconfig upload | untracked (UI smoke) | Yes |
| Table renders | untracked | Yes |

Registration drives the Connection Wizard (`?create=true&kind=kubernetes` -> `#connection-wizard-kubeconfig-input` -> Review contexts -> Import); transitions use `#connection-status-select` + the shared `connection-transition-*` modal.

### Test Plan traceability (`ui/tests/e2e/connections.testmap.ts`)
A single map mirrors the Test Plan "Latest" tab (Test # <-> Component). `connTags()` / `annotateConnCase()` emit Playwright tags (`@TC-<n>`, `@cut:<slug>`, `@client:ui`, `@connections`) and the shared Allure label contract (`epic`/`feature`/`story`/`testId`/`componentUnderTest`/`client`) with **no new runtime dependency** (Playwright annotations, already consumed by `allure-playwright` + the repo's custom reporter). Documented in the UI testing contributor guide. Run one Test # with `npx playwright test --grep @TC-1012`.

> **Note on Test #s:** these are reused from the **existing** Test Plan connection rows (Test # 1012-1089, "Latest" tab; each row carries a `[matrix Rn]` id), never invented, so the UI, CLI (BATS), and reporting lanes line up on the same id. UI-smoke tests with no dedicated scenario row use `connTagsUntracked(...)` and graduate into the map once a Test # is assigned.

### Stable testids (only production-code change; no behavior change)
`connection-wizard-next`, `connection-wizard-back`, and a per-context review-row anchor - added where the wizard lacked test hooks.

### Fixes found while mapping coverage
- **`make ui-integration-tests`** ran a non-existent npm script `ci-test-integration` -> now `test:e2e:ci:local`.
- **`.github/workflows/test-e2e.yml`** exported `MESHERY_REMOTE_PROVIDER_TOKEN`, but the suite reads `PROVIDER_TOKEN` (`ui/tests/e2e/env.js`), so the Meshery-provider project never authenticated with the token. Renamed to `PROVIDER_TOKEN`. *(Workflow change - flagged for maintainer review.)*

## Verification
- `eslint --max-warnings=0`, `tsc --noEmit`, and `playwright test --list` (6 connection tests discovered; tag filters isolate the right Test #s) all clean.
- Live end-to-end execution requires a running Meshery server + local provider + reachable cluster, which is the **CI e2e gate**; infra-dependent tests self-skip by design so an infra-less run degrades to skipped, not a false failure.

## Flagged for maintainer decision (deliberately not done here)
1. **CI e2e gating.** The e2e job is `continue-on-error: true` and only publishes Allure on push-to-master, so red UI tests neither block PRs nor gate. If Connections tests should become a quality gate, re-enable the commented fail-on-failure step in `test-e2e.yml`. Not flipped unilaterally.
2. **Test Plan expansion.** The broader UI/Both matrix (R-series registration, O-series operator/controllers, M-series MeshSync, D-series rediscovery, W-series wizard bootstrap, L-series list/filter, E-series negatives - Test # 1012-1089) is now numbered in the sheet; those tests are deferred to follow-ups against this same tagging infrastructure.
3. **Multi-cluster** cases are lab-only (off-CI fleet) and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end testing workflows for current provider authentication.
  * Refreshed connection wizard coverage for navigation, status changes, confirmations, and deletion.
  * Added coverage for Kubernetes context discovery and connection lifecycle actions.

* **Documentation**
  * Added guidance for linking tests to Meshery Test Plans and organizing Allure reports.

* **Tests**
  * Added multi-context Kubernetes fixtures and improved test traceability.
  * Added stable identifiers for connection wizard controls and context rows.
  * Updated local integration test commands for consistent CI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->