### PR TITLE
fix connection tests

### DIFF
--- a/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
+++ b/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
@@ -51,13 +51,21 @@ require_connection_id() {
     assert_file_exists "$SAVED_FILE"
 }
 
+# The nil UUID is syntactically well-formed, so view takes the by-id path
+# (isArgumentUUID) and the server rejects it in GetConnectionByID
+# (server/handlers/connections_handlers.go), which writes a 400
+# models.ErrInvalidUUID. That envelope carries "Invalid UUID" as its short
+# description and "invalid connection ID" as its cause. Assert those, not
+# "Invalid connection ID" (capitalised) — that string is emitted nowhere in
+# mesheryctl or meshery server, so the assertion could never pass.
 @test "[TC-1080][cut=Kubernetes Connection][tg=Connection Lifecycle] given an invalid connection-id is provided as an argument when running mesheryctl connection view --save then a message error is displayed" {
-    NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
+    INVALID_ID="00000000-0000-0000-0000-000000000000"
 
-    run $MESHERYCTL_BIN connection view --save "$NONEXISTENT_ID"
+    run $MESHERYCTL_BIN connection view --save "$INVALID_ID"
     assert_failure
     assert_output --partial "Error"
-    assert_output --partial "Invalid connection ID"
+    assert_output --partial "Invalid UUID"
+    assert_output --partial "invalid connection ID"
 }
 
 @test "[TC-1080][cut=Kubernetes Connection][tg=Connection Lifecycle] given no argument is provided when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
@@ -75,8 +83,14 @@ require_connection_id() {
     run $MESHERYCTL_BIN connection view "$CONNECTION_ID" --output-format foo
     assert_failure
     assert_output --partial "Error"
-    assert_output --partial "output-format choice is invalid"
-    assert_output --partial "use [json|yaml]"
+    # display.ErrInvalidOutputFormat: short description "Invalid Output Format",
+    # cause `Provided output format "foo" is invalid`, remediation
+    # "Ensure using [json|yaml] as the output format". The previously asserted
+    # "output-format choice is invalid" / "use [json|yaml]" are not emitted by
+    # any of those four parts.
+    assert_output --partial "Invalid Output Format"
+    assert_output --partial "is invalid"
+    assert_output --partial "[json|yaml]"
 }
 
 @test "[TC-1080][cut=Kubernetes Connection][tg=Connection Lifecycle] given a valid argument is provided as an argument when running mesheryctl connection view connection-id --output-format yaml then a details in default format is displayed" {
@@ -105,13 +119,17 @@ require_connection_id() {
     assert_output --partial "\"createdAt\""
 }
 
+# Same 400 models.ErrInvalidUUID envelope as the --save case above; the
+# rejection happens before any output formatting, so --output-format json does
+# not change the error text.
 @test "[TC-1080][cut=Kubernetes Connection][tg=Connection Lifecycle] given an invalid connection-id is provided as an argument when running mesheryctl connection view --output-format json/yaml then a message error is displayed" {
-    NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
+    INVALID_ID="00000000-0000-0000-0000-000000000000"
 
-    run $MESHERYCTL_BIN connection view "$NONEXISTENT_ID" --output-format json
+    run $MESHERYCTL_BIN connection view "$INVALID_ID" --output-format json
     assert_failure
     assert_output --partial "Error"
-    assert_output --partial "Invalid connection ID"
+    assert_output --partial "Invalid UUID"
+    assert_output --partial "invalid connection ID"
 }
 
 @test "[TC-1080][cut=Kubernetes Connection][tg=Connection Lifecycle] given no connection-id is provided as an argument when running mesheryctl connection view --output-format then a message error is displayed" {

--- a/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
+++ b/mesheryctl/tests/e2e/007-connection/04-connection-delete.bats
@@ -18,8 +18,15 @@ teardown_file() {
     assert_output --partial "Error"
 }
 
+# The id must be a well-formed, *non-nil* UUID. The server treats the nil UUID
+# as invalid rather than missing (GetConnectionByID rejects it outright with a
+# 400 ErrInvalidUUID, and the remote provider 401s a DELETE on it), so it never
+# reaches the not-found branch this test covers. Any syntactically valid UUID
+# that was never issued does: the persister returns ErrResultNotFound, the
+# handler maps that to 404, and delete.go turns a 404 into a warning and exit 0
+# ("No connection with ID %q found") rather than a hard failure.
 @test "[TC-1066][cut=Kubernetes Connection][tg=Connection Lifecycle] given a non existing connection-id is provided as an argument when running mesheryctl connection delete non-existing-id then an error message is displayed" {
-    NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
+    NONEXISTENT_ID="deadbeef-dead-4ead-8ead-deadbeefdead"
 
     run $MESHERYCTL_BIN connection delete "$NONEXISTENT_ID"
     assert_success


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated connection view tests to verify accurate invalid UUID and output-format error messages.
  * Added coverage for invalid connection IDs when saving results and using JSON output.
  * Improved connection deletion coverage by using a valid, non-empty UUID for non-existent connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->