### PR TITLE
Partly Fix inconsistent 'Related' section heading in docs

### DIFF
--- a/docs/content/en/guides/configuration-management/pattern-management/index.md
+++ b/docs/content/en/guides/configuration-management/pattern-management/index.md
@@ -76,6 +76,6 @@ Deploying application “BookCatalog”...
 Deployed. Endpoint(s) available at: http://localhost:8000/catalog
 ```
 
-## Related Reading
+## Related
 
 - [`mesheryctl design`]({{< ref "reference/references/mesheryctl/design/_index.md" >}})

--- a/docs/content/en/installation/mesheryctl/_index.md
+++ b/docs/content/en/installation/mesheryctl/_index.md
@@ -31,8 +31,6 @@ Mesheryctl is configured for Kubernetes by default. To specify a different suppo
 
 Continue deploying Meshery onto one of the [Supported Platforms]({{< ref "installation/_index.md" >}}).
 
-# Related Reading
-
 ## Meshery CLI Guides
 
 Guides to using Meshery's various features and components.

--- a/docs/content/en/installation/mesheryctl/windows/_index.md
+++ b/docs/content/en/installation/mesheryctl/windows/_index.md
@@ -32,8 +32,6 @@ Optionally, move the `mesheryctl` binary to a directory in your `PATH`.
 
 Type `yes` when prompted to choose to configure a file. To get started, choose Docker as your platform to deploy Meshery. -->
 
-# Related Reading
-
 ## Meshery CLI Guides
 
 Guides to using Meshery's various features and components.


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21096

This PR standardizes the "Related" section heading across documentation pages:
- Changed "Related Reading" to "Related" on the Pattern Management page, to match the heading style used elsewhere (e.g. Creating a Meshery Design page).
- Removed the "Related Reading" heading from the Windows CLI installation page, since it had no related content listed below it.
- Removed the same empty "Related Reading" heading from the mesheryctl installation guides index page (`docs/content/en/installation/mesheryctl/_index.md`).

Here's a screen recording showing changes:


https://github.com/user-attachments/assets/97d8c465-69c6-495d-a65d-c0c0036b0bbc




**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the pattern management guide by renaming “Related Reading” to “Related.”
  * Removed the “Related Reading” section heading from the Meshery CLI installation guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->