### PR TITLE
[mesheryctl] Close the response body in dashboard keepConnectionAlive

### DIFF
--- a/mesheryctl/internal/cli/root/system/dashboard.go
+++ b/mesheryctl/internal/cli/root/system/dashboard.go
@@ -238,10 +238,12 @@ Note: Meshery's web-based user interface is embedded in Meshery Server and is av
 
 // keepConnectionAlive to stop being timed out with port forwarding
 func keepConnectionAlive(url string) {
-	_, err := http.Get(url)
+	resp, err := http.Get(url)
 	if err != nil {
 		utils.Log.Debugf("connection request failed %v", err)
+		return
 	}
+	defer func() { _ = resp.Body.Close() }()
 	utils.Log.Debug("connection request success")
 }
 


### PR DESCRIPTION
## What

`keepConnectionAlive` in `mesheryctl system dashboard` discards the `http.Get` response with `_`, so `resp.Body` is never closed. It also logs `"connection request success"` on the error path because there is no early return.

```go
func keepConnectionAlive(url string) {
	_, err := http.Get(url)
	if err != nil {
		utils.Log.Debugf("connection request failed %v", err)
	}
	utils.Log.Debug("connection request success")   // also runs when the request failed
}
```

## Why it matters

Per the `net/http` docs for `Get`: "When err is nil, resp always contains a non-nil resp.Body. Caller should close resp.Body when done reading from it." Discarding the response with `_` leaves the body open.

This is not a one-off call. It runs inside the port-forward keep-alive goroutine on a 10-second ticker for the entire lifetime of the session:

```go
ticker := time.NewTicker(10 * time.Second)
go func() {
	for {
		select {
		case <-signals:
			...
		case <-ticker.C:
			keepConnectionAlive(mesheryURL)
		}
	}
}()
```

So `mesheryctl system dashboard --port-forward` leaks one connection every 10 seconds. Over a long-lived dashboard session this accumulates until the process hits its open-file-descriptor limit ("too many open files"). Secondarily, the missing early return means a failed request still logs success, which is misleading when debugging a flaky port-forward.

## The fix

Keep the response, close its body via defer, and return early on error:

```go
func keepConnectionAlive(url string) {
	resp, err := http.Get(url)
	if err != nil {
		utils.Log.Debugf("connection request failed %v", err)
		return
	}
	defer func() { _ = resp.Body.Close() }()
	utils.Log.Debug("connection request success")
}
```

This matches the existing convention in the same package, where every other HTTP response body is closed with `defer func() { _ = resp.Body.Close() }()` (see `system/check.go` and `system/config.go`). No behavior change beyond closing the body and no longer logging success on failure.

## Testing

- `go build ./internal/cli/root/system/` passes.
- `go vet` / the `bodyclose` linter no longer flags `keepConnectionAlive`.
- Manual: `mesheryctl system dashboard --port-forward` no longer accumulates open connections across ticker fires (verified by watching the process handle/fd count stay flat instead of climbing every 10s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard connection handling by properly closing HTTP responses.
  * Prevented additional processing when connection requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->