### PR TITLE
[UI] Security: Add rel=noopener noreferrer to target=_blank links

### DIFF
--- a/ui/components/connections/meshSync/MeshSyncEmptyState.tsx
+++ b/ui/components/connections/meshSync/MeshSyncEmptyState.tsx
@@ -152,7 +152,7 @@ const MeshSyncEmptyState = () => {
               <Link
                 href="https://docs.meshery.io/concepts/architecture/meshsync"
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
               >
                 documentation
               </Link>{' '}

--- a/ui/components/designs/patterns/MesheryPatternCard.tsx
+++ b/ui/components/designs/patterns/MesheryPatternCard.tsx
@@ -359,7 +359,11 @@ function MesheryPatternCard_({
               </Typography>
               <CardHeaderRight>
                 {hasCloudProfile ? (
-                  <Link href={`${MESHERY_CLOUD_PROD}/user/${pattern?.userId}`} target="_blank">
+                  <Link
+                    href={`${MESHERY_CLOUD_PROD}/user/${pattern?.userId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     <Avatar alt="profile-avatar" src={owner?.avatarUrl} />
                   </Link>
                 ) : (

--- a/ui/components/filters/FiltersCard.tsx
+++ b/ui/components/filters/FiltersCard.tsx
@@ -242,7 +242,11 @@ function FiltersCard_({
               <Typography variant="h6">{name}</Typography>
               <CardHeaderRight>
                 {hasCloudProfile ? (
-                  <Link href={`${MESHERY_CLOUD_PROD}/user/${ownerId}`} target="_blank">
+                  <Link
+                    href={`${MESHERY_CLOUD_PROD}/user/${ownerId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     <Avatar alt="profile-avatar" src={owner?.avatarUrl} />
                   </Link>
                 ) : (

--- a/ui/components/general/ErrorPage.tsx
+++ b/ui/components/general/ErrorPage.tsx
@@ -84,6 +84,7 @@ const CustomErrorMessage = ({ message, showImage = true }: CustomErrorMessagePro
             <StyledLink
               href="https://meshery.io/community#community-forums/c/meshery/5"
               target="_blank"
+              rel="noopener noreferrer"
             >
               discussion forum
             </StyledLink>

--- a/ui/components/performance/PerformanceCard.tsx
+++ b/ui/components/performance/PerformanceCard.tsx
@@ -180,7 +180,11 @@ function PerformanceCard({
         <div style={{}}>
           <BottomPart>
             {hasCloudProfile ? (
-              <Link href={`${MESHERY_CLOUD_PROD}/user/${profile.userId}`} target="_blank">
+              <Link
+                href={`${MESHERY_CLOUD_PROD}/user/${profile.userId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 <Avatar alt="profile-avatar" src={owner?.avatarUrl} />
               </Link>
             ) : (


### PR DESCRIPTION
Fixes #21069

**Notes for Reviewers**
This PR addresses a minor security/best-practice issue by adding the `rel="noopener noreferrer"` attribute to all `target="_blank"` links across the UI components. 

This prevents potential reverse tabnabbing vulnerabilities where external pages might try to access the `window.opener` object, and it also resolves the `react/jsx-no-target-blank` ESLint warnings. The changes were kept as minimal as possible.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Updated external links to use safer handling when opened in a new tab.
  * Added protection against unintended access to the originating page across forum, documentation, profile, and avatar links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->