### PR TITLE
[mesheryctl] Fix stale TC-1080 connection view invalid-id assertions (Invalid UUID / meshery-server-1432)

### DIFF
--- a/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
+++ b/mesheryctl/tests/e2e/007-connection/03-connection-view.bats
@@ -57,7 +57,10 @@ require_connection_id() {
     run $MESHERYCTL_BIN connection view --save "$NONEXISTENT_ID"
     assert_failure
     assert_output --partial "Error"
-    assert_output --partial "Invalid connection ID"
+    # Server rejects a non-parseable/nil connection id with ErrInvalidUUID
+    # ("Invalid UUID", meshery-server-1432). Assert on the stable error code
+    # rather than the human-readable message, which has drifted before.
+    assert_output --partial "meshery-server-1432"
 }
 
 @test "[TC-1080][cut=Kubernetes Connection][tg=Connection Lifecycle] given no argument is provided when running mesheryctl connection view connection-id --output-format then a message error is displayed" {
@@ -111,7 +114,10 @@ require_connection_id() {
     run $MESHERYCTL_BIN connection view "$NONEXISTENT_ID" --output-format json
     assert_failure
     assert_output --partial "Error"
-    assert_output --partial "Invalid connection ID"
+    # Server rejects a non-parseable/nil connection id with ErrInvalidUUID
+    # ("Invalid UUID", meshery-server-1432). Assert on the stable error code
+    # rather than the human-readable message, which has drifted before.
+    assert_output --partial "meshery-server-1432"
 }
 
 @test "[TC-1080][cut=Kubernetes Connection][tg=Connection Lifecycle] given no connection-id is provided as an argument when running mesheryctl connection view --output-format then a message error is displayed" {


### PR DESCRIPTION
## Description

Fixes the two stale **TC-1080** assertions in the mesheryctl Connection
Lifecycle e2e suite.

`03-connection-view.bats` asserted `--partial "Invalid connection ID"` for
`connection view --save <invalid-id>` and `connection view <invalid-id>
--output-format json`. The server's invalid-identifier error was changed to
`ErrInvalidUUID` — short description **"Invalid UUID"**, code
**`meshery-server-1432`** (`server/models/error.go:388`) — so the old substring
no longer matches and both tests fail. The CLI is behaving correctly; the tests
were stale.

Both assertions now check for the stable **`meshery-server-1432`** error code
rather than a human-readable message, which is robust to future wording drift.

Verified against the exact CLI output captured in the failing CI run
(`mesheryctl-e2e`, job `91602906279`):

```
Error: Response Status Code 400. Server emitted an error:
{"error":"Invalid UUID","code":"meshery-server-1432", …}
```

The two TC-1080 tests reach the server and receive this 400 directly (they are
not affected by the separate remote-provider auth problem), so the code-based
assertion matches the real output.

## Notes / context

This is one of three captain-approved follow-ups from a 12-failure Connection
Lifecycle e2e diagnosis:

- **This PR** — the stale TC-1080 assertions (test-only fix).
- Filed separately: #21094 — a possible server product bug (TC-1066: deleting a
  non-existent connection UUID attempts a provider save/de-register instead of
  returning "No connection with ID …"), plus the misleading `ErrQueryGet`
  remediation on `GetConnections` failures.
- The remaining failures are an expired remote-provider token in CI (being
  handled out of band).

## Type of change

- Bug fix (test correctness; no production code change)

## Test coverage

- `mesheryctl/tests/e2e/007-connection/03-connection-view.bats` parses cleanly
  (`bats --count` = 12). The change is a substring swap in two
  `assert_output --partial` lines; the new substring is taken verbatim from the
  captured server response.

Signed-off-by: marblom007 <158522975+marblom007@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated connection validation tests to verify the stable `meshery-server-1432` error code for invalid connection IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->