### PR TITLE
[ci] Point mesheryctl-e2e BATS suite at the dedicated remote-provider test-user token

### DIFF
--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -109,7 +109,16 @@ jobs:
         shell: bash
         working-directory: ./mesheryctl/tests/e2e
         env:
-          MESHERY_PROVIDER_TOKEN: ${{ secrets.PROVIDER_TOKEN }}
+          # Authenticate the BATS suite as the dedicated remote-provider CI test
+          # user. The connection (and perf) tests round-trip through the remote
+          # provider (setup_suite.bash sets context to "Meshery"), so they need a
+          # valid session token. The previous PROVIDER_TOKEN secret was a static
+          # token last refreshed 2024-03-08 and had expired, so the remote
+          # provider answered every call with a 401 ("user must be logged in") —
+          # surfacing as meshery-server-1032 on reads and meshery-server-1051 on
+          # delete. REMOTE_PROVIDER_TEST_USER_TOKEN is the maintained token for a
+          # purpose-built CI test user.
+          MESHERY_PROVIDER_TOKEN: ${{ secrets.REMOTE_PROVIDER_TEST_USER_TOKEN }}
           MESHERY_PLATFORM: ${{ matrix.platform }}
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
           E2E_HELPERS_PATH: "${{ github.workspace }}/mesheryctl/tests/e2e/helpers"


### PR DESCRIPTION
## Description

Points the **mesheryctl-e2e BATS suite** at the dedicated remote-provider CI
test-user token so the connection lifecycle tests authenticate against a working
provider session.

### Root cause

The mesheryctl connection (and perf) e2e tests round-trip through the Meshery
**remote provider** — `setup_suite.bash` runs `create_auth_file` +
`set_context_to_meshery`, so connection list/count/create/delete all go through
`provider.GetConnections(...)` / `provider.DeleteConnection(...)` to the remote
provider backend.

The suite authenticated with the static **`PROVIDER_TOKEN`** secret, which was
last refreshed **2024-03-08** and had **expired**. The remote provider is
reachable, but it answered every call with:

```
Status Code: 401 … "user must be logged in to perform this operation"
… Session might have expired; token could be invalid.
```

surfacing as `meshery-server-1032` ("unable to get: .connections") on
list/count and `meshery-server-1051` ("Failed to Save: .connection") on delete —
i.e. this was an **authentication** failure, not backend unreachability.

### Fix

Switch the BATS job's `MESHERY_PROVIDER_TOKEN` from `secrets.PROVIDER_TOKEN` to
**`secrets.REMOTE_PROVIDER_TEST_USER_TOKEN`**, the maintained token for a
purpose-built CI test user.

```diff
-          MESHERY_PROVIDER_TOKEN: ${{ secrets.PROVIDER_TOKEN }}
+          MESHERY_PROVIDER_TOKEN: ${{ secrets.REMOTE_PROVIDER_TEST_USER_TOKEN }}
```

## Secret value

`REMOTE_PROVIDER_TEST_USER_TOKEN` is a **non-expiring API token** for the CI test
user, so it is expected to be valid as-is — this repoint is not gated on a secret
refresh.

## How this gets verified (CI trigger note)

The `manual-bats` job that runs the connection suite triggers on **push to
master with path filter `mesheryctl/**`** (or a manual `workflow_dispatch` with
`bats_test=true`). This PR only touches `.github/workflows/`, so merging it does
**not** auto-run the suite. Verification is therefore a manual `workflow_dispatch`
of *Meshery End-to-End Tests with mesheryctl* (`bats_test=true`) on `master`
after merge, confirming the previously-failing connection tests now authenticate
and pass with the repointed token.

## Out of scope (flagged for follow-up)

The **perf/pattern jobs** in this same workflow (`manual-test`, `scheduled-test`)
still reference the stale `secrets.PROVIDER_TOKEN` (6 occurrences). They are
`workflow_dispatch`/`schedule`-triggered and separate from the connection BATS
suite, so they are left unchanged here per scope. They will keep failing on the
expired token until similarly repointed or `PROVIDER_TOKEN` is refreshed — worth
a follow-up.

## Related

- Stale TC-1080 assertions already fixed on master by #21093.
- Server-side follow-ups (misleading `ErrQueryGet` remediation; remote-provider
  delete-of-never-issued-UUID behavior): #21094.

## Type of change

- CI configuration fix (no production code change)

Signed-off-by: marblom007 <158522975+marblom007@users.noreply.github.com>
