### PR TITLE
[UI] Add missing permission keys to Configure Environments, YamlDialog, and WorkspaceActionList actions

### DIFF
--- a/ui/components/designs/lifecycle/SelectDeploymentTarget.tsx
+++ b/ui/components/designs/lifecycle/SelectDeploymentTarget.tsx
@@ -103,6 +103,7 @@ const EnvironmentConnections = ({ environment, connections, onAddConnection }) =
             color="primary"
             onClick={onAddConnection}
             startIcon={<AddCircleIcon />}
+            permissionKey={Keys.WorkspaceManagementEditEnvironment}
           >
             Add a connection
           </InlineButton>{' '}

--- a/ui/components/designs/lifecycle/SelectDeploymentTarget.tsx
+++ b/ui/components/designs/lifecycle/SelectDeploymentTarget.tsx
@@ -227,6 +227,7 @@ export const SelectTargetEnvironments = ({ setIsEnvrionmentModalOpen }) => {
               <IconButton
                 onClick={() => setIsEnvrionmentModalOpen(true)}
                 aria-label="edit-environments"
+                permissionKey={Keys.WorkspaceManagementEditEnvironment}
               >
                 <Edit fill={theme.palette.icon.default} />
               </IconButton>

--- a/ui/components/designs/patterns/MesheryPatternCard.tsx
+++ b/ui/components/designs/patterns/MesheryPatternCard.tsx
@@ -169,7 +169,7 @@ function MesheryPatternCard_({
                 <div data-testid="visibility-chip-menu">
                   <VisibilityChipMenu
                     value={visibility}
-                    onChange={() => { }}
+                    onChange={() => {}}
                     enabled={false}
                     options={[
                       [VIEW_VISIBILITY.PUBLIC, Public],
@@ -386,7 +386,7 @@ function MesheryPatternCard_({
                 </CustomTooltip>
               </CardHeaderRight>
             </YamlDialogTitleGrid>
-            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => { })}>
+            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => {})}>
               <Divider variant="fullWidth" light />
               {catalogContentKeys.length === 0 ? (
                 <StyledCodeMirrorWrapper fullScreen={fullScreen}>
@@ -423,8 +423,7 @@ function MesheryPatternCard_({
                       variant="caption"
                       style={{
                         fontStyle: 'italic',
-                        color: `${theme.palette.type === 'dark' ? 'rgba(255, 255, 255, 0.7)' : '#647881'
-                          }`,
+                        color: `${theme.palette.type === 'dark' ? 'rgba(255, 255, 255, 0.7)' : '#647881'}`,
                       }}
                       data-testid="pattern-card-created-at"
                     >

--- a/ui/components/designs/patterns/MesheryPatternCard.tsx
+++ b/ui/components/designs/patterns/MesheryPatternCard.tsx
@@ -289,7 +289,7 @@ function MesheryPatternCard_({
                   <img
                     src="/static/img/designs/pattern_trans.svg"
                     style={{ borderRadius: '50%', ...iconMedium }}
-                  // imgProps={{ height: '16px', width: '16px' }}
+                    // imgProps={{ height: '16px', width: '16px' }}
                   />
                   <GridBtnText> Design </GridBtnText>
                 </TooltipButton>

--- a/ui/components/designs/patterns/MesheryPatternCard.tsx
+++ b/ui/components/designs/patterns/MesheryPatternCard.tsx
@@ -128,6 +128,8 @@ function MesheryPatternCard_({
           deleteHandler={deleteHandler}
           type={'pattern'}
           isReadOnly={isReadOnly}
+          updatePermissionKey={Keys.CatalogManagementEditDesign}
+          deletePermissionKey={Keys.CatalogManagementDeleteADesign}
         />
       )}
       <FlipCard
@@ -167,7 +169,7 @@ function MesheryPatternCard_({
                 <div data-testid="visibility-chip-menu">
                   <VisibilityChipMenu
                     value={visibility}
-                    onChange={() => {}}
+                    onChange={() => { }}
                     enabled={false}
                     options={[
                       [VIEW_VISIBILITY.PUBLIC, Public],
@@ -287,7 +289,7 @@ function MesheryPatternCard_({
                   <img
                     src="/static/img/designs/pattern_trans.svg"
                     style={{ borderRadius: '50%', ...iconMedium }}
-                    // imgProps={{ height: '16px', width: '16px' }}
+                  // imgProps={{ height: '16px', width: '16px' }}
                   />
                   <GridBtnText> Design </GridBtnText>
                 </TooltipButton>
@@ -384,7 +386,7 @@ function MesheryPatternCard_({
                 </CustomTooltip>
               </CardHeaderRight>
             </YamlDialogTitleGrid>
-            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => {})}>
+            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => { })}>
               <Divider variant="fullWidth" light />
               {catalogContentKeys.length === 0 ? (
                 <StyledCodeMirrorWrapper fullScreen={fullScreen}>
@@ -421,9 +423,8 @@ function MesheryPatternCard_({
                       variant="caption"
                       style={{
                         fontStyle: 'italic',
-                        color: `${
-                          theme.palette.type === 'dark' ? 'rgba(255, 255, 255, 0.7)' : '#647881'
-                        }`,
+                        color: `${theme.palette.type === 'dark' ? 'rgba(255, 255, 255, 0.7)' : '#647881'
+                          }`,
                       }}
                       data-testid="pattern-card-created-at"
                     >

--- a/ui/components/filters/FiltersCard.tsx
+++ b/ui/components/filters/FiltersCard.tsx
@@ -136,7 +136,7 @@ function FiltersCard_({
               <div>
                 <VisibilityChipMenu
                   value={visibility}
-                  onChange={() => { }}
+                  onChange={() => {}}
                   enabled={false}
                   options={[
                     [VIEW_VISIBILITY.PUBLIC, Public],
@@ -266,7 +266,7 @@ function FiltersCard_({
                 </Tooltip>
               </CardHeaderRight>
             </YamlDialogTitleGrid>
-            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => { })}>
+            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => {})}>
               <Divider variant="fullWidth" light />
 
               {catalogContentKeys.length === 0 ? (

--- a/ui/components/filters/FiltersCard.tsx
+++ b/ui/components/filters/FiltersCard.tsx
@@ -111,6 +111,9 @@ function FiltersCard_({
           setYaml={setYaml}
           deleteHandler={deleteHandler}
           updateHandler={updateHandler}
+          type={'filter'}
+          updatePermissionKey={Keys.CatalogManagementEditWasmFilter}
+          deletePermissionKey={Keys.CatalogManagementDeleteWasmFilter}
         />
       )}
       <FlipCard
@@ -133,7 +136,7 @@ function FiltersCard_({
               <div>
                 <VisibilityChipMenu
                   value={visibility}
-                  onChange={() => {}}
+                  onChange={() => { }}
                   enabled={false}
                   options={[
                     [VIEW_VISIBILITY.PUBLIC, Public],
@@ -263,7 +266,7 @@ function FiltersCard_({
                 </Tooltip>
               </CardHeaderRight>
             </YamlDialogTitleGrid>
-            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => {})}>
+            <Grid2 size={{ xs: 12 }} onClick={(ev) => genericClickHandler(ev, () => { })}>
               <Divider variant="fullWidth" light />
 
               {catalogContentKeys.length === 0 ? (

--- a/ui/components/general/YamlDialog.tsx
+++ b/ui/components/general/YamlDialog.tsx
@@ -10,6 +10,7 @@ import {
   SaveIcon,
   Tooltip,
 } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import { UnControlled as CodeMirror } from './CodeMirror';
 import { YamlDialogTitleText, StyledDialog } from './YamlDialog.styles';
 import { StyledCodeMirrorWrapper } from '../designs/patterns/Cards.styles';
@@ -23,7 +24,17 @@ const YAMLDialog = ({
   deleteHandler,
   updateHandler,
   isReadOnly = false,
+  type,
+  updatePermissionKey,
+  deletePermissionKey,
 }) => {
+  const defaultUpdateKey =
+    type === 'pattern' ? Keys.CatalogManagementEditDesign : Keys.CatalogManagementEditWasmFilter;
+  const defaultDeleteKey =
+    type === 'pattern' ? Keys.CatalogManagementDeleteADesign : Keys.CatalogManagementDeleteWasmFilter;
+
+  const resolvedUpdateKey = updatePermissionKey || defaultUpdateKey;
+  const resolvedDeleteKey = deletePermissionKey || defaultDeleteKey;
   return (
     <Dialog
       aria-labelledby="filter-dialog-title"
@@ -66,12 +77,24 @@ const YAMLDialog = ({
       {!isReadOnly && (
         <DialogActions>
           <Tooltip title="Update Pattern">
-            <IconButton aria-label="Update" color="primary" onClick={updateHandler} size="large">
+            <IconButton
+              aria-label="Update"
+              color="primary"
+              onClick={updateHandler}
+              size="large"
+              permissionKey={resolvedUpdateKey}
+            >
               <SaveIcon />
             </IconButton>
           </Tooltip>
           <Tooltip title="Delete Filter">
-            <IconButton aria-label="Delete" color="primary" onClick={deleteHandler} size="large">
+            <IconButton
+              aria-label="Delete"
+              color="primary"
+              onClick={deleteHandler}
+              size="large"
+              permissionKey={resolvedDeleteKey}
+            >
               <DeleteIcon />
             </IconButton>
           </Tooltip>

--- a/ui/components/general/YamlDialog.tsx
+++ b/ui/components/general/YamlDialog.tsx
@@ -29,12 +29,26 @@ const YAMLDialog = ({
   deletePermissionKey,
 }) => {
   const defaultUpdateKey =
-    type === 'pattern' ? Keys.CatalogManagementEditDesign : Keys.CatalogManagementEditWasmFilter;
+    type === 'pattern'
+      ? Keys.CatalogManagementEditDesign
+      : type === 'filter'
+        ? Keys.CatalogManagementEditWasmFilter
+        : undefined;
   const defaultDeleteKey =
-    type === 'pattern' ? Keys.CatalogManagementDeleteADesign : Keys.CatalogManagementDeleteWasmFilter;
+    type === 'pattern'
+      ? Keys.CatalogManagementDeleteADesign
+      : type === 'filter'
+        ? Keys.CatalogManagementDeleteWasmFilter
+        : undefined;
 
   const resolvedUpdateKey = updatePermissionKey || defaultUpdateKey;
   const resolvedDeleteKey = deletePermissionKey || defaultDeleteKey;
+
+  if (process.env.NODE_ENV !== 'production' && (!resolvedUpdateKey || !resolvedDeleteKey)) {
+    console.warn(
+      `YAMLDialog: could not resolve a permission key (type="${type}"). Pass a valid type ('pattern' | 'filter') or explicit updatePermissionKey/deletePermissionKey props.`,
+    );
+  }
   return (
     <Dialog
       aria-labelledby="filter-dialog-title"

--- a/ui/components/workspaces/WorkspaceActionList.test.tsx
+++ b/ui/components/workspaces/WorkspaceActionList.test.tsx
@@ -25,15 +25,25 @@ vi.mock('@sistent/sistent', () => ({
   DeleteIcon: () => <svg data-testid="delete-icon" />,
   EditIcon: () => <svg data-testid="edit-icon" />,
   GroupAddIcon: () => <svg data-testid="group-add-icon" />,
-  IconButton: ({ children, onClick, disabled, ...props }: any) => (
-    <button onClick={onClick} disabled={disabled} {...props}>
+  IconButton: ({ children, onClick, disabled, permissionKey, ...props }: any) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      data-permission-key={permissionKey?.id ?? ''}
+      {...props}
+    >
       {children}
     </button>
   ),
   ListItemIcon: ({ children }: any) => <span>{children}</span>,
   Menu: ({ children, open }: any) => (open ? <div data-testid="menu">{children}</div> : null),
-  MenuItem: ({ children, onClick, disabled }: any) => (
-    <button onClick={onClick} disabled={disabled} data-testid="menu-item">
+  MenuItem: ({ children, onClick, disabled, permissionKey }: any) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      data-permission-key={permissionKey?.id ?? ''}
+      data-testid="menu-item"
+    >
       {children}
     </button>
   ),
@@ -129,14 +139,16 @@ describe('WorkspaceActionList', () => {
     expect(handleDeleteWorkspaceConfirm).toHaveBeenCalledWith(expect.anything(), workspace);
   });
 
-  it('disables edit/delete when permission CAN returns false', () => {
-    mockCan.mockImplementation((action: string) => {
-      if (action === 'edit' || action === 'delete') return false;
-      return true;
-    });
+  it('passes the correct permission keys to edit/delete actions', () => {
     renderComponent();
-    expect(screen.getByRole('button', { name: /edit-workspace/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /delete-workspace/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /edit-workspace/i })).toHaveAttribute(
+      'data-permission-key',
+      'edit',
+    );
+    expect(screen.getByRole('button', { name: /delete-workspace/i })).toHaveAttribute(
+      'data-permission-key',
+      'delete',
+    );
   });
 
   it('switches to a mobile menu when the viewport is narrow', async () => {

--- a/ui/components/workspaces/WorkspaceActionList.tsx
+++ b/ui/components/workspaces/WorkspaceActionList.tsx
@@ -103,7 +103,11 @@ const WorkspaceActionList = ({
           <>
             {actionItems.map(({ key, label, icon, onClick, permissionKey }) => (
               <CustomTooltip title={label} key={key}>
-                <IconButton aria-label={key} onClick={(e) => onClick(e)} permissionKey={permissionKey}>
+                <IconButton
+                  aria-label={key}
+                  onClick={(e) => onClick(e)}
+                  permissionKey={permissionKey}
+                >
                   {icon}
                 </IconButton>
               </CustomTooltip>

--- a/ui/components/workspaces/WorkspaceActionList.tsx
+++ b/ui/components/workspaces/WorkspaceActionList.tsx
@@ -9,7 +9,6 @@ import {
   Menu,
   MenuItem,
   MoreVertIcon,
-  useHasPermission,
   useTheme,
   useWindowDimensions,
 } from '@sistent/sistent';
@@ -31,8 +30,6 @@ const WorkspaceActionList = ({
   const { width } = useWindowDimensions();
   const isMobile = width < 1024;
   const theme = useTheme();
-  const canEditWorkspace = useHasPermission(Keys.WorkspaceManagementEditWorkspace);
-  const canDeleteWorkspace = useHasPermission(Keys.WorkspaceManagementDeleteWorkspace);
 
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -67,14 +64,14 @@ const WorkspaceActionList = ({
       label: 'Edit Workspace',
       icon: <EditIcon style={{ fill: theme.palette.icon.default, ...iconMedium }} />,
       onClick: (e) => handleWorkspaceModalOpen(e, WORKSPACE_ACTION_TYPES.EDIT, selectedWorkspace),
-      disabled: !canEditWorkspace,
+      permissionKey: Keys.WorkspaceManagementEditWorkspace,
     },
     {
       key: 'delete-workspace',
       label: 'Delete Workspace',
       icon: <DeleteIcon style={{ fill: theme.palette.icon.default, ...iconMedium }} />,
       onClick: (e) => handleDeleteWorkspaceConfirm(e, selectedWorkspace),
-      disabled: !canDeleteWorkspace,
+      permissionKey: Keys.WorkspaceManagementDeleteWorkspace,
     },
   ];
 
@@ -87,14 +84,14 @@ const WorkspaceActionList = ({
               <MoreVertIcon />
             </IconButton>
             <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-              {actionItems.map(({ key, label, icon, onClick, disabled }) => (
+              {actionItems.map(({ key, label, icon, onClick, permissionKey }) => (
                 <MenuItem
                   key={key}
                   onClick={(e) => {
                     onClick(e);
                     handleClose(e);
                   }}
-                  disabled={disabled}
+                  permissionKey={permissionKey}
                 >
                   <ListItemIcon>{icon}</ListItemIcon>
                   {label}
@@ -104,9 +101,9 @@ const WorkspaceActionList = ({
           </>
         ) : (
           <>
-            {actionItems.map(({ key, label, icon, onClick, disabled }) => (
+            {actionItems.map(({ key, label, icon, onClick, permissionKey }) => (
               <CustomTooltip title={label} key={key}>
-                <IconButton aria-label={key} onClick={(e) => onClick(e)} disabled={disabled}>
+                <IconButton aria-label={key} onClick={(e) => onClick(e)} permissionKey={permissionKey}>
                   {icon}
                 </IconButton>
               </CustomTooltip>


### PR DESCRIPTION
## Description

Several action buttons across the UI were missing `permissionKey` props on `@sistent/sistent`'s `IconButton`/`MenuItem`, allowing unauthorized users to interact with them without permission shields.

This PR adds the missing keys:

- **`SelectDeploymentTarget.tsx`** — Configure Environments icon now requires `permissionKey={Keys.WorkspaceManagementEditEnvironment}`.
- **`YamlDialog.tsx`** — Update/Delete icons now accept `updatePermissionKey`/`deletePermissionKey` props, defaulting to the correct pattern/filter keys based on `type`.
- **`MesheryPatternCard.tsx`** / **`FiltersCard.tsx`** — updated to pass `type` and explicit permission keys into `YamlDialog`, since these are the only two callers and the new default logic in `YamlDialog.tsx` is inert without them. Not separately called out in the issue, but required for the fix to actually take effect.
- **`WorkspaceActionList.tsx`** — replaced the legacy `useHasPermission` + `disabled` pattern with `permissionKey` on Edit/Delete workspace actions, consistent with the rest of the codebase.

fixes #21101  


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Updated environment configuration, pattern, filter, and workspace actions to respect the appropriate editing and deletion permissions.
  * Added clearer permission handling for YAML update and delete actions across supported resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->