### PR TITLE
[Chore] Add validate-schema-principles agent hook

### DIFF
--- a/.agents/hooks/validate-schema-principles.sh
+++ b/.agents/hooks/validate-schema-principles.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# validate-schema-principles.sh — Enforce Meshery schema-driven development principles
+#
+# Usage:
+#   ./validate-schema-principles.sh <file_path>
+#
+# Exits non-zero (blocks the edit) if the file violates Meshery's core principles:
+#   1. No hand-rolled JSON request bodies — use @meshery/schemas generated types
+#   2. No manual RTK Query endpoints for APIs covered by meshery/schemas
+#   3. No snake_case field names on the wire (JSON tags / TS properties must be camelCase)
+#
+# RTK Query opt-out: If a file must keep manual endpoints because @meshery/schemas
+# does not yet cover them, add this comment anywhere in the file:
+#   // schema-rtk-exempt: <reason>
+# This will skip the builder.query/builder.mutation check for that file only.
+#
+# Can be wired into any coding agent's post-edit hook system.
+# Reference: https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md
+
+set -euo pipefail
+
+FILE="${1:-${CLAUDE_FILE_PATH:-}}"
+
+if [[ -z "$FILE" ]]; then
+  exit 0
+fi
+
+# Only check TypeScript, TSX, and Go files
+if [[ ! "$FILE" =~ \.(ts|tsx|go)$ ]]; then
+  exit 0
+fi
+
+# Fail closed: exit non-zero if the file cannot be read
+if [[ ! -r "$FILE" ]]; then
+  echo "[validate-schema-principles] ERROR: Cannot read file: $FILE" >&2
+  exit 1
+fi
+
+BASENAME="$(basename "$FILE")"
+VIOLATIONS=()
+
+# ─── TypeScript / TSX checks ─────────────────────────────────────────────────
+if [[ "$FILE" =~ \.(ts|tsx)$ ]]; then
+
+  # 1. Hand-rolled JSON body with snake_case keys
+  #    Use perl for syntax-aware multiline matching of JSON.stringify({ ... snake_case: ... })
+  if perl -0777 -ne 'exit 0 if /JSON\.stringify\s*\(\s*\{[^}]*?['\''"]?[a-z0-9]+_[a-z0-9_]+['\''"]?\s*:/s; exit 1' -- "$FILE"; then
+    VIOLATIONS+=("Hand-rolled JSON.stringify() body with snake_case key detected in $BASENAME. Use @meshery/schemas generated types for request payloads (wire format is camelCase).")
+  fi
+
+  # 2. Manual RTK Query endpoint definitions (builder.query / builder.mutation)
+  #    in ui/rtk-query/** — these should come from @meshery/schemas/mesheryApi
+  #    Files may opt out with:  // schema-rtk-exempt: <reason>
+  if [[ "$FILE" == ui/rtk-query/* || "$FILE" == */ui/rtk-query/* ]]; then
+    if ! grep -qE 'schema-rtk-exempt' -- "$FILE"; then
+      if grep -qE 'builder\.(query|mutation)' -- "$FILE"; then
+        VIOLATIONS+=("Manual RTK Query endpoint (builder.query/builder.mutation) in $BASENAME. Use generated hooks from @meshery/schemas/mesheryApi instead of hand-rolling endpoints. If this endpoint is not yet in schemas, add '// schema-rtk-exempt: <reason>' to the file.")
+      fi
+    fi
+  fi
+
+  # 3. Importing deprecated v1beta1 in new code (use v1beta3 or v1beta2)
+  #    Use [[:space:]] — POSIX ERE compatible, works on both macOS BSD grep and GNU grep
+  if grep -qE "from[[:space:]]+['\"]@meshery/schemas/models/v1beta1" -- "$FILE"; then
+    VIOLATIONS+=("Deprecated v1beta1 import in $BASENAME. Use v1beta3 (or v1beta2 where v1beta3 is absent).")
+  fi
+
+fi
+
+# ─── Go checks ───────────────────────────────────────────────────────────────
+if [[ "$FILE" =~ \.go$ ]]; then
+
+  # 4. Go struct json tags with snake_case values
+  #    Pattern: json:"file_name" or json:"file_name,omitempty" — wire must be camelCase
+  if grep -qE 'json:"[^"]*[a-z]+_[a-z0-9_]*[^"]*"' -- "$FILE"; then
+    VIOLATIONS+=("Go struct in $BASENAME has a json tag with snake_case value. Wire is camelCase — json tags must be camelCase (e.g., json:\"fileName\" not json:\"file_name\").")
+  fi
+
+  # 5. Importing deprecated v1beta1 in new Go code
+  if grep -qE '"github\.com/meshery/schemas/models/v1beta1"' -- "$FILE"; then
+    VIOLATIONS+=("Deprecated v1beta1 import in $BASENAME. Use v1beta3 (or v1beta2 where v1beta3 is absent) in new Go code.")
+  fi
+
+fi
+
+# ─── Report ──────────────────────────────────────────────────────────────────
+if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+  echo ""
+  echo "╔══════════════════════════════════════════════════════════════════════╗"
+  echo "║   MESHERY SCHEMA-DRIVEN PRINCIPLES VIOLATION                        ║"
+  echo "╚══════════════════════════════════════════════════════════════════════╝"
+  echo ""
+  echo "Meshery is a schema-driven project. All API types, wire field names,"
+  echo "and RTK Query hooks must come from meshery/schemas — not be hand-rolled."
+  echo "See: https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md"
+  echo ""
+  for v in "${VIOLATIONS[@]}"; do
+    echo "  ✗  $v"
+  done
+  echo ""
+  echo "Fix the violations above before proceeding."
+  exit 1
+fi
+
+exit 0

--- a/.claude/hooks/validate-schema-principles.sh
+++ b/.claude/hooks/validate-schema-principles.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# PreToolUse guard — block edits that violate Meshery's schema-driven principles.
+#
+# Meshery is schema-driven: all API types, wire field names, and RTK Query hooks
+# are owned by github.com/meshery/schemas. @sistent/sistent owns the UI design
+# system. Hand-rolling any of these silently diverges the wire contract.
+#
+# Checks (NET-NEW only — migrating away from a violation is never blocked):
+#   1. Hand-rolled JSON.stringify() with snake_case keys (wire is camelCase)
+#   2. Manual builder.query/builder.mutation in ui/rtk-query/ (use schemas hooks)
+#   3. Deprecated v1beta1 import declarations (use v1beta3 or v1beta2)
+#   4. Go json: tags with snake_case values (wire is camelCase)
+#
+# RTK opt-out: files that intentionally keep manual endpoints because
+# meshery/schemas does not yet cover them must contain:
+#   // schema-rtk-exempt: <reason>
+#
+# Contract: reads the PreToolUse JSON payload on stdin; exits 2 (deny, message
+# shown to the agent). Anything else passes (exit 0).
+set -uo pipefail
+
+command -v jq    >/dev/null 2>&1 || exit 0  # no jq → fail open
+command -v perl  >/dev/null 2>&1 || exit 0  # no perl → fail open
+
+payload="$(cat)"
+tool="$(jq -r '.tool_name // empty' <<<"$payload")"
+path="$(jq -r '.tool_input.file_path // empty' <<<"$payload")"
+
+case "$tool" in
+  Edit | Write | MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+case "$path" in
+  *.ts | *.tsx | *.go) ;;
+  *) exit 0 ;;
+esac
+
+# Text being ADDED
+new="$(jq -r '[ .tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string) ]
+              | map(select(. != null)) | join("\n")' <<<"$payload")"
+
+# Text being REMOVED.
+# For Write (full-file overwrite), load the current on-disk content as the
+# baseline so pre-existing violations in an unrelated edit are never blocked.
+if [ "$tool" = "Write" ] && [ -f "$path" ]; then
+  old="$(cat -- "$path")"
+else
+  old="$(jq -r '[ .tool_input.old_string, (.tool_input.edits[]?.old_string) ]
+                | map(select(. != null)) | join("\n")' <<<"$payload")"
+fi
+
+[ -z "$new" ] && exit 0
+
+# count <text> <ERE-pattern> — returns integer count (0 if none, never empty)
+count() { printf '%s' "$1" | grep -oE "$2" 2>/dev/null | grep -c . || true; }
+
+VIOLATIONS=()
+
+# ─── TypeScript / TSX checks ─────────────────────────────────────────────────
+case "$path" in
+  *.ts | *.tsx)
+
+    # 1. Hand-rolled JSON.stringify with snake_case keys (multiline-aware)
+    new_s=$(count "$new" 'JSON\.stringify')
+    old_s=$(count "$old" 'JSON\.stringify')
+    if [ "$new_s" -gt "$old_s" ]; then
+      if perl -0777 -ne 'exit 0 if /JSON\.stringify\s*\(\s*\{[^}]*?[a-z0-9]+_[a-z0-9_]+\s*:/s; exit 1' <<<"$new"; then
+        VIOLATIONS+=("Hand-rolled JSON.stringify() with snake_case key. Use @meshery/schemas generated types — wire format is camelCase (e.g. fileName not file_name).")
+      fi
+    fi
+
+    # 2. Manual RTK Query endpoints in ui/rtk-query/ (net-new)
+    #    Match both absolute and repository-relative paths
+    case "$path" in
+      ui/rtk-query/* | */ui/rtk-query/*)
+        # Check for schema-rtk-exempt in BOTH the new content AND the existing file
+        existing_file_content=""
+        [ -f "$path" ] && existing_file_content="$(cat -- "$path")"
+        if ! printf '%s\n%s' "$new" "$existing_file_content" | grep -qE 'schema-rtk-exempt'; then
+          new_b=$(count "$new" 'builder\.(query|mutation)')
+          old_b=$(count "$old" 'builder\.(query|mutation)')
+          if [ "$new_b" -gt "$old_b" ]; then
+            VIOLATIONS+=("New manual RTK Query endpoint (builder.query/builder.mutation). Use generated hooks from @meshery/schemas/mesheryApi. If not yet in schemas, add '// schema-rtk-exempt: <reason>' to the file.")
+          fi
+        fi
+        ;;
+    esac
+
+    # 3. Deprecated v1beta1 import declarations only (not comments or docs)
+    new_v=$(count "$new" "from[[:space:]]+['\"]@meshery/schemas/models/v1beta1")
+    old_v=$(count "$old" "from[[:space:]]+['\"]@meshery/schemas/models/v1beta1")
+    if [ "$new_v" -gt "$old_v" ]; then
+      VIOLATIONS+=("Deprecated v1beta1 import declaration. Use v1beta3 (or v1beta2 where v1beta3 is absent).")
+    fi
+    ;;
+esac
+
+# ─── Go checks ───────────────────────────────────────────────────────────────
+case "$path" in
+  *.go)
+
+    # 4. Go json tags with snake_case values (net-new)
+    new_snake=$(count "$new" 'json:"[^"]*[a-z]+_[a-z0-9_]*[^"]*"')
+    old_snake=$(count "$old" 'json:"[^"]*[a-z]+_[a-z0-9_]*[^"]*"')
+    if [ "$new_snake" -gt "$old_snake" ]; then
+      tags="$(printf '%s' "$new" | grep -oE 'json:"[^"]*[a-z]+_[a-z0-9_]*[^"]*"' | paste -sd', ' -)"
+      VIOLATIONS+=("Go json tag with snake_case value: $tags. Wire is camelCase — use json:\"fileName\" not json:\"file_name\".")
+    fi
+
+    # 5. Deprecated v1beta1 Go import paths only (not comments or docs)
+    #    Match only inside import declarations: "github.com/meshery/schemas/models/v1beta1"
+    new_gv=$(count "$new" '"github\.com/meshery/schemas/models/v1beta1[^"]*"')
+    old_gv=$(count "$old" '"github\.com/meshery/schemas/models/v1beta1[^"]*"')
+    if [ "$new_gv" -gt "$old_gv" ]; then
+      VIOLATIONS+=("Deprecated v1beta1 Go import path. Use v1beta3 (or v1beta2 where v1beta3 is absent).")
+    fi
+    ;;
+esac
+
+# ─── Report ──────────────────────────────────────────────────────────────────
+if [ ${#VIOLATIONS[@]} -gt 0 ]; then
+  {
+    echo "⛔ schema-principles guard — ${path##*/}"
+    echo
+    echo "Meshery is a SCHEMA-DRIVEN project. This edit introduces code that"
+    echo "bypasses the schema-first workflow:"
+    echo
+    for v in "${VIOLATIONS[@]}"; do
+      echo "  ✗  $v"
+    done
+    echo
+    echo "All API types, wire field names, and RTK Query hooks are owned by"
+    echo "meshery/schemas. UI components are owned by @sistent/sistent."
+    echo "Import the generated types and hooks — do NOT hand-roll them."
+    echo
+    echo "Ref: https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md"
+    echo
+    echo "Note: only NET-NEW violations are blocked. Migrating existing code"
+    echo "(removing as many violations as you add) passes cleanly."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,12 +393,19 @@ above fail with "No such file or directory". Enable Windows developer mode or se
 
 ## Automation Hooks
 
-Scripts in `.agents/hooks/`:
+Scripts in `.agents/hooks/` (tool-agnostic, takes file path as `$1`):
 
 | Hook | Script | Trigger | Purpose |
-|------|--------|---------|---------|
+|------|--------|---------|---------| 
 | Format Frontend | `.agents/hooks/format-frontend.sh` | Post-edit | Auto-format JS/TS with Prettier |
 | Block Lock Files | `.agents/hooks/block-lockfiles.sh` | Pre-edit | Prevent direct edits to lock files |
+| Validate Schema Principles | `.agents/hooks/validate-schema-principles.sh` | Post-edit | Block hand-rolled payloads, manual RTK hooks, snake_case wire fields, and deprecated v1beta1 imports |
+
+Scripts in `.claude/hooks/` (Claude Code PreToolUse/PostToolUse, reads JSON on stdin):
+
+| Hook | Script | Trigger | Purpose |
+|------|--------|---------|---------| 
+| Validate Schema Principles | `.claude/hooks/validate-schema-principles.sh` | PreToolUse | Block NET-NEW hand-rolled payloads, manual RTK hooks, snake_case json tags, and deprecated v1beta1 imports |
 
 ## Further Reading
 

--- a/ui/rtk-query/connection.ts
+++ b/ui/rtk-query/connection.ts
@@ -24,6 +24,7 @@ const TAGS = {
 // addKubernetesConfig, discoverKubernetesContexts, pingKubernetes). Only the
 // {kind}-scoped connection routes below remain hand-rolled — they are not yet
 // defined in meshery/schemas.
+// schema-rtk-exempt: {kind}-scoped connection routes not yet defined in meshery/schemas
 const connectionsApi = api.injectEndpoints({
   overrideExisting: true,
   endpoints: (builder) => ({


### PR DESCRIPTION
## What does this PR do?

Meshery is a schema-driven project. All API types, wire field names, and RTK Query hooks must come from `meshery/schemas` or `@sistent/sistent` — never hand-rolled.

This PR adds a **post-edit agent hook** (`.agents/hooks/validate-schema-principles.sh`) that automatically enforces that principle every time a coding agent edits a `.ts`, `.tsx`, or `.go` file.

---

## Motivation — The Root Cause

**Meshery is a schema-driven project.** All API types, wire field names, and RTK Query hooks have a single source of truth — they must never be hand-rolled.

### meshery/schemas
[`meshery/schemas`](https://github.com/meshery/schemas) is the authoritative source for every HTTP API contract. One OpenAPI definition generates:
- **Go structs** with correct `json:` tags (camelCase on the wire, snake_case in the DB)
- **TypeScript types** — the compiler enforces field names so typos are caught at build time
- **RTK Query hooks** (`@meshery/schemas/mesheryApi`) — ready to import, no hand-rolling needed

### @sistent/sistent
[`@sistent/sistent`](https://github.com/layer5io/sistent) is the UI design system. It owns all MUI components, form schemas, and the host ↔ extension contract. Components and schemas that already exist in Sistent must be imported, not recreated.

### Why this hook exists
When a developer (or AI agent) types a field name, a type, or a component **from memory** instead of importing it from the sources above, they silently diverge from the wire contract. That divergence causes production bugs.

PR #21105 is a concrete example: a hand-rolled request body used `file_name` (snake_case) instead of `fileName` (camelCase), causing a `400 Bad Request`. The field name existed correctly in `meshery/schemas` — the developer just didn't use it.

Contributors to remember the schema-first principle on every session creates drift. This hook makes the principle **machine-enforced**: if an agent edits a file and introduces a hand-rolled payload, wrong casing, or a deprecated import, the hook fires immediately and blocks the edit before it reaches a commit.

---

## What the hook checks

| Rule | Bad code it blocks | What to do instead |
|---|---|---|
| Hand-rolled JSON payload with snake_case keys | `JSON.stringify({ file_name: "x" })` | Use `@meshery/schemas` generated TypeScript types |
| Manual RTK Query endpoints in `ui/rtk-query/` | `builder.query(...)` for a schema-covered API | Use generated hooks from `@meshery/schemas/mesheryApi` |
| Deprecated `v1beta1` TS imports | `import from '@meshery/schemas/models/v1beta1'` | Use `v1beta3` (or `v1beta2` where absent) |
| Go `json:` tags with snake_case values | `json:"file_name,omitempty"` | Use camelCase — `json:"fileName,omitempty"` |
| Deprecated `v1beta1` Go imports | `"github.com/meshery/schemas/models/v1beta1"` | Use `v1beta3` or `v1beta2` |

When a violation is found, the hook prints a clear error banner and exits non-zero, blocking the agent from proceeding:

```
╔══════════════════════════════════════════════════════════════════════╗
║   MESHERY SCHEMA-DRIVEN PRINCIPLES VIOLATION                        ║
╚══════════════════════════════════════════════════════════════════════╝

  ✗  Hand-rolled JSON.stringify() body with snake_case key detected in import-design-request.ts.
     Use @meshery/schemas generated types for request payloads (wire format is camelCase).

Fix the violations above before proceeding.
```

---

## RTK Query opt-out

Some files in `ui/rtk-query/` intentionally keep manual endpoints because `meshery/schemas` does not yet define them. These files can opt out by adding a comment:

```ts
// schema-rtk-exempt: <reason why schemas don't cover this yet>
```

`ui/rtk-query/connection.ts` already documents its `{kind}`-scoped routes as intentionally hand-rolled. This PR adds the `schema-rtk-exempt` comment to that file so the hook skips it correctly.

---

## Files changed

| File | Change |
|---|---|
| `.agents/hooks/validate-schema-principles.sh` | **[NEW]** The validation hook |
| `AGENTS.md` | **[MODIFIED]** Registers the hook in the Automation Hooks table |
| `ui/rtk-query/connection.ts` | **[MODIFIED]** Adds `schema-rtk-exempt` opt-out comment |

---

## Implementation notes

- Uses `perl -0777` with `/s` flag for multiline-aware `JSON.stringify` detection (handles object bodies spanning multiple lines)
- Uses `grep -E` with `[[:space:]]` (POSIX ERE) — works on macOS BSD grep and GNU grep
- Uses `--` before `$FILE` in every `grep`/`perl` call to prevent path-as-option injection
- Fails closed: exits non-zero if the target file cannot be read
- RTK path match uses exact directory prefix (`ui/rtk-query/*`) not substring to avoid false positives

---

## Testing

```bash
# Should PASS — clean file
./.agents/hooks/validate-schema-principles.sh ui/components/designs/import-design-request.ts

# Should FAIL — hand-rolled snake_case JSON body
echo 'JSON.stringify({ file_name: "x" })' > /tmp/bad.ts
./.agents/hooks/validate-schema-principles.sh /tmp/bad.ts

# Should FAIL — deprecated v1beta1 import
echo "import { X } from '@meshery/schemas/models/v1beta1/x'" > /tmp/old.ts
./.agents/hooks/validate-schema-principles.sh /tmp/old.ts

# Should PASS — has schema-rtk-exempt comment
./.agents/hooks/validate-schema-principles.sh ui/rtk-query/connection.ts
```

---

## Related

- Closes the structural gap identified after PR #21105
- References: [meshery/schemas naming guide](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added automated checks to flag schema inconsistencies, unsupported API integration patterns, and deprecated imports during code changes.
  - Added edit-time safeguards that block newly introduced validation violations.

- **Documentation**
  - Expanded automation hook guidance, including supported validation behavior and usage.
  - Documented an intentional exception for connection routes not yet covered by schema-generated API support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->