### PR TITLE
feat(ui): preview Kubernetes contexts after kubeconfig upload

### DIFF
--- a/ui/components/connections/ConnectionWizardStepContent.tsx
+++ b/ui/components/connections/ConnectionWizardStepContent.tsx
@@ -3,7 +3,6 @@ import {
   Checkbox,
   CheckCircleIcon,
   CircularProgress,
-  CloudUploadIcon,
   MenuItem,
   TextField,
   Typography,
@@ -28,18 +27,12 @@ type CredentialOption = {
   name?: string;
 };
 
-const StepLayout = styled(Box)(({ theme }) => ({
+export const StepLayout = styled(Box)(({ theme }) => ({
   display: 'grid',
   gap: theme.spacing(3),
 }));
 
-// ---------------------------------------------------------------------------
-// Shared step header: a bold title with a muted one-line subtitle. Replaces the
-// loose body paragraphs each step used to lead with, giving every step a
-// consistent visual hierarchy.
-// ---------------------------------------------------------------------------
-
-const StepHeader = ({ title, subtitle }: { title: string; subtitle?: ReactNode }) => (
+export const StepHeader = ({ title, subtitle }: { title: string; subtitle?: ReactNode }) => (
   <Box sx={{ display: 'grid', gap: 0.5 }}>
     <Typography variant="h6" sx={{ fontWeight: 600 }}>
       {title}
@@ -68,8 +61,6 @@ const KindCard = styled('button', {
   background: selected
     ? alpha(theme.palette.background.brand.default, 0.06)
     : theme.palette.background.card,
-  // A native <button> defaults to the UA text color; set it explicitly so the
-  // Typography children (which inherit) follow the theme in dark mode.
   color: theme.palette.text.primary,
   padding: theme.spacing(2.5),
   cursor: 'pointer',
@@ -101,8 +92,6 @@ const KindIconWrap = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  // A light, neutral tile so colored integration logos read clearly on the
-  // dark card surface.
   background: theme.palette.common.white,
   border: `1px solid ${theme.palette.divider}`,
   marginBottom: theme.spacing(0.5),
@@ -188,46 +177,6 @@ const InlineNotice = styled(Box)(({ theme }) => ({
   padding: theme.spacing(1, 1.5),
 }));
 
-const UploadDropzone = styled('button')(({ theme }) => ({
-  width: '100%',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  gap: theme.spacing(1),
-  padding: theme.spacing(4),
-  borderRadius: theme.spacing(1.5),
-  border: `1.5px dashed ${theme.palette.divider}`,
-  background: theme.palette.background.card,
-  color: theme.palette.text.primary,
-  cursor: 'pointer',
-  textAlign: 'center',
-  transition: 'border-color 0.15s ease, background 0.15s ease',
-  '&:hover': {
-    borderColor: theme.palette.background.brand.default,
-    background: alpha(theme.palette.background.brand.default, 0.04),
-  },
-}));
-
-const UploadIconCircle = styled(Box)(({ theme }) => ({
-  width: 56,
-  height: 56,
-  borderRadius: '50%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  background: alpha(theme.palette.background.brand.default, 0.12),
-}));
-
-const UploadIcon = styled(CloudUploadIcon)(({ theme }) => ({
-  width: 28,
-  height: 28,
-  fill: theme.palette.background.brand.default,
-}));
-
-const HiddenFileInput = styled('input')({
-  display: 'none',
-});
-
 const FormContainer = styled(Box)(({ theme }) => ({
   borderRadius: theme.spacing(1.5),
   border: `1px solid ${theme.palette.divider}`,
@@ -271,14 +220,6 @@ export const ConnectionKindSelectionStep = ({
         <KindGrid>
           {kinds.map((config) => {
             const isPermitted = canUseKind(config);
-            // Prefer the SVG carried on the connection definition, then the redux
-            // connection metadata icon, then the per-kind static asset.
-            // normalizeStaticImagePath turns inline SVG markup into a data URI and
-            // normalizes repo-relative paths.
-            //
-            // The icon tile (KindIconWrap) is always a white surface, so always
-            // use the COLOR variant — the white variant (e.g. Kubernetes' all-white
-            // logo) would render white-on-white and disappear.
             const definitionSvg = config.svgColor || config.svgWhite;
             const iconSrc =
               normalizeStaticImagePath(definitionSvg) ||
@@ -328,10 +269,6 @@ export const ConnectionKindSelectionStep = ({
   );
 };
 
-// Derive an RJSF uiSchema from a connection/credential JSON schema so each
-// field gets a placeholder hint. Meshery's RJSF widgets already surface a
-// field's `description` as a hover info-button; we mirror that text into a
-// `ui:placeholder` so the guidance is also visible inline in the empty input.
 const buildPlaceholderUiSchema = (
   schema: Record<string, unknown> | null,
 ): Record<string, { 'ui:placeholder': string }> => {
@@ -523,57 +460,6 @@ export const CredentialAssociationStep = ({
   );
 };
 
-type KubernetesImportStepProps = {
-  kubeconfigFile: File | null;
-  onPickFile: (file: File | null) => void;
-};
-
-export const KubernetesImportStep = ({ kubeconfigFile, onPickFile }: KubernetesImportStepProps) => (
-  <StepLayout>
-    <StepHeader
-      title="Upload a kubeconfig"
-      subtitle="Upload a kubeconfig file. Meshery will read the Kubernetes contexts inside and let you choose which ones to import."
-    />
-    <UploadDropzone
-      type="button"
-      onClick={() => document.getElementById('connection-wizard-kubeconfig-input')?.click()}
-    >
-      <UploadIconCircle>
-        <UploadIcon />
-      </UploadIconCircle>
-      {kubeconfigFile ? (
-        <Typography
-          variant="body1"
-          title={kubeconfigFile.name}
-          sx={{
-            fontWeight: 600,
-            maxWidth: '100%',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {kubeconfigFile.name}
-        </Typography>
-      ) : (
-        <Typography variant="body1" sx={{ fontWeight: 600 }}>
-          Click to choose a kubeconfig file
-        </Typography>
-      )}
-      <Typography variant="caption" color="text.secondary">
-        {kubeconfigFile
-          ? 'Click to replace the selected file'
-          : 'Accepts kubeconfigs with embedded certificates'}
-      </Typography>
-    </UploadDropzone>
-    <HiddenFileInput
-      id="connection-wizard-kubeconfig-input"
-      type="file"
-      onChange={(event) => onPickFile(event.target.files?.[0] || null)}
-    />
-  </StepLayout>
-);
-
 type ConnectionReviewStepProps = {
   isKubernetes: boolean;
   label?: string;
@@ -645,7 +531,3 @@ export const ConnectionReviewStep = ({
     </SummaryCard>
   </StepLayout>
 );
-
-// Re-exported so step modules can compose the shared header for steps that
-// don't use one of the components above.
-export { StepHeader };

--- a/ui/components/connections/wizard/kubernetesExtension.tsx
+++ b/ui/components/connections/wizard/kubernetesExtension.tsx
@@ -8,6 +8,8 @@ import {
   Typography,
   SettingsIcon,
 } from '@sistent/sistent';
+import { EVENT_TYPES } from 'lib/event-types';
+import { formatWizardError } from './errors';
 import { useSelector } from 'react-redux';
 import { alpha, styled } from '@/theme';
 import { CONNECTION_STATES } from '@/utils/Enum';
@@ -114,8 +116,8 @@ const ContextsStepBody = ({ ctx }: { ctx: WizardContext }) => {
       });
     } catch (error) {
       ctx.services.notify({
-        message: `Failed to update ${context.name}: ${error}`,
-        event_type: 'error',
+        message: `Failed to update ${context.name}: ${formatWizardError(error)}`,
+        event_type: EVENT_TYPES.ERROR,
       });
     } finally {
       setBusyId(null);

--- a/ui/components/connections/wizard/kubernetesExtension.tsx
+++ b/ui/components/connections/wizard/kubernetesExtension.tsx
@@ -1,49 +1,25 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
-  Alert,
   Box,
-  Checkbox,
   CheckCircleIcon,
   Chip,
   CircularProgress,
-  CustomTooltip,
-  MenuItem,
-  TextField,
   Typography,
-  CloudUploadIcon,
-  AssignmentTurnedInIcon,
   SettingsIcon,
 } from '@sistent/sistent';
 import { useSelector } from 'react-redux';
 import { alpha, styled } from '@/theme';
-import { EVENT_TYPES } from 'lib/event-types';
 import { CONNECTION_STATES } from '@/utils/Enum';
-import {
-  CONNECTIONS_PATH,
-  getKubernetesContexts,
-  kubernetesImportedNotify,
-} from '../ConnectionWizard.helpers';
-import { formatWizardError } from './errors';
-import {
-  DEFAULT_MESHSYNC_DEPLOYMENT_MODE,
-  getMeshsyncModeTooltip,
-  MESHSYNC_DEPLOYMENT_MODE_OPTIONS,
-  MESHSYNC_MODES_DOCS_URL,
-} from './kubernetesDeploymentMode';
+import { CONNECTIONS_PATH, getKubernetesContexts } from '../ConnectionWizard.helpers';
 import { kubernetesSettingsStep } from './kubernetesSettings';
 import FormatConnectionMetadata from '../metadata';
 import { ConnectionStateChip } from '../ConnectionChip';
-import { KubernetesImportStep, StepHeader } from '../ConnectionWizardStepContent';
-import type {
-  ConnectionExtension,
-  DiscoveredKubeContext,
-  GenericRecord,
-  WizardContext,
-  WizardStep,
-} from './types';
+import { StepHeader } from '../ConnectionWizardStepContent';
+import { kubernetesDetailsStep } from './kubernetesImportStep';
+import { kubernetesReviewStep } from './kubernetesReviewStep';
+import type { ConnectionExtension, GenericRecord, WizardContext, WizardStep } from './types';
 
-const KUBECONFIG_DOCS_URL = 'https://docs.meshery.io/installation/kubernetes';
 const KUBERNETES_CONNECTION_DOCS_URL =
   'https://docs.meshery.io/guides/infrastructure-management/kubernetes-connection-lifecycle';
 
@@ -62,16 +38,6 @@ const ContextRow = styled(Box, {
   '&:hover': {
     borderColor: theme.palette.background.brand?.default,
   },
-}));
-
-const ConnectNotice = styled(Box)(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: theme.spacing(1),
-  borderRadius: theme.spacing(1),
-  border: `1px solid ${theme.palette.divider}`,
-  background: alpha(theme.palette.info.main, 0.06),
-  padding: theme.spacing(1, 1.5),
 }));
 
 const SuccessBadge = styled(Box)(({ theme }) => ({
@@ -96,327 +62,6 @@ const ConnectionsLink = styled(Link)(({ theme }) => ({
   textDecoration: 'underline',
   textUnderlineOffset: 2,
 }));
-
-type ContextChoice = { selected: boolean; name: string; meshsyncDeploymentMode: string };
-
-// ---------------------------------------------------------------------------
-// postConfig accessors. The kubernetes flow keeps its working state on the
-// wizard's free-form postConfig bag.
-// ---------------------------------------------------------------------------
-
-const getDiscovered = (ctx: WizardContext): DiscoveredKubeContext[] =>
-  (ctx.data.postConfig.discoveredContexts as DiscoveredKubeContext[]) || [];
-
-const getChoices = (ctx: WizardContext): Record<string, ContextChoice> =>
-  (ctx.data.postConfig.contextChoices as Record<string, ContextChoice>) || {};
-
-const getConnectOnImport = (ctx: WizardContext): boolean =>
-  ctx.data.postConfig.connectOnImport !== false;
-
-// A discovered context's choice, defaulted for contexts not yet touched.
-const defaultChoice = (name: string): ContextChoice => ({
-  selected: true,
-  name,
-  meshsyncDeploymentMode: DEFAULT_MESHSYNC_DEPLOYMENT_MODE,
-});
-
-// ---------------------------------------------------------------------------
-// 2. Import kubeconfig (overrides the generic details step). Picks a file and,
-// on Next, discovers its contexts WITHOUT persisting them.
-// ---------------------------------------------------------------------------
-
-const KubeconfigStepBody = ({ ctx }: { ctx: WizardContext }) => (
-  <KubernetesImportStep
-    kubeconfigFile={ctx.data.kubeconfigFile}
-    onPickFile={(kubeconfigFile) => {
-      ctx.patch({ kubeconfigFile, registrationResult: null, registrationError: null });
-      // Drop any previously discovered contexts so a new file is re-discovered.
-      ctx.patchPostConfig({ discoveredContexts: undefined, contextChoices: undefined });
-    }}
-  />
-);
-
-const kubernetesDetailsStep: WizardStep = {
-  id: 'kubeconfig',
-  label: 'Import Kubeconfig',
-  icon: CloudUploadIcon,
-  Component: KubeconfigStepBody,
-  canProceed: (ctx) => Boolean(ctx.data.kubeconfigFile),
-  nextLabel: () => 'Continue',
-  helpText: `Upload a kubeconfig with embedded certificates. Meshery reads the file's contexts, then registers the ones you select as Kubernetes connections. [Learn more about connecting Kubernetes](${KUBECONFIG_DOCS_URL}).`,
-  onNext: async (ctx) => {
-    if (!ctx.data.kubeconfigFile) {
-      return false;
-    }
-    ctx.patch({ registrationError: null });
-    try {
-      const discovered = await ctx.services.discoverKubeContexts(ctx.data.kubeconfigFile);
-      if (discovered.length === 0) {
-        ctx.services.notify({
-          message: 'No Kubernetes contexts were found in the kubeconfig.',
-          event_type: EVENT_TYPES.WARNING,
-        });
-        return false;
-      }
-      const contextChoices = Object.fromEntries(
-        discovered.map((context) => [context.id, defaultChoice(context.name)]),
-      );
-      ctx.patchPostConfig({
-        discoveredContexts: discovered,
-        contextChoices,
-        connectOnImport: true,
-      });
-      return true;
-    } catch (error) {
-      ctx.patch({ registrationError: error });
-      ctx.services.notify({
-        message: `Failed to read kubeconfig: ${formatWizardError(error)}`,
-        event_type: EVENT_TYPES.ERROR,
-      });
-      return false;
-    }
-  },
-};
-
-// ---------------------------------------------------------------------------
-// 3. Review contexts (overrides the generic register step). Select which
-// discovered contexts to import, rename them, and choose whether reachable
-// clusters are connected on import. On Next the selected contexts are created
-// and the reachable ones (when chosen) are transitioned to connected.
-// ---------------------------------------------------------------------------
-
-const ReviewContextsStepBody = ({ ctx }: { ctx: WizardContext }) => {
-  const discovered = getDiscovered(ctx);
-  const choices = getChoices(ctx);
-  const connectOnImport = getConnectOnImport(ctx);
-  const hasReachable = discovered.some((context) => context.reachable);
-
-  const updateChoice = (id: string, partial: Partial<ContextChoice>) =>
-    ctx.patchPostConfig({
-      contextChoices: { ...choices, [id]: { ...choices[id], ...partial } },
-    });
-
-  return (
-    <Box sx={{ display: 'grid', gap: 3 }}>
-      <StepHeader
-        title="Review contexts"
-        subtitle="Choose which clusters to import, rename them if you like, and decide whether reachable clusters should be connected."
-      />
-      {Boolean(ctx.data.registrationError) && (
-        <Alert severity="error" variant="filled">
-          {formatWizardError(ctx.data.registrationError)}
-        </Alert>
-      )}
-      <Box sx={{ display: 'grid', gap: 1.5 }}>
-        {discovered.map((context) => {
-          const choice = choices[context.id] || defaultChoice(context.name);
-          return (
-            <ContextRow key={context.id} muted={!choice.selected}>
-              <Checkbox
-                checked={choice.selected}
-                onChange={(event) => updateChoice(context.id, { selected: event.target.checked })}
-                sx={{ p: 0 }}
-              />
-              {/* data-testid anchors each discovered context row for e2e. */}
-              <Box sx={{ flex: 1, minWidth: 0 }} data-testid="connection-wizard-context-row">
-                <TextField
-                  variant="standard"
-                  fullWidth
-                  value={choice.name}
-                  disabled={!choice.selected}
-                  onChange={(event) => updateChoice(context.id, { name: event.target.value })}
-                  inputProps={{
-                    'aria-label': `Name for ${context.name}`,
-                    title: choice.name,
-                  }}
-                  sx={{
-                    maxWidth: '100%',
-                    '& .MuiInput-input': {
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    },
-                    '& .MuiInput-underline:before, & .MuiInput-underline:after': {
-                      maxWidth: '100%',
-                    },
-                  }}
-                />
-                <Typography variant="caption" color="text.secondary" noWrap component="div">
-                  {context.server || 'unknown server'}
-                </Typography>
-              </Box>
-              {/* MeshSync mode per context; hover shows details + docs link. */}
-              <TextField
-                select
-                variant="standard"
-                label="MeshSync"
-                value={choice.meshsyncDeploymentMode}
-                disabled={!choice.selected}
-                onChange={(event) =>
-                  updateChoice(context.id, { meshsyncDeploymentMode: event.target.value })
-                }
-                sx={{ minWidth: 120 }}
-                inputProps={{ 'aria-label': `MeshSync deployment mode for ${context.name}` }}
-              >
-                {MESHSYNC_DEPLOYMENT_MODE_OPTIONS.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>
-                    <CustomTooltip
-                      interactive
-                      title={getMeshsyncModeTooltip(option)}
-                      placement="left"
-                    >
-                      <Box component="span" sx={{ display: 'block', width: '100%' }}>
-                        {option.label}
-                      </Box>
-                    </CustomTooltip>
-                  </MenuItem>
-                ))}
-              </TextField>
-              <ConnectionStateChip
-                status={
-                  context.reachable ? CONNECTION_STATES.DISCOVERED : CONNECTION_STATES.NOTFOUND
-                }
-              />
-            </ContextRow>
-          );
-        })}
-      </Box>
-      <ConnectNotice
-        onClick={() => hasReachable && ctx.patchPostConfig({ connectOnImport: !connectOnImport })}
-        sx={{ cursor: hasReachable ? 'pointer' : 'default' }}
-      >
-        <Checkbox
-          checked={connectOnImport}
-          disabled={!hasReachable}
-          onChange={(event) => ctx.patchPostConfig({ connectOnImport: event.target.checked })}
-          onClick={(event) => event.stopPropagation()}
-          sx={{ p: 0 }}
-        />
-        <Typography variant="body2">
-          Connect reachable clusters after import. Unreachable clusters are imported as discovered
-          and can be connected later.
-        </Typography>
-      </ConnectNotice>
-    </Box>
-  );
-};
-
-/** Connections returned by the upload endpoint, with how they should be acted on. */
-type CreatedContext = {
-  connectionId: string;
-  name: string;
-  reachable: boolean;
-  alreadyConnected: boolean;
-};
-
-const collectCreated = (result: GenericRecord | null): CreatedContext[] => {
-  const toCreated = (records: GenericRecord[], alreadyConnected: boolean): CreatedContext[] =>
-    records.map((record) => ({
-      connectionId: String(record.connectionId ?? record.id ?? ''),
-      name: String(record.name ?? ''),
-      reachable: Boolean(record.reachable),
-      alreadyConnected,
-    }));
-
-  return [
-    ...toCreated(getKubernetesContexts(result, 'registered'), false),
-    ...toCreated(getKubernetesContexts(result, 'connected'), true),
-  ];
-};
-
-const kubernetesReviewStep: WizardStep = {
-  id: 'kubernetes-review',
-  label: 'Review Contexts',
-  icon: AssignmentTurnedInIcon,
-  Component: ReviewContextsStepBody,
-  nextLabel: () => 'Import',
-  helpText: `Select which contexts to import, choose a MeshSync mode (embedded or operator), and decide whether reachable clusters should connect immediately. Hover a MeshSync option for details. [MeshSync modes](${MESHSYNC_MODES_DOCS_URL}). [Kubernetes connection lifecycle](${KUBERNETES_CONNECTION_DOCS_URL}).`,
-  canProceed: (ctx) => getDiscovered(ctx).some((context) => getChoices(ctx)[context.id]?.selected),
-  onNext: async (ctx) => {
-    const discovered = getDiscovered(ctx);
-    const choices = getChoices(ctx);
-    const selected = discovered.filter((context) => choices[context.id]?.selected);
-    if (!ctx.data.kubeconfigFile || selected.length === 0) {
-      return false;
-    }
-    ctx.patch({ registrationError: null });
-    try {
-      const contexts = Object.fromEntries(
-        selected.map((context) => {
-          const choice = choices[context.id];
-          return [
-            context.id,
-            {
-              name: choice.name.trim() || context.name,
-              meshsyncDeploymentMode: choice.meshsyncDeploymentMode,
-            },
-          ];
-        }),
-      );
-      const result = await ctx.services.uploadKubeconfig(ctx.data.kubeconfigFile, {
-        selectedContextIds: selected.map((context) => context.id),
-        contexts,
-      });
-      ctx.patch({ registrationResult: result ?? {} });
-
-      const created = collectCreated(result ?? {});
-      const connectedIds = new Set(
-        created
-          .filter((context) => context.alreadyConnected)
-          .map((context) => context.connectionId),
-      );
-      if (getConnectOnImport(ctx)) {
-        const toConnect = created.filter(
-          (context) => context.reachable && !context.alreadyConnected && context.connectionId,
-        );
-        const outcomes = await Promise.allSettled(
-          toConnect.map((context) =>
-            ctx.services.updateConnectionById(context.connectionId, {
-              status: CONNECTION_STATES.CONNECTED,
-            }),
-          ),
-        );
-        toConnect.forEach((context, index) => {
-          if (outcomes[index].status === 'fulfilled') {
-            connectedIds.add(context.connectionId);
-          }
-        });
-      }
-
-      // Per-context final state, mapped to the canonical connection states so
-      // the receipt can reuse the shared status chip.
-      const importedContexts = created.map((context) => ({
-        name: context.name,
-        status: connectedIds.has(context.connectionId)
-          ? CONNECTION_STATES.CONNECTED
-          : context.reachable
-            ? CONNECTION_STATES.DISCOVERED
-            : CONNECTION_STATES.NOTFOUND,
-      }));
-
-      ctx.patchPostConfig({
-        importedContexts,
-        createdCount: created.length,
-        connectedCount: connectedIds.size,
-        unreachableCount: created.filter((context) => !context.reachable).length,
-      });
-      ctx.services.notify(kubernetesImportedNotify(created.length));
-      return true;
-    } catch (error) {
-      ctx.patch({ registrationError: error });
-      ctx.services.notify({
-        message: `Failed to import kubeconfig: ${formatWizardError(error)}`,
-        event_type: EVENT_TYPES.ERROR,
-      });
-      return false;
-    }
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Post-config (configure mode only): act on an already-registered connection's
-// contexts. Hidden during creation, where the review step covers connecting.
-// ---------------------------------------------------------------------------
 
 type DiscoveredContext = {
   connectionId: string;
@@ -454,7 +99,6 @@ const ContextsStepBody = ({ ctx }: { ctx: WizardContext }) => {
     () => collectContexts(ctx.data.registrationResult),
     [ctx.data.registrationResult],
   );
-  // Per-context status overrides applied during this session.
   const overrides = (ctx.data.postConfig.contextStatuses as Record<string, string>) || {};
   const [busyId, setBusyId] = useState<string | null>(null);
 
@@ -470,8 +114,8 @@ const ContextsStepBody = ({ ctx }: { ctx: WizardContext }) => {
       });
     } catch (error) {
       ctx.services.notify({
-        message: `Failed to update ${context.name}: ${formatWizardError(error)}`,
-        event_type: EVENT_TYPES.ERROR,
+        message: `Failed to update ${context.name}: ${error}`,
+        event_type: 'error',
       });
     } finally {
       setBusyId(null);
@@ -553,25 +197,15 @@ const kubernetesContextsStep: WizardStep = {
   label: 'Manage Clusters',
   icon: SettingsIcon,
   Component: ContextsStepBody,
-  // The creation flow handles selecting + connecting in the review step; this
-  // step only adds value when (re)configuring an existing connection that
-  // actually carries discovered contexts to manage.
   hidden: (ctx) =>
     ctx.mode === 'create' || collectContexts(ctx.data.registrationResult).length === 0,
 };
-
-// ---------------------------------------------------------------------------
-// 5. Receipt
-// ---------------------------------------------------------------------------
 
 const KubernetesReceiptBody = ({ ctx }: { ctx: WizardContext }) => {
   const controllerState = useSelector(
     (state: { ui: { controllerState: unknown } }) => state.ui.controllerState,
   );
 
-  // Configure mode operates on a single connection: show the same live detail
-  // "receipt" that the Connections table renders when a row is expanded —
-  // status chips, controller versions, and the Diagnostics section.
   const configuredConnection = (ctx.data.registrationResult as GenericRecord) || {};
   if (
     ctx.mode === 'configure' &&
@@ -668,7 +302,7 @@ const kubernetesReceiptStep: WizardStep = {
 export const kubernetesExtension: ConnectionExtension = {
   match: { kind: 'kubernetes' },
   detailsStep: kubernetesDetailsStep,
-  credentialStep: null, // the kubeconfig is the credential
+  credentialStep: null,
   registerStep: kubernetesReviewStep,
   postConfigSteps: [kubernetesSettingsStep, kubernetesContextsStep],
   receiptStep: kubernetesReceiptStep,

--- a/ui/components/connections/wizard/kubernetesImportStep.test.tsx
+++ b/ui/components/connections/wizard/kubernetesImportStep.test.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// @sistent/sistent — styled-component factory + the specific primitives used
+// by KubernetesImportStep/KubeconfigStepBody.
+//
+// Mirrors the pattern in styles.test.tsx (styledFactory) and
+// ConnectionStateTransitionModal.test.tsx (named-component stubs).
+// ---------------------------------------------------------------------------
+
+vi.mock('@sistent/sistent', () => {
+  type AnyProps = React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode };
+
+  return {
+    Alert: ({ children }: AnyProps) => <div role="alert">{children}</div>,
+    Box: ({ children, ...props }: AnyProps) => <div {...props}>{children}</div>,
+    CircularProgress: () => <span data-testid="preview-spinner" />,
+    CloudUploadIcon: () => <svg data-testid="cloud-upload-icon" />,
+    Typography: ({ children }: AnyProps) => <span>{children}</span>,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// @/theme — alpha is only used inside styled-factory callbacks, which the mock
+// above never invokes. Matches the minimal stub in styles.test.tsx line 55-57.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/theme', () => {
+  type AnyProps = React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode };
+
+  // styled(tag)(styleFactory) → passthrough rendered as the underlying element.
+  // Same two-call curried shape as used in Filters.styled.test.tsx.
+  const styledFactory = (Component: React.ComponentType<AnyProps> | string) => () => {
+    const el = typeof Component === 'string' ? Component : 'div';
+    const Passthrough = ({ children, ...props }: AnyProps) =>
+      React.createElement(el as 'div', props as React.HTMLAttributes<HTMLElement>, children);
+    Passthrough.displayName = 'StyledMock';
+    return Passthrough;
+  };
+
+  return {
+    styled: styledFactory,
+    alpha: (color: string, value: number) => `alpha(${color},${value})`,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Transitive deps imported at the module level by kubernetesImportStep.tsx
+// that are not exercised by the race-guard test but must resolve cleanly.
+// ---------------------------------------------------------------------------
+
+vi.mock('../ConnectionWizardStepContent', () => ({
+  StepLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  StepHeader: () => null,
+}));
+
+vi.mock('./kubernetesReviewStep', () => ({
+  defaultChoice: (name: string) => ({ selected: true, name, meshsyncDeploymentMode: 'operator' }),
+}));
+
+vi.mock('./errors', () => ({
+  formatWizardError: (err: unknown) => String(err),
+}));
+
+vi.mock('lib/event-types', () => ({
+  EVENT_TYPES: { ERROR: 'error', WARNING: 'warning' },
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (must come after vi.mock calls — vitest hoists them).
+// ---------------------------------------------------------------------------
+
+import { kubernetesDetailsStep } from './kubernetesImportStep';
+import type { WizardContext, DiscoveredKubeContext } from './types';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a promise together with its resolve/reject handles so individual
+ * test steps can release it at a controlled moment. */
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Builds the smallest WizardContext that KubeconfigStepBody actually reads.
+ *
+ * `data` is a plain object mutated by the `patch`/`patchPostConfig` stubs so
+ * that subsequent reads inside the same async flow see the updated values —
+ * the same pattern used by ConnectionStateTransitionModal.test.tsx's
+ * `mockStoreState` object. Neither Redux nor React state is involved. */
+function makeMockCtx(discoverKubeContexts: WizardContext['services']['discoverKubeContexts']): {
+  ctx: WizardContext;
+  patchPostConfig: ReturnType<typeof vi.fn>;
+} {
+  const data = {
+    kubeconfigFile: null as File | null,
+    postConfig: {} as Record<string, unknown>,
+  } as unknown as WizardContext['data'];
+
+  const patchPostConfig = vi.fn((partial: Record<string, unknown>) => {
+    Object.assign(data.postConfig, partial);
+  });
+
+  const ctx: WizardContext = {
+    mode: 'create',
+    data,
+    patch: vi.fn((partial) => Object.assign(data, partial)),
+    patchPostConfig,
+    services: {
+      discoverKubeContexts,
+      notify: vi.fn(),
+      registerConnection: vi.fn(),
+      connectConnection: vi.fn(),
+      uploadKubeconfig: vi.fn(),
+      updateConnectionById: vi.fn(),
+      setMeshsyncMode: vi.fn(),
+      flushMeshsync: vi.fn(),
+      credentials: [],
+    },
+    formRefs: {
+      connection: { current: null },
+      credential: { current: null },
+    },
+    advance: vi.fn(),
+  } as unknown as WizardContext;
+
+  return { ctx, patchPostConfig };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const { Component: KubeconfigStepBody } = kubernetesDetailsStep;
+
+describe('KubeconfigStepBody preview race-guard (requestVersionRef)', () => {
+  // Regression guard for the CodeRabbit fix: `requestVersion` must be
+  // incremented before the early return on null-file so that any in-flight
+  // discovery promise from a previous pick cannot write its stale result.
+  it('discards a stale preview result when the file is cleared before discovery resolves', async () => {
+    const fileA = new File(['apiVersion: v1\nclusters: []'], 'cluster-a.yaml', {
+      type: 'application/yaml',
+    });
+
+    const staleResult: DiscoveredKubeContext[] = [
+      { id: 'ctx-a', name: 'cluster-a', server: 'https://a.example.com', reachable: true },
+    ];
+
+    // Deferred discovery: the test controls when file A's request settles.
+    const deferred = createDeferred<DiscoveredKubeContext[]>();
+    const discoverKubeContexts = vi.fn(() => deferred.promise);
+
+    const { ctx, patchPostConfig } = makeMockCtx(
+      discoverKubeContexts as unknown as WizardContext['services']['discoverKubeContexts'],
+    );
+
+    const { container } = render(<KubeconfigStepBody ctx={ctx} />);
+
+    const fileInput = container.querySelector(
+      '#connection-wizard-kubeconfig-input',
+    ) as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+
+    // Step 1: pick file A — requestVersion becomes 1, discovery starts in the background.
+    await act(async () => {
+      Object.defineProperty(fileInput, 'files', { value: [fileA], configurable: true });
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(discoverKubeContexts).toHaveBeenCalledTimes(1);
+    expect(discoverKubeContexts).toHaveBeenCalledWith(fileA);
+
+    // Step 2: clear the file before the discovery resolves — requestVersion
+    // becomes 2. The early-return path executes without awaiting anything.
+    await act(async () => {
+      Object.defineProperty(fileInput, 'files', { value: [], configurable: true });
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    // Step 3: resolve the now-stale discovery with real-looking data.
+    await act(async () => {
+      deferred.resolve(staleResult);
+    });
+
+    // The version mismatch (1 !== 2) must have caused handlePickFile to exit
+    // before calling patchPostConfig with the preview contexts.
+    const callsWithPreviewData = patchPostConfig.mock.calls.filter(
+      ([partial]) => partial.previewContexts !== undefined,
+    );
+    expect(callsWithPreviewData).toHaveLength(0);
+  });
+
+  it('writes preview contexts when discovery resolves before the file is changed again', async () => {
+    const fileA = new File(['apiVersion: v1\nclusters: []'], 'cluster-a.yaml', {
+      type: 'application/yaml',
+    });
+
+    const validResult: DiscoveredKubeContext[] = [
+      { id: 'ctx-a', name: 'cluster-a', server: 'https://a.example.com', reachable: true },
+    ];
+
+    const discoverKubeContexts = vi.fn(() => Promise.resolve(validResult));
+
+    const { ctx, patchPostConfig } = makeMockCtx(
+      discoverKubeContexts as unknown as WizardContext['services']['discoverKubeContexts'],
+    );
+
+    const { container } = render(<KubeconfigStepBody ctx={ctx} />);
+
+    const fileInput = container.querySelector(
+      '#connection-wizard-kubeconfig-input',
+    ) as HTMLInputElement;
+
+    // Pick a file and let discovery resolve immediately.
+    await act(async () => {
+      Object.defineProperty(fileInput, 'files', { value: [fileA], configurable: true });
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    // The request version still matches — preview must have been written.
+    const callsWithPreviewData = patchPostConfig.mock.calls.filter(
+      ([partial]) => partial.previewContexts !== undefined,
+    );
+    expect(callsWithPreviewData).toHaveLength(1);
+    expect(callsWithPreviewData[0][0].previewContexts).toEqual(validResult);
+  });
+});

--- a/ui/components/connections/wizard/kubernetesImportStep.tsx
+++ b/ui/components/connections/wizard/kubernetesImportStep.tsx
@@ -1,0 +1,256 @@
+import { useRef, useState } from 'react';
+import { Alert, Box, CircularProgress, CloudUploadIcon, Typography } from '@sistent/sistent';
+import { alpha, styled } from '@/theme';
+import { EVENT_TYPES } from 'lib/event-types';
+import { StepHeader, StepLayout } from '../ConnectionWizardStepContent';
+import { formatWizardError } from './errors';
+import { defaultChoice } from './kubernetesReviewStep';
+import type { DiscoveredKubeContext, WizardContext, WizardStep } from './types';
+
+const KUBECONFIG_DOCS_URL = 'https://docs.meshery.io/installation/kubernetes';
+
+const UploadDropzone = styled('button')(({ theme }) => ({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  padding: theme.spacing(4),
+  borderRadius: theme.spacing(1.5),
+  border: `1.5px dashed ${theme.palette.divider}`,
+  background: theme.palette.background.card,
+  color: theme.palette.text.primary,
+  cursor: 'pointer',
+  textAlign: 'center',
+  transition: 'border-color 0.15s ease, background 0.15s ease',
+  '&:hover': {
+    borderColor: theme.palette.background.brand.default,
+    background: alpha(theme.palette.background.brand.default, 0.04),
+  },
+}));
+
+const UploadIconCircle = styled(Box)(({ theme }) => ({
+  width: 56,
+  height: 56,
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: alpha(theme.palette.background.brand.default, 0.12),
+}));
+
+const UploadIcon = styled(CloudUploadIcon)(({ theme }) => ({
+  width: 28,
+  height: 28,
+  fill: theme.palette.background.brand.default,
+}));
+
+const HiddenFileInput = styled('input')({
+  display: 'none',
+});
+
+type KubernetesImportStepProps = {
+  kubeconfigFile: File | null;
+  previewContexts?: DiscoveredKubeContext[];
+  previewLoading?: boolean;
+  onPickFile: (file: File | null) => void;
+};
+
+const KubernetesImportStep = ({
+  kubeconfigFile,
+  previewContexts,
+  previewLoading,
+  onPickFile,
+}: KubernetesImportStepProps) => (
+  <StepLayout>
+    <StepHeader
+      title="Upload a kubeconfig"
+      subtitle="Upload a kubeconfig file. Meshery will read the Kubernetes contexts inside and let you choose which ones to import."
+    />
+    <UploadDropzone
+      type="button"
+      onClick={() => document.getElementById('connection-wizard-kubeconfig-input')?.click()}
+    >
+      <UploadIconCircle>
+        <UploadIcon />
+      </UploadIconCircle>
+      {kubeconfigFile ? (
+        <Typography
+          variant="body1"
+          title={kubeconfigFile.name}
+          sx={{
+            fontWeight: 600,
+            maxWidth: '100%',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {kubeconfigFile.name}
+        </Typography>
+      ) : (
+        <Typography variant="body1" sx={{ fontWeight: 600 }}>
+          Click to choose a kubeconfig file
+        </Typography>
+      )}
+      <Typography variant="caption" color="text.secondary">
+        {kubeconfigFile
+          ? 'Click to replace the selected file'
+          : 'Accepts kubeconfigs with embedded certificates'}
+      </Typography>
+    </UploadDropzone>
+    {previewLoading && (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          mt: 2,
+        }}
+      >
+        <CircularProgress size={18} />
+        <Typography variant="body2" color="text.secondary">
+          Discovering Kubernetes contexts...
+        </Typography>
+      </Box>
+    )}
+    {!previewLoading && previewContexts && previewContexts.length > 0 && (
+      <Box
+        sx={{
+          mt: 2,
+          display: 'grid',
+          gap: 1,
+        }}
+      >
+        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+          Detected Kubernetes contexts
+        </Typography>
+
+        {previewContexts.map((context) => (
+          <Box
+            key={context.id}
+            sx={{
+              p: 1.5,
+              border: (theme) => `1px solid ${theme.palette.divider}`,
+              borderRadius: 1,
+            }}
+          >
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {context.name}
+            </Typography>
+
+            <Typography variant="caption" color="text.secondary" component="div">
+              {context.server || 'Unknown server'}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    )}
+    {!previewLoading && previewContexts && previewContexts.length === 0 && (
+      <Alert severity="warning">
+        No Kubernetes contexts were found in the selected kubeconfig.
+      </Alert>
+    )}
+    <HiddenFileInput
+      id="connection-wizard-kubeconfig-input"
+      type="file"
+      onChange={(event) => onPickFile(event.target.files?.[0] || null)}
+    />
+  </StepLayout>
+);
+
+const KubeconfigStepBody = ({ ctx }: { ctx: WizardContext }) => {
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const requestVersionRef = useRef(0);
+
+  const handlePickFile = async (kubeconfigFile: File | null) => {
+    ctx.patch({
+      kubeconfigFile,
+      registrationResult: null,
+      registrationError: null,
+    });
+
+    ctx.patchPostConfig({
+      discoveredContexts: undefined,
+      contextChoices: undefined,
+      previewContexts: undefined,
+    });
+
+    if (!kubeconfigFile) {
+      return;
+    }
+
+    const requestVersion = ++requestVersionRef.current;
+    setPreviewLoading(true);
+
+    try {
+      const previewContexts = await ctx.services.discoverKubeContexts(kubeconfigFile);
+
+      if (requestVersion !== requestVersionRef.current) {
+        return;
+      }
+
+      ctx.patchPostConfig({
+        previewContexts,
+      });
+    } catch {
+      // Preview discovery is best-effort. Swallow errors so they do not surface
+      // as unhandled rejections; Continue performs authoritative discovery and error handling.
+    } finally {
+      if (requestVersion === requestVersionRef.current) {
+        setPreviewLoading(false);
+      }
+    }
+  };
+
+  return (
+    <KubernetesImportStep
+      kubeconfigFile={ctx.data.kubeconfigFile}
+      previewContexts={ctx.data.postConfig.previewContexts as DiscoveredKubeContext[] | undefined}
+      previewLoading={previewLoading}
+      onPickFile={handlePickFile}
+    />
+  );
+};
+
+export const kubernetesDetailsStep: WizardStep = {
+  id: 'kubeconfig',
+  label: 'Import Kubeconfig',
+  icon: CloudUploadIcon,
+  Component: KubeconfigStepBody,
+  canProceed: (ctx) => Boolean(ctx.data.kubeconfigFile),
+  nextLabel: () => 'Continue',
+  helpText: `Upload a kubeconfig with embedded certificates. Meshery reads the file's contexts, then registers the ones you select as Kubernetes connections. [Learn more about connecting Kubernetes](${KUBECONFIG_DOCS_URL}).`,
+  onNext: async (ctx) => {
+    if (!ctx.data.kubeconfigFile) {
+      return false;
+    }
+    ctx.patch({ registrationError: null });
+    try {
+      const discovered = await ctx.services.discoverKubeContexts(ctx.data.kubeconfigFile);
+      if (discovered.length === 0) {
+        ctx.services.notify({
+          message: 'No Kubernetes contexts were found in the kubeconfig.',
+          event_type: EVENT_TYPES.WARNING,
+        });
+        return false;
+      }
+      const contextChoices = Object.fromEntries(
+        discovered.map((context) => [context.id, defaultChoice(context.name)]),
+      );
+      ctx.patchPostConfig({
+        discoveredContexts: discovered,
+        contextChoices,
+        connectOnImport: true,
+      });
+      return true;
+    } catch (error) {
+      ctx.patch({ registrationError: error });
+      ctx.services.notify({
+        message: `Failed to read kubeconfig: ${formatWizardError(error)}`,
+        event_type: EVENT_TYPES.ERROR,
+      });
+      return false;
+    }
+  },
+};

--- a/ui/components/connections/wizard/kubernetesImportStep.tsx
+++ b/ui/components/connections/wizard/kubernetesImportStep.tsx
@@ -164,6 +164,8 @@ const KubeconfigStepBody = ({ ctx }: { ctx: WizardContext }) => {
   const requestVersionRef = useRef(0);
 
   const handlePickFile = async (kubeconfigFile: File | null) => {
+    const requestVersion = ++requestVersionRef.current;
+
     ctx.patch({
       kubeconfigFile,
       registrationResult: null,
@@ -180,7 +182,6 @@ const KubeconfigStepBody = ({ ctx }: { ctx: WizardContext }) => {
       return;
     }
 
-    const requestVersion = ++requestVersionRef.current;
     setPreviewLoading(true);
 
     try {

--- a/ui/components/connections/wizard/kubernetesReviewStep.tsx
+++ b/ui/components/connections/wizard/kubernetesReviewStep.tsx
@@ -1,0 +1,294 @@
+import {
+  Alert,
+  Box,
+  Checkbox,
+  CustomTooltip,
+  MenuItem,
+  TextField,
+  Typography,
+  AssignmentTurnedInIcon,
+} from '@sistent/sistent';
+import { alpha, styled } from '@/theme';
+import { EVENT_TYPES } from 'lib/event-types';
+import { CONNECTION_STATES } from '@/utils/Enum';
+import { getKubernetesContexts, kubernetesImportedNotify } from '../ConnectionWizard.helpers';
+import { formatWizardError } from './errors';
+import {
+  DEFAULT_MESHSYNC_DEPLOYMENT_MODE,
+  getMeshsyncModeTooltip,
+  MESHSYNC_DEPLOYMENT_MODE_OPTIONS,
+  MESHSYNC_MODES_DOCS_URL,
+} from './kubernetesDeploymentMode';
+import { ConnectionStateChip } from '../ConnectionChip';
+import { StepHeader } from '../ConnectionWizardStepContent';
+import type { DiscoveredKubeContext, GenericRecord, WizardContext, WizardStep } from './types';
+
+const KUBERNETES_CONNECTION_DOCS_URL =
+  'https://docs.meshery.io/guides/infrastructure-management/kubernetes-connection-lifecycle';
+
+const ContextRow = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'muted',
+})<{ muted?: boolean }>(({ theme, muted }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1.5),
+  padding: theme.spacing(1.5, 2),
+  borderRadius: theme.spacing(1),
+  border: `1px solid ${theme.palette.divider}`,
+  background: theme.palette.background.card,
+  opacity: muted ? 0.6 : 1,
+  transition: 'border-color 0.15s ease, opacity 0.15s ease',
+  '&:hover': {
+    borderColor: theme.palette.background.brand?.default,
+  },
+}));
+
+const ConnectNotice = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  borderRadius: theme.spacing(1),
+  border: `1px solid ${theme.palette.divider}`,
+  background: alpha(theme.palette.info.main, 0.06),
+  padding: theme.spacing(1, 1.5),
+}));
+
+type ContextChoice = { selected: boolean; name: string; meshsyncDeploymentMode: string };
+
+const getDiscovered = (ctx: WizardContext): DiscoveredKubeContext[] =>
+  (ctx.data.postConfig.discoveredContexts as DiscoveredKubeContext[]) || [];
+
+const getChoices = (ctx: WizardContext): Record<string, ContextChoice> =>
+  (ctx.data.postConfig.contextChoices as Record<string, ContextChoice>) || {};
+
+const getConnectOnImport = (ctx: WizardContext): boolean =>
+  ctx.data.postConfig.connectOnImport !== false;
+
+export const defaultChoice = (name: string): ContextChoice => ({
+  selected: true,
+  name,
+  meshsyncDeploymentMode: DEFAULT_MESHSYNC_DEPLOYMENT_MODE,
+});
+
+const ReviewContextsStepBody = ({ ctx }: { ctx: WizardContext }) => {
+  const discovered = getDiscovered(ctx);
+  const choices = getChoices(ctx);
+  const connectOnImport = getConnectOnImport(ctx);
+  const hasReachable = discovered.some((context) => context.reachable);
+
+  const updateChoice = (id: string, partial: Partial<ContextChoice>) =>
+    ctx.patchPostConfig({
+      contextChoices: { ...choices, [id]: { ...choices[id], ...partial } },
+    });
+
+  return (
+    <Box sx={{ display: 'grid', gap: 3 }}>
+      <StepHeader
+        title="Review contexts"
+        subtitle="Choose which clusters to import, rename them if you like, and decide whether reachable clusters should be connected."
+      />
+      {Boolean(ctx.data.registrationError) && (
+        <Alert severity="error" variant="filled">
+          {formatWizardError(ctx.data.registrationError)}
+        </Alert>
+      )}
+      <Box sx={{ display: 'grid', gap: 1.5 }}>
+        {discovered.map((context) => {
+          const choice = choices[context.id] || defaultChoice(context.name);
+          return (
+            <ContextRow key={context.id} muted={!choice.selected}>
+              <Checkbox
+                checked={choice.selected}
+                onChange={(event) => updateChoice(context.id, { selected: event.target.checked })}
+                sx={{ p: 0 }}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <TextField
+                  variant="standard"
+                  fullWidth
+                  value={choice.name}
+                  disabled={!choice.selected}
+                  onChange={(event) => updateChoice(context.id, { name: event.target.value })}
+                  inputProps={{
+                    'aria-label': `Name for ${context.name}`,
+                    title: choice.name,
+                  }}
+                  sx={{
+                    maxWidth: '100%',
+                    '& .MuiInput-input': {
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    },
+                    '& .MuiInput-underline:before, & .MuiInput-underline:after': {
+                      maxWidth: '100%',
+                    },
+                  }}
+                />
+                <Typography variant="caption" color="text.secondary" noWrap component="div">
+                  {context.server || 'unknown server'}
+                </Typography>
+              </Box>
+              <TextField
+                select
+                variant="standard"
+                label="MeshSync"
+                value={choice.meshsyncDeploymentMode}
+                disabled={!choice.selected}
+                onChange={(event) =>
+                  updateChoice(context.id, { meshsyncDeploymentMode: event.target.value })
+                }
+                sx={{ minWidth: 120 }}
+                inputProps={{ 'aria-label': `MeshSync deployment mode for ${context.name}` }}
+              >
+                {MESHSYNC_DEPLOYMENT_MODE_OPTIONS.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    <CustomTooltip
+                      interactive
+                      title={getMeshsyncModeTooltip(option)}
+                      placement="left"
+                    >
+                      <Box component="span" sx={{ display: 'block', width: '100%' }}>
+                        {option.label}
+                      </Box>
+                    </CustomTooltip>
+                  </MenuItem>
+                ))}
+              </TextField>
+              <ConnectionStateChip
+                status={
+                  context.reachable ? CONNECTION_STATES.DISCOVERED : CONNECTION_STATES.NOTFOUND
+                }
+              />
+            </ContextRow>
+          );
+        })}
+      </Box>
+      <ConnectNotice
+        onClick={() => hasReachable && ctx.patchPostConfig({ connectOnImport: !connectOnImport })}
+        sx={{ cursor: hasReachable ? 'pointer' : 'default' }}
+      >
+        <Checkbox
+          checked={connectOnImport}
+          disabled={!hasReachable}
+          onChange={(event) => ctx.patchPostConfig({ connectOnImport: event.target.checked })}
+          onClick={(event) => event.stopPropagation()}
+          sx={{ p: 0 }}
+        />
+        <Typography variant="body2">
+          Connect reachable clusters after import. Unreachable clusters are imported as discovered
+          and can be connected later.
+        </Typography>
+      </ConnectNotice>
+    </Box>
+  );
+};
+
+type CreatedContext = {
+  connectionId: string;
+  name: string;
+  reachable: boolean;
+  alreadyConnected: boolean;
+};
+
+const collectCreated = (result: GenericRecord | null): CreatedContext[] => {
+  const toCreated = (records: GenericRecord[], alreadyConnected: boolean): CreatedContext[] =>
+    records.map((record) => ({
+      connectionId: String(record.connectionId ?? record.id ?? ''),
+      name: String(record.name ?? ''),
+      reachable: Boolean(record.reachable),
+      alreadyConnected,
+    }));
+
+  return [
+    ...toCreated(getKubernetesContexts(result, 'registered'), false),
+    ...toCreated(getKubernetesContexts(result, 'connected'), true),
+  ];
+};
+
+export const kubernetesReviewStep: WizardStep = {
+  id: 'kubernetes-review',
+  label: 'Review Contexts',
+  icon: AssignmentTurnedInIcon,
+  Component: ReviewContextsStepBody,
+  nextLabel: () => 'Import',
+  helpText: `Select which contexts to import, choose a MeshSync mode (embedded or operator), and decide whether reachable clusters should connect immediately. Hover a MeshSync option for details. [MeshSync modes](${MESHSYNC_MODES_DOCS_URL}). [Kubernetes connection lifecycle](${KUBERNETES_CONNECTION_DOCS_URL}).`,
+  canProceed: (ctx) => getDiscovered(ctx).some((context) => getChoices(ctx)[context.id]?.selected),
+  onNext: async (ctx) => {
+    const discovered = getDiscovered(ctx);
+    const choices = getChoices(ctx);
+    const selected = discovered.filter((context) => choices[context.id]?.selected);
+    if (!ctx.data.kubeconfigFile || selected.length === 0) {
+      return false;
+    }
+    ctx.patch({ registrationError: null });
+    try {
+      const contexts = Object.fromEntries(
+        selected.map((context) => {
+          const choice = choices[context.id];
+          return [
+            context.id,
+            {
+              name: choice.name.trim() || context.name,
+              meshsyncDeploymentMode: choice.meshsyncDeploymentMode,
+            },
+          ];
+        }),
+      );
+      const result = await ctx.services.uploadKubeconfig(ctx.data.kubeconfigFile, {
+        selectedContextIds: selected.map((context) => context.id),
+        contexts,
+      });
+      ctx.patch({ registrationResult: result ?? {} });
+
+      const created = collectCreated(result ?? {});
+      const connectedIds = new Set(
+        created
+          .filter((context) => context.alreadyConnected)
+          .map((context) => context.connectionId),
+      );
+      if (getConnectOnImport(ctx)) {
+        const toConnect = created.filter(
+          (context) => context.reachable && !context.alreadyConnected && context.connectionId,
+        );
+        const outcomes = await Promise.allSettled(
+          toConnect.map((context) =>
+            ctx.services.updateConnectionById(context.connectionId, {
+              status: CONNECTION_STATES.CONNECTED,
+            }),
+          ),
+        );
+        toConnect.forEach((context, index) => {
+          if (outcomes[index].status === 'fulfilled') {
+            connectedIds.add(context.connectionId);
+          }
+        });
+      }
+
+      const importedContexts = created.map((context) => ({
+        name: context.name,
+        status: connectedIds.has(context.connectionId)
+          ? CONNECTION_STATES.CONNECTED
+          : context.reachable
+            ? CONNECTION_STATES.DISCOVERED
+            : CONNECTION_STATES.NOTFOUND,
+      }));
+
+      ctx.patchPostConfig({
+        importedContexts,
+        createdCount: created.length,
+        connectedCount: connectedIds.size,
+        unreachableCount: created.filter((context) => !context.reachable).length,
+      });
+      ctx.services.notify(kubernetesImportedNotify(created.length));
+      return true;
+    } catch (error) {
+      ctx.patch({ registrationError: error });
+      ctx.services.notify({
+        message: `Failed to import kubeconfig: ${formatWizardError(error)}`,
+        event_type: EVENT_TYPES.ERROR,
+      });
+      return false;
+    }
+  },
+};


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21052 
- Improves the Kubernetes import workflow by previewing discovered contexts immediately after kubeconfig upload, giving users early feedback before proceeding to the review step.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

## After
<img width="1507" height="815" alt="Screenshot 2026-08-01 at 9 34 12 PM" src="https://github.com/user-attachments/assets/560092df-536d-4512-bc38-a369672284ff" />

<img width="1282" height="686" alt="Screenshot 2026-08-02 at 2 43 33 PM" src="https://github.com/user-attachments/assets/2046d67b-9a04-4942-ac2a-788124808441" />

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes connection wizard step for importing kubeconfig files via file selection or drag and drop.
  * Preview discovered Kubernetes contexts before continuing, with loading and empty states.
  * Review, select, and rename contexts during setup.
  * Configure deployment options and optionally connect reachable clusters.
  * Added clearer reachability, success, and error feedback.

* **Refactor**
  * Streamlined the Kubernetes connection flow into dedicated import and review steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->