### PR TITLE
[UI] Fix design import: correct fileName wire field and prevent duplicate submissions

### DIFF
--- a/ui/components/designs/ImportDesignModal.tsx
+++ b/ui/components/designs/ImportDesignModal.tsx
@@ -52,7 +52,7 @@ const ImportDesignModalComponent: FC<ImportDesignModalProps> = ({
   return (
     <FormModal
       isOpen
-      onClose={handleClose}
+      onClose={isSubmitting ? () => {} : handleClose}
       title="Import Design"
       headerIcon={<DesignModalHeaderIcon />}
       size="sm"

--- a/ui/components/designs/ImportDesignModal.tsx
+++ b/ui/components/designs/ImportDesignModal.tsx
@@ -11,7 +11,7 @@
  * handles the RJSF ref + submit plumbing, so callers only need to provide
  * a close handler and a submit callback receiving the form data.
  */
-import { FC, memo, useCallback, useState } from 'react';
+import { FC, memo, useCallback, useRef, useState } from 'react';
 import { importDesignSchema, importDesignUiSchema } from '@sistent/sistent';
 import { FormModal } from '@/components/shared/Modal';
 import { DesignModalHeaderIcon } from './design-modal-header';
@@ -32,18 +32,21 @@ const ImportDesignModalComponent: FC<ImportDesignModalProps> = ({
   handleImportDesign,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
 
   const handleSubmit = useCallback(
     async (formData: unknown) => {
-      if (isSubmitting) return;
+      if (isSubmittingRef.current) return;
+      isSubmittingRef.current = true;
       setIsSubmitting(true);
       try {
         await handleImportDesign(formData);
       } finally {
+        isSubmittingRef.current = false;
         setIsSubmitting(false);
       }
     },
-    [isSubmitting, handleImportDesign],
+    [handleImportDesign],
   );
 
   return (

--- a/ui/components/designs/ImportDesignModal.tsx
+++ b/ui/components/designs/ImportDesignModal.tsx
@@ -11,7 +11,7 @@
  * handles the RJSF ref + submit plumbing, so callers only need to provide
  * a close handler and a submit callback receiving the form data.
  */
-import { FC, memo } from 'react';
+import { FC, memo, useCallback, useState } from 'react';
 import { importDesignSchema, importDesignUiSchema } from '@sistent/sistent';
 import { FormModal } from '@/components/shared/Modal';
 import { DesignModalHeaderIcon } from './design-modal-header';
@@ -22,26 +22,45 @@ export interface ImportDesignModalProps {
   /**
    * Called with the validated import payload (URL, uploaded file, or pasted
    * YAML/JSON) — same shape RJSF emits for `importDesignSchema`.
+   * May return a Promise; the modal disables the submit button until it settles.
    */
-  handleImportDesign: (formData: unknown) => void;
+  handleImportDesign: (formData: unknown) => void | Promise<void>;
 }
 
 const ImportDesignModalComponent: FC<ImportDesignModalProps> = ({
   handleClose,
   handleImportDesign,
-}) => (
-  <FormModal
-    isOpen
-    onClose={handleClose}
-    title="Import Design"
-    headerIcon={<DesignModalHeaderIcon />}
-    size="sm"
-    schema={importDesignSchema}
-    uiSchema={importDesignUiSchema}
-    submitText="Import"
-    onSubmit={handleImportDesign}
-  />
-);
+}) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (formData: unknown) => {
+      if (isSubmitting) return;
+      setIsSubmitting(true);
+      try {
+        await handleImportDesign(formData);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [isSubmitting, handleImportDesign],
+  );
+
+  return (
+    <FormModal
+      isOpen
+      onClose={handleClose}
+      title="Import Design"
+      headerIcon={<DesignModalHeaderIcon />}
+      size="sm"
+      schema={importDesignSchema}
+      uiSchema={importDesignUiSchema}
+      submitText={isSubmitting ? 'Importing…' : 'Import'}
+      isSubmitDisabled={isSubmitting}
+      onSubmit={handleSubmit}
+    />
+  );
+};
 
 ImportDesignModalComponent.displayName = 'ImportDesignModal';
 

--- a/ui/components/designs/import-design-request.test.ts
+++ b/ui/components/designs/import-design-request.test.ts
@@ -28,7 +28,7 @@ describe('buildImportDesignRequestBody', () => {
     ).resolves.toEqual({
       requestBody: JSON.stringify({
         name: 'Imported design',
-        file_name: 'imported-design.yaml',
+        fileName: 'imported-design.yaml',
         file: [1, 2, 3],
       }),
     });

--- a/ui/components/designs/import-design-request.ts
+++ b/ui/components/designs/import-design-request.ts
@@ -25,7 +25,7 @@ export const buildImportDesignRequestBody = async (
         return {
           requestBody: JSON.stringify({
             name,
-            file_name: importedFile.fileName,
+            fileName: importedFile.fileName,
             file: importedFile.fileData,
           }),
         };

--- a/ui/components/designs/patterns/patterns-actions.test.tsx
+++ b/ui/components/designs/patterns/patterns-actions.test.tsx
@@ -226,7 +226,7 @@ describe('createPatternsActions', () => {
     buildImportDesignRequestBody.mockResolvedValue({
       requestBody: JSON.stringify({
         name: 'Imported design',
-        file_name: 'imported-design.yaml',
+        fileName: 'imported-design.yaml',
         file: [1, 2, 3],
       }),
     });
@@ -246,7 +246,7 @@ describe('createPatternsActions', () => {
     expect(deps.importPattern).toHaveBeenCalledWith({
       importBody: JSON.stringify({
         name: 'Imported design',
-        file_name: 'imported-design.yaml',
+        fileName: 'imported-design.yaml',
         file: [1, 2, 3],
       }),
     });

--- a/ui/components/designs/patterns/patterns-actions.ts
+++ b/ui/components/designs/patterns/patterns-actions.ts
@@ -321,7 +321,7 @@ export function createPatternsActions(deps) {
       return;
     }
 
-    importPattern({
+    return importPattern({
       importBody: importRequest.requestBody,
     })
       .unwrap()

--- a/ui/components/workspaces/SpacesSwitcher/components.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/components.tsx
@@ -341,7 +341,7 @@ export const ImportButton = ({ workspaceId, disabled = false, refetch, permissio
       return;
     }
 
-    importPattern({
+    return importPattern({
       importBody: importRequest.requestBody,
     })
       .unwrap()


### PR DESCRIPTION
## Description

This PR fixes two related bugs in the design import flow (`POST /api/pattern/import`):

1. **400 Bad Request on every file upload** — the request body sent `file_name` (snake_case) instead of `fileName` (camelCase), so the server's oneOf decoder never matched the File variant.
2. **Duplicate imports on rapid clicks** — clicking "Import" multiple times while a request was in-flight fired one request per click, creating duplicate designs.

---

## Bug 1 — 400 Bad Request

### Root Cause

The server's `resolveImportVariant` decodes the body against `MesheryPatternImportRequestBody`. The File variant is accepted only when both `file` **and** `fileName` are present. The Go struct generated from the OpenAPI schema uses the camelCase wire name:

```go
// github.com/meshery/schemas/.../design.go
type MesheryPatternImportFilePayload struct {
    File     []byte  `json:"file"`
    FileName string  `json:"fileName"`   // ← camelCase per naming conventions
    Name     *string `json:"name,omitempty"`
}
```

The UI was serialising the key as `file_name` (snake_case), so `FileName` decoded as `""`, `hasFile` was `false`, and the handler fell into the `!hasFile && !hasURL` branch → 400 every time.

---

## Bug 2 — Duplicate imports on rapid clicks

### Root Cause

`handleImportDesign` is `async` and fires `importPattern` (an RTK mutation) with no in-flight guard. Rapid clicks each completed validation and each fired a separate POST, creating duplicate design records.

### Fix

The guard lives in `ImportDesignModal` — the single component both call-sites go through — so no per-caller changes are needed. Both `handleImportDesign` implementations now `return` the `importPattern` Promise chain so the modal can `await` it accurately

### Before

https://github.com/user-attachments/assets/a1d874b6-ded8-4f0c-acd5-0fd57e8f05cc

### After

https://github.com/user-attachments/assets/4acf4252-bb9e-4518-a7f8-d583589ce6eb

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Design imports now display an “Importing…” state while processing.
  * Import actions and dialog closing are temporarily disabled to prevent duplicate submissions.
  * Import workflows support asynchronous completion handling and reset correctly afterward.

* **Bug Fixes**
  * Improved import request compatibility by using the correct file name field.
  * Import completion and error handling remain synchronized across design and workspace flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->