### PR TITLE
[Docs] Remove stale Examples link from Sistent docs TOC

### DIFF
--- a/docs/content/en/project/contributing/ui/sistent.md
+++ b/docs/content/en/project/contributing/ui/sistent.md
@@ -29,7 +29,6 @@ Sistent leverages Material UI libraries and provides a custom theme on top of it
 
 - [Usage](#usage)
 - [How to use Sistent tokens/theme colors](#how-to-use-tokenscolors-from-sistent-theme)
-- [Examples](#examples)
 
 The Sistent design system includes a variety of base components such as `Button`, `Textfield`, `Checkbox`, and more. These components are designed to be flexible and customizable, allowing developers to easily adapt them to their specific needs while maintaining a consistent design language across the application.
 


### PR DESCRIPTION
### Summary

- Remove the stale `Examples` entry from the Table of Contents on the Sistent documentation page.
- Eliminate the broken internal `#examples` anchor reference.
- Preserve the existing example content and overall document structure.

---

### Description

This PR fixes #21102 

The Sistent documentation page contained an **Examples** entry in its Table of Contents that linked to the `#examples` anchor. However, the page does not define a corresponding Markdown heading, so clicking the link updated the URL hash without navigating anywhere.

After reviewing the page structure, the existing example content is intended to serve as introductory material rather than a standalone section. As a result, the appropriate fix is to remove the stale Table of Contents entry instead of introducing an unnecessary heading solely to satisfy the broken anchor.

This change restores accurate internal navigation while keeping the documentation content and layout unchanged.

---

### Notes for Reviewers

- Documentation-only change.
- Removed only the stale `Examples` entry from the Table of Contents.
- No documentation content or examples were removed.
- No headings, section ordering, or page structure were modified.
- Remaining internal Table of Contents links continue to function as expected.

---
### Before: 
[Screen Recording ](https://drive.google.com/file/d/1DBpt58Ovi5Tgp9F_nCH2fPJRKFn7Qxgi/view?usp=drive_link)

### After: 
<img width="2765" height="1557" alt="Screenshot 2026-08-03 182106" src="https://github.com/user-attachments/assets/85cd7093-ab4a-4097-b9d4-18a271abd18d" />

---

### Validation

- [x] Verified the documentation builds successfully.
- [x] Verified the `Examples` entry no longer appears in the Table of Contents.
- [x] Verified the remaining Table of Contents links continue to navigate correctly.
- [x] Confirmed no other documentation content was modified.

---

### Signed commits

**[Signed commits](https://docs.meshery.io/project/contributing#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the outdated “Examples” entry from the Sistent contribution guide’s table of contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->