### PR TITLE
[UI] Add permission shield to Connect Clusters button

### DIFF
--- a/ui/components/general/ConnectClustersBtn.test.tsx
+++ b/ui/components/general/ConnectClustersBtn.test.tsx
@@ -18,8 +18,13 @@ vi.mock('@/utils/context/ConnectionWizardContextProvider', () => ({
 
 vi.mock('@sistent/sistent', () => ({
   AddCircleIcon: (props: any) => <svg data-testid="add-icon" {...props} />,
-  Button: ({ children, onClick, ...props }: any) => (
-    <button type="button" onClick={onClick} {...props}>
+  Button: ({ children, onClick, permissionKey, ...props }: any) => (
+    <button
+      type="button"
+      onClick={onClick}
+      data-permission-key={permissionKey?.id ?? ''}
+      {...props}
+    >
       {children}
     </button>
   ),
@@ -52,5 +57,12 @@ describe('ConnectClustersBtn', () => {
     render(<ConnectClustersBtn />);
     expect(screen.getByText(/Connect Clusters/i)).toBeInTheDocument();
     expect(screen.getByTestId('add-icon')).toBeInTheDocument();
+  });
+
+  it('passes the LifecycleManagementAddCluster permission key to the Button', () => {
+    render(<ConnectClustersBtn />);
+    const button = screen.getByRole('button', { name: /Connect Clusters/i });
+    expect(button).toHaveAttribute('data-permission-key');
+    expect(button.getAttribute('data-permission-key')).not.toBe('');
   });
 });

--- a/ui/components/general/ConnectClustersBtn.tsx
+++ b/ui/components/general/ConnectClustersBtn.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { iconMedium } from '../../css/icons.styles';
 import { AddCircleIcon as AddIcon, Button, useTheme } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import { CoreConnectionKinds } from '@/utils/Enum';
 import { useConnectionWizardModal } from '@/utils/context/ConnectionWizardContextProvider';
 
@@ -29,6 +30,7 @@ function ConnectClustersBtn() {
       color="primary"
       size="large"
       onClick={handleClick}
+      permissionKey={Keys.LifecycleManagementAddCluster}
       style={{ margin: '0.5rem 0.5rem', whiteSpace: 'nowrap' }}
     >
       <AddIcon


### PR DESCRIPTION
## Description

The "Connect Clusters" button on the dashboard empty states was missing a permission shield, allowing it to render as a fully clickable action even when the user lacks the `LifecycleManagementAddCluster` permission. 

This adds `permissionKey={Keys.LifecycleManagementAddCluster}` to the `ConnectClustersBtn` component — the same key used by the equivalent "Add Cluster" button in the context-switcher ([MesherySettingsEnvButtons](file:///Users/rishiraj/Desktop/meshery/ui/components/MesherySettingsEnvButtons.tsx#L43)) and the [ConnectionWizardLauncher](file:///Users/rishiraj/Desktop/meshery/ui/components/connections/ConnectionWizardLauncher.tsx#L20-L29). The sistent `Button` component handles disabling and showing the lock overlay when the permission is denied.

## Changes

- **[ConnectClustersBtn.tsx](file:///Users/rishiraj/Desktop/meshery/ui/components/general/ConnectClustersBtn.tsx)**: Import `Keys` from `@meshery/schemas/permissions`, pass `permissionKey={Keys.LifecycleManagementAddCluster}` to the `Button`
- **[ConnectClustersBtn.test.tsx](file:///Users/rishiraj/Desktop/meshery/ui/components/general/ConnectClustersBtn.test.tsx)**: Update Button mock to forward `permissionKey`, add test asserting the permission key is passed


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the required lifecycle-management permission to the Connect Clusters button.
  * Improved permission validation to ensure the button is configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->