### PR TITLE
[mesheryctl] Fix response body leak and nil pointer dereference in au…

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -233,12 +233,12 @@ func UpdateAuthDetails(filepath string) error {
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	defer SafeClose(resp.Body)
 
 	if err != nil {
 		err = errors.Wrap(err, "error dispatching there request: ")
 		return err
 	}
+	defer SafeClose(resp.Body)
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -352,6 +352,7 @@ func GetProviderInfo(mctCfg *config.MesheryCtlConfig) (map[string]Provider, erro
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = resp.Body.Close() }()
 
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err


### PR DESCRIPTION
**Notes for Reviewers**

This PR addresses two bugs in `mesheryctl/pkg/utils/auth.go`:
1. **Nil Pointer Dereference:** Moved `defer SafeClose(resp.Body)` in `UpdateAuthDetails` to after the `err != nil` check. Previously, it would panic if the request failed because `resp` was nil.
2. **Response Body Leak:** Added `defer func() { _ = resp.Body.Close() }()` to `GetProviderInfo` to properly close the response body.

- This PR fixes #21159

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication request handling to prevent errors when responses are unavailable.
  * Ensured provider response resources are properly closed after successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->