### PR TITLE
feat(catalog): add AWS 3-Tier Web Application design

### DIFF
--- a/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/artifacthub-pkg.yml
+++ b/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/artifacthub-pkg.yml
@@ -1,0 +1,24 @@
+createdAt: '2026-08-04T13:23:00Z'
+description: Provisions a standard 3-tier web application infrastructure utilizing
+  VPC, public/private subnets, Elastic Load Balancers, EC2 Web/App instances, and
+  RDS databases.
+displayName: AWS 3-Tier Web Application
+homeURL: https://docs.meshery.io/concepts/logical/designs
+install: mesheryctl design import -f
+license: Apache-2.0
+links:
+- name: download
+  url: ../../catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/design.yml
+- name: Meshery Catalog
+  url: https://meshery.io/catalog
+logoURL: https://raw.githubusercontent.com/meshery/meshery.io/0b8585231c6e2b3251d38f749259360491c9ee6b/assets/images/brand/meshery-logo.svg
+name: aws-3-tier-web-application
+provider:
+  name: 54a58e68-8c83-4683-a84e-4cf8d3256649
+readme: "Provisions a standard 3-tier web application infrastructure utilizing VPC,\
+  \ public/private subnets, Elastic Load Balancers, EC2 Web/App instances, and RDS\
+  \ databases.\n ##h4 Caveats and Consideration \n"
+screenshots:
+- title: Meshery Project
+  url: https://raw.githubusercontent.com/meshery/meshery.io/master/assets/images/logos/meshery-gradient.png
+version: 0.0.1

--- a/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/artifacthub-pkg.yml
+++ b/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/artifacthub-pkg.yml
@@ -17,7 +17,8 @@ provider:
   name: 54a58e68-8c83-4683-a84e-4cf8d3256649
 readme: "Provisions a standard 3-tier web application infrastructure utilizing VPC,\
   \ public/private subnets, Elastic Load Balancers, EC2 Web/App instances, and RDS\
-  \ databases.\n ##h4 Caveats and Consideration \n"
+  \ databases.\n\n#### Caveats and Consideration\n\nSubnet parenting relationships\
+  \ require PR #21072 to be merged for full visual nesting.\n"
 screenshots:
 - title: Meshery Project
   url: https://raw.githubusercontent.com/meshery/meshery.io/master/assets/images/logos/meshery-gradient.png

--- a/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/design.yml
+++ b/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/design.yml
@@ -1,0 +1,1475 @@
+components:
+- capabilities: null
+  component:
+    kind: VPC
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      labels:
+        aws-3tier-vpc: ''
+      namespace: default
+    spec:
+      cidrBlocks: []
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: aws-3tier-vpc
+  format: JSON
+  id: e62998a2-032c-460a-8ace-961f0688eef5
+  metadata:
+    configurationUISchema: ''
+    genealogy: parent
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1380.0756071277533
+      y: 1164.117186060431
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/vpc-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/vpc-white.svg
+    width: 24
+    z-index: 3
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: Subnet
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      vpcRef:
+        from:
+          name: aws-3tier-vpc
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: private-db-subnet
+  format: JSON
+  id: 4c67bacc-4e85-4113-9aca-24a335032042
+  metadata:
+    configurationUISchema: ''
+    genealogy: parent
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 30.476828
+    opacity: 1
+    padding: 6
+    position:
+      x: 1700
+      y: 1100
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/subnet-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/subnet-white.svg
+    width: 125.00802
+    z-index: 4
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: Subnet
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      vpcRef:
+        from:
+          name: aws-3tier-vpc
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: private-app-subnet
+  format: JSON
+  id: 682e3318-527d-4a42-9ea0-c2831b738d99
+  metadata:
+    configurationUISchema: ''
+    genealogy: parent
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1400
+      y: 1100
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/subnet-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/subnet-white.svg
+    width: 24
+    z-index: 5
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: Subnet
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      vpcRef:
+        from:
+          name: aws-3tier-vpc
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: public-web-subnet
+  format: JSON
+  id: 33017ce6-4acd-4253-8884-e49c4e383d15
+  metadata:
+    configurationUISchema: ''
+    genealogy: parent
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1100
+      y: 1100
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/subnet-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/subnet-white.svg
+    width: 24
+    z-index: 6
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: AWS Elastic Load Balancing
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration: {}
+  created_at: '0001-01-01T00:00:00Z'
+  description: AWS Elastic Load Balancing distributes incoming application traffic across multiple targets.
+  displayName: aws-load-balancer
+  format: JSON
+  id: 8e5100ce-9bba-4973-9204-274cb647ddaf
+  metadata:
+    configurationUISchema: ''
+    genealogy: child
+    instanceDetails: null
+    isAnnotation: true
+    isNamespaced: false
+    published: true
+  model: null
+  modelReference:
+    displayName: Amazon Web Services
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: 0.7.2
+    name: aws
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 0
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1100
+      y: 1100
+    primaryColor: '#8C4FFF'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws/color/aws elastic load balancing-color.svg
+    svgComplete: ui/public/static/img/meshmodels/aws/complete/aws elastic load balancing-complete.svg
+    svgWhite: ui/public/static/img/meshmodels/aws/white/aws elastic load balancing-white.svg
+    width: 24
+    z-index: 8
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: Instance
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      subnetRef:
+        from:
+          name: private-app-subnet
+  created_at: '0001-01-01T00:00:00Z'
+  description: AWS EC2 Instance represents a virtual compute resource.
+  displayName: aws-instance
+  format: JSON
+  id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+  metadata:
+    configurationUISchema: ''
+    genealogy: child
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1400
+      y: 1100
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/instance-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/instance-white.svg
+    width: 24
+    z-index: 8
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: DBInstance
+    schema: ''
+    version: rds.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      dbInstanceClass: db.t3.micro
+      dbInstanceIdentifier: aws-rds-db
+      engine: mysql
+      subnetRef:
+        from:
+          name: private-db-subnet
+  created_at: '0001-01-01T00:00:00Z'
+  description: AWS RDS DBInstance represents a secure relational database instance.
+  displayName: aws-rds-db
+  format: JSON
+  id: b0f3c3d2-e4d5-5a6b-7c8d-9e0f1a2b3c4d
+  metadata:
+    configurationUISchema: ''
+    genealogy: child
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/rds-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS Relational Database Service
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.0.0
+    name: aws-rds-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1700
+      y: 1100
+    primaryColor: '#C925D1'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-rds-controller/color/dbinstance-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-rds-controller/white/dbinstance-white.svg
+    width: 24
+    z-index: 8
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: InternetGateway
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      vpcRef:
+        from:
+          name: aws-3tier-vpc
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: IGW-Main
+  format: JSON
+  id: 892fc6e3-8115-5ad2-945c-ce8ebad33dc8
+  metadata:
+    configurationUISchema: ''
+    genealogy: ''
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: &id001
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant: &id002
+      kind: github
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1100
+      y: 900
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/internetgateway-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/internetgateway-white.svg
+    width: 24
+    z-index: 9
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: ElasticIPAddress
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec: {}
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: NAT-EIP
+  format: JSON
+  id: e924f3b7-13b9-5d81-abe8-f5b9408c6852
+  metadata:
+    configurationUISchema: ''
+    genealogy: ''
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1400
+      y: 900
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/elasticipaddress-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/elasticipaddress-white.svg
+    width: 24
+    z-index: 9
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: NATGateway
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      allocationRef:
+        from:
+          name: NAT-EIP
+      subnetRef:
+        from:
+          name: public-web-subnet
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: NAT-Gateway
+  format: JSON
+  id: 860e5882-5527-5985-92a3-d9a17e456974
+  metadata:
+    configurationUISchema: ''
+    genealogy: ''
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1100
+      y: 1050
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/natgateway-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/natgateway-white.svg
+    width: 24
+    z-index: 9
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: RouteTable
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      routes:
+      - destinationCIDRBlock: 0.0.0.0/0
+        gatewayRef:
+          from:
+            name: IGW-Main
+      vpcRef:
+        from:
+          name: aws-3tier-vpc
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: RouteTable-Public
+  format: JSON
+  id: b5fdc97f-c9ed-5fe7-8eb3-dbadc7b966ee
+  metadata:
+    configurationUISchema: ''
+    genealogy: ''
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1000
+      y: 1250
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/routetable-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/routetable-white.svg
+    width: 24
+    z-index: 9
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+- capabilities: null
+  component:
+    kind: RouteTable
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    metadata:
+      namespace: default
+    spec:
+      routes:
+      - destinationCIDRBlock: 0.0.0.0/0
+        natGatewayRef:
+          from:
+            name: NAT-Gateway
+      vpcRef:
+        from:
+          name: aws-3tier-vpc
+  created_at: '0001-01-01T00:00:00Z'
+  description: ''
+  displayName: RouteTable-Private
+  format: JSON
+  id: 522e9a17-f767-50f6-8c40-9d22b661025b
+  metadata:
+    configurationUISchema: ''
+    genealogy: ''
+    instanceDetails: null
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    source_uri: git://github.com/aws-controllers-k8s/ec2-controller/main/helm
+  model: null
+  modelReference:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: components.meshery.io/v1beta2
+  status: enabled
+  styles:
+    background-opacity: 1
+    body-text: ''
+    body-text-color: '#808080'
+    body-text-font-family: Qanelas Soft
+    body-text-font-size: 12
+    body-text-font-weight: '400'
+    body-text-horizontal-align: center
+    body-text-text-decoration: none
+    body-text-vertical-align: center
+    border-width: 0
+    height: 24
+    opacity: 1
+    padding: 6
+    position:
+      x: 1400
+      y: 1250
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    shape: rectangle
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/routetable-color.svg
+    svgComplete: ''
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/routetable-white.svg
+    width: 24
+    z-index: 9
+  updated_at: '0001-01-01T00:00:00Z'
+  version: v1.0.0
+id: 313ecf58-8c0c-475a-88ca-6d378f8ce95c
+name: AWS 3-Tier Web Application Better
+preferences:
+  layers:
+    expandedComponents:
+      e62998a2-032c-460a-8ace-961f0688eef5: true
+relationships:
+- evaluationQuery: null
+  id: 1bb63774-ffec-4030-931d-5d5471a90cf2
+  kind: hierarchical
+  metadata:
+    description: ''
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: 4c67bacc-4e85-4113-9aca-24a335032042
+        kind: Subnet
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model:
+            version: ''
+          name: aws-ec2-controller
+          registrant:
+            kind: github
+          version: ''
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - vpcRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: e62998a2-032c-460a-8ace-961f0688eef5
+        kind: VPC
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model:
+            version: ''
+          name: aws-ec2-controller
+          registrant:
+            kind: github
+          version: ''
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: be8b8506-0a51-4010-bc62-9e43cbcacca2
+  kind: hierarchical
+  metadata:
+    description: ''
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: 682e3318-527d-4a42-9ea0-c2831b738d99
+        kind: Subnet
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model:
+            version: ''
+          name: aws-ec2-controller
+          registrant:
+            kind: github
+          version: ''
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - vpcRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: e62998a2-032c-460a-8ace-961f0688eef5
+        kind: VPC
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model:
+            version: ''
+          name: aws-ec2-controller
+          registrant:
+            kind: github
+          version: ''
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: 0cc08644-c99b-4dd1-b5e1-ebdeff9d069d
+  kind: hierarchical
+  metadata:
+    description: ''
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: 33017ce6-4acd-4253-8884-e49c4e383d15
+        kind: Subnet
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model:
+            version: ''
+          name: aws-ec2-controller
+          registrant:
+            kind: github
+          version: ''
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - vpcRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: e62998a2-032c-460a-8ace-961f0688eef5
+        kind: VPC
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model:
+            version: ''
+          name: aws-ec2-controller
+          registrant:
+            kind: github
+          version: ''
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: 11b00c3d-3847-472d-aadb-f3b53f6c8516
+  kind: hierarchical
+  metadata:
+    description: Nests AWS Elastic Load Balancer inside public-web-subnet
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: 8e5100ce-9bba-4973-9204-274cb647ddaf
+        kind: AWS Elastic Load Balancing
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws
+      to:
+      - id: 33017ce6-4acd-4253-8884-e49c4e383d15
+        kind: Subnet
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: 27ea0c49-b532-406e-8545-5c188d90b87a
+  kind: hierarchical
+  metadata:
+    description: Nests Instance inside private-app-subnet
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.18.4
+    name: aws-ec2-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+        kind: Instance
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - subnetRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: 682e3318-527d-4a42-9ea0-c2831b738d99
+        kind: Subnet
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: 27348a57-141b-46a7-8a25-21ca9ecca008
+  kind: hierarchical
+  metadata:
+    description: Nests DBInstance inside private-db-subnet
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS Relational Database Service
+    id: 00000000-0000-0000-0000-000000000000
+    model:
+      version: v1.0.0
+    name: aws-rds-controller
+    registrant:
+      kind: github
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: b0f3c3d2-e4d5-5a6b-7c8d-9e0f1a2b3c4d
+        kind: DBInstance
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-rds-controller
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - subnetRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: 4c67bacc-4e85-4113-9aca-24a335032042
+        kind: Subnet
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- id: d50fa882-0dd2-4a07-b14e-11741ccb7d4e
+  kind: edge
+  metadata:
+    description: Network connection from Load Balancer to EC2 Instance
+  selectors:
+  - allow:
+      from:
+      - id: 8e5100ce-9bba-4973-9204-274cb647ddaf
+        kind: AWS Elastic Load Balancing
+        model:
+          name: aws
+      to:
+      - id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+        kind: Instance
+        model:
+          name: aws-ec2-controller
+  status: approved
+  subType: network
+  type: connection
+- id: 6119b89e-d18a-43b7-9cdb-f43ee7c09997
+  kind: edge
+  metadata:
+    description: Network connection from EC2 Instance to RDS Database
+  selectors:
+  - allow:
+      from:
+      - id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+        kind: Instance
+        model:
+          name: aws-ec2-controller
+      to:
+      - id: b0f3c3d2-e4d5-5a6b-7c8d-9e0f1a2b3c4d
+        kind: DBInstance
+        model:
+          name: aws-rds-controller
+  status: approved
+  subType: network
+  type: connection
+- evaluationQuery: null
+  id: 0d105cc6-c4eb-52ff-ba2a-4b49c20f09cd
+  kind: hierarchical
+  metadata:
+    description: Nests IGW-Main inside the VPC (attaches via spec.vpcRef).
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: 892fc6e3-8115-5ad2-945c-ce8ebad33dc8
+        kind: InternetGateway
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - vpcRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: e62998a2-032c-460a-8ace-961f0688eef5
+        kind: VPC
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: 3c420272-3346-549f-8dbc-a741c34078a2
+  kind: hierarchical
+  metadata:
+    description: Nests RouteTable-Public inside the VPC (attaches via spec.vpcRef).
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: b5fdc97f-c9ed-5fe7-8eb3-dbadc7b966ee
+        kind: RouteTable
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - vpcRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: e62998a2-032c-460a-8ace-961f0688eef5
+        kind: VPC
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: b4b04ae3-e9f5-5237-9cc3-9158f3459998
+  kind: hierarchical
+  metadata:
+    description: Nests RouteTable-Private inside the VPC (attaches via spec.vpcRef).
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: 522e9a17-f767-50f6-8c40-9d22b661025b
+        kind: RouteTable
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - vpcRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: e62998a2-032c-460a-8ace-961f0688eef5
+        kind: VPC
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- evaluationQuery: null
+  id: 53d81672-c4c4-590c-87a3-9a6536ef09d0
+  kind: hierarchical
+  metadata:
+    description: Nests NAT-Gateway inside public-web-subnet (attaches via spec.subnetRef).
+    isAnnotation: false
+    styles:
+      primaryColor: ''
+      svgColor: ''
+      svgWhite: ''
+  model:
+    displayName: AWS EC2
+    id: 00000000-0000-0000-0000-000000000000
+    model: *id001
+    name: aws-ec2-controller
+    registrant: *id002
+    version: v1.0.0
+  schemaVersion: ''
+  selectors:
+  - allow:
+      from:
+      - id: 860e5882-5527-5985-92a3-d9a17e456974
+        kind: NATGateway
+        match: {}
+        matchStrategyMatrix: null
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatedRef:
+          - - configuration
+            - spec
+            - subnetRef
+            - from
+            - name
+          patchStrategy: replace
+      to:
+      - id: 33017ce6-4acd-4253-8884-e49c4e383d15
+        kind: Subnet
+        match: {}
+        model:
+          displayName: ''
+          id: 00000000-0000-0000-0000-000000000000
+          model: {}
+          name: aws-ec2-controller
+        patch:
+          mutatorRef:
+          - - displayName
+          patchStrategy: replace
+    deny:
+      from: []
+      to: []
+  status: pending
+  subType: inventory
+  type: parent
+  version: ''
+- id: 1018c06b-3658-56fd-891c-076af932aa69
+  kind: edge
+  metadata:
+    description: RouteTable-Public sends 0.0.0.0/0 to IGW-Main.
+  selectors:
+  - allow:
+      from:
+      - id: b5fdc97f-c9ed-5fe7-8eb3-dbadc7b966ee
+        kind: RouteTable
+        model:
+          name: aws-ec2-controller
+      to:
+      - id: 892fc6e3-8115-5ad2-945c-ce8ebad33dc8
+        kind: InternetGateway
+        model:
+          name: aws-ec2-controller
+  status: approved
+  subType: network
+  type: connection
+- id: a59a81df-649f-5aff-a396-9a01998f8198
+  kind: edge
+  metadata:
+    description: RouteTable-Private sends 0.0.0.0/0 to NAT-Gateway.
+  selectors:
+  - allow:
+      from:
+      - id: 522e9a17-f767-50f6-8c40-9d22b661025b
+        kind: RouteTable
+        model:
+          name: aws-ec2-controller
+      to:
+      - id: 860e5882-5527-5985-92a3-d9a17e456974
+        kind: NATGateway
+        model:
+          name: aws-ec2-controller
+  status: approved
+  subType: network
+  type: connection
+- id: e924f3b7-13b9-5d81-abe8-f5b9408c6852
+  kind: edge
+  metadata:
+    description: NAT-Gateway uses NAT-EIP as its public IP allocation.
+  selectors:
+  - allow:
+      from:
+      - id: 860e5882-5527-5985-92a3-d9a17e456974
+        kind: NATGateway
+        model:
+          name: aws-ec2-controller
+      to:
+      - id: e924f3b7-13b9-5d81-abe8-f5b9408c6852
+        kind: ElasticIPAddress
+        model:
+          name: aws-ec2-controller
+  status: approved
+  subType: network
+  type: connection
+schemaVersion: designs.meshery.io/v1beta3
+version: 0.0.48

--- a/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/design.yml
+++ b/docs/data/catalog/313ecf58-8c0c-475a-88ca-6d378f8ce95c/0.0.1/design.yml
@@ -10,7 +10,8 @@ components:
         aws-3tier-vpc: ''
       namespace: default
     spec:
-      cidrBlocks: []
+      cidrBlocks:
+      - 10.0.0.0/16
   created_at: '0001-01-01T00:00:00Z'
   description: ''
   displayName: aws-3tier-vpc
@@ -72,6 +73,8 @@ components:
     metadata:
       namespace: default
     spec:
+      cidrBlock: 10.0.3.0/24
+      availabilityZone: us-east-1c
       vpcRef:
         from:
           name: aws-3tier-vpc
@@ -136,6 +139,8 @@ components:
     metadata:
       namespace: default
     spec:
+      cidrBlock: 10.0.2.0/24
+      availabilityZone: us-east-1b
       vpcRef:
         from:
           name: aws-3tier-vpc
@@ -200,6 +205,9 @@ components:
     metadata:
       namespace: default
     spec:
+      cidrBlock: 10.0.1.0/24
+      availabilityZone: us-east-1a
+      mapPublicIPOnLaunch: true
       vpcRef:
         from:
           name: aws-3tier-vpc
@@ -321,6 +329,8 @@ components:
     metadata:
       namespace: default
     spec:
+      imageID: ami-0c02fb55956c7d316
+      instanceType: t3.micro
       subnetRef:
         from:
           name: private-app-subnet
@@ -328,7 +338,7 @@ components:
   description: AWS EC2 Instance represents a virtual compute resource.
   displayName: aws-instance
   format: JSON
-  id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+  id: 79548ad5-fcbf-495c-9786-353832b50257
   metadata:
     configurationUISchema: ''
     genealogy: child
@@ -395,7 +405,7 @@ components:
   description: AWS RDS DBInstance represents a secure relational database instance.
   displayName: aws-rds-db
   format: JSON
-  id: b0f3c3d2-e4d5-5a6b-7c8d-9e0f1a2b3c4d
+  id: b083c727-a274-46c9-946f-02db402f71ac
   metadata:
     configurationUISchema: ''
     genealogy: child
@@ -766,7 +776,7 @@ components:
   updated_at: '0001-01-01T00:00:00Z'
   version: v1.0.0
 id: 313ecf58-8c0c-475a-88ca-6d378f8ce95c
-name: AWS 3-Tier Web Application Better
+name: AWS 3-Tier Web Application
 preferences:
   layers:
     expandedComponents:
@@ -1049,7 +1059,7 @@ relationships:
   selectors:
   - allow:
       from:
-      - id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+      - id: 79548ad5-fcbf-495c-9786-353832b50257
         kind: Instance
         match: {}
         model:
@@ -1108,7 +1118,7 @@ relationships:
   selectors:
   - allow:
       from:
-      - id: b0f3c3d2-e4d5-5a6b-7c8d-9e0f1a2b3c4d
+      - id: b083c727-a274-46c9-946f-02db402f71ac
         kind: DBInstance
         match: {}
         model:
@@ -1156,7 +1166,7 @@ relationships:
         model:
           name: aws
       to:
-      - id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+      - id: 79548ad5-fcbf-495c-9786-353832b50257
         kind: Instance
         model:
           name: aws-ec2-controller
@@ -1170,12 +1180,12 @@ relationships:
   selectors:
   - allow:
       from:
-      - id: a0f2b2c1-d3c4-4a5b-6c7d-8e9f0a1b2c3d
+      - id: 79548ad5-fcbf-495c-9786-353832b50257
         kind: Instance
         model:
           name: aws-ec2-controller
       to:
-      - id: b0f3c3d2-e4d5-5a6b-7c8d-9e0f1a2b3c4d
+      - id: b083c727-a274-46c9-946f-02db402f71ac
         kind: DBInstance
         model:
           name: aws-rds-controller


### PR DESCRIPTION
### Description
This PR adds a pre-configured, production-ready **AWS 3-Tier Web Application** design entry to the Meshery catalog. The topology provisions a classic cloud infrastructure including a VPC, public/private subnets, an Elastic Load Balancer (ELB), EC2 Web/App instances, and an RDS Database.

### Playground Link
 **[View Design on Meshery Playground](https://playground.meshery.io/extension/meshmap?mode=design&design=28a4fbb9-489c-4aaa-980b-6357e3af8edd)**

### Note on Parenting Relationship
> [!NOTE]
> The visual containment nesting (parent-child relationship) for Subnets inside the VPC and Instances/RDS inside the Subnets will not render completely on `master` yet. This design relies on the subnet parenting relationships added in PR #21072. Once both are merged, the layout nesting will resolve automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AWS three-tier web application design to the Meshery catalog.
  * Included public, private application, and private database networking with routing, load balancing, compute, and database resources.
  * Added catalog metadata, installation instructions, documentation links, visual assets, and readme content.
  * The design can now be discovered and imported through the catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->