### PR TITLE
chore: update CodeQL analysis workflow to include build modes for lan…

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,10 +24,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        include:
+          - language: javascript
+            build-mode: autobuild
+    
+          - language: go
+            build-mode: manual
 
     steps:
       - name: 🔍 Introspect Inputs
@@ -56,26 +58,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql-config.yml
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      #- run: |
-      #   make bootstrap
-      #   make release
+          build-mode: ${{ matrix.build-mode }}
+      
+      - name: Build Go
+        if: matrix.language == 'go'
+        run: |
+          go build -v ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
           - language: javascript
-            build-mode: autobuild
+            build-mode: none
     
           - language: go
             build-mode: manual


### PR DESCRIPTION
Getting an error on the codeql workflow. Added to matrix to manual build the go trying to use go.build ./... to see if it works to just grab all go packages but may need to use the make commands. 

```
2026-08-01T22:51:42.6428885Z ##[group]Go files were found but not processed (1 result)
2026-08-01T22:51:42.6430483Z   * [Specify a custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages) that includes one or more `go build` commands to build the `.go` files to be analyzed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code scanning workflow configuration for more consistent checks across supported languages.
  * Improved build handling for Go during analysis with tailored setup for different language modes.
  * Simplified automated analysis by removing unnecessary build steps and outdated configuration comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->