### PR TITLE
[server] Replace log.Fatal with regexp.MustCompile in filler

### DIFF
--- a/server/models/pattern/stages/filler.go
+++ b/server/models/pattern/stages/filler.go
@@ -2,7 +2,6 @@ package stages
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 
@@ -15,15 +14,7 @@ import (
 
 const FillerPattern = `\$\(#ref\..+\)`
 
-var FillerRegex *regexp.Regexp
-
-func init() {
-	var err error
-	FillerRegex, err = regexp.Compile(FillerPattern)
-	if err != nil {
-		log.Fatal("failed to compile filler design regex")
-	}
-}
+var FillerRegex = regexp.MustCompile(FillerPattern)
 
 // Filler - filler stage processes the pattern to subsitute Pattern
 func Filler(skipPrintLogs bool) ChainStageFunction {


### PR DESCRIPTION
**Notes for Reviewers**
Removed the `init()` function and `log.Fatal` in `server/models/pattern/stages/filler.go`. Refactored `FillerRegex` to be initialized directly using `regexp.MustCompile()`, which adheres to Go best practices for package-level regular expressions and avoids abrupt program crashes from `log.Fatal`.

- This PR fixes #21087

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for invalid filler pattern configuration, ensuring failures are surfaced immediately and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->