### PR TITLE
[mesheryctl][UI] Link Connection Lifecycle tests to Test Plan rows + capture run output

### DIFF
--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -99,6 +99,10 @@ The "Latest" tab columns are: **A = Test #, B = Test Group, C = Client, D = Comp
 
 The report keys on `testGroup`, so tagged tests still appear in their `project` report (Meshery or Mesheryctl); the Connection Lifecycle report is an additional lens, not a relocation. **Transitional:** results carrying no `testGroup` label are still matched via the legacy `epic` (with a `componentUnderTest` fallback) selector, so results predating the `testGroup` label remain visible; this fallback drops once every connection result carries `testGroup`. The full token-to-label mapping lives in the [`mesheryctl/bats-to-allure.js`](https://github.com/meshery/meshery/blob/master/mesheryctl/bats-to-allure.js) header (CLI `[tg=...]`/`[cut=...]` tokens) and `ui/tests/e2e/connections.testmap.ts` (UI).
 
+**Row deep-link.** Each connection result also carries an Allure `tms` **link** ("Test Plan TC-\<n\>") that opens that test's exact row on the "Latest" tab, so a reviewer can click from a report test back to its source case. Both lanes derive the row from the Test # by the same fixed offset (`ROW = TestNum - 778`) encoding the *current* tab layout; the offset lives - with a prominent regenerate-if-re-sorted caveat - in `mesheryctl/bats-to-allure.js` (CLI) and `ui/tests/e2e/connections.testmap.ts` (UI), and the two MUST stay in lockstep.
+
+**Failure evidence.** A failed test carries its captured run output in the report, not just the assertion line. The CLI lane runs BATS with `--print-output-on-failure` and the converter attaches the captured `mesheryctl` transcript (`statusDetails` message + trace, plus a "CLI output (bats)" text attachment); the UI lane runs Playwright with `trace`, `screenshot`, and `video` all `retain-on-failure`, which the `allure-playwright` reporter attaches to each failed result alongside the error and stack.
+
 > The `mesheryctl` BATS e2e results and Go unit results are committed to separate directories (`mesheryctl-bats-results/` and `mesheryctl-unit-results/`) in `meshery/qa` and merged at report-build time, so the two feeders no longer overwrite each other.
 
 ### UI Build System

--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -280,6 +280,12 @@ The tokens are stripped from the displayed test name, so the naming convention a
 
 The full token-to-label mapping (including how the report `epic` is derived from the component) is documented in the header comment of [`mesheryctl/bats-to-allure.js`](https://github.com/meshery/meshery/blob/master/mesheryctl/bats-to-allure.js), the single injection point for this contract. Do not restate the mapping here; keep it in sync there.
 
+From a `[TC-<n>]` token in the connection block, the converter also emits an Allure `tms` **link** ("Test Plan TC-\<n\>") that deep-links straight to that test's row on the Test Plan "Latest" tab, so a reviewer can click from a report test to its source case. The row is derived from the Test # by a fixed offset (`ROW = TestNum - 778`) that encodes the *current* Latest-tab layout - if the tab is re-sorted, the offset must be regenerated (see the prominent caveat in [`mesheryctl/bats-to-allure.js`](https://github.com/meshery/meshery/blob/master/mesheryctl/bats-to-allure.js) and its UI-lane twin `ui/tests/e2e/connections.testmap.ts`).
+
+##### Failure output in the report
+
+The BATS suite runs with `--print-output-on-failure`, so a failing test's captured `mesheryctl` output (`$output`/`$stderr`) is emitted as TAP diagnostics. The converter turns that into debuggable Allure detail on the failed result: a concise headline (`statusDetails.message`), the full transcript (`statusDetails.trace`), and the same transcript as a **text attachment** ("CLI output (bats)"). Passing and skipped tests carry no such attachment. No test needs to opt in - this is automatic for every failure.
+
 #### Test Data
 
 If a command requries a specific id, name or any predefined value ensure that the data is created by your test or another test beforehand. Do not rely on external or uncontrolled data as it will lead to unexpected results.

--- a/mesheryctl/bats-to-allure.js
+++ b/mesheryctl/bats-to-allure.js
@@ -44,6 +44,47 @@ const TAP_SKIP_DIRECTIVE_RE = /\s*#\s*skip\b\s*(.*)$/i;
 const CONNECTION_COMPONENTS = new Set(["kubernetes connection"]);
 const CONNECTION_EPIC = "Kubernetes Connections";
 
+// ---------------------------------------------------------------------------
+// Test Plan deep-link (traceability contract, part A) -----------------------
+//
+// Each connection result carries an Allure `tms` link back to its exact row in
+// the Meshery Test Plan Google Sheet "Latest" tab, so a reviewer can click
+// straight from a report test to its source case. The row is derived from the
+// Test # (col A, i.e. the TC-<n> id): for the connection block,
+//   ROW = TestNum - CONN_ROW_OFFSET
+//
+// !!!  CURRENT-LAYOUT-DEPENDENT - REGENERATE IF THE SHEET IS RE-SORTED  !!!
+// The offset below encodes the CURRENT "Latest" tab layout, in which the
+// connection cases Test# 1012..1089 occupy the contiguous rows 234..311
+// (1012 - 778 = 234 ... 1089 - 778 = 311, verified against the live sheet).
+// If the Latest tab is re-sorted, or rows are inserted above the connection
+// block, both the offset AND the [CONN_TEST_MIN, CONN_TEST_MAX] range MUST be
+// recomputed - otherwise the deep-link silently points at the wrong row. The
+// range guard is deliberate: results outside the connection block get NO link
+// rather than a wrong one (the offset is only known-good for that block).
+const CONN_TEST_MIN = 1012;
+const CONN_TEST_MAX = 1089;
+const CONN_ROW_OFFSET = 778; // ROW = TestNum - 778 (Test# 1012 -> row 234).
+const TEST_PLAN_SHEET_ID = "13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs";
+const TEST_PLAN_GID = "838298230";
+
+// testPlanLink builds the Allure `tms` link back to the Test Plan row for a
+// connection Test # (`TC-<n>`), or returns null when the id is malformed or
+// falls outside the connection block the offset is valid for. See the caveat
+// above: the offset is layout-specific, so a non-connection id must never be
+// turned into a (wrong) deep-link.
+function testPlanLink(testId) {
+  const m = /^TC-(\d+)$/i.exec((testId || "").trim());
+  if (!m) return null;
+  const testNum = Number(m[1]);
+  if (testNum < CONN_TEST_MIN || testNum > CONN_TEST_MAX) return null;
+  const row = testNum - CONN_ROW_OFFSET;
+  const url =
+    `https://docs.google.com/spreadsheets/d/${TEST_PLAN_SHEET_ID}` +
+    `/edit?gid=${TEST_PLAN_GID}#gid=${TEST_PLAN_GID}&range=A${row}`;
+  return { name: `Test Plan ${testId}`, url, type: "tms" };
+}
+
 // Parse suite-wide labels from env: ALLURE_LABELS="key=value,key=value".
 function parseExtraLabels() {
   const raw = process.env.ALLURE_LABELS;
@@ -80,6 +121,7 @@ function tapStatusToAllure(status) {
 // duplicate.
 function parseTitleTokens(rawName, extraLabels = []) {
   const labels = [];
+  const links = [];
   let name = rawName;
   let cut = null;
   let epic = null;
@@ -92,10 +134,14 @@ function parseTitleTokens(rawName, extraLabels = []) {
     name = name.slice(match[0].length);
 
     if (/^TC-/i.test(token)) {
-      // [TC-<n>] — the Test Plan Test #. Emit both testId and a tag.
+      // [TC-<n>] — the Test Plan Test #. Emit both testId and a tag, plus the
+      // deep-link back to the Test Plan row (connection block only; see
+      // testPlanLink).
       const testId = token;
       labels.push({ name: "testId", value: testId });
       labels.push({ name: "tag", value: testId });
+      const link = testPlanLink(testId);
+      if (link) links.push(link);
       continue;
     }
 
@@ -141,7 +187,7 @@ function parseTitleTokens(rawName, extraLabels = []) {
     labels.push({ name: "epic", value: CONNECTION_EPIC });
   }
 
-  return { name: name.trim(), labels };
+  return { name: name.trim(), labels, links };
 }
 
 // parseTestLine turns a single TAP "ok/not ok" line into a normalized record:
@@ -161,8 +207,8 @@ function parseTestLine(rawStatus, rawName, extraLabels = []) {
     name = name.slice(0, skipMatch.index);
   }
 
-  const { name: cleanName, labels } = parseTitleTokens(name, extraLabels);
-  return { status, name: cleanName, skipReason, labels };
+  const { name: cleanName, labels, links } = parseTitleTokens(name, extraLabels);
+  return { status, name: cleanName, skipReason, labels, links };
 }
 
 function baseLabels(extraLabels) {
@@ -203,8 +249,8 @@ function dedupeLabels(labels) {
   return out;
 }
 
-function createAllureResult({ name, status, start, stop, details, labels }) {
-  return {
+function createAllureResult({ name, status, start, stop, details, labels, links }) {
+  const result = {
     uuid: uuid(),
     name,
     status,
@@ -212,8 +258,47 @@ function createAllureResult({ name, status, start, stop, details, labels }) {
     start,
     stop,
     statusDetails: details ? { message: details } : {},
-    labels
+    labels,
+    // _diag accumulates the TAP `#` diagnostic lines that follow this test (its
+    // captured command transcript on failure). It is a scratch field consumed
+    // by finalizeDiagnostics() and deleted before the result JSON is written.
+    _diag: []
   };
+  if (links && links.length) result.links = links;
+  return result;
+}
+
+// summarizeDiagnostics picks a one-line headline for statusDetails.message from
+// the captured diagnostic lines: prefer the assertion "...' failed" line (the
+// most informative), falling back to the first non-empty line.
+function summarizeDiagnostics(diagLines) {
+  const failLine = diagLines.find(l => /\bfailed\b/.test(l));
+  return (failLine || diagLines.find(l => l.trim()) || "").trim();
+}
+
+// finalizeDiagnostics turns a failed result's captured BATS output (part B) into
+// debuggable Allure detail: a concise headline (message), the full transcript
+// (trace), AND a text attachment holding the same transcript (the command +
+// captured $output/$stderr surfaced by `bats --print-output-on-failure`). It
+// writes the attachment file into ALLURE_RESULTS_DIR and strips the scratch
+// `_diag` field. Skipped results keep their skip-reason message untouched;
+// passed results carry no diagnostics.
+function finalizeDiagnostics(result) {
+  const diag = result._diag || [];
+  delete result._diag;
+
+  if (result.status !== "failed" || diag.length === 0) return;
+
+  const transcript = diag.join("\n");
+  result.statusDetails.message =
+    summarizeDiagnostics(diag) || result.statusDetails.message || "test failed";
+  result.statusDetails.trace = transcript;
+
+  const attachmentFile = `${result.uuid}-attachment.txt`;
+  fs.writeFileSync(path.join(ALLURE_RESULTS_DIR, attachmentFile), transcript);
+  result.attachments = [
+    { name: "CLI output (bats)", source: attachmentFile, type: "text/plain" }
+  ];
 }
 
 function convertTapToAllure(tapFile) {
@@ -244,7 +329,8 @@ function convertTapToAllure(tapFile) {
         start,
         stop: start + 1,
         details: parsed.skipReason || null,
-        labels: dedupeLabels([...baseLabels(extraLabels), ...parsed.labels])
+        labels: dedupeLabels([...baseLabels(extraLabels), ...parsed.labels]),
+        links: parsed.links
       });
 
       results.push(result);
@@ -252,18 +338,18 @@ function convertTapToAllure(tapFile) {
       continue;
     }
 
-    // Diagnostic lines describe the test that PRECEDES them (e.g. a failing
-    // test's stack in BATS TAP), so attach them to the current result.
+    // Diagnostic lines describe the test that PRECEDES them (a failing test's
+    // stack + captured output in BATS TAP), so accumulate them on the current
+    // result. finalizeDiagnostics() later turns them into message/trace/an
+    // attachment for failed tests.
     const diagMatch = trimmed.match(TAP_DIAGNOSTIC_RE);
     if (diagMatch && current) {
-      const existing = current.statusDetails.message;
-      current.statusDetails.message = existing
-        ? `${existing}\n${diagMatch[1]}`
-        : diagMatch[1];
+      current._diag.push(diagMatch[1]);
     }
   }
 
   for (const result of results) {
+    finalizeDiagnostics(result);
     const outputPath = path.join(ALLURE_RESULTS_DIR, `${result.uuid}-result.json`);
     fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
   }
@@ -277,6 +363,8 @@ module.exports = {
   parseTestLine,
   dedupeLabels,
   convertTapToAllure,
+  testPlanLink,
+  summarizeDiagnostics,
   CONNECTION_EPIC
 };
 

--- a/mesheryctl/bats-to-allure.test.js
+++ b/mesheryctl/bats-to-allure.test.js
@@ -14,6 +14,8 @@ const {
   parseTestLine,
   dedupeLabels,
   convertTapToAllure,
+  testPlanLink,
+  summarizeDiagnostics,
   CONNECTION_EPIC
 } = require("./bats-to-allure.js");
 
@@ -209,6 +211,148 @@ test("convertTapToAllure end-to-end writes results with base + per-test labels",
     // Results are written to allure-results/.
     const files = fs.readdirSync(path.join(tmp, "allure-results"));
     assert.equal(files.filter(f => f.endsWith("-result.json")).length, 3);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- Part A: Test Plan deep-link -------------------------------------------
+
+test("testPlanLink maps a connection Test # to its Latest-tab row (ROW = n - 778)", () => {
+  const link = testPlanLink("TC-1012");
+  assert.equal(link.type, "tms");
+  assert.equal(link.name, "Test Plan TC-1012");
+  // Test# 1012 -> row 234; the deep-link targets A234 on the Latest tab.
+  assert.match(link.url, /range=A234$/);
+  assert.match(link.url, /13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/);
+  assert.match(link.url, /gid=838298230/);
+});
+
+test("testPlanLink covers both ends of the connection block", () => {
+  assert.match(testPlanLink("TC-1012").url, /range=A234$/); // first
+  assert.match(testPlanLink("TC-1089").url, /range=A311$/); // last (1089 - 778)
+});
+
+test("testPlanLink returns null outside the connection block or for malformed ids", () => {
+  assert.equal(testPlanLink("TC-1011"), null); // below the block
+  assert.equal(testPlanLink("TC-1090"), null); // above the block
+  assert.equal(testPlanLink("TC-500"), null); // unrelated case
+  assert.equal(testPlanLink("nonsense"), null);
+  assert.equal(testPlanLink(""), null);
+  assert.equal(testPlanLink(undefined), null);
+});
+
+test("parseTitleTokens emits a Test Plan tms link for a connection TC", () => {
+  const { links } = parseTitleTokens("[TC-1042][cut=Kubernetes Connection] view works");
+  assert.equal(links.length, 1);
+  assert.equal(links[0].type, "tms");
+  assert.equal(links[0].name, "Test Plan TC-1042");
+  assert.match(links[0].url, /range=A264$/); // 1042 - 778
+});
+
+test("parseTitleTokens emits no link for a non-connection Test #", () => {
+  const { links } = parseTitleTokens("[TC-2001][cut=Model] import works");
+  assert.equal(links.length, 0);
+});
+
+test("convertTapToAllure attaches the Test Plan link to the result", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "b2a-"));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tmp);
+    fs.writeFileSync(
+      path.join(tmp, "s.tap"),
+      "1..1\nok 1 [TC-1013][cut=Kubernetes Connection][tg=Connection Lifecycle] create\n"
+    );
+    const [r] = convertTapToAllure(path.join(tmp, "s.tap"));
+    assert.equal(r.links.length, 1);
+    assert.equal(r.links[0].name, "Test Plan TC-1013");
+    assert.match(r.links[0].url, /range=A235$/); // 1013 - 778
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- Part B: failure output capture ----------------------------------------
+
+test("summarizeDiagnostics prefers the assertion '...failed' line", () => {
+  const diag = [
+    "(in test file 007-connection/02-connection-list.bats, line 25)",
+    "  `assert_success' failed",
+    "-- command failed --",
+    "status : 1"
+  ];
+  assert.equal(summarizeDiagnostics(diag), "`assert_success' failed");
+});
+
+test("summarizeDiagnostics falls back to the first non-empty line", () => {
+  assert.equal(summarizeDiagnostics(["", "   ", "boom happened"]), "boom happened");
+  assert.equal(summarizeDiagnostics([]), "");
+});
+
+test("failed tests get a trace + text attachment holding the captured output", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "b2a-"));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tmp);
+    const tap = [
+      "1..2",
+      "ok 1 [TC-1041][cut=Kubernetes Connection] list works",
+      "not ok 2 [TC-1043][cut=Kubernetes Connection] create fails",
+      "# (in test file 007-connection/01-connection-create.bats, line 55)",
+      "#   `assert_success' failed",
+      "# -- command failed --",
+      "# status : 1",
+      "# output : Error: unable to get: .connections"
+    ].join("\n");
+    fs.writeFileSync(path.join(tmp, "sample.tap"), tap);
+
+    const results = convertTapToAllure(path.join(tmp, "sample.tap"));
+    const passed = results.find(r => r.status === "passed");
+    const failed = results.find(r => r.status === "failed");
+
+    // Headline message is the concise assertion line.
+    assert.equal(failed.statusDetails.message, "`assert_success' failed");
+    // Full transcript is in the trace...
+    assert.match(failed.statusDetails.trace, /unable to get: \.connections/);
+    assert.match(failed.statusDetails.trace, /command failed/);
+    // ...and duplicated as a text attachment file on disk.
+    assert.equal(failed.attachments.length, 1);
+    assert.equal(failed.attachments[0].type, "text/plain");
+    assert.equal(failed.attachments[0].source, `${failed.uuid}-attachment.txt`);
+    const attachmentBody = fs.readFileSync(
+      path.join(tmp, "allure-results", failed.attachments[0].source),
+      "utf-8"
+    );
+    assert.match(attachmentBody, /unable to get: \.connections/);
+
+    // A passing test carries no trace/attachment and no leaked scratch field.
+    assert.equal(passed.statusDetails.trace, undefined);
+    assert.equal(passed.attachments, undefined);
+    assert.equal(passed._diag, undefined);
+    assert.equal(failed._diag, undefined);
+  } finally {
+    process.chdir(cwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("skipped tests keep their skip-reason message and get no attachment", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "b2a-"));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tmp);
+    fs.writeFileSync(
+      path.join(tmp, "s.tap"),
+      "1..1\nok 1 [TC-1013][cut=Kubernetes Connection] create # skip minikube not installed\n"
+    );
+    const [r] = convertTapToAllure(path.join(tmp, "s.tap"));
+    assert.equal(r.status, "skipped");
+    assert.equal(r.statusDetails.message, "minikube not installed");
+    assert.equal(r.statusDetails.trace, undefined);
+    assert.equal(r.attachments, undefined);
   } finally {
     process.chdir(cwd);
     fs.rmSync(tmp, { recursive: true, force: true });

--- a/mesheryctl/tests/e2e/run_tests.bash
+++ b/mesheryctl/tests/e2e/run_tests.bash
@@ -10,7 +10,11 @@ source ./setup_suite.bash
 # Uncomment the following line to enable junit format output
 FORMATTER="--formatter tap"
 
-bats $FORMATTER *-*/*.bats
+# --print-output-on-failure makes BATS emit each failing test's captured $output
+# / $stderr as TAP `#` diagnostics. bats-to-allure.js turns those into the
+# Allure failure trace + a text attachment, so a failed test is debuggable in
+# the Connection Lifecycle report instead of showing only the assertion line.
+bats $FORMATTER --print-output-on-failure *-*/*.bats
 
 test_result=$?  # Capture the exit code of bats
 

--- a/mesheryctl/tests/e2e/run_tests_local.sh
+++ b/mesheryctl/tests/e2e/run_tests_local.sh
@@ -73,13 +73,16 @@ main() {
    # Uncomment the following line to enable junit format output
    # FORMATTER="--formatter tap"
 
+   # --print-output-on-failure surfaces each failing test's captured $output /
+   # $stderr (mirrors CI, and feeds the Allure failure attachment via
+   # bats-to-allure.js), so local failures are debuggable too.
    if [[ -z "$FILE" ]]; then
       echo "Running all E2E tests."
-      bats $FORMATTER *-*/*.bats
+      bats $FORMATTER --print-output-on-failure *-*/*.bats
    else
       if [[ "$FILE" == *.bats && -f "$FILE" ]]; then
          echo "Running E2E for specified file: $FILE"
-         bats $FORMATTER $FILE
+         bats $FORMATTER --print-output-on-failure $FILE
       else
          echo "X Invalid file format or file not found"
          exit 1

--- a/ui/playwright.config.js
+++ b/ui/playwright.config.js
@@ -44,6 +44,11 @@ module.exports = defineConfig({
     video: {
       mode: 'retain-on-failure',
     },
+    /* Keep a screenshot of the final failed state. Together with trace + video
+     * (all retain-on-failure), the allure-playwright reporter attaches these to
+     * each failed result, so a failure is debuggable in the Allure report
+     * (e.g. the Connection Lifecycle report) instead of showing only the error. */
+    screenshot: 'only-on-failure',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
     provider: process.env.MESHERY_PROVIDER || 'Local',

--- a/ui/tests/e2e/connections.spec.ts
+++ b/ui/tests/e2e/connections.spec.ts
@@ -144,7 +144,7 @@ test.describe.serial('Connection Management Tests', () => {
     'Discover multiple kubeconfig contexts in the wizard',
     { tag: connTags('wizardDiscoverContexts') },
     async ({ page }, testInfo) => {
-      annotateConnCase(testInfo, 'wizardDiscoverContexts');
+      await annotateConnCase(testInfo, 'wizardDiscoverContexts');
       test.slow();
 
       if (!fs.existsSync(MULTI_CONTEXT_KUBECONFIG)) {
@@ -194,7 +194,7 @@ test.describe.serial('Connection Management Tests', () => {
     'Register and connect a Kubernetes cluster via kubeconfig upload',
     { tag: connTags('kubeconfigConnect') },
     async ({ page }, testInfo) => {
-      annotateConnCase(testInfo, 'kubeconfigConnect');
+      await annotateConnCase(testInfo, 'kubeconfigConnect');
       test.slow();
 
       if (!fs.existsSync(HOST_KUBECONFIG)) {
@@ -257,7 +257,7 @@ test.describe.serial('Connection Management Tests', () => {
     'Transition a Kubernetes connection between lifecycle states',
     { tag: connTags('stateTransition') },
     async ({ page, clusterMetaData }, testInfo) => {
-      annotateConnCase(testInfo, 'stateTransition');
+      await annotateConnCase(testInfo, 'stateTransition');
       test.slow();
 
       // Narrow to the connected data row for the cluster under test.
@@ -319,7 +319,7 @@ test.describe.serial('Connection Management Tests', () => {
     'Delete Kubernetes cluster connections',
     { tag: connTags('delete') },
     async ({ page, clusterMetaData }, testInfo) => {
-      annotateConnCase(testInfo, 'delete');
+      await annotateConnCase(testInfo, 'delete');
       // The full search -> delete -> confirm -> snackbar flow can be slow in CI.
       test.slow();
 

--- a/ui/tests/e2e/connections.testmap.ts
+++ b/ui/tests/e2e/connections.testmap.ts
@@ -1,5 +1,6 @@
 import type { TestInfo } from '@playwright/test';
 import * as allure from 'allure-js-commons';
+import { testPlanLink } from './testPlanLink';
 
 /**
  * Traceability map for the Kubernetes Connection Playwright suite.
@@ -29,36 +30,14 @@ export const CONN_EPIC = 'Kubernetes Connections';
 /** Client label for the shared cross-lane contract (UI vs CLI). */
 export const CONN_CLIENT = 'UI';
 
-// Test Plan deep-link (part A). Each tracked case links back to its exact row in
-// the Meshery Test Plan "Latest" tab so a reviewer can click from a report test
-// straight to its source case. The row is derived from the Test # (col A):
-//   ROW = TestNum - CONN_ROW_OFFSET
-//
-// !!!  CURRENT-LAYOUT-DEPENDENT - REGENERATE IF THE SHEET IS RE-SORTED  !!!
-// The offset encodes the CURRENT "Latest" tab layout, in which the connection
-// cases Test# 1012..1089 occupy the contiguous rows 234..311 (1012 - 778 = 234
-// ... 1089 - 778 = 311). This is the SAME offset used by the CLI lane in
-// mesheryctl/bats-to-allure.js; the two MUST be kept in lockstep. If the Latest
-// tab is re-sorted, or rows are inserted above the connection block, recompute
-// the offset in BOTH files. Every CONN_CASES testId is inside that block by
-// construction (see CONN_CASES below).
-const CONN_ROW_OFFSET = 778;
-const TEST_PLAN_SHEET_ID = '13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs';
-const TEST_PLAN_GID = '838298230';
-
-/**
- * Build the Test Plan "Latest" tab deep-link for a connection Test # (`TC-<n>`).
- * Returns the URL and the human-facing link name used across both lanes
- * ("Test Plan TC-<n>"). See the offset caveat above.
- */
-export function testPlanLink(testId: string): { url: string; name: string } {
-  const testNum = Number(testId.replace(/^TC-/i, ''));
-  const row = testNum - CONN_ROW_OFFSET;
-  const url =
-    `https://docs.google.com/spreadsheets/d/${TEST_PLAN_SHEET_ID}` +
-    `/edit?gid=${TEST_PLAN_GID}#gid=${TEST_PLAN_GID}&range=A${row}`;
-  return { url, name: `Test Plan ${testId}` };
-}
+// Test Plan deep-link (part A): the row-derivation contract lives in the pure,
+// unit-tested `./testPlanLink` helper (guards the `TC-<n>` shape and the
+// 1012..1089 connection block, returning null otherwise so a malformed/
+// out-of-block id never becomes a wrong link). Every CONN_CASES testId is inside
+// that block by construction (see CONN_CASES below), so the guard normally
+// passes - it exists so a future out-of-block id fails safe instead of emitting
+// `range=ANaN`. Re-exported here for back-compat with existing importers.
+export { testPlanLink } from './testPlanLink';
 
 export interface ConnCase {
   /** Meshery Test Plan "Latest" tab, column A ("Test #"), e.g. `TC-98`. */
@@ -172,9 +151,13 @@ export async function annotateConnCase(testInfo: TestInfo, key: ConnCaseKey): Pr
   // counterpart to the CLI converter's `links` entry. This uses the
   // allure-js-commons runtime API for the same reason as the testGroup label:
   // allure-playwright maps only known annotation types (epic/feature/story) to
-  // the report, so a custom link must be set through allure.link to appear.
-  const { url, name } = testPlanLink(testCase.testId);
-  await allure.link(url, name, 'tms');
+  // the report, so a custom link must be set through allure.link to appear. The
+  // helper returns null for an out-of-block/malformed id (fail-safe, no wrong
+  // link); every tracked case is in-block so this normally yields a link.
+  const link = testPlanLink(testCase.testId);
+  if (link) {
+    await allure.link(link.url, link.name, 'tms');
+  }
 }
 
 /**

--- a/ui/tests/e2e/connections.testmap.ts
+++ b/ui/tests/e2e/connections.testmap.ts
@@ -1,4 +1,5 @@
 import type { TestInfo } from '@playwright/test';
+import * as allure from 'allure-js-commons';
 
 /**
  * Traceability map for the Kubernetes Connection Playwright suite.
@@ -27,6 +28,37 @@ export const CONN_EPIC = 'Kubernetes Connections';
 
 /** Client label for the shared cross-lane contract (UI vs CLI). */
 export const CONN_CLIENT = 'UI';
+
+// Test Plan deep-link (part A). Each tracked case links back to its exact row in
+// the Meshery Test Plan "Latest" tab so a reviewer can click from a report test
+// straight to its source case. The row is derived from the Test # (col A):
+//   ROW = TestNum - CONN_ROW_OFFSET
+//
+// !!!  CURRENT-LAYOUT-DEPENDENT - REGENERATE IF THE SHEET IS RE-SORTED  !!!
+// The offset encodes the CURRENT "Latest" tab layout, in which the connection
+// cases Test# 1012..1089 occupy the contiguous rows 234..311 (1012 - 778 = 234
+// ... 1089 - 778 = 311). This is the SAME offset used by the CLI lane in
+// mesheryctl/bats-to-allure.js; the two MUST be kept in lockstep. If the Latest
+// tab is re-sorted, or rows are inserted above the connection block, recompute
+// the offset in BOTH files. Every CONN_CASES testId is inside that block by
+// construction (see CONN_CASES below).
+const CONN_ROW_OFFSET = 778;
+const TEST_PLAN_SHEET_ID = '13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs';
+const TEST_PLAN_GID = '838298230';
+
+/**
+ * Build the Test Plan "Latest" tab deep-link for a connection Test # (`TC-<n>`).
+ * Returns the URL and the human-facing link name used across both lanes
+ * ("Test Plan TC-<n>"). See the offset caveat above.
+ */
+export function testPlanLink(testId: string): { url: string; name: string } {
+  const testNum = Number(testId.replace(/^TC-/i, ''));
+  const row = testNum - CONN_ROW_OFFSET;
+  const url =
+    `https://docs.google.com/spreadsheets/d/${TEST_PLAN_SHEET_ID}` +
+    `/edit?gid=${TEST_PLAN_GID}#gid=${TEST_PLAN_GID}&range=A${row}`;
+  return { url, name: `Test Plan ${testId}` };
+}
 
 export interface ConnCase {
   /** Meshery Test Plan "Latest" tab, column A ("Test #"), e.g. `TC-98`. */
@@ -125,7 +157,7 @@ export function connTagsUntracked(componentUnderTest: string): string[] {
  * Playwright reporter only processes `relationship` annotations - it does not
  * read these; the tags from {@link connTags} are what it surfaces.)
  */
-export function annotateConnCase(testInfo: TestInfo, key: ConnCaseKey): void {
+export async function annotateConnCase(testInfo: TestInfo, key: ConnCaseKey): Promise<void> {
   const testCase = CONN_CASES[key];
   testInfo.annotations.push(
     { type: 'testId', description: testCase.testId },
@@ -135,6 +167,14 @@ export function annotateConnCase(testInfo: TestInfo, key: ConnCaseKey): void {
     { type: 'feature', description: testCase.feature },
     { type: 'story', description: testCase.story },
   );
+
+  // Emit the Test Plan row as a real Allure `tms` link (part A) - the UI-lane
+  // counterpart to the CLI converter's `links` entry. This uses the
+  // allure-js-commons runtime API for the same reason as the testGroup label:
+  // allure-playwright maps only known annotation types (epic/feature/story) to
+  // the report, so a custom link must be set through allure.link to appear.
+  const { url, name } = testPlanLink(testCase.testId);
+  await allure.link(url, name, 'tms');
 }
 
 /**

--- a/ui/tests/e2e/testPlanLink.ts
+++ b/ui/tests/e2e/testPlanLink.ts
@@ -1,0 +1,43 @@
+// Test Plan deep-link helper (part A), shared by the connection test map and its
+// unit test. Kept as a standalone, dependency-free module (no allure / Playwright
+// imports) so the pure row-derivation logic can be unit-tested under vitest -
+// which excludes `tests/e2e` from test discovery but can still import a helper
+// from it.
+//
+// Each tracked connection case links back to its exact row in the Meshery Test
+// Plan "Latest" tab so a reviewer can click from a report test straight to its
+// source case. The row is derived from the Test # (col A, the `TC-<n>` id):
+//   ROW = TestNum - CONN_ROW_OFFSET
+//
+// !!!  CURRENT-LAYOUT-DEPENDENT - REGENERATE IF THE SHEET IS RE-SORTED  !!!
+// The offset and range below encode the CURRENT "Latest" tab layout, in which
+// the connection cases Test# 1012..1089 occupy the contiguous rows 234..311
+// (1012 - 778 = 234 ... 1089 - 778 = 311). This is the SAME contract as the CLI
+// lane in `mesheryctl/bats-to-allure.js`; the two MUST be kept in lockstep. If
+// the Latest tab is re-sorted, or rows are inserted above the connection block,
+// recompute the offset AND the [CONN_TEST_MIN, CONN_TEST_MAX] range in BOTH
+// files. The range guard is deliberate: an id outside the connection block (or a
+// malformed one) yields NO link rather than a wrong one (e.g. `range=ANaN`).
+export const CONN_TEST_MIN = 1012;
+export const CONN_TEST_MAX = 1089;
+export const CONN_ROW_OFFSET = 778;
+const TEST_PLAN_SHEET_ID = '13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs';
+const TEST_PLAN_GID = '838298230';
+
+/**
+ * Build the Test Plan "Latest" tab deep-link for a connection Test # (`TC-<n>`),
+ * or return `null` when the id is malformed or falls outside the connection
+ * block the offset is valid for. The link name ("Test Plan TC-<n>") matches the
+ * CLI lane. See the offset caveat above.
+ */
+export function testPlanLink(testId: string): { url: string; name: string } | null {
+  const match = /^TC-(\d+)$/i.exec((testId ?? '').trim());
+  if (!match) return null;
+  const testNum = Number(match[1]);
+  if (testNum < CONN_TEST_MIN || testNum > CONN_TEST_MAX) return null;
+  const row = testNum - CONN_ROW_OFFSET;
+  const url =
+    `https://docs.google.com/spreadsheets/d/${TEST_PLAN_SHEET_ID}` +
+    `/edit?gid=${TEST_PLAN_GID}#gid=${TEST_PLAN_GID}&range=A${row}`;
+  return { url, name: `Test Plan ${testId}` };
+}

--- a/ui/tests/testPlanLink.test.ts
+++ b/ui/tests/testPlanLink.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+// Unit tests for the Test Plan deep-link helper (part A). This lives outside
+// `tests/e2e` on purpose: vitest excludes `tests/e2e` from test discovery, and
+// Playwright (testDir `tests/e2e`) would otherwise try to run a `*.test.ts`
+// placed there. It imports the pure helper (no allure/Playwright coupling),
+// mirroring the CLI-lane contract tests in `mesheryctl/bats-to-allure.test.js`.
+import { testPlanLink } from './e2e/testPlanLink';
+
+describe('testPlanLink', () => {
+  it('maps a connection Test # to its Latest-tab row (ROW = n - 778)', () => {
+    const link = testPlanLink('TC-1012');
+    expect(link).not.toBeNull();
+    expect(link?.name).toBe('Test Plan TC-1012');
+    // Test# 1012 -> row 234.
+    expect(link?.url).toMatch(/range=A234$/);
+    expect(link?.url).toContain('13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs');
+    expect(link?.url).toContain('gid=838298230');
+  });
+
+  it('covers both ends of the connection block', () => {
+    expect(testPlanLink('TC-1012')?.url).toMatch(/range=A234$/); // first
+    expect(testPlanLink('TC-1089')?.url).toMatch(/range=A311$/); // last (1089 - 778)
+  });
+
+  it('returns null outside the connection block', () => {
+    expect(testPlanLink('TC-1011')).toBeNull(); // below the block
+    expect(testPlanLink('TC-1090')).toBeNull(); // above the block
+    expect(testPlanLink('TC-500')).toBeNull(); // unrelated case
+  });
+
+  it('returns null for malformed or empty ids (no ANaN link)', () => {
+    expect(testPlanLink('nonsense')).toBeNull();
+    expect(testPlanLink('1012')).toBeNull(); // missing TC- prefix
+    expect(testPlanLink('')).toBeNull();
+    // @ts-expect-error - exercise the runtime guard against nullish input
+    expect(testPlanLink(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Motivation

The live **Connection Lifecycle** QA report ([qa.meshery.io/connections](https://qa.meshery.io/connections/)) lets a reviewer see connection tests from both the UI and CLI lanes, but two things were missing: there was no way to jump from a report test back to its source case in the Test Plan, and a failed test showed almost no detail. This PR adds both, additively - no test assertions change.

## What changed

### A. Test Plan row deep-link (traceability)

Each connection test now carries an Allure `tms` **link** ("Test Plan TC-\<n\>") that opens its exact row on the Test Plan "Latest" tab.

- The row is derived from the Test # by a fixed offset `ROW = TestNum - 778`, encoding the **current** Latest-tab layout where the connection block (Test# 1012-1089) occupies rows 234-311. A prominent, hard-to-miss caveat in both files says to regenerate the offset if the sheet is re-sorted.
- **CLI** (`mesheryctl/bats-to-allure.js`): emits a `links` entry per connection result, guarded to the connection block so a non-connection Test # never gets a wrong deep-link.
- **UI** (`ui/tests/e2e/connections.testmap.ts`): emits the same link via `allure.link(url, "Test Plan TC-<n>", "tms")` through the shared per-test annotate helper. The two offsets are kept in lockstep.

### B. Capture run output on failure (debuggability)

- **CLI**: the BATS suite now runs with `--print-output-on-failure`, and the converter turns a failing test's captured `mesheryctl` output into a concise `statusDetails.message` (the assertion line), the full transcript as `statusDetails.trace`, **and** a "CLI output (bats)" text attachment. Passing/skipped tests are unaffected.
- **UI**: added `screenshot: 'only-on-failure'` to `ui/playwright.config.js` (`trace` and `video` were already `retain-on-failure`), so `allure-playwright` attaches trace + screenshot + video + error + stack to each failed result.

### Tests & docs

- Extended the converter unit tests (`bats-to-allure.test.js`): link derivation at both ends of the block, out-of-block guard, malformed ids, diagnostics summary, and the trace + text-attachment path. All 27 pass (`node --test bats-to-allure.test.js`).
- Updated the traceability docs: `docs/.../cli/tests.md` and `docs/.../build-and-release.md`.

## Verification

- `node --test mesheryctl/bats-to-allure.test.js` -> 27/27 pass.
- Manual conversion of a sample TAP confirms links (TC-1012 -> `range=A234`, TC-1077 -> `range=A299`), the `statusDetails.trace`, and the on-disk `*-attachment.txt`.
- `eslint` + `tsc --noEmit` clean on the changed UI files.
- Report-surface verification (name/link/output visible at qa.meshery.io/connections) happens after merge, once the push-to-master CI re-runs the connection tests and the qa publish runs.

## Notes

- No workflow files touched; `run_tests.bash` / `run_tests_local.sh` are shell scripts, `playwright.config.js` is test config.
- The qa-side report rename/nesting is a separate PR in `meshery/qa`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clickable Test Plan links to connection test results.
  * Enhanced failed-test reports with CLI output, traces, screenshots, and videos.
  * Added clearer diagnostic summaries for failed tests.
* **Bug Fixes**
  * Screenshots are now retained for failed UI tests to support troubleshooting.
  * Passing and skipped tests no longer include unnecessary failure attachments.
* **Documentation**
  * Updated testing and release documentation to explain Test Plan links and captured failure evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->