### PR TITLE
[UI] Add missing permission keys to action buttons across Connections, Workspaces, and Empty States

### DIFF
--- a/ui/components/connections/ConnectionActionMenu.tsx
+++ b/ui/components/connections/ConnectionActionMenu.tsx
@@ -1,4 +1,5 @@
 import { Button, Popover, Typography, SettingsIcon, CopyLinkIcon } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import { ActionListItem } from './styles';
 import { iconMedium } from '../../css/icons.styles';
 
@@ -31,7 +32,12 @@ export const ConnectionActionMenu = ({
     >
       {onConfigure && (
         <ActionListItem>
-          <Button type="button" onClick={onConfigure} data-cy="btnConfigureConnection">
+          <Button
+            type="button"
+            onClick={onConfigure}
+            data-cy="btnConfigureConnection"
+            permissionKey={Keys.LifecycleManagementEditConnection}
+          >
             <SettingsIcon {...iconMedium} />
             <Typography variant="body1" style={{ marginLeft: '0.5rem' }}>
               Configure
@@ -45,6 +51,7 @@ export const ConnectionActionMenu = ({
             type="button"
             onClick={onConfigureControllers}
             data-cy="btnConfigureConnectionControllers"
+            permissionKey={Keys.LifecycleManagementEditConnection}
           >
             <SettingsIcon {...iconMedium} />
             <Typography variant="body1" style={{ marginLeft: '0.5rem' }}>

--- a/ui/components/connections/wizard/kubernetesSettings.tsx
+++ b/ui/components/connections/wizard/kubernetesSettings.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   SettingsIcon,
 } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import { useSelector } from 'react-redux';
 import { EVENT_TYPES } from 'lib/event-types';
 import { CONNECTION_STATES, MESHSYNC_DEPLOYMENT_TYPE } from '@/utils/Enum';
@@ -257,7 +258,12 @@ const SettingsStepBody = ({ ctx }: { ctx: WizardContext }) => {
             Clear this cluster&apos;s cached state; it is repopulated by a running MeshSync.
           </Typography>
         </Box>
-        <Button variant="outlined" onClick={flushMeshSync} disabled={flushBusy}>
+        <Button
+          variant="outlined"
+          onClick={flushMeshSync}
+          disabled={flushBusy}
+          permissionKey={Keys.LifecycleManagementFlushMeshsyncData}
+        >
           {flushBusy ? <CircularProgress size={16} /> : 'Flush MeshSync'}
         </Button>
       </Box>

--- a/ui/components/designs/lifecycle/SelectDeploymentTarget.tsx
+++ b/ui/components/designs/lifecycle/SelectDeploymentTarget.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/store/slices/globalEnvironmentContext';
 import { Button } from '@sistent/sistent';
 import { AddIcon, AddCircleIcon } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import { useDispatch, useSelector } from 'react-redux';
 
 export const DeploymentTargetContext = createContext({
@@ -194,6 +195,7 @@ export const EnvironmentsEmptyState = ({ message, onButtonClick }) => {
         color="primary"
         onClick={onButtonClick}
         style={{ margin: '0.6rem 0.6rem', whiteSpace: 'nowrap' }}
+        permissionKey={Keys.WorkspaceManagementCreateEnvironment}
       >
         <AddIcon fill={theme.palette.background.constant.white} />
         Add Environments

--- a/ui/components/designs/patterns/ActionPopover.tsx
+++ b/ui/components/designs/patterns/ActionPopover.tsx
@@ -54,6 +54,7 @@ const ActionPopover = ({ actions = [] }) => {
               {actions.map((action, index) => (
                 <MenuItem
                   disabled={action.disabled}
+                  permissionKey={action.permissionKey}
                   key={index}
                   onClick={(event) => {
                     event.stopPropagation();

--- a/ui/components/designs/patterns/MesheryPatterns.columns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.columns.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, crimson, InfoOutlinedIcon, AccountTreeIcon, EditIcon } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import Moment from 'react-moment';
 import { GetApp as GetAppIcon } from '@/assets/icons';
 import { DoneAll as DoneAllIcon, Public as PublicIcon } from '@/assets/icons';
@@ -53,6 +54,7 @@ export function buildPatternActions({
         handleOpenInConfigurator(rowData.id);
       },
       disabled: !permissions.editDesign,
+      permissionKey: Keys.CatalogManagementEditDesign,
       condition: userCanEdit(rowData),
     },
     {
@@ -63,6 +65,7 @@ export function buildPatternActions({
         handleClone(rowData.id, rowData.name);
       },
       disabled: !permissions.cloneDesign,
+      permissionKey: Keys.CatalogManagementCloneDesign,
       condition: visibility === VISIBILITY.PUBLISHED,
     },
     {
@@ -73,6 +76,7 @@ export function buildPatternActions({
         handleOpenInConfigurator(patterns[tableMeta.rowIndex].id);
       },
       disabled: !permissions.editDesign,
+      permissionKey: Keys.CatalogManagementEditDesign,
       condition: visibility !== VISIBILITY.PUBLISHED,
     },
     {
@@ -82,6 +86,7 @@ export function buildPatternActions({
         openValidateModal(e, rowData.patternFile, rowData.name, rowData.id);
       },
       disabled: !permissions.validateDesign,
+      permissionKey: Keys.CatalogManagementValidateDesign,
     },
     {
       label: 'Dry Run',
@@ -90,6 +95,7 @@ export function buildPatternActions({
         openDryRunModal(e, rowData.patternFile, rowData.name, rowData.id);
       },
       disabled: !permissions.validateDesign,
+      permissionKey: Keys.CatalogManagementValidateDesign,
     },
     {
       label: 'Evaluate',
@@ -99,6 +105,7 @@ export function buildPatternActions({
         handleEvaluateRelationship(rowData);
       },
       disabled: !permissions.evaluateRelationships,
+      permissionKey: Keys.CatalogManagementEvaluateRelationships,
     },
     {
       label: 'Undeploy',
@@ -107,6 +114,7 @@ export function buildPatternActions({
         openUndeployModal(e, rowData.patternFile, rowData.name, rowData.id);
       },
       disabled: !permissions.undeployDesign,
+      permissionKey: Keys.CatalogManagementUndeployDesign,
     },
     {
       label: 'Deploy',
@@ -115,6 +123,7 @@ export function buildPatternActions({
         openDeployModal(e, rowData.patternFile, rowData.name, rowData.id);
       },
       disabled: !permissions.deployDesign,
+      permissionKey: Keys.CatalogManagementDeployDesign,
     },
     {
       label: 'Download',
@@ -123,6 +132,7 @@ export function buildPatternActions({
         handleDesignDownloadModal(e, rowData);
       },
       disabled: !permissions.downloadDesign,
+      permissionKey: Keys.CatalogManagementDownloadADesign,
     },
     {
       label: 'Design Information',
@@ -131,6 +141,7 @@ export function buildPatternActions({
         genericClickHandler(e, () => handleInfoModal(rowData));
       },
       disabled: !permissions.detailsOfDesign,
+      permissionKey: Keys.CatalogManagementDetailsOfDesign,
     },
 
     /* Publish action can be done through Info modal so we might not need separate publish action */
@@ -149,6 +160,7 @@ export function buildPatternActions({
         handleUnpublishModal(e, rowData)();
       },
       disabled: !permissions.unpublishDesign,
+      permissionKey: Keys.CatalogManagementUnpublishDesign,
       condition: visibility === VISIBILITY.PUBLISHED,
     },
   ].filter((action) => action.condition === undefined || action.condition);

--- a/ui/components/shared/EmptyState/K8sContextEmptyState.test.tsx
+++ b/ui/components/shared/EmptyState/K8sContextEmptyState.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { K8sEmptyState } from './K8sContextEmptyState';
+import { Keys } from '@meshery/schemas/permissions';
 
 const h = vi.hoisted(() => ({
   openCreateConnectionMock: vi.fn(),
@@ -107,7 +108,6 @@ describe('K8sEmptyState', () => {
     mockMode = 'light';
     render(<K8sEmptyState message={undefined} />);
     const button = screen.getByRole('button', { name: /Connect Clusters/i });
-    expect(button).toHaveAttribute('data-permission-key');
-    expect(button.getAttribute('data-permission-key')).not.toBe('');
+    expect(button).toHaveAttribute('data-permission-key', Keys.LifecycleManagementAddCluster.id);
   });
 });

--- a/ui/components/shared/EmptyState/K8sContextEmptyState.test.tsx
+++ b/ui/components/shared/EmptyState/K8sContextEmptyState.test.tsx
@@ -28,13 +28,14 @@ vi.mock('@sistent/sistent', () => {
 
   return {
     AddIcon: (props: any) => <svg data-testid="add-icon" {...props} />,
-    Button: ({ children, type, variant, color, sx, onClick, ...rest }: any) => (
+    Button: ({ children, type, variant, color, sx, onClick, permissionKey, ...rest }: any) => (
       <button
         type={type}
         data-variant={variant}
         data-color={color}
         data-sx={JSON.stringify(sx || {})}
         onClick={onClick}
+        data-permission-key={permissionKey?.id ?? ''}
         {...rest}
       >
         {children}
@@ -100,5 +101,13 @@ describe('K8sEmptyState', () => {
     render(<K8sEmptyState message="No active cluster found" />);
 
     expect(screen.getByTestId('typography')).toHaveTextContent('No active cluster found');
+  });
+
+  it('passes the LifecycleManagementAddCluster permission key to the Button', () => {
+    mockMode = 'light';
+    render(<K8sEmptyState message={undefined} />);
+    const button = screen.getByRole('button', { name: /Connect Clusters/i });
+    expect(button).toHaveAttribute('data-permission-key');
+    expect(button.getAttribute('data-permission-key')).not.toBe('');
   });
 });

--- a/ui/components/shared/EmptyState/K8sContextEmptyState.tsx
+++ b/ui/components/shared/EmptyState/K8sContextEmptyState.tsx
@@ -1,4 +1,5 @@
 import { AddIcon, Button, styled, Typography, useTheme } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import OperatorLight from '../../../assets/img/OperatorLight';
 import Operator from '../../../assets/img/Operator';
 import { CoreConnectionKinds } from '@/utils/Enum';
@@ -44,6 +45,7 @@ export const K8sEmptyState = ({ message }) => {
         variant="contained"
         color="primary"
         onClick={handleClick}
+        permissionKey={Keys.LifecycleManagementAddCluster}
         sx={{ margin: '0.6rem 0.6rem', whiteSpace: 'nowrap' }}
       >
         <StyledAddIcon />

--- a/ui/components/workspaces/SpacesSwitcher/MyDesignsContent.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MyDesignsContent.tsx
@@ -1,5 +1,6 @@
 import { useGetUserDesignsQuery } from '@/rtk-query/design';
 import { useGetLoggedInUserQuery } from '@/rtk-query/user';
+import { Keys } from '@meshery/schemas/permissions';
 import React, { useCallback, useRef, useState } from 'react';
 import MainDesignsContent from './MainDesignsContent';
 import { RESOURCE_TYPE, VISIBILITY } from '@/utils/Enum';
@@ -138,7 +139,7 @@ const MyDesignsContent = () => {
 
         {/* Import Button */}
         <Grid2 size={{ xs: 4, md: 1 }}>
-          <ImportButton refetch={refetch} />
+          <ImportButton refetch={refetch} permissionKey={Keys.CatalogManagementImportDesign} />
         </Grid2>
       </Grid2>
       <MultiContentSelectToolbar

--- a/ui/components/workspaces/SpacesSwitcher/RecentContent.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/RecentContent.tsx
@@ -222,7 +222,7 @@ const RecentContent = () => {
           {/* Import Button */}
           {filters.type === RESOURCE_TYPE.DESIGN && (
             <Grid2 size={{ xs: 6, sm: 3, md: 3, lg: 1 }}>
-              <ImportButton refetch={refetch} />
+              <ImportButton refetch={refetch} permissionKey={Keys.CatalogManagementImportDesign} />
             </Grid2>
           )}
         </Grid2>

--- a/ui/components/workspaces/SpacesSwitcher/components.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/components.tsx
@@ -1,3 +1,4 @@
+import { Keys } from '@meshery/schemas/permissions';
 import {
   Autocomplete,
   Avatar,
@@ -457,6 +458,11 @@ export const MultiContentSelectToolbar = ({
                   handleContentMove(true);
                 }}
                 disabled={!multiSelectedContent.length}
+                permissionKey={
+                  type === RESOURCE_TYPE.DESIGN
+                    ? Keys.WorkspaceManagementAssignDesignsToWorkspaces
+                    : undefined
+                }
               >
                 <Box sx={{ display: { xs: 'none', sm: 'block' } }}>Move</Box>
               </StyledResponsiveButton>
@@ -471,6 +477,9 @@ export const MultiContentSelectToolbar = ({
                 setMultiSelectedContent([]);
               }}
               disabled={!multiSelectedContent.length}
+              permissionKey={
+                type === RESOURCE_TYPE.DESIGN ? Keys.CatalogManagementDownloadADesign : undefined
+              }
             >
               <Box sx={{ display: { xs: 'none', sm: 'block' } }}>Download</Box>
             </StyledResponsiveButton>{' '}
@@ -483,6 +492,9 @@ export const MultiContentSelectToolbar = ({
                   setMultiSelectedContent([]);
                 }}
                 disabled={!multiSelectedContent.length}
+                permissionKey={
+                  type === RESOURCE_TYPE.DESIGN ? Keys.CatalogManagementShareDesign : undefined
+                }
               >
                 <Box sx={{ display: { xs: 'none', sm: 'block' } }}>Share</Box>
               </StyledResponsiveButton>
@@ -498,6 +510,9 @@ export const MultiContentSelectToolbar = ({
                 );
                 setMultiSelectedContent([]);
               }}
+              permissionKey={
+                type === RESOURCE_TYPE.DESIGN ? Keys.CatalogManagementDeleteADesign : undefined
+              }
               sx={{
                 backgroundColor: `${theme.palette.error.dark} !important`,
               }}


### PR DESCRIPTION
### Description

Adds missing `permissionKey` props to action buttons and dropdown menus across Connections, Workspaces, Designs, and Empty States so Sistent's `PermissionShield` correctly disables them (displaying lock icons and permission tooltips) for users who lack the required permissions.

### Summary of Changes

1. **`K8sContextEmptyState.tsx`** — "Connect Clusters" button → `Keys.LifecycleManagementAddCluster` *(+ updated `K8sContextEmptyState.test.tsx` to assert the key is passed)*.
2. **`ConnectionActionMenu.tsx`** — "Configure" & "Configure Controllers" menu items → `Keys.LifecycleManagementEditConnection`.
3. **`kubernetesSettings.tsx`** — "Flush MeshSync" button → `Keys.LifecycleManagementFlushMeshsyncData`.
4. **`SelectDeploymentTarget.tsx`** — "Add Environments" empty state button → `Keys.WorkspaceManagementCreateEnvironment`.
5. **`MultiContentSelectToolbar` (`components.tsx`)** — Bulk selection toolbar buttons:
   - **Move:** `Keys.WorkspaceManagementAssignDesignsToWorkspaces`
   - **Download:** `Keys.CatalogManagementDownloadADesign`
   - **Share:** `Keys.CatalogManagementShareDesign`
   - **Delete:** `Keys.CatalogManagementDeleteADesign`
6. **`MyDesignsContent.tsx` & `RecentContent.tsx`** — Design "Import" button → `Keys.CatalogManagementImportDesign`.
7. **`ActionPopover.tsx` & `MesheryPatterns.columns.tsx`** — Table View per-row actions menu items (**Edit**, **Clone**, **Validate**, **Dry Run**, **Deploy**, **Undeploy**, **Download**, **Design Info**, **Unpublish**) now accept and render `permissionKey` so permission shields display in Table View dropdown popovers.

Fixes #21073

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added permission checks for connection configuration, controller configuration, MeshSync data actions, deployment environments, and Kubernetes cluster connections.
  * Added permission checks for design actions, including importing, editing, cloning, validating, evaluating, deploying, downloading, sharing, moving, and deleting designs.
  * Restricted these actions to users with the appropriate permissions.

* **Tests**
  * Added coverage verifying the required permission for connecting Kubernetes clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->