### PR TITLE
feat(model): add AWS VPC relationships and Subnet parenting for v1.18.4

### DIFF
--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/components/Subnet.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/components/Subnet.json
@@ -189,7 +189,7 @@
   "status": "enabled",
   "metadata": {
     "configurationUISchema": "",
-    "genealogy": "",
+    "genealogy": "parent",
     "instanceDetails": null,
     "isAnnotation": false,
     "isNamespaced": true,

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-connection-network-elb-instance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-connection-network-elb-instance.json
@@ -1,0 +1,67 @@
+{
+  "id": "0fc2886e-a27c-428e-a2ce-eb5e3c5fa6fd",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Network connection from AWS Load Balancer to EC2 Instance",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "AWS Elastic Load Balancing",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Instance",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "connection",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-connection-network-instance-dbinstance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-connection-network-instance-dbinstance.json
@@ -1,0 +1,67 @@
+{
+  "id": "abb51b28-07b2-40a7-87be-635d9ca794dd",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Network connection from EC2 Instance to RDS DBInstance",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Instance",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-rds-controller"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "connection",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-firewall-vpcendpoint-securitygroup.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-firewall-vpcendpoint-securitygroup.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Attaches a SecurityGroup to an EC2 VPCEndpoint via spec.securityGroupIDs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCEndpoint",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupIDs",
+                  "0"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-firewall-vpcendpoint-securitygroup.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-firewall-vpcendpoint-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-firewall-vpcendpoint-securitygroup.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-firewall-vpcendpoint-securitygroup.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-egressonlyigw-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-egressonlyigw-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-egressonlyigw-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-egressonlyigw-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-egressonlyigw-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-egressonlyigw-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EgressOnlyInternetGateway to its VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "EgressOnlyInternetGateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-elb-instance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-elb-instance.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-elb-instance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-elb-instance.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-elb-instance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-elb-instance.json
@@ -62,6 +62,6 @@
   ],
   "subType": "network",
   "status": "enabled",
-  "type": "connection",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-dbinstance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-dbinstance.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-dbinstance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-dbinstance.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-dbinstance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-dbinstance.json
@@ -62,6 +62,6 @@
   ],
   "subType": "network",
   "status": "enabled",
-  "type": "connection",
+  "type": "non-binding",
   "version": "v1.0.0"
 }

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-launchtemplate.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-launchtemplate.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-launchtemplate.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-launchtemplate.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-launchtemplate.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-instance-launchtemplate.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 Instance to a LaunchTemplate via spec.launchTemplate.launchTemplateID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Instance",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "launchTemplate",
+                  "launchTemplateID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "LaunchTemplate",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-natgateway-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-natgateway-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 NATGateway to its VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "NATGateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-natgateway-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-natgateway-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-natgateway-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-natgateway-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-networkacl-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-networkacl-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-networkacl-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-networkacl-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-networkacl-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-networkacl-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 NetworkACL to its VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "NetworkACL",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-internetgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-internetgateway.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Routes an EC2 RouteTable to an InternetGateway via spec.routes[].gatewayID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "RouteTable",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "routes",
+                  "0",
+                  "gatewayID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "InternetGateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-internetgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-internetgateway.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-internetgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-internetgateway.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-natgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-natgateway.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-natgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-natgateway.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-natgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-natgateway.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Routes an EC2 RouteTable to a NATGateway via spec.routes[].natGatewayID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "RouteTable",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "routes",
+                  "0",
+                  "natGatewayID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "NATGateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-transitgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-transitgateway.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Routes an EC2 RouteTable to a TransitGateway via spec.routes[].transitGatewayID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "RouteTable",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "routes",
+                  "0",
+                  "transitGatewayID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "TransitGateway",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-transitgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-transitgateway.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-transitgateway.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-transitgateway.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 RouteTable to its VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "RouteTable",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcendpoint.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcendpoint.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcendpoint.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcendpoint.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Routes an EC2 RouteTable to a VPCEndpoint via spec.routes[].vpcEndpointID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "RouteTable",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "routes",
+                  "0",
+                  "vpcEndpointID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPCEndpoint",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcendpoint.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcendpoint.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcpeeringconnection.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcpeeringconnection.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcpeeringconnection.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcpeeringconnection.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcpeeringconnection.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-routetable-vpcpeeringconnection.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Routes an EC2 RouteTable to a VPCPeeringConnection via spec.routes[].vpcPeeringConnectionID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "RouteTable",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "routes",
+                  "0",
+                  "vpcPeeringConnectionID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPCPeeringConnection",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-securitygroup-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-securitygroup-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-securitygroup-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-securitygroup-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-securitygroup-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-securitygroup-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 SecurityGroup to its VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-subnet-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-subnet-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 Subnet to its VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-subnet-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-subnet-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-subnet-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-subnet-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-routetable.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-routetable.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-routetable.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-routetable.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-routetable.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-routetable.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Associates an EC2 VPCEndpoint with a RouteTable via spec.routeTableIDs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCEndpoint",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "routeTableIDs",
+                  "0"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "RouteTable",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-subnet.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-subnet.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Places an EC2 VPCEndpoint in a Subnet via spec.subnetIDs.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCEndpoint",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetIDs",
+                  "0"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-subnet.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-subnet.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-subnet.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 VPCEndpoint to its VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCEndpoint",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcendpoint-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-peervpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-peervpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-peervpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-peervpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-peervpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-peervpc.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 VPCPeeringConnection to its peer VPC via spec.peerVPCID.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCPeeringConnection",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "peerVPCID"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-vpc.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-vpc.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-network-vpcpeering-vpc.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Binds an EC2 VPCPeeringConnection to its requester VPC via spec.vpcRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "VPCPeeringConnection",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcRef",
+                  "from",
+                  "name"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "VPC",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-permission-flowlog-role.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-permission-flowlog-role.json
@@ -1,0 +1,99 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Grants an EC2 FlowLog its delivery IAM Role via spec.deliverLogsPermissionARN.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "FlowLog",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "deliverLogsPermissionARN"
+                ]
+              ]
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-permission-flowlog-role.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-permission-flowlog-role.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-permission-flowlog-role.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/edge-non-binding-permission-flowlog-role.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-elb.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-elb.json
@@ -1,0 +1,67 @@
+{
+  "id": "8d8e1c4d-28fc-4827-9c08-558a323933e1",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "Nests AWS Elastic Load Balancer inside a Subnet",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "AWS Elastic Load Balancing",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-elb.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-elb.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-elb.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-elb.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-instance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-instance.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-instance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-instance.json
@@ -1,0 +1,87 @@
+{
+  "id": "344e4a88-f4d4-4e96-ace6-8088ac107774",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "Nests EC2 Instances inside a Subnet",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.18.4"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Instance",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-instance.json
+++ b/models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/hierarchical-parent-inventory-subnet-instance.json
@@ -23,11 +23,32 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {
         "from": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
           {
             "id": null,
             "kind": "Instance",
@@ -46,27 +67,6 @@
                   "subnetRef",
                   "from",
                   "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "Subnet",
-            "match": {},
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {},
-              "name": "aws-ec2-controller"
-            },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/aws-rds-controller/v1.10.2/v1.0.0/relationships/hierarchical-parent-inventory-subnet-dbinstance.json
+++ b/models/aws-rds-controller/v1.10.2/v1.0.0/relationships/hierarchical-parent-inventory-subnet-dbinstance.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-rds-controller/v1.10.2/v1.0.0/relationships/hierarchical-parent-inventory-subnet-dbinstance.json
+++ b/models/aws-rds-controller/v1.10.2/v1.0.0/relationships/hierarchical-parent-inventory-subnet-dbinstance.json
@@ -1,0 +1,87 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "Nests RDS DBInstances inside a Subnet",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.10.2"
+    },
+    "name": "aws-rds-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "DBInstance",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-rds-controller"
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "subnetRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/models/aws-rds-controller/v1.10.2/v1.0.0/relationships/hierarchical-parent-inventory-subnet-dbinstance.json
+++ b/models/aws-rds-controller/v1.10.2/v1.0.0/relationships/hierarchical-parent-inventory-subnet-dbinstance.json
@@ -23,11 +23,32 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {
         "from": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {},
+              "name": "aws-ec2-controller"
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
           {
             "id": null,
             "kind": "DBInstance",
@@ -46,27 +67,6 @@
                   "subnetRef",
                   "from",
                   "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
-            "kind": "Subnet",
-            "match": {},
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {},
-              "name": "aws-ec2-controller"
-            },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "displayName"
                 ]
               ],
               "patchStrategy": "replace"


### PR DESCRIPTION
## Description

This PR restores valid AWS VPC core relationships, enables hierarchical container nesting (`parenting`) for AWS Subnets, and registers missing network connection rules for a complete AWS 3-Tier Web Application design flow.

### Key Changes

1. **Restored AWS VPC Core Relationships (19 files):**
   * Target version directory: `models/aws-ec2-controller/v1.18.4/v1.0.0/relationships/`.
   * Restored 19 valid VPC relationships (originally merged under **`v1.18.2`** / **`v1.18.3`**) forwarded to the latest **`v1.18.4`** model directory.
   * Stripped out all deprecated `evaluationQuery` keys to match standard relationships syntax.

2. **Enabled Subnet Parenting (Nesting Capabilities):**
   * Configured `Subnet` (version `v1.18.4`) as a parent container (`"genealogy": "parent"`).
   * Added hierarchical parent relationships to allow EC2 `Instance`, RDS `DBInstance`, and `AWS Elastic Load Balancing` (ELB) to snap and nest inside a Subnet.
   * Defined configuration patches (`mutatedRef` and `mutatorRef`) where supported, and fallback visual-only parenting (e.g., for ELB) to prevent invalid spec changes.

3. **Added Network Connection Rules:**
   * Registered `edge` network connection relationships for **`ELB ➡️ Instance`** and **`Instance ➡️ DBInstance`**.
   * Sanitized selectors to omit strict registrant sources (`github` vs `meshery`) and model version constraints, preventing canvas linking failures due to registry cache/source mismatches.





---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive AWS infrastructure relationship mapping across VPCs, subnets, route tables, gateways, endpoints, security groups, peering connections, and flow logs.
  * Added hierarchical views nesting EC2 instances, load balancers, and database instances within their associated subnets.
  * Added network connections between load balancers, EC2 instances, and database instances.
  * Improved subnet metadata to support clearer parent-child inventory relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->