### PR TITLE
[Server] Fix more response body leaks in remote auth and local provid…

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -1972,11 +1972,11 @@ func genericHTTPPatternFile(fileURL string, log logger.Handler) ([]MesheryPatter
 	if err != nil {
 		return nil, err
 	}
+	defer SafeClose(resp.Body, log)
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("file not found")
 	}
-
-	defer SafeClose(resp.Body, log)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -2009,11 +2009,11 @@ func genericHTTPFilterFile(fileURL string, log logger.Handler) ([]MesheryFilter,
 	if err != nil {
 		return nil, err
 	}
+	defer SafeClose(resp.Body, log)
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("file not found")
 	}
-
-	defer SafeClose(resp.Body, log)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/server/models/remote_auth.go
+++ b/server/models/remote_auth.go
@@ -383,6 +383,7 @@ func (l *RemoteProvider) revokeToken(tokenString string) error {
 		l.Log.Error(err)
 		return err
 	}
+	defer SafeClose(r.Body, l.Log)
 
 	if r.StatusCode != http.StatusOK {
 		return ErrTokenRevoke(fmt.Errorf("failed to revoke token: status %d", r.StatusCode))
@@ -416,6 +417,7 @@ func (l *RemoteProvider) introspectToken(tokenString string) error {
 		l.Log.Error(err)
 		return err
 	}
+	defer SafeClose(r.Body, l.Log)
 
 	if r.StatusCode == http.StatusUnauthorized {
 		return ErrTokenIntrospect(fmt.Errorf("unauthorized access: status %d", r.StatusCode))


### PR DESCRIPTION
This fixes additional response body leaks where `defer SafeClose(resp.Body, log)` was either missing entirely or called after checking the response status code and returning an error.
- `revokeToken` and `introspectToken` in `server/models/remote_auth.go`
- `genericHTTPPatternFile` and `genericHTTPFilterFile` in `server/models/default_local_provider.go`

**Notes for Reviewers**

- This PR fixes #21106 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- 
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of HTTP response resources during provider and authentication operations.
  * Ensured response bodies are closed reliably, including when requests return errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->