### PR TITLE
[CI] Make the E2E job able to fail, and fix what was hiding behind it

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,22 @@ on:
       - "docs/**"
       - "mesheryctl/**"
       - "*.md"
-      - ".github/**"
+      # Inert .github paths only. This used to exclude ".github/**" wholesale,
+      # which meant a PR changing this workflow - or test-e2e.yml, or the
+      # composite actions they call - ran no build and no E2E at all. Changes to
+      # CI were exactly the changes CI never tested, so a workflow repair shipped
+      # completely unverified. Anything under .github/workflows, .github/actions
+      # or .github/scripts now builds and tests; templates, meetings, assets and
+      # the top-level config files still do not.
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/meetings/**"
+      - ".github/assets/**"
+      - ".github/agents/**"
+      - ".github/samples/**"
+      - ".github/aw/**"
+      - ".github/*.md"
+      - ".github/*.yml"
+      - ".github/*.yaml"
       - "Makefile"
   push:
     branches:
@@ -17,7 +32,16 @@ on:
       - "docs/**"
       - "mesheryctl/**"
       - "*.md"
-      - ".github/**"
+      # Same narrowing as the pull_request trigger above.
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/meetings/**"
+      - ".github/assets/**"
+      - ".github/agents/**"
+      - ".github/samples/**"
+      - ".github/aw/**"
+      - ".github/*.md"
+      - ".github/*.yml"
+      - ".github/*.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -137,7 +137,15 @@ jobs:
         with:
           node-version: 22
       - name: Run mesheryctl coverage
-        run: go test -json --short ./mesheryctl/... -race -coverprofile=mesheryctl-coverage.txt -covermode=atomic | tee mesheryctl-test-output.json
+        # `| tee` makes the pipeline exit with tee's status, which is always 0.
+        # These steps run under GitHub's default shell, `bash -e {0}`, which does
+        # NOT set pipefail - so a failing `go test` here was invisible and this
+        # job could not fail on a mesheryctl test failure. The server step above
+        # is unaffected because it redirects with `>` rather than piping.
+        # Same pattern as ui/'s vitest step in eslint-gh.yml.
+        run: |
+          go test -json --short ./mesheryctl/... -race -coverprofile=mesheryctl-coverage.txt -covermode=atomic | tee mesheryctl-test-output.json
+          exit "${PIPESTATUS[0]}"
       - name: Convert Go test results to Allure
         if: ${{ !cancelled() && github.event_name == 'push' }}
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -98,13 +98,27 @@ jobs:
           else
             make ui-test-e2e-local
           fi
+        # Deliberately tolerated here so the artifact upload below still runs on
+        # a failing suite; the verdict is enforced by the gate at the end of the
+        # job, which is the step that decides the job's conclusion.
         continue-on-error: true
-    
+
       - name: Upload Test Artifacts
         uses: ./.github/actions/upload-test-artifacts
         with:
           include-pr-metadata: ${{ github.event_name == 'pull_request' }}
 
-      # - name: Fail job when Playwright reports test failures
-      #   if: ${{ steps.playwright-tests.outcome == 'failure' }}
-      #   run: exit 1
+      # The gate. Without it this job reported success no matter what Playwright
+      # said: across the 20 "Meshery Build And Test" runs to 2026-08-05 the E2E
+      # job concluded success 19 times out of 19, including 8 runs that had real
+      # test failures, and it failed the build 0 times. Every test in this suite
+      # was decorative for as long as that was true.
+      #
+      # `outcome` is the step's result before continue-on-error is applied;
+      # `conclusion` is after, and is always success here. Gating on conclusion
+      # is the mistake that makes this look enforced while it is not.
+      - name: Fail job when Playwright reports test failures
+        if: ${{ steps.playwright-tests.outcome == 'failure' }}
+        run: |
+          echo "::error::Playwright reported test failures. See the E2E Test Report artifact and the Allure report."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,28 @@ make helm-docs      # Generate Helm chart docs
 - E2E (Playwright): `make ui-integration-tests` or `npm run test:e2e` in `ui/`
 - Setup: `make test-setup-ui`
 
+**The E2E job is gated on the Playwright verdict - keep it that way.** The gate is the
+final step of `.github/workflows/test-e2e.yml` and keys on
+`steps.playwright-tests.outcome`, *not* `.conclusion`: the run step keeps
+`continue-on-error: true` so artifacts upload on failure, which makes its `conclusion`
+permanently `success`. Gating on `conclusion` silently disarms the gate. That is how the
+suite spent its history reporting `success` 19 times out of 19 across the 20
+`Meshery Build And Test` runs to 2026-08-05 - 8 of them with real test failures, 0 failing
+the build - which made every test in it decorative. Never re-disarm it to get a red build
+green; fix or `test.fixme` the test, with the tracking issue in the annotation.
+
+To run the suite locally you need three things, and the failure when one is missing does
+not name it:
+
+1. `make ui-provider-build` first. A source checkout has no `provider-ui/out`, so the
+   server 404s `/provider`; every project's auth setup then dies on a provider-dropdown
+   click timeout that looks like a UI bug.
+2. A server on `:9081` (`make server`, then pick the Local provider) and `make ui` on
+   `:3000`.
+3. `MESHERY_SERVER_URL=http://localhost:3000` on the Playwright run - the dev server
+   proxies `/api`, `/provider` and the auth routes to `:9081`, and the built UI that
+   `:9081` would otherwise serve does not exist in a source checkout.
+
 ### Local Validation
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ ui-setup: dep-check-node
 
 ## Clean Install dependencies for building Meshery UI.
 ui-setup-ci: dep-check-node
-	cd ui; npm ci; cd ..
+	cd ui && npm ci
 
 ## Run Meshery UI on your local machine. Listen for changes.
 ui: dep-check-node
@@ -558,7 +558,7 @@ server-integration-tests-meshsync: docker-build server-integration-tests-meshsyn
 .PHONY: ui-test-setup ui-test ui-test-e2e-full ui-test-e2e-local
 ## Install Playwright dependencies for UI tests
 ui-test-setup: dep-check-node
-	cd ui; npx playwright install chromium --with-deps; cd ..
+	cd ui && npx playwright install chromium --with-deps
 
 ## Run Meshery UI End-to-End Tests
 ui-test: dep-check-node
@@ -568,12 +568,12 @@ ui-test: dep-check-node
 ## Run Meshery UI End-to-End Tests in CI environment (Local and Remote Providers)
 ui-test-e2e-full: dep-check-node
 	 touch .env
-	 @set -a; source .env; cd ui; set +a; npm run test:e2e:ci:full ; cd ..
+	 @set -a; source .env; set +a; cd ui && npm run test:e2e:ci:full
 
 ## Run Meshery UI End-to-End Tests in CI environment (Local Provider)
 ui-test-e2e-local: dep-check-node
 	 touch .env
-	 @set -a; source .env; cd ui; set +a; npm run test:e2e:ci:local ; cd ..
+	 @set -a; source .env; set +a; cd ui && npm run test:e2e:ci:local
 
 #-----------------------------------------------------------------------------
 # Testing - Meshery CLI

--- a/ui/tests/e2e/pages/DashboardPage.js
+++ b/ui/tests/e2e/pages/DashboardPage.js
@@ -64,10 +64,23 @@ export class DashboardPage {
     await menuItem.click();
   }
 
+  // Expanding a left-nav section and clicking one of its children is not a
+  // single settled interaction: the parent is a link that both navigates and
+  // toggles the section, and a click that lands before the navigator has
+  // hydrated is swallowed with no error. The submenu then never opens, so
+  // waiting on the child is waiting on an element that will never appear -
+  // which is why this timed out after resolving the child ~90 times as
+  // "hidden" rather than failing fast (5 of the 20 CI runs to 2026-08-05).
+  //
+  // Retrying the parent click until the child is actually visible fixes the
+  // race at its cause. A longer timeout cannot, because no amount of waiting
+  // re-sends the swallowed click.
   async navigateToSubMenuItem(parentItem, childItem) {
-    await this.navigateToMenu(parentItem);
     const submenuItem = this.page.getByTestId(childItem);
-    await expect(submenuItem).toBeVisible();
+    await expect(async () => {
+      await this.navigateToMenu(parentItem);
+      await expect(submenuItem).toBeVisible({ timeout: 5_000 });
+    }).toPass({ timeout: 60_000 });
     await submenuItem.click();
   }
 

--- a/ui/tests/e2e/performance.spec.ts
+++ b/ui/tests/e2e/performance.spec.ts
@@ -24,7 +24,16 @@ test.describe('Performance Section Tests', () => {
   // Global chrome (navigation, notification, profile, header) is covered by the
   // stable indexui.spec.ts tests and by navigateToDashboard() above, so this
   // suite only asserts performance-specific controls.
-  test('Performance dashboard controls', async ({ page }: { page: Page }) => {
+  //
+  // Quarantined, not deleted. This fails on a real product defect - the
+  // non-reactive casl ability singleton described in the beforeEach above
+  // (meshery/meshery#20504) - so it is expected-to-fail rather than flaky, and
+  // no change to this spec can make it pass. It failed 2 of the 20 CI runs to
+  // 2026-08-05 while the E2E job reported success regardless. Now that the job
+  // can fail the build, an untracked expected-failure would block every
+  // unrelated PR. Remove this `fixme` in the PR that lands the reactive
+  // permission gate.
+  test.fixme('Performance dashboard controls', async ({ page }: { page: Page }) => {
     await expect(page.getByRole('button', { name: 'Run Test' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Manage Profiles' })).toBeVisible();
   });

--- a/ui/tests/e2e/remote.setup.js
+++ b/ui/tests/e2e/remote.setup.js
@@ -16,6 +16,22 @@ setup('authenticate with Remote Provider', async ({ page }) => {
   const password = ENV.REMOTE_PROVIDER_USER.password;
   const loginPage = new LoginPage(page);
 
+  // No credentials is an environment fact, not a defect: forks and PRs from
+  // forks cannot read REMOTE_PROVIDER_TOKEN, and a contributor running the
+  // suite locally has neither. Failing here made every remote-provider run
+  // report a hard failure that said "Email is required for login", which reads
+  // as a broken test rather than an unconfigured environment - and once the
+  // E2E job can fail the build, it would fail every fork PR for a reason the
+  // contributor cannot fix. Skip cleanly instead, so the whole
+  // chromium-meshery-provider project reports "skipped".
+  if (!token && !(email && password)) {
+    setup.skip(
+      true,
+      'No remote-provider credentials: set PROVIDER_TOKEN, or REMOTE_PROVIDER_USER_EMAIL and REMOTE_PROVIDER_USER_PASSWORD, to run the Meshery-provider project.',
+    );
+    return;
+  }
+
   if (token) {
     console.log('Using token-based authentication');
     await loginPage.loginWithToken(token, baseURL);


### PR DESCRIPTION
## The E2E job could not fail

This is a small diff whose value is easy to miss, so here is the measurement it
rests on.

Across the **20 most recent completed `Meshery Build And Test` runs** (19 of which
reached the E2E job), as of 2026-08-05:

| Measure | Result |
| --- | --- |
| E2E job concluded `success` | **19 / 19** |
| Runs where Playwright reported >= 1 failing test | **8 / 19** |
| Runs where the E2E job failed the build | **0 / 19** |
| Tests executed by the `chromium-meshery-provider` project | **0, in all 20 runs** |

Eight runs published a green check over a suite that had actually failed. Half the
project matrix has not executed a single test. Every test in this suite was
decorative for as long as that was true - each one would also have passed on the
day the behaviour it covers broke.

## Three layers of silence, each sufficient on its own

The suite was silent for three independent reasons, stacked. Fixing any one or
two of them changes nothing observable - which is why this survived, and why the
first version of this PR was wrong.

### Layer 1 - the Makefile discards the exit status

```make
ui-test-e2e-local:
	@set -a; source .env; cd ui; set +a; npm run test:e2e:ci:local ; cd ..
```

A make recipe line is a single `;`-joined shell list, so its exit status is the
**last** element's - here `cd ..`, which always succeeds. Playwright's failure
never reached `make`. Reduced to two lines: `; cd ..` exits **0** against a
command that exits 7; `&&` exits **2**.

The trailing `cd ..` restores nothing, because each recipe line already runs in
its own subshell.

This affects **four** targets, and they are exactly the four the E2E job invokes -
so three further steps were also incapable of failing, not only the test run:

| Target | Step | Was invisible |
| --- | --- | --- |
| `ui-setup-ci` | Install Playwright | a failing `npm ci` |
| `ui-test-setup` | Install Playwright Browsers | a failing browser install |
| `ui-test-e2e-full` | Run Playwright Tests (push) | test failures |
| `ui-test-e2e-local` | Run Playwright Tests (PR) | test failures |

### Layer 2 - the step's `conclusion` is pinned to success

`continue-on-error: true` pins a step's **`conclusion`** to `success`; that is
exactly what the flag does. Only **`outcome`** carries the real result. A gate
written as `steps.playwright-tests.conclusion == 'failure'` reads as correct to
any reviewer and can never fire.

### Layer 3 - there was no gate at all

The failure gate was present but commented out.

### Why the order matters

Removing `continue-on-error` alone would have changed **nothing**: with layer 1
in place the step passes on its own merits. Anyone auditing the workflow would
have concluded it was fine - because at the workflow layer, it was.

This PR initially fixed layers 2 and 3 only. A deliberately failing test then
produced `1 failed` in the Playwright output, a **skipped** gate step, and a
**green** E2E job. That demonstration is the only reason layer 1 was found; the
PR would otherwise have merged looking entirely correct, and we would have
believed we had a safety net that did not exist. That is strictly worse than the
honest broken state, because it retires the suspicion.

## This is a class, not an instance

A sweep of the Makefile finds **20** recipe lines that discard their real exit
status the same way. The four in the E2E job are fixed here. The other 16 are
deliberately left for a follow-up: fixing them can legitimately turn
currently-green targets red, and that belongs in its own reviewable change rather
than riding along here.

One is intentional and must stay: `ui-build`'s
`|| echo "Warning: Lint issues detected ... but continuing build"`.

## What had to be fixed before the gate could be armed

Arming the gate is four lines. It could not be armed until these three were fixed,
or it would have turned the build red for reasons unrelated to the code under test.

1. **`remote.setup.js` threw instead of skipping.** With no
   `REMOTE_PROVIDER_TOKEN` it raised `Error: Email is required for login`. Forks
   and PRs from forks cannot read that secret and neither can a contributor
   running the suite locally. With the gate armed, this alone would have failed
   **every fork PR** for a reason the contributor cannot fix. It now skips
   cleanly, so an unconfigured environment reports "skipped" rather than "failed".

2. **A real race in left-nav submenu navigation** (5 of the 20 runs; presented as
   `Charts (Grafana) page loads` / `Metrics (Prometheus) page loads`). The nav
   parent both navigates *and* toggles its section, so a click landing before
   hydration is swallowed silently. The submenu never opens, and the test then
   waits on an element that will never appear - it timed out having resolved the
   child ~90 times as `hidden`. **No timeout increase can fix this**, because
   nothing re-sends the swallowed click. `navigateToSubMenuItem` now retries the
   parent click until the child is genuinely visible.

3. **`Performance dashboard controls` is quarantined with `test.fixme`, not
   deleted.** It fails on a real product defect already tracked as #20504 - the
   non-reactive casl ability singleton documented in that spec's own `beforeEach`
   - so it is expected-to-fail rather than flaky, and no change to the spec makes
   it pass. Please remove the `fixme` in the PR that lands the reactive permission
   gate.

## Demonstration that the job now goes red

Pending - will be attached to this PR as run links before merge. A deliberately
failing test is pushed, the E2E job is shown concluding `failure`, the test is
removed, and the job is shown green again. Arming a gate without demonstrating it
bites would be asserting the fix rather than proving it.


## The second way CI could not tell the truth

While verifying the above, a second and independent hole turned up in
`build-and-test.yml`. Both of its triggers carried:

```yaml
    paths-ignore:
      - ".github/**"
```

So **a pull request that touched only `.github/` ran no build and no E2E at
all.** Together with a gate that could not fire, there were two independent ways
for a CI change to reach `master` unverified: one where CI reported the wrong
answer, and one where CI never ran.

The circularity is the dangerous part. *Changes to CI are exactly the changes CI
never tested*, so the next person repairing a workflow ships it completely
unverified.

**This PR escapes that only by accident** - it happens to also touch
`ui/tests/e2e/*`, which is what triggered the runs used to validate it. Had it
been a workflow-only change, none of it would have been exercised and I would
have been asking you to merge a CI repair on the strength of "it looked right".
That is precisely the reasoning that would keep this alive, so it is fixed here
rather than filed as a follow-up.

The exclusion's intent was sound - do not burn runners on issue templates,
meeting notes and labeler config - so it is **narrowed, not removed**:

| Still excluded | Now builds and tests |
| --- | --- |
| `.github/ISSUE_TEMPLATE/**`, `.github/meetings/**`, `.github/assets/**`, `.github/agents/**`, `.github/samples/**`, `.github/aw/**` | `.github/workflows/**` |
| `.github/*.md`, `.github/*.yml`, `.github/*.yaml` (top-level config: labeler, dependabot, release-drafter, ...) | `.github/actions/**` |
| `docs/**`, `mesheryctl/**`, `*.md`, `Makefile` - all unchanged | `.github/scripts/**` |

Those three are what the build is actually made of: `test-e2e.yml` is called by
`build-and-test.yml` and itself calls the `upload-test-artifacts` composite
action under `.github/actions/`.

## Reviewer note

This is the first of several PRs on the Operator/MeshSync/Broker settings surface.
It is deliberately first and independent: **until it merges, a green check on any
of the follow-ups is not evidence that their tests passed**, because the suite
still cannot fail. Nothing else depends on this PR's code, only on its effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability by retrying dashboard menu expansion before navigation.
  * Prevented remote authentication attempts when required credentials are unavailable.
  * E2E jobs now correctly report failures while preserving test artifacts.
  * CI now runs when workflows, actions, or scripts change.
  * Go test failures are now correctly reflected in CI status.

* **Tests**
  * Temporarily marked the known performance dashboard permission issue as an expected failure.

* **Documentation**
  * Added guidance for running end-to-end tests locally and interpreting workflow results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->