### PR TITLE
[Server][CLI][CI] Fix Connection Lifecycle e2e failures: unknown-id delete, non-interactive listing, broker name drift, provider auth

### DIFF
--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -89,16 +89,29 @@ jobs:
           ./mesheryctl system start --platform ${{ matrix.platform }} --skip-browser --skip-update --verbose
         shell: bash
         working-directory: ./mesheryctl
-      - name: Enable operator-mode MeshSync for controller diagnostics
-        # The controllers-diagnostics suite (009-diagnostics) needs an in-cluster
-        # broker: operator-mode MeshSync plus a deterministic (unmanaged) broker
-        # port-forward so the broker_unreachable baseline is real. Inject those
-        # server env vars into the in-cluster deployment and wait for the rollout.
-        # Without this the suite self-skips (embedded MeshSync has no broker).
-        # The other suites are unaffected by the MeshSync deployment mode.
+      - name: Configure Meshery server env for the e2e suite
+        # Two server-side settings the BATS suite depends on, injected into the
+        # in-cluster deployment in one rollout:
+        #
+        # 1. PROVIDER_BASE_URLS - pin the "Meshery" remote provider to the single
+        #    https://cloud.meshery.io backend that REMOTE_PROVIDER_TEST_USER_TOKEN
+        #    authenticates against (see install/providers.env: "Meshery" maps to
+        #    cloud.meshery.io). The released image ships the full default provider
+        #    list, where a second URL can win the "Meshery" providerName by
+        #    collision re-keying and the connection tests then authenticate the
+        #    token against the wrong backend - a 401 ("user must be logged in").
+        #    Pinning a single URL makes the "Meshery" context resolve
+        #    unambiguously to the provider the token is valid for.
+        #
+        # 2. Operator-mode MeshSync + unmanaged broker port-forward - the
+        #    controllers-diagnostics suite (009-diagnostics) needs a real
+        #    in-cluster broker for its broker_unreachable baseline; without this
+        #    it self-skips (embedded MeshSync has no broker). Other suites are
+        #    unaffected by the MeshSync deployment mode.
         run: |
           kubectl -n meshery rollout status deployment/meshery --timeout=180s
           kubectl -n meshery set env deployment/meshery \
+            PROVIDER_BASE_URLS=https://cloud.meshery.io \
             MESHSYNC_DEFAULT_DEPLOYMENT_MODE=operator \
             MESHERY_MANAGED_BROKER_PORTFORWARD=false
           kubectl -n meshery rollout status deployment/meshery --timeout=180s
@@ -158,7 +171,7 @@ jobs:
           # provider (setup_suite.bash sets context to "Meshery"), so they need a
           # valid session token. The previous PROVIDER_TOKEN secret was a static
           # token last refreshed 2024-03-08 and had expired, so the remote
-          # provider answered every call with a 401 ("user must be logged in") —
+          # provider answered every call with a 401 ("user must be logged in") -
           # surfacing as meshery-server-1032 on reads and meshery-server-1051 on
           # delete. REMOTE_PROVIDER_TEST_USER_TOKEN is the maintained token for a
           # purpose-built CI test user.
@@ -166,6 +179,23 @@ jobs:
           MESHERY_PLATFORM: ${{ matrix.platform }}
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
           E2E_HELPERS_PATH: "${{ github.workspace }}/mesheryctl/tests/e2e/helpers"
+
+      - name: Remote-provider auth diagnostics
+        # Surface the actual provider wiring behind any connection-test auth
+        # failure: which remote provider the server registered as "Meshery", the
+        # auth.json shape (token length only, never the value), and any provider
+        # request / 401 lines from the server log. Runs even on failure.
+        if: ${{ !cancelled() }}
+        run: |
+          echo "### auth.json shape (token redacted) ###"
+          jq '.token = (if .token == null then null else "REDACTED len=\(.token | length)" end)' \
+            "$HOME/.meshery/auth.json" || true
+          echo "### registered providers + provider auth exchange (server log) ###"
+          kubectl -n meshery logs deployment/meshery --tail=1500 2>/dev/null \
+            | grep -iE "provider name|register|capabilit|cloud\.meshery|cloud\.layer5|RemoteProviderURL|401|unauthor|logged in|de-register" \
+            | grep -viE "token|authorization|bearer" \
+            || echo "(no matching provider log lines)"
+        shell: bash
 
       - name: Convert TAP to Allure results
         if: ${{ !cancelled() && github.event_name == 'push' }}

--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -121,40 +121,58 @@ jobs:
         # both assert the broker is up, and nothing else in the job waits for it:
         # the previous step waits only on the meshery deployment. The broker is
         # deployed indirectly - Meshery installs the Meshery Operator, the
-        # operator reconciles the Broker CR into the meshery-broker statefulset,
-        # and only then does a pod appear - so it can trail the meshery rollout
-        # by a long way.
+        # operator reconciles the Broker custom resource into a statefulset, and
+        # only then does a pod appear - so it can trail the meshery rollout by a
+        # long way.
         #
-        # `kubectl rollout status` cannot express that wait on its own: against a
+        # Both workload names are accepted: Meshery Operator >= 1.0.0 renders the
+        # broker from the official NATS chart as meshery-nats, earlier operators
+        # used meshery-broker (see the same note in
+        # server/integration-tests/meshsync/infrastructure/setup.sh). Only the
+        # workload was renamed - the Broker custom resource is still called
+        # meshery-broker.
+        #
+        # `kubectl rollout status` cannot express this wait on its own: against a
         # statefulset that does not exist *yet* it fails immediately with
         # NotFound instead of waiting, so a bare `rollout status ... || true`
         # returns at once and waits for nothing. Poll for the object to appear
         # first, then hand over to rollout status for readiness.
         #
         # Never fails the job: a broker that never arrives is a finding for the
-        # tests that assert on it, not a reason to skip the other 190. The
-        # diagnostics below exist so that finding is explainable from this log
-        # instead of only visible as "Meshery Broker is not running".
+        # handful of tests that assert on it, not a reason to skip the other 190.
+        # The diagnostics below exist so that finding is explainable from this
+        # log instead of only visible as "Meshery Broker is not running".
         run: |
           set +e
+          find_broker() {
+            for sts in meshery-nats meshery-broker; do
+              if kubectl -n meshery get "statefulset/$sts" >/dev/null 2>&1; then
+                echo "$sts"
+                return 0
+              fi
+            done
+            return 1
+          }
+
           deadline=$(( SECONDS + 300 ))
-          until kubectl -n meshery get statefulset/meshery-broker >/dev/null 2>&1; do
+          until broker=$(find_broker); do
             if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "::warning::meshery-broker statefulset did not appear within 300s"
+              echo "::warning::no broker statefulset (meshery-nats or meshery-broker) appeared within 300s"
               break
             fi
             sleep 5
           done
 
-          if kubectl -n meshery get statefulset/meshery-broker >/dev/null 2>&1; then
-            kubectl -n meshery rollout status statefulset/meshery-broker --timeout=180s
+          if [ -n "$broker" ]; then
+            echo "Broker statefulset: $broker"
+            kubectl -n meshery rollout status "statefulset/$broker" --timeout=180s
           fi
 
           echo "### broker / operator state ###"
           kubectl -n meshery get pods -o wide
           kubectl -n meshery get statefulsets,deployments
           echo "### operator custom resources ###"
-          kubectl -n meshery get brokers.core.meshery.io,meshsyncs.core.meshery.io -o wide 2>&1 \
+          kubectl -n meshery get brokers.meshery.io,meshsyncs.meshery.io -o wide 2>&1 \
             || echo "(operator CRDs not registered)"
           echo "### meshery-operator log tail ###"
           kubectl -n meshery logs deployment/meshery-operator --tail=100 2>&1 \

--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -103,6 +103,50 @@ jobs:
             MESHERY_MANAGED_BROKER_PORTFORWARD=false
           kubectl -n meshery rollout status deployment/meshery --timeout=180s
         shell: bash
+      - name: Wait for the Meshery Broker to be ready
+        # 000-prerequisites/00-servert.bats and 001-system/03-system-checks.bats:49
+        # both assert the broker is up, and nothing else in the job waits for it:
+        # the previous step waits only on the meshery deployment. The broker is
+        # deployed indirectly - Meshery installs the Meshery Operator, the
+        # operator reconciles the Broker CR into the meshery-broker statefulset,
+        # and only then does a pod appear - so it can trail the meshery rollout
+        # by a long way.
+        #
+        # `kubectl rollout status` cannot express that wait on its own: against a
+        # statefulset that does not exist *yet* it fails immediately with
+        # NotFound instead of waiting, so a bare `rollout status ... || true`
+        # returns at once and waits for nothing. Poll for the object to appear
+        # first, then hand over to rollout status for readiness.
+        #
+        # Never fails the job: a broker that never arrives is a finding for the
+        # tests that assert on it, not a reason to skip the other 190. The
+        # diagnostics below exist so that finding is explainable from this log
+        # instead of only visible as "Meshery Broker is not running".
+        run: |
+          set +e
+          deadline=$(( SECONDS + 300 ))
+          until kubectl -n meshery get statefulset/meshery-broker >/dev/null 2>&1; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::warning::meshery-broker statefulset did not appear within 300s"
+              break
+            fi
+            sleep 5
+          done
+
+          if kubectl -n meshery get statefulset/meshery-broker >/dev/null 2>&1; then
+            kubectl -n meshery rollout status statefulset/meshery-broker --timeout=180s
+          fi
+
+          echo "### broker / operator state ###"
+          kubectl -n meshery get pods -o wide
+          kubectl -n meshery get statefulsets,deployments
+          echo "### operator custom resources ###"
+          kubectl -n meshery get brokers.core.meshery.io,meshsyncs.core.meshery.io -o wide 2>&1 \
+            || echo "(operator CRDs not registered)"
+          echo "### meshery-operator log tail ###"
+          kubectl -n meshery logs deployment/meshery-operator --tail=100 2>&1 \
+            || echo "(no meshery-operator deployment)"
+        shell: bash
       - name: Run mesheryctl end2end tests
         run: |
           bash run_tests.bash | tee bats.tap

--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -233,10 +233,17 @@ registered provider and the `auth.json` shape (token length only) to tell the tw
 **MeshSync runs in operator mode, and the broker is waited for.** The job sets
 `MESHSYNC_DEFAULT_DEPLOYMENT_MODE=operator` and `MESHERY_MANAGED_BROKER_PORTFORWARD=false` so
 the `009-diagnostics` suite has a real in-cluster broker and a deterministic unreachable
-baseline, then waits for the `meshery-broker` statefulset. The broker arrives indirectly -
-Meshery installs the Meshery Operator, the operator reconciles the Broker custom resource -
-so it trails the `meshery` deployment rollout, and the wait step prints pod, statefulset,
+baseline, then waits for the broker statefulset. The broker arrives indirectly - Meshery
+installs the Meshery Operator, the operator reconciles the Broker custom resource - so it
+trails the `meshery` deployment rollout, and the wait step prints pod, statefulset,
 custom-resource and operator-log state when it does not arrive.
+
+Mind the name. Meshery Operator >= 1.0.0 renders the broker from the official NATS chart, so
+the workload is `meshery-nats` (pod `meshery-nats-0`, service `meshery-nats`); earlier
+operators used `meshery-broker`. Only the *workload* was renamed - the Broker custom resource
+is still `meshery-broker`. Anything matching on the workload name should accept both, since
+the operator version belongs to the cluster under test. Assuming the old name is why a healthy,
+Running broker was reported for a long time as `!! Meshery Broker is not running`.
 
 **Nothing is attached to a terminal.** Commands that page interactively stop after the first
 page and say so rather than prompting; commands that would resolve an ambiguous name by

--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -209,6 +209,40 @@ This involves parsing a flag for the binary to be built whether it exists or not
   bash run_tests_local.sh -b
 ```
 
+## Run End-to-End (in CI)
+
+The same suite runs in GitHub Actions as the `Meshery End-to-End Tests with mesheryctl`
+workflow (`.github/workflows/mesheryctl-e2e.yaml`) - on every push to `master` touching
+`mesheryctl/**`, on a schedule, and on demand via `workflow_dispatch` with `bats_test=true`.
+It is worth knowing the four ways that run differs from your local one, because most CI-only
+failures come from one of them.
+
+**The server is the released image, not your branch.** The job builds `mesheryctl` from the
+checkout and then runs `mesheryctl system start`, which deploys the released Meshery Server.
+A server-side change in the same pull request is therefore *not* exercised by this workflow -
+it is exercised once a release carrying it is out. Cover server changes with Go tests as well.
+
+**Authentication is a remote-provider session.** `setup_suite.bash` sets the context provider
+to `Meshery`, so the connection and perf suites round-trip through Meshery Cloud. The job
+authenticates with the `REMOTE_PROVIDER_TEST_USER_TOKEN` organisation secret and pins
+`PROVIDER_BASE_URLS=https://cloud.meshery.io` on the deployment so the token is presented to
+the backend it is valid for. A stale token surfaces as `meshery-server-1032` on reads rather
+than as an obvious auth error; the job's *Remote-provider auth diagnostics* step prints the
+registered provider and the `auth.json` shape (token length only) to tell the two apart.
+
+**MeshSync runs in operator mode, and the broker is waited for.** The job sets
+`MESHSYNC_DEFAULT_DEPLOYMENT_MODE=operator` and `MESHERY_MANAGED_BROKER_PORTFORWARD=false` so
+the `009-diagnostics` suite has a real in-cluster broker and a deterministic unreachable
+baseline, then waits for the `meshery-broker` statefulset. The broker arrives indirectly -
+Meshery installs the Meshery Operator, the operator reconciles the Broker custom resource -
+so it trails the `meshery` deployment rollout, and the wait step prints pod, statefulset,
+custom-resource and operator-log state when it does not arrive.
+
+**Nothing is attached to a terminal.** Commands that page interactively stop after the first
+page and say so rather than prompting; commands that would resolve an ambiguous name by
+prompting fail with `mesheryctl-1253` instead. Write assertions against a unique ID, or pass
+`--page`/`--pagesize`, rather than relying on a full listing.
+
 ### Find Tests here
 Refer to [Meshery Test Plan](https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit?usp=sharing) for test scenarios.
 

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.64.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/api v0.287.0
@@ -402,7 +403,6 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools/godoc v0.1.0-deprecated // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1253
+  "next_error_code": 1254
 }

--- a/mesheryctl/internal/cli/pkg/display/error.go
+++ b/mesheryctl/internal/cli/pkg/display/error.go
@@ -13,6 +13,7 @@ var (
 	ErrUnsupportedFormatCode      = "mesheryctl-1184"
 	ErrOutputFileNotSpecifiedCode = "mesheryctl-1194"
 	ErrInvalidOutputFormatCode    = "mesheryctl-1198"
+	ErrAmbiguousSelectionCode     = "mesheryctl-1253"
 )
 
 func ErrPagination(err error, currentPage int) error {
@@ -43,5 +44,21 @@ func ErrInvalidOutputFormat(format string) error {
 		[]string{fmt.Sprintf("Provided output format %q is invalid", format)},
 		[]string{"The specified output format is not supported"},
 		[]string{fmt.Sprintf("Ensure using [%s] as the output format", strings.Join(validOutputFormat, "|"))},
+	)
+}
+
+// ErrAmbiguousSelection reports a lookup that matched more than one item while
+// running without a terminal to disambiguate it on. Selecting one on the user's
+// behalf would act on a resource they did not name, so this is a hard failure -
+// but it must say so plainly, rather than surfacing the selection library's
+// "open /dev/tty" as if the device were the problem.
+func ErrAmbiguousSelection(matches int64) error {
+	return errors.New(
+		ErrAmbiguousSelectionCode,
+		errors.Alert,
+		[]string{"Ambiguous match, and no terminal to resolve it on"},
+		[]string{fmt.Sprintf("%d items matched, which requires an interactive selection, but mesheryctl is not attached to a terminal", matches)},
+		[]string{"The command is running in a script, pipeline or CI job where stdin or stdout is redirected"},
+		[]string{"Identify the item by its unique ID instead of its name", "Narrow the search so exactly one item matches"},
 	)
 }

--- a/mesheryctl/internal/cli/pkg/display/noninteractive_test.go
+++ b/mesheryctl/internal/cli/pkg/display/noninteractive_test.go
@@ -110,3 +110,32 @@ func TestPromptPageHandlerAutoSelectsSingleMatch(t *testing.T) {
 		t.Errorf("selected = %q, want %q", selected.ID, "only")
 	}
 }
+
+// TestPromptPageHandlerDoesNotAutoSelectOnePageOfMany is the other side of that
+// boundary. A page holding one row is not the same as one match: the caller
+// picks the page size, and `--pagesize 1` makes every page look like a single
+// match. Auto-selecting there would act on the first of several candidates as
+// though the search had been unambiguous - the exact outcome the terminal check
+// exists to prevent.
+func TestPromptPageHandlerDoesNotAutoSelectOnePageOfMany(t *testing.T) {
+	withTerminal(t, false)
+
+	var selected paginationTestItem
+	handler := promptPageHandler(
+		DisplayDataAsync{DataType: "connections"},
+		func(rows []paginationTestItem) []string { return []string{rows[0].ID} },
+		func(_ *[]paginationTestItem) ([]paginationTestItem, int64) {
+			// One row on this page, 93 matches overall - `connection view
+			// minikube` against the CI provider account.
+			return []paginationTestItem{{ID: "first-of-93"}}, 93
+		},
+		&selected,
+	)
+
+	if _, err := handler(&[]paginationTestItem{}, 0, 1); err == nil {
+		t.Fatal("expected an ambiguous-match error, got nil")
+	}
+	if selected.ID != "" {
+		t.Errorf("expected nothing to be selected, got %q", selected.ID)
+	}
+}

--- a/mesheryctl/internal/cli/pkg/display/noninteractive_test.go
+++ b/mesheryctl/internal/cli/pkg/display/noninteractive_test.go
@@ -1,0 +1,112 @@
+package display
+
+import (
+	"testing"
+
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshkit/errors"
+)
+
+type paginationTestItem struct {
+	ID string
+}
+
+// withTerminal swaps the interactive-terminal probe for the duration of a test,
+// and gives utils.Log somewhere to write - the CLI installs it at startup, so
+// it is nil in a unit test.
+func withTerminal(t *testing.T, interactive bool) {
+	t.Helper()
+
+	utils.SetupMeshkitLoggerTesting(t, false)
+
+	original := utils.IsInteractiveTerminal
+	utils.IsInteractiveTerminal = func() bool { return interactive }
+	t.Cleanup(func() { utils.IsInteractiveTerminal = original })
+}
+
+// TestListPageHandlerStopsWithoutTerminal pins the behaviour that makes
+// mesheryctl usable in scripts, pipelines and CI: with more results than fit on
+// one page and no terminal to page on, the handler stops after the page it has
+// printed and reports success.
+//
+// It used to fall through to the keyboard library, which reads the controlling
+// terminal directly and fails with "open /dev/tty: no such device or address"
+// where there isn't one - so `mesheryctl connection list` printed a correct
+// first page and then exited non-zero, which is how it failed in CI for an
+// account holding more than one page of connections.
+func TestListPageHandlerStopsWithoutTerminal(t *testing.T) {
+	withTerminal(t, false)
+
+	handler := listPageHandler(
+		DisplayDataAsync{DataType: "connections", Header: []string{"ID"}},
+		func(_ *[]paginationTestItem) ([][]string, int64) {
+			// One page of rows out of a much larger total, so the handler
+			// reaches the "wait for a keypress" decision.
+			return [][]string{{"1"}, {"2"}}, 294
+		},
+	)
+
+	shouldContinue, err := handler(&[]paginationTestItem{}, 0, 2)
+	if err != nil {
+		t.Fatalf("expected no error without a terminal, got %v", err)
+	}
+	if shouldContinue {
+		t.Error("expected paging to stop without a terminal, got shouldContinue=true")
+	}
+}
+
+// TestPromptPageHandlerFailsClearlyWithoutTerminal covers the other half: an
+// ambiguous match genuinely cannot be resolved without a terminal, because
+// picking for the user would act on a resource they did not name. It must fail
+// - but with an error that names the ambiguity, not with the selection
+// library's "open /dev/tty".
+func TestPromptPageHandlerFailsClearlyWithoutTerminal(t *testing.T) {
+	withTerminal(t, false)
+
+	var selected paginationTestItem
+	handler := promptPageHandler(
+		DisplayDataAsync{DataType: "connections"},
+		func(rows []paginationTestItem) []string { return []string{rows[0].ID, rows[1].ID} },
+		func(_ *[]paginationTestItem) ([]paginationTestItem, int64) {
+			return []paginationTestItem{{ID: "1"}, {ID: "2"}}, 93
+		},
+		&selected,
+	)
+
+	shouldContinue, err := handler(&[]paginationTestItem{}, 0, 2)
+	if err == nil {
+		t.Fatal("expected an error for an ambiguous match without a terminal, got nil")
+	}
+	if got := errors.GetCode(err); got != ErrAmbiguousSelectionCode {
+		t.Errorf("error code = %q, want %q (err: %v)", got, ErrAmbiguousSelectionCode, err)
+	}
+	if shouldContinue {
+		t.Error("expected the handler to stop, got shouldContinue=true")
+	}
+	if selected.ID != "" {
+		t.Errorf("expected nothing to be selected on the user's behalf, got %q", selected.ID)
+	}
+}
+
+// TestPromptPageHandlerAutoSelectsSingleMatch guards the boundary: a single
+// match is unambiguous, so it is still resolved without a terminal.
+func TestPromptPageHandlerAutoSelectsSingleMatch(t *testing.T) {
+	withTerminal(t, false)
+
+	var selected paginationTestItem
+	handler := promptPageHandler(
+		DisplayDataAsync{DataType: "connections"},
+		func(rows []paginationTestItem) []string { return []string{rows[0].ID} },
+		func(_ *[]paginationTestItem) ([]paginationTestItem, int64) {
+			return []paginationTestItem{{ID: "only"}}, 1
+		},
+		&selected,
+	)
+
+	if _, err := handler(&[]paginationTestItem{}, 0, 2); err != nil {
+		t.Fatalf("expected a single match to resolve without a terminal, got %v", err)
+	}
+	if selected.ID != "only" {
+		t.Errorf("selected = %q, want %q", selected.ID, "only")
+	}
+}

--- a/mesheryctl/internal/cli/pkg/display/pagination_handlers.go
+++ b/mesheryctl/internal/cli/pkg/display/pagination_handlers.go
@@ -118,14 +118,18 @@ func promptPageHandler[T any, R any](displayData DisplayDataAsync, processData p
 			return false, nil
 		}
 
-		// Auto-select if only one result on the first page
-		if len(rows) == 1 && currentPage == 0 {
+		// Auto-select the sole match. The test is on totalCount, not on the size
+		// of this page: a page can hold one row while further pages hold more
+		// (the caller chooses the page size, and --pagesize 1 makes every page
+		// look like a single match), and selecting then would act on the first
+		// of several candidates as though the search had been unambiguous.
+		if totalCount == 1 && len(rows) == 1 && currentPage == 0 {
 			*selectedItem = rows[0]
 			return false, nil
 		}
 
-		// An ambiguous match needs a choice, and a choice needs somebody to make
-		// it. Unlike paging there is no sensible non-interactive fallback -
+		// More than one match needs a choice, and a choice needs somebody to
+		// make it. Unlike paging there is no sensible non-interactive fallback -
 		// picking for the user would act on a resource they did not name - so
 		// this is a genuine failure. Say what happened and what to do about it,
 		// rather than letting promptui fail on /dev/tty with an error that

--- a/mesheryctl/internal/cli/pkg/display/pagination_handlers.go
+++ b/mesheryctl/internal/cli/pkg/display/pagination_handlers.go
@@ -57,6 +57,21 @@ func listPageHandler[T any](displayData DisplayDataAsync, processDataFunc listRo
 			return false, nil
 		}
 
+		// Paging on a keypress needs somebody to press the key. Without a
+		// terminal the keyboard library below fails on /dev/tty and the command
+		// exits non-zero having already printed a perfectly good first page -
+		// which is how `mesheryctl connection list` came to fail outright in CI
+		// and in any pipeline, as soon as the account held more than one page.
+		// Stop after this page instead, and say so, so the output stays usable
+		// and the exit status stays honest.
+		if !utils.IsInteractiveTerminal() {
+			utils.Log.Infof(
+				"Showing page %d only: paging through results needs an interactive terminal. Use --page and --pagesize to select a page, or --count for the total.",
+				currentPage+1,
+			)
+			return false, nil
+		}
+
 		// Wait for user input to navigate pages
 		keysEvents, err := keyboard.GetKeys(10)
 		if err != nil {
@@ -107,6 +122,16 @@ func promptPageHandler[T any, R any](displayData DisplayDataAsync, processData p
 		if len(rows) == 1 && currentPage == 0 {
 			*selectedItem = rows[0]
 			return false, nil
+		}
+
+		// An ambiguous match needs a choice, and a choice needs somebody to make
+		// it. Unlike paging there is no sensible non-interactive fallback -
+		// picking for the user would act on a resource they did not name - so
+		// this is a genuine failure. Say what happened and what to do about it,
+		// rather than letting promptui fail on /dev/tty with an error that
+		// describes neither.
+		if !utils.IsInteractiveTerminal() {
+			return false, ErrAmbiguousSelection(totalCount)
 		}
 
 		picked, itemSelected, err := SelectFromPagedResults(rows, processData, pgSize, currentPage, totalCount)

--- a/mesheryctl/internal/cli/root/system/broker_name_test.go
+++ b/mesheryctl/internal/cli/root/system/broker_name_test.go
@@ -1,0 +1,43 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+)
+
+// TestIsBrokerPodName pins that `mesheryctl system check --operator` recognises
+// the broker under the name the operator actually deploys it as.
+//
+// Meshery Operator >= 1.0.0 renders the broker from the official NATS chart, so
+// the pod is meshery-nats-0; matching only the pre-1.0.0 meshery-broker name
+// reported a healthy, Running broker as "!! Meshery Broker is not running" on
+// every current cluster. Both names are accepted because the operator version
+// belongs to the cluster, not to the CLI.
+func TestIsBrokerPodName(t *testing.T) {
+	cases := []struct {
+		podName string
+		want    bool
+	}{
+		// Operator >= 1.0.0 (NATS chart).
+		{podName: "meshery-nats-0", want: true},
+		{podName: "meshery-nats-1", want: true},
+		// Operator < 1.0.0.
+		{podName: "meshery-broker-0", want: true},
+		// Everything else in the namespace.
+		{podName: "meshery-operator-84945fd54c-45cck", want: false},
+		{podName: "meshery-meshsync-c4b96d647-kl5l6", want: false},
+		{podName: "meshery-6c54448cc8-fhvwj", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.podName, func(t *testing.T) {
+			// Go through GetCleanPodName, because that is what the health check
+			// feeds the matcher - asserting on the raw pod name would pass while
+			// the real call site failed.
+			if got := isBrokerPodName(utils.GetCleanPodName(tc.podName)); got != tc.want {
+				t.Errorf("isBrokerPodName(GetCleanPodName(%q)) = %v, want %v", tc.podName, got, tc.want)
+			}
+		})
+	}
+}

--- a/mesheryctl/internal/cli/root/system/check.go
+++ b/mesheryctl/internal/cli/root/system/check.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -580,6 +581,25 @@ func (hc *HealthChecker) runComponentsHealthChecks() error {
 	return hc.runAdapterHealthChecks("")
 }
 
+// brokerPodNames are the cleaned pod names the Meshery Broker runs under.
+//
+// Meshery Operator >= 1.0.0 renders the broker from the official NATS chart, so
+// the workload is meshery-nats (pod meshery-nats-0); before that it was
+// meshery-broker. Both are accepted because a given cluster's operator version
+// is not ours to assume - matching only the old name reported a healthy broker
+// as "!! Meshery Broker is not running" on every current cluster.
+//
+// Only the *workload* was renamed. The Broker custom resource is still named
+// meshery-broker (see the CR lookup below, and system/stop.go), so those must
+// not be changed to match.
+var brokerPodNames = []string{"meshery-nats", "meshery-broker"}
+
+// isBrokerPodName reports whether a cleaned pod name (see utils.GetCleanPodName)
+// belongs to the Meshery Broker.
+func isBrokerPodName(cleanedName string) bool {
+	return slices.Contains(brokerPodNames, cleanedName)
+}
+
 // runOperatorHealthChecks executes health-checks for Operators
 func (hc *HealthChecker) runOperatorHealthChecks() error {
 	if hc.Options.PrintLogs {
@@ -609,7 +629,7 @@ func (hc *HealthChecker) runOperatorHealthChecks() error {
 			operatorCheck = true
 		}
 
-		if name == "meshery-broker" {
+		if isBrokerPodName(name) {
 			brokerCheck = true
 		}
 

--- a/mesheryctl/pkg/utils/helpers.go
+++ b/mesheryctl/pkg/utils/helpers.go
@@ -1267,6 +1267,18 @@ func HandlePagination(pageSize int, component string, data [][]string, header []
 			break
 		}
 
+		// Same reasoning as display.listPageHandler: without a terminal there is
+		// nobody to press the key, and keyboard.GetKeys fails on /dev/tty rather
+		// than blocking. Stop after this page instead of turning a successful
+		// listing into a non-zero exit.
+		if !IsInteractiveTerminal() {
+			Log.Infof(
+				"Showing page %d only: paging through results needs an interactive terminal. Use --page to select a page.",
+				startIndex/pageSize+1,
+			)
+			break
+		}
+
 		keysEvents, err := keyboard.GetKeys(10)
 		if err != nil {
 			return err

--- a/mesheryctl/pkg/utils/interactive.go
+++ b/mesheryctl/pkg/utils/interactive.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// IsInteractiveTerminal reports whether mesheryctl is attached to a terminal a
+// human can answer from, i.e. whether interactive affordances (paging on a
+// keypress, selection prompts) are possible at all.
+//
+// Both streams have to be terminals. Stdin is where the keystroke would come
+// from and stdout is where the prompt would be shown, and either being
+// redirected means there is nobody on the other end: `mesheryctl connection
+// list | grep ...` and a bats `run` both take stdout; a CI job and a cron entry
+// both take stdin.
+//
+// This matters because the keyboard library used for interactive paging reads
+// the *controlling terminal* directly (/dev/tty). Where there isn't one it
+// fails with "open /dev/tty: no such device or address", and a list command
+// that had already printed its first page exited non-zero on that error -
+// making mesheryctl unusable in scripts, pipelines and CI for any list longer
+// than a page. Callers use this to fall back to non-interactive behaviour
+// instead of failing.
+//
+// It is a var so tests can state which environment they are describing.
+var IsInteractiveTerminal = func() bool {
+	return isTerminal(os.Stdin) && isTerminal(os.Stdout)
+}
+
+// isTerminal reports whether f is a terminal. It asks the terminal driver
+// rather than inspecting the file mode, so that /dev/null - a character device
+// that is emphatically not a terminal, and what stdin usually is in CI - is
+// answered correctly.
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}

--- a/mesheryctl/pkg/utils/interactive_test.go
+++ b/mesheryctl/pkg/utils/interactive_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+// TestIsTerminal pins what the interactive-terminal probe decides on, using the
+// shapes stdin/stdout take when nobody is at the keyboard: a pipe
+// (`mesheryctl connection list | grep ...`, a bats `run`), /dev/null (a CI job,
+// a cron entry) and a regular file (output redirected to a log).
+//
+// /dev/null is the case a file-mode check gets wrong - it is a character device
+// but not a terminal - which is why this asks the terminal driver instead.
+func TestIsTerminal(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("open pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	t.Cleanup(func() { _ = devNull.Close() })
+
+	regular, err := os.CreateTemp(t.TempDir(), "interactive")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	t.Cleanup(func() { _ = regular.Close() })
+
+	cases := []struct {
+		name string
+		file *os.File
+		want bool
+	}{
+		{name: "pipe read end", file: r, want: false},
+		{name: "pipe write end", file: w, want: false},
+		{name: "dev null", file: devNull, want: false},
+		{name: "regular file", file: regular, want: false},
+		{name: "nil file", file: nil, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTerminal(tc.file); got != tc.want {
+				t.Errorf("isTerminal(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/mesheryctl/tests/e2e/000-prerequisites/00-servert.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-servert.bats
@@ -15,8 +15,13 @@ setup() {
 	assert_success
 }
 
+# Meshery Operator >= 1.0.0 renders the broker from the official NATS chart, so
+# the workload is meshery-nats (pod meshery-nats-0); earlier operators used
+# meshery-broker. Accept either, because the operator version is a property of
+# the cluster under test, not of this suite. Only the workload was renamed - the
+# Broker custom resource is still meshery-broker.
 @test "meshery-broker pod is deployed" {
-	run verify "there are more than 0 pod named '^meshery-broker-[0-9]+$'"
+	run verify "there are more than 0 pod named '^meshery-(nats|broker)-[0-9]+$'"
 	assert_success
 }
 
@@ -36,8 +41,11 @@ setup() {
 	assert_success
 }
 
+# See the pod test above for why both names are accepted. The NATS chart also
+# publishes a meshery-nats-headless service; the anchored pattern matches only
+# the addressable one, so the count stays 1.
 @test "meshery-broker service is deployed" {
-	run verify "there is 1 service named '^meshery-broker$'"
+	run verify "there is 1 service named '^meshery-(nats|broker)$'"
 	assert_success
 }
 

--- a/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
+++ b/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
@@ -29,9 +29,33 @@ setup() {
     _load_bats_libraries
     load "$E2E_HELPERS_PATH/constants"
 
-    export MESHERY_URL="${MESHERY_SERVER_URL:-http://localhost:9081}"
     export MESHERY_NS="meshery"
     export MESHERY_AUTH_FILE="${MESHERY_AUTH_FILE:-$HOME/.meshery/auth.json}"
+    export MESHERY_CONFIG_FILE="${MESHERY_CONFIG_FILE_PATH:-$HOME/.meshery/config.yaml}"
+    export MESHERY_URL="${MESHERY_SERVER_URL:-$(_meshery_endpoint)}"
+}
+
+# _meshery_endpoint returns the server URL mesheryctl is configured to talk to.
+#
+# http://localhost:9081 is only right when the server is reachable on loopback,
+# as it is under `make server`. Started with
+# `mesheryctl system start --platform kubernetes` it is published at the
+# context's endpoint instead, and the raw curl below then failed to connect
+# (curl exit 7) - which aborted the test outright, since the failure propagated
+# out of the `diag=$(...)` assignment before the reachability guard that was
+# meant to skip could run. Read the endpoint the rest of the suite already uses,
+# and keep loopback only as the last resort.
+_meshery_endpoint() {
+    local endpoint=""
+    if [ -r "${MESHERY_CONFIG_FILE:-$HOME/.meshery/config.yaml}" ] && command -v yq >/dev/null 2>&1; then
+        endpoint=$(yq -r '.contexts.local.endpoint // ""' \
+            "${MESHERY_CONFIG_FILE:-$HOME/.meshery/config.yaml}" 2>/dev/null)
+    fi
+    if [ -n "$endpoint" ] && [ "$endpoint" != "null" ]; then
+        echo "$endpoint"
+        return
+    fi
+    echo "http://localhost:9081"
 }
 
 # _need skips the test unless the given command is available.
@@ -46,8 +70,12 @@ _diagnostics() {
     local token provider
     token=$(jq -r '.token // empty' "$MESHERY_AUTH_FILE")
     provider=$(jq -r '."meshery-provider" // "Meshery"' "$MESHERY_AUTH_FILE")
+    # `|| true` so an unreachable server yields empty output instead of a
+    # non-zero exit: every caller assigns this with `diag=$(_diagnostics ...)`,
+    # and the failure would otherwise abort the test before the guard that is
+    # meant to skip on exactly that condition.
     curl -s --cookie "token=${token}; meshery-provider=${provider}" \
-        "${MESHERY_URL}/api/system/controllers/diagnostics?connectionId=${conn_id}"
+        "${MESHERY_URL}/api/system/controllers/diagnostics?connectionId=${conn_id}" || true
 }
 
 @test "[TC-1031][cut=Kubernetes Connection][tg=Connection Lifecycle] kubernetes connection broker diagnostics recover once NATS is reachable" {

--- a/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
+++ b/mesheryctl/tests/e2e/009-diagnostics/00-controllers-diagnostics.bats
@@ -74,8 +74,37 @@ _diagnostics() {
     # non-zero exit: every caller assigns this with `diag=$(_diagnostics ...)`,
     # and the failure would otherwise abort the test before the guard that is
     # meant to skip on exactly that condition.
+    _authed_get "/api/system/controllers/diagnostics?connectionId=${conn_id}"
+}
+
+# _authed_get <path> -> GETs path from the Meshery server with the provider
+# session cookies mesheryctl uses (token + meshery-provider from auth.json).
+_authed_get() {
+    local token provider
+    token=$(jq -r '.token // empty' "$MESHERY_AUTH_FILE")
+    provider=$(jq -r '."meshery-provider" // "Meshery"' "$MESHERY_AUTH_FILE")
+    # `|| true` so an unreachable server yields empty output instead of a
+    # non-zero exit: callers assign this with `x=$(...)`, and the failure would
+    # otherwise abort the test before the guard meant to skip on exactly that
+    # condition.
     curl -s --cookie "token=${token}; meshery-provider=${provider}" \
-        "${MESHERY_URL}/api/system/controllers/diagnostics?connectionId=${conn_id}" || true
+        "${MESHERY_URL}${1}" || true
+}
+
+# _this_servers_connection_id prints the connection id of a kubernetes context
+# registered to *this* Meshery server, or nothing.
+#
+# `connection list --kind kubernetes` is the wrong source here. Under the remote
+# provider it lists every kubernetes connection on the account - 294 of them on
+# the shared CI provider account, most from other clusters and earlier runs -
+# and taking the first would ask for diagnostics on a connection this server
+# holds no session for, which reports connection_inactive and skips. The k8s
+# contexts endpoint is scoped by mesheryInstanceId (see
+# RemoteProvider.GetK8sContexts), so it answers the question actually being
+# asked: which kubernetes connection is *this* server's.
+_this_servers_connection_id() {
+    _authed_get "/api/system/kubernetes/contexts?pagesize=25" \
+        | jq -r '[.contexts[]? | .connectionId // empty] | first // empty' 2>/dev/null
 }
 
 @test "[TC-1031][cut=Kubernetes Connection][tg=Connection Lifecycle] kubernetes connection broker diagnostics recover once NATS is reachable" {
@@ -94,12 +123,20 @@ _diagnostics() {
     [ "${nats_ready:-0}" -ge 1 ] 2>/dev/null \
         || skip "meshery-nats not Ready (readyReplicas=${nats_ready:-0}); if crash-looping, the operator injects the NATS token unquoted into nats.conf"
 
-    # --- 1. resolve the kubernetes connection id ---
-    run "$MESHERYCTL_BIN" connection list --kind kubernetes
-    assert_success
+    # --- 1. resolve *this server's* kubernetes connection id ---
     local conn_id
-    conn_id=$(echo "$output" | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -n1)
+    conn_id=$(_this_servers_connection_id)
+
+    # Fall back to the account-wide listing only when the contexts endpoint gave
+    # nothing (a local provider, or an older server). It is a weaker source - see
+    # the note on _this_servers_connection_id - so it is second, not first.
+    if [ -z "$conn_id" ]; then
+        run "$MESHERYCTL_BIN" connection list --kind kubernetes
+        assert_success
+        conn_id=$(echo "$output" | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -n1)
+    fi
     [ -n "$conn_id" ] || skip "no kubernetes connection found; connect the current context first"
+    echo "connectionId=$conn_id"
 
     # --- 2. sanity: diagnostics endpoint is reachable + authed, returns valid JSON ---
     local diag

--- a/mesheryctl/tests/e2e/setup_suite.bash
+++ b/mesheryctl/tests/e2e/setup_suite.bash
@@ -12,7 +12,14 @@ create_meshery_config_folder() {
 # Generate auth file to communicate with meshery server
 create_auth_file() {
     echo "start: authentication configuration"
-    echo '{ "meshery-provider": "Meshery", "token": null }' | jq -c '.token = "'$MESHERY_PROVIDER_TOKEN'"' > "$MESHERY_AUTH_FILE"
+    # Build the token in with jq --arg so the value is passed as data, never
+    # spliced into the jq program. The previous form,
+    # jq '.token = "'$MESHERY_PROVIDER_TOKEN'"', interpolated the token into the
+    # filter text: any '"' or '\' in the token would break the JSON, and an
+    # unset var would silently yield an empty token. --arg is injection-safe for
+    # any token shape.
+    jq -cn --arg token "$MESHERY_PROVIDER_TOKEN" \
+        '{ "meshery-provider": "Meshery", token: $token }' > "$MESHERY_AUTH_FILE"
     echo "done: authentication configuration"
 }
 

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -584,6 +584,7 @@ func (h *Handler) NotifySmOfConnectionStatusChange(ctx context.Context, userID c
 func (h *Handler) DeleteConnection(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
 	connectionID := uuid.FromStringOrNil(mux.Vars(req)["connectionId"])
 	userID := user.ID
+
 	token, err := provider.GetProviderToken(req)
 	if err != nil {
 		h.log.Error(ErrRetrieveUserToken(err))
@@ -594,8 +595,27 @@ func (h *Handler) DeleteConnection(w http.ResponseWriter, req *http.Request, _ *
 
 	deletedConnection, err := provider.DeleteConnection(req, connectionID)
 	if err != nil {
-		obj := "connection"
-		_err := ErrFailToSave(err, obj)
+		// Deleting an id the provider never issued is "not found", not a
+		// failure to write. The local provider says so with ErrResultNotFound;
+		// the remote provider says so with its own 404, which ErrDelete now
+		// carries (models.ErrDelete -> httputil.WithProviderStatus). Answer 404
+		// for either, and answer it *before* the failure event: a delete
+		// addressed to a stale id is a client mistake, not an incident worth a
+		// persisted error notification.
+		//
+		// Previously every failure - including a plain 404 - was wrapped in
+		// ErrFailToSave and answered 500, so `mesheryctl connection delete
+		// <unknown-uuid>` reported "Failed to Save: .connection"
+		// (meshery-server-1051), "Provider Database could be down or not
+		// reachable". That is the wrong verb, the wrong code and the wrong
+		// diagnosis for a connection that simply is not there.
+		if errors.GetCode(err) == models.ErrResultNotFoundCode || providerStatus(err) == http.StatusNotFound {
+			h.log.Warnf("No connection with ID %q found to delete", connectionID)
+			writeMeshkitError(w, err, http.StatusNotFound)
+			return
+		}
+
+		_err := ErrFailToDelete(err, "connection")
 		metadata := map[string]interface{}{
 			"error": _err,
 		}
@@ -603,17 +623,22 @@ func (h *Handler) DeleteConnection(w http.ResponseWriter, req *http.Request, _ *
 		_ = provider.PersistEvent(*event, token)
 		go h.config.EventBroadcaster.Publish(userID, event)
 
-		if errors.GetCode(err) == models.ErrResultNotFoundCode {
-			h.log.Warnf("No connection with ID %q found to delete", connectionID)
-			writeMeshkitError(w, _err, http.StatusNotFound)
-			return
-		}
 		h.log.Error(_err)
-		writeMeshkitError(w, _err, http.StatusInternalServerError)
+		// Surface the status the provider actually returned (403, 409, 5xx ...)
+		// rather than reporting every upstream refusal as a fault inside
+		// Meshery Server. The fallback stays 500 because this path is also the
+		// local provider's, where an untagged failure really is ours.
+		writeMeshkitError(w, _err, providerStatusOrInternal(err))
 		return
 	}
 
-	description := fmt.Sprintf("Connection %s deleted.", deletedConnection.Name)
+	// A provider is free to answer a successful delete without echoing the
+	// deleted row back; dereferencing it unconditionally panicked the request.
+	deletedName := connectionID.String()
+	if deletedConnection != nil && deletedConnection.Name != "" {
+		deletedName = deletedConnection.Name
+	}
+	description := fmt.Sprintf("Connection %s deleted.", deletedName)
 	event := eventBuilder.WithSeverity(events.Informational).WithDescription(description).Build()
 
 	_ = provider.PersistEvent(*event, token)

--- a/server/handlers/delete_connection_test.go
+++ b/server/handlers/delete_connection_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/gorilla/mux"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/meshkit/models/events"
+)
+
+// newDeleteConnectionFixture wires the handler the way the router does, over an
+// in-memory database. It deliberately goes through DefaultLocalProvider rather
+// than a stub: the behaviour under test is what the handler makes of a
+// provider's error, and the local provider is the one whose "not found" the
+// remote provider was taught to match.
+func newDeleteConnectionFixture(t *testing.T) (*Handler, *models.DefaultLocalProvider) {
+	t.Helper()
+
+	db, err := database.New(database.Options{Engine: database.SQLITE, Filename: ":memory:"})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := db.AutoMigrate(connections.Connection{}, events.Event{}); err != nil {
+		t.Fatalf("migrate tables: %v", err)
+	}
+
+	systemID := uuid.Must(uuid.NewV4())
+	h := &Handler{
+		config:   &models.HandlerConfig{EventBroadcaster: &models.Broadcast{}},
+		log:      newTestLogger(t),
+		SystemID: &systemID,
+	}
+	provider := &models.DefaultLocalProvider{
+		ConnectionPersister: &models.ConnectionPersister{DB: &db},
+		EventsPersister:     &models.EventsPersister{DB: &db},
+	}
+	return h, provider
+}
+
+func deleteConnection(t *testing.T, h *Handler, provider models.Provider, connectionID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/integrations/connections/"+connectionID.String(), nil)
+	req = mux.SetURLVars(req, map[string]string{"connectionId": connectionID.String()})
+	rec := httptest.NewRecorder()
+
+	h.DeleteConnection(rec, req, nil, &models.User{ID: uuid.Must(uuid.NewV4())}, provider)
+	return rec
+}
+
+// TestDeleteConnectionNotFound pins the status `mesheryctl connection delete`
+// keys off. A syntactically valid id that was never issued must come back 404,
+// which the CLI turns into a "No connection with ID ..." warning and exit 0.
+// It used to come back 500 "Failed to Save: .connection"
+// (meshery-server-1051), because every provider error - not-found included -
+// was wrapped in ErrFailToSave.
+func TestDeleteConnectionNotFound(t *testing.T) {
+	h, provider := newDeleteConnectionFixture(t)
+
+	rec := deleteConnection(t, h, provider, uuid.Must(uuid.NewV4()))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d. body: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+// TestDeleteConnectionExisting is the regression guard for the fix's blast
+// radius: the not-found path must not swallow real deletes. An earlier attempt
+// short-circuited on the handler's own database before calling the provider,
+// which 404s every connection under a remote provider - those rows live at the
+// provider, not in Meshery Server's database.
+func TestDeleteConnectionExisting(t *testing.T) {
+	h, provider := newDeleteConnectionFixture(t)
+
+	saved, err := provider.ConnectionPersister.SaveConnection(&connections.Connection{
+		Name:           "test-connection",
+		Kind:           "kubernetes",
+		ConnectionType: "platform",
+	})
+	if err != nil {
+		t.Fatalf("save connection: %v", err)
+	}
+
+	rec := deleteConnection(t, h, provider, saved.ID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if _, err := provider.ConnectionPersister.GetConnection(saved.ID, ""); err == nil {
+		t.Error("connection is still readable after a successful delete")
+	}
+}

--- a/server/handlers/utils.go
+++ b/server/handlers/utils.go
@@ -73,6 +73,15 @@ func providerStatus(err error) int {
 	return httputil.StatusForProviderError(err, http.StatusBadGateway)
 }
 
+// providerStatusOrInternal is providerStatus for a code path the *local*
+// provider also reaches. There the failure is a Meshery Server one - its own
+// database - and 502 would blame an upstream that was never involved, so the
+// fallback stays 500. A tagged provider status is still honoured, which is the
+// whole point of reading it back.
+func providerStatusOrInternal(err error) int {
+	return httputil.StatusForProviderError(err, http.StatusInternalServerError)
+}
+
 const (
 	defaultPageSize = 25
 	queryParamTrue  = "true"

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -213,9 +214,14 @@ func (cp *ConnectionPersister) DeleteConnectionById(connectionID core.Uuid) (*co
 	connection := connections.Connection{}
 	err := cp.DB.Where("id = ?", connectionID).First(&connection).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrResultNotFound(err)
 		}
+		// Any other read failure left `connection` zero-valued and fell through
+		// to Delete, which then issued an unscoped DELETE against a struct with
+		// no primary key. Report the read failure instead of acting on a row we
+		// never loaded.
+		return nil, ErrDBRead(err)
 	}
 	err = cp.DB.Delete(connection).Error
 	if err != nil {

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -347,8 +347,17 @@ func ErrRemoteProviderAuthExhausted(err error) error {
 	)
 }
 
+// ErrDelete reports a delete that the remote provider refused. Like ErrFetch
+// and ErrPost it tags the error with the provider's own HTTP status, so a
+// handler can answer with the status the provider actually returned instead of
+// fabricating one. Without the tag a DELETE of an id the provider had never
+// issued reached the client as a 500 "Failed to Save: .connection", which
+// reads as "the provider database is down" for what is only a missing record.
 func ErrDelete(err error, obj string, statusCode int) error {
-	return errors.New(ErrDeleteCode, errors.Alert, []string{"Unable to de-register Meshery Server from Remote Provider", obj}, []string{"Status Code: " + fmt.Sprint(statusCode) + " ", err.Error()}, []string{"Network connectivity to Remote Provider may not be available. Session might have expired; token could be invalid."}, []string{"Verify that the Remote Provider is available. Ensure that you have an active session / valid token."})
+	return httputil.WithProviderStatus(
+		errors.New(ErrDeleteCode, errors.Alert, []string{"Unable to de-register Meshery Server from Remote Provider", obj}, []string{"Status Code: " + fmt.Sprint(statusCode) + " ", err.Error()}, []string{"Network connectivity to Remote Provider may not be available. Session might have expired; token could be invalid."}, []string{"Verify that the Remote Provider is available. Ensure that you have an active session / valid token."}),
+		statusCode,
+	)
 }
 
 func ErrDecodeBase64(err error, obj string) error {

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -46,6 +46,23 @@ const (
 	SKIP_DOWNLOAD_EXTENSIONS_ENV       = "SKIP_DOWNLOAD_EXTENSIONS"
 )
 
+// statusOf reports the HTTP status carried by resp, or 0 when there is no
+// response to read one from.
+//
+// DoRequest returns (nil, err) for every transport-level failure and for a
+// failed token refresh, so the `if err != nil` branch of each call site holds a
+// nil response. Reading resp.StatusCode there - which ten call sites did -
+// panics precisely when the remote provider is unreachable, i.e. exactly when
+// the error path is meant to report a clean failure. 0 is the honest value:
+// the request never produced a status, and httputil.WithProviderStatus ignores
+// anything outside 400-599, so no fabricated status is propagated either.
+func statusOf(resp *http.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.StatusCode
+}
+
 func shouldPropagateProviderVersion(version string) bool {
 	normalized := strings.TrimSpace(version)
 	if normalized == "" {
@@ -1804,7 +1821,7 @@ func (l *RemoteProvider) GetEventTypes(token string, userID core.Uuid, sysID cor
 
 	resp, err := l.DoRequest(cReq, token)
 	if err != nil {
-		return eventTypes, ErrFetch(err, "Events", resp.StatusCode)
+		return eventTypes, ErrFetch(err, "Events", statusOf(resp))
 	}
 
 	defer func() {
@@ -4552,7 +4569,7 @@ func (l *RemoteProvider) GetConnections(req *http.Request, userID string, page, 
 	}
 	resp, err := l.DoRequest(cReq, tokenString)
 	if err != nil {
-		return nil, ErrFetch(err, "Connections Page", resp.StatusCode)
+		return nil, ErrFetch(err, "Connections Page", statusOf(resp))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -4687,7 +4704,7 @@ func (l *RemoteProvider) UpdateConnection(req *http.Request, connection *connect
 
 	resp, err := l.DoRequest(cReq, tokenString)
 	if err != nil {
-		return nil, ErrFetch(err, "Update Connection", resp.StatusCode)
+		return nil, ErrFetch(err, "Update Connection", statusOf(resp))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -4795,7 +4812,7 @@ func (l *RemoteProvider) DeleteConnection(req *http.Request, connectionID core.U
 	}
 	resp, err := l.DoRequest(cReq, tokenString)
 	if err != nil {
-		err = ErrDelete(err, "Connection: "+connectionID.String(), resp.StatusCode)
+		err = ErrDelete(err, "Connection: "+connectionID.String(), statusOf(resp))
 		l.Log.Error(err)
 		return nil, err
 	}
@@ -5095,7 +5112,7 @@ func (l *RemoteProvider) GetUserCredentials(req *http.Request, _ string, page, p
 	}
 	resp, err := l.DoRequest(cReq, tokenString)
 	if err != nil {
-		return nil, ErrFetch(err, "Credentials Page", resp.StatusCode)
+		return nil, ErrFetch(err, "Credentials Page", statusOf(resp))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -5131,7 +5148,7 @@ func (l *RemoteProvider) GetCredentialByID(token string, credentialID core.Uuid)
 		if resp != nil {
 			statusCode = resp.StatusCode
 		}
-		return nil, statusCode, ErrFetch(err, "Credentials Page", resp.StatusCode)
+		return nil, statusCode, ErrFetch(err, "Credentials Page", statusOf(resp))
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -5221,7 +5238,7 @@ func (l *RemoteProvider) DeleteUserCredential(req *http.Request, credentialID co
 	}
 	resp, err := l.DoRequest(cReq, tokenString)
 	if err != nil {
-		err = ErrDelete(err, "Credential: "+credentialID.String(), resp.StatusCode)
+		err = ErrDelete(err, "Credential: "+credentialID.String(), statusOf(resp))
 		l.Log.Error(err)
 		return nil, err
 	}
@@ -6086,7 +6103,7 @@ func (l *RemoteProvider) GetEnvironmentsOfWorkspace(req *http.Request, workspace
 
 	resp, err := l.DoRequest(cReq, token)
 	if err != nil {
-		return nil, ErrFetch(err, "Workspace", resp.StatusCode)
+		return nil, ErrFetch(err, "Workspace", statusOf(resp))
 	}
 
 	defer func() {
@@ -6121,7 +6138,7 @@ func (l *RemoteProvider) AddDesignToWorkspace(req *http.Request, workspaceID str
 	}
 	resp, err := l.DoRequest(cReq, token)
 	if err != nil {
-		return nil, ErrFetch(err, "Workspace", resp.StatusCode)
+		return nil, ErrFetch(err, "Workspace", statusOf(resp))
 	}
 	defer func() {
 		_ = resp.Body.Close()
@@ -6178,7 +6195,7 @@ func (l *RemoteProvider) GetDesignsOfWorkspace(req *http.Request, workspaceID, p
 	}
 	resp, err := l.DoRequest(cReq, token)
 	if err != nil {
-		return nil, ErrFetch(err, "Workspace", resp.StatusCode)
+		return nil, ErrFetch(err, "Workspace", statusOf(resp))
 	}
 	defer func() {
 		_ = resp.Body.Close()

--- a/server/models/remote_provider_connections_test.go
+++ b/server/models/remote_provider_connections_test.go
@@ -1,0 +1,116 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models/httputil"
+	"github.com/meshery/meshkit/errors"
+)
+
+// newDeleteConnectionRequest builds the inbound request DeleteConnection reads
+// its provider token off. RemoteProvider.GetToken takes the token from the
+// session cookie, so a request without one never reaches the outbound call.
+func newDeleteConnectionRequest(t *testing.T) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/integrations/connections/x", nil)
+	req.AddCookie(&http.Cookie{Name: TokenCookieName, Value: "test-token"})
+	return req
+}
+
+// TestRemoteProviderDeleteConnectionPropagatesStatus pins the contract the
+// connection handler depends on: whatever status the remote provider returned
+// for a DELETE must survive on the error, so the handler can answer with it
+// rather than inventing one.
+//
+// The case that mattered is 404. `mesheryctl connection delete <unknown-uuid>`
+// is expected to warn "No connection with ID ..." and exit 0, which it decides
+// from an HTTP 404. Before ErrDelete carried the provider status, a remote 404
+// reached the handler as an opaque error, was wrapped in ErrFailToSave and
+// answered 500 "Failed to Save: .connection" (meshery-server-1051) with a
+// "Provider Database could be down or not reachable" remediation - for an id
+// that was simply never issued.
+func TestRemoteProviderDeleteConnectionPropagatesStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteCode int
+		wantStatus int
+	}{
+		{name: "not found", remoteCode: http.StatusNotFound, wantStatus: http.StatusNotFound},
+		{name: "forbidden", remoteCode: http.StatusForbidden, wantStatus: http.StatusForbidden},
+		{name: "provider error", remoteCode: http.StatusInternalServerError, wantStatus: http.StatusInternalServerError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf("expected DELETE, got %s", r.Method)
+				}
+				w.WriteHeader(tc.remoteCode)
+				_, _ = w.Write([]byte(`{"error":"no such connection"}`))
+			}))
+			defer server.Close()
+
+			provider := newTestRemoteProvider(t, server.URL)
+			provider.Capabilities = Capabilities{
+				{Feature: PersistConnection, Endpoint: "/api/integrations/connections"},
+			}
+
+			conn, err := provider.DeleteConnection(newDeleteConnectionRequest(t), uuid.Must(uuid.NewV4()))
+			if err == nil {
+				t.Fatalf("expected an error for remote status %d, got connection %+v", tc.remoteCode, conn)
+			}
+			if conn != nil {
+				t.Errorf("expected no connection alongside the error, got %+v", conn)
+			}
+
+			got, ok := httputil.ProviderStatusCode(err)
+			if !ok {
+				t.Fatalf("error did not carry the provider status: %v", err)
+			}
+			if got != tc.wantStatus {
+				t.Errorf("provider status = %d, want %d (err: %v)", got, tc.wantStatus, err)
+			}
+		})
+	}
+}
+
+// TestRemoteProviderDeleteConnectionUnreachableProvider covers the error path
+// that used to panic: DoRequest returns (nil, err) when the provider cannot be
+// reached, and every caller then read resp.StatusCode off that nil response.
+// The failure has to come back as an error, not a nil-pointer dereference in
+// the request goroutine.
+func TestRemoteProviderDeleteConnectionUnreachableProvider(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	unreachableURL := server.URL
+	server.Close() // nothing is listening on this port any more
+
+	provider := newTestRemoteProvider(t, unreachableURL)
+	provider.Capabilities = Capabilities{
+		{Feature: PersistConnection, Endpoint: "/api/integrations/connections"},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("DeleteConnection panicked on an unreachable provider: %v", r)
+		}
+	}()
+
+	conn, err := provider.DeleteConnection(newDeleteConnectionRequest(t), uuid.Must(uuid.NewV4()))
+	if err == nil {
+		t.Fatalf("expected an error for an unreachable provider, got connection %+v", conn)
+	}
+	if errors.GetCode(err) != ErrDeleteCode {
+		t.Errorf("error code = %q, want %q (err: %v)", errors.GetCode(err), ErrDeleteCode, err)
+	}
+	// The request never produced an HTTP status, so none must be claimed - a
+	// fabricated status is what makes an unreachable provider look like a
+	// deliberate refusal.
+	if status, ok := httputil.ProviderStatusCode(err); ok {
+		t.Errorf("expected no provider status for an unreachable provider, got %d", status)
+	}
+}


### PR DESCRIPTION
## Description

Fixes the Connection Lifecycle failures in the `mesheryctl-e2e` BATS suite, at the layer each one
actually lives in. Three of the four causes were not what the failing output suggested - in
particular, **the Meshery Broker was healthy the entire time.**

### 1. `[mesheryctl]` The broker is fine; we were looking for the wrong name - TC-1034

`mesheryctl system check --operator` reports `!! Meshery Broker is not running`. Diagnostics
added to the e2e job show the broker up and Ready throughout:

```
meshery-nats-0                  2/2   Running   5m30s
statefulset.apps/meshery-nats   1/1   5m30s
```

**Root cause.** Meshery Operator >= 1.0.0 renders the broker from the official NATS chart, so the
workload is `meshery-nats`; before that it was `meshery-broker`. The rename is already recorded in
`server/integration-tests/meshsync/infrastructure/setup.sh`, which was updated - and three other
places were not:

- `check.go` scans pod names for `meshery-broker`, which is TC-1034 itself;
- `000-prerequisites/00-servert.bats` asserts the pod `^meshery-broker-[0-9]+$` and the service
  `^meshery-broker$` - two more failures with the same cause and nothing to do with broker health;
- the job's broker wait polled its full 300s against a statefulset that does not exist, while the
  broker had been ready for five minutes.

All three now accept either name, because which one applies is a property of the cluster's operator
version, not of the CLI. **Only the workload was renamed** - the Broker *custom resource* is still
`meshery-broker`, so the CR lookups in `check.go` and `system/stop.go` are correct as they stand and
are deliberately untouched.

### 2. `[mesheryctl]` A list must not fail because there is no terminal to page on - TC-1031

`mesheryctl connection list` exits non-zero in CI, in a pipeline, or under any script, as soon as
the account holds more than one page of results. It prints a correct first page and then:

```
Error: open /dev/tty: no such device or address
```

**Root cause.** Interactive paging waits on a keypress via `keyboard.GetKeys`, which reads the
*controlling terminal* directly. Where there is no controlling terminal that call does not block -
it fails - and the error was returned as the command's error. Nothing checked first whether
interactive input was possible at all.

**Fix.** Probe for a terminal (`utils.IsInteractiveTerminal`: both stdin and stdout, via the
terminal driver rather than the file mode, so `/dev/null` answers correctly) and degrade instead of
failing. Paging stops after the page it has printed and names the flags that select another - what
`--page` already gives, and what makes `mesheryctl ... list | grep` behave like every other CLI
whose pager is off when output is not a tty. Selection prompts still fail, because choosing on the
user's behalf would act on a resource the user did not name - but with `ErrAmbiguousSelection`
(`mesheryctl-1253`), which says the match was ambiguous and to use an ID, rather than naming
`/dev/tty` as though the device were the problem.

Two further defects on the same test, both making TC-1031 fail for reasons unrelated to the broker:

- It curls the diagnostics endpoint at a hardcoded `http://localhost:9081`, right only when the
  server is on loopback. Under `mesheryctl system start --platform kubernetes` it is published at
  the context's endpoint, so the curl could not connect. It now resolves the endpoint from the
  config the rest of the suite uses.
- That failure *aborted* the test rather than skipping it: the test has a reachability guard, but it
  sits after `diag=$(_diagnostics ...)`, and curl's non-zero exit propagated out of the assignment
  first.

### 3. `[Server]` Answer 404 when deleting a connection the provider does not have - TC-1066

**Symptom.** `mesheryctl connection delete <valid-but-unknown-uuid>` failed with
`500 "Failed to Save: .connection"` (`meshery-server-1051`), probable cause *"Provider Database
could be down or not reachable"*. The test expects the documented behaviour: warn
`No connection with ID ...` and exit 0, which the CLI decides from an HTTP 404.

**Root cause.** `models.ErrDelete` was the only member of the provider-error family that did not
record the provider's HTTP status. `ErrFetch` and `ErrPost` both wrap themselves in
`httputil.WithProviderStatus` so a handler can answer with the status the provider actually returned
(see the rationale on `handlers/utils.go:providerStatus`); `ErrDelete` only rendered the status into
its cause *text*, where nothing can read it. Every provider failure - not-found included - therefore
reached the client as `ErrFailToSave` and a hardcoded 500.

**Fix**, at each layer that owns part of it:

- `models.ErrDelete` now tags the provider status, like `ErrFetch`/`ErrPost`.
- `handlers.DeleteConnection` answers 404 for either provider's "not found" (the local provider's
  `ErrResultNotFound`, or a tagged remote 404), and does so *before* building the failure event - a
  delete addressed to a stale id is a client mistake, not an incident worth a persisted error
  notification. Other failures use `ErrFailToDelete` (`meshery-server-1052`) instead of
  `ErrFailToSave`, and the provider's real status instead of a hardcoded 500.

**This half is necessary but not sufficient, and TC-1066 still fails.** Meshery Cloud answers
**500**, not 404, for a delete of an id it does not have. From the run log:

```
Status Code: 500 .error while deleting connection: sql: no rows in result set
| Short Description: Unable to update connection status
| Probable Cause: Connection was already deleted. User might not have necessary privileges
```

`layer5io/meshery-cloud` `server/handlers/connections.go:DeleteConnection` maps every DAO error to
`http.StatusInternalServerError`. `DeleteMesheryConnection`, immediately below it in the same file,
already does the right thing (`if err == sql.ErrNoRows { ... http.StatusNotFound }`) and documents
why. TC-1066 goes green once `DeleteConnection` follows that precedent; the change here is what
carries the 404 through to the CLI when it does. Tracked separately - different repository.

**Watch for.** An earlier attempt at this fix checked the connection's existence against Meshery
Server's own database before calling the provider. That 404s *every* connection under a remote
provider, where those rows do not live locally. `TestDeleteConnectionExisting` is the regression
guard.

### Out-of-scope defects found on the same paths, fixed here

- **Nil-pointer dereference, 10 call sites.** `l.DoRequest` returns `(nil, err)` on every
  transport-level failure, yet ten call sites read `resp.StatusCode` inside `if err != nil` - a
  panic precisely when the remote provider is unreachable. Routed through a `statusOf` helper that
  reports 0 when there is no response; 0 is outside `WithProviderStatus`'s 400-599 range, so an
  unreachable provider claims no status rather than a fabricated one.
- **`ConnectionPersister.DeleteConnectionById` fell through on a read error.** It returned only for
  `ErrRecordNotFound`; any other read failure left the struct zero-valued and proceeded to `Delete`
  with no primary key. It now reports the read failure.
- **`DeleteConnection` dereferenced the provider's returned connection** without a nil check when
  naming the success event.

### 4. `[CI]` Make provider auth deterministic and diagnosable - TC-1076 x4, TC-1077, TC-1078, TC-1013

- Pin `PROVIDER_BASE_URLS=https://cloud.meshery.io` on the in-cluster deployment. The released image
  ships the full default provider list, where a second URL can win the `Meshery` providerName by
  collision re-keying - the token is then presented to the wrong backend and comes back 401,
  surfacing as `meshery-server-1032` on reads.
- Build `auth.json` with `jq --arg` instead of splicing the token into the jq program. The previous
  form interpolated the secret into the filter text: any quote or backslash produced invalid JSON,
  and an unset variable silently produced an empty token.
- Add a remote-provider auth diagnostics step (registered provider, `auth.json` shape - token
  *length* only, never the value - and provider/401 lines from the server log).

## Testing

**E2E, read as actual BATS verdicts rather than job badges.** Across three `workflow_dispatch`
runs on this branch the Connection Lifecycle results went 41 pass / 1 skip / 3 fail ->
**42 pass / 2 skip / 1 fail**. Of the twelve cases this PR targets, **ten pass**: TC-1076 x4,
TC-1077, TC-1078, TC-1013, TC-1080 x2 and TC-1034. TC-1031 skips on a precondition the job
itself creates, and TC-1066 is blocked in meshery-cloud. Both are set out with evidence in a
[comment on this PR](https://github.com/meshery/meshery/pull/21120#issuecomment-5182647700),
along with the two `000-prerequisites` broker tests that this also fixes.

**Go unit tests, added:**

- `server/models/remote_provider_connections_test.go` - the remote provider's status propagation
  (404 / 403 / 500), and the unreachable-provider case that used to panic.
- `server/handlers/delete_connection_test.go` - 404 for an unknown id, 200 for an existing one (the
  latter guarding the blast radius described above).
- `mesheryctl/internal/cli/root/system/broker_name_test.go` - the broker is recognised under both
  workload names, via `GetCleanPodName`, and nothing else in the namespace is.
- `mesheryctl/internal/cli/pkg/display/noninteractive_test.go` - paging stops rather than failing
  without a terminal; an ambiguous match fails with `mesheryctl-1253`; a single match still
  resolves; one page of many does not auto-select.
- `mesheryctl/pkg/utils/interactive_test.go` - the terminal probe against a pipe, `/dev/null` and a
  regular file.

**Local:** `go test ./server/...` and `go test --short ./mesheryctl/...` pass, except three failures
that reproduce identically on `master` without this branch's changes (`TestFetchKubernetesVersion`,
which needs a live cluster; `TestProfileCmd`; `TestRunProviderWithNoCmdOrFlag`, a docs-URL
mismatch). `golangci-lint run` reports 0 issues on every package touched.

**Note on TC-1066 in CI:** the `mesheryctl-e2e` job builds only `mesheryctl` and then runs
`mesheryctl system start`, which deploys the *released* Meshery Server image - not a server built
from this branch. The server-side half of TC-1066 is therefore not exercised by a pre-merge run of
that workflow at all; it is covered by the unit tests above. That difference, and three others that
account for every CI-only failure in this suite so far, are now written down in the contributing
docs.

## Notes for Reviewers

`ErrDelete` now carrying a provider status changes the HTTP status of *other* delete paths that
surface it, from a hardcoded 500 to the provider's real status. That is the direction
`handlers/utils.go:providerStatus` already documents as intended; calling it out because it reaches
beyond the connection handler. The connection handler uses a 500 fallback rather than that helper's
502, because it is also the local provider's path, where an untagged failure really is ours.

The diff is over the 500-line guideline. Roughly half is tests and docs.

## Signed commits

- [x] Yes, I signed off my commits.
