### PR TITLE
[Docs] Improve FAQ layout on Meshery Playground page

### DIFF
--- a/docs/content/en/installation/playground.md
+++ b/docs/content/en/installation/playground.md
@@ -21,34 +21,34 @@ Meshery Playground also has pre-built scenarios that demonstrate how to implemen
 
 ## Meshery Playground FAQ
 
-#### Question: Why do I need to sign up or register to use Meshery Playground?
+### Q: Why do I need to sign up or register to use Meshery Playground?
 
-**Answer:** _The Playground is connected to live Kubernetes clusters. While these clusters are refreshed on a daily basis, they do need to be protected from nefarious actors who might use these clusters for cryptomining, for example._
+The Playground is connected to live Kubernetes clusters. While these clusters are refreshed on a daily basis, they do need to be protected from nefarious actors who might use these clusters for cryptomining, for example.
 
-_Sign up to receive a user account with perpetually free, full access to the Playground environment._
+Sign up to receive a user account with perpetually free, full access to the Playground environment.
 
-_The Meshery Playground is connected to live Kubernetes cluster(s) and allows users full control over those clusters. Requiring users to register a user account keeps the Playground safe and healthy for all to enjoy. Without requiring users to sign in, the Meshery Playground would allow anonymous access for anyone and everyone to potentially perform nefarious acts._
+The Meshery Playground is connected to live Kubernetes cluster(s) and allows users full control over those clusters. Requiring users to register a user account keeps the Playground safe and healthy for all to enjoy. Without requiring users to sign in, the Meshery Playground would allow anonymous access for anyone and everyone to potentially perform nefarious acts.
 
-#### Question: Will I lose my Meshery designs in the Cloud Native Playground?
+### Q: Will I lose my Meshery designs in the Cloud Native Playground?
 
-**Answer:** _No, all of the designs that you have created in the Meshery Playground are saved to your user account and will be available to you each time you sign in to your account. Your designs will be available in the Meshery Playground and any of your other Meshery deployments, too._
+No, all of the designs that you have created in the Meshery Playground are saved to your user account and will be available to you each time you sign in to your account. Your designs will be available in the Meshery Playground and any of your other Meshery deployments, too.
 
-_In other words, all work done in Meshery Design Configurator is persisted to your user account._
+In other words, all work done in Meshery Design Configurator is persisted to your user account.
 
-#### Question: Will I lose my Meshery deployments in the Cloud Native Playground?
+### Q: Will I lose my Meshery deployments in the Cloud Native Playground?
 
-**Answer:** _Yes, the Meshery Playground clusters are reset on a daily basis. However, only deployments (not designs) that you may have created will be lost._
+Yes, the Meshery Playground clusters are reset on a daily basis. However, only deployments (not designs) that you may have created will be lost.
 
-_In other words, only Meshery Dashboard is reset. All of your work in Meshery UI and Meshery Design Configurator will remain in your user account._
+In other words, only Meshery Dashboard is reset. All of your work in Meshery UI and Meshery Design Configurator will remain in your user account.
 
-#### Question: Is there a demo user account that everyone can use?
+### Q: Is there a demo user account that everyone can use?
 
-**Answer:** _It is imperative that each user has their own account to ensure seamless real-time collaboration within the Playground. The use of individual accounts is critical to enable multiple people to access and utilize the powerful collaboration features._
+It is imperative that each user has their own account to ensure seamless real-time collaboration within the Playground. The use of individual accounts is critical to enable multiple people to access and utilize the powerful collaboration features.
 
-_Creating your own account ensures that any designs you create or save will be stored and accessible across sessions, preventing any loss of work._
+Creating your own account ensures that any designs you create or save will be stored and accessible across sessions, preventing any loss of work.
 
-_To ensure accountability in the Playground, it's crucial to promote the use of individual named accounts. This helps prevent bad actors from hiding behind anonymous general-use accounts and maliciously abusing the Playground. Therefore, the use of named accounts is an essential step towards achieving this goal._
+To ensure accountability in the Playground, it's crucial to promote the use of individual named accounts. This helps prevent bad actors from hiding behind anonymous general-use accounts and maliciously abusing the Playground. Therefore, the use of named accounts is an essential step towards achieving this goal.
 
-#### Question: Can I deploy Meshery on-premises?
+### Q: Can I deploy Meshery on-premises?
 
-**Answer:** _Yes, Meshery can be deployed on-premises with a single command to download, install, and run your own instance of Meshery in your environment. See all supported platforms to deploy your own Meshery instance at [https://docs.meshery.io/installation]({{< ref "installation/_index.md" >}})._
+Yes, Meshery can be deployed on-premises with a single command to download, install, and run your own instance of Meshery in your environment. See all supported platforms to deploy your own Meshery instance at [https://docs.meshery.io/installation]({{< ref "installation/_index.md" >}}).


### PR DESCRIPTION
## Description

This PR improves the FAQ layout on the Meshery Playground documentation page by aligning it with the FAQ formatting used in the rest of the Meshery documentation.

### Changes
- Changed FAQ headings from `#### Question:` to `### Q:`
- Removed the `**Answer:**` label
- Removed italic formatting from answer text
- Preserved all existing wording, links, and Hugo shortcodes

Fixes #20755

**Notes for Reviewers**

- This PR fixes #20755.
- The change is limited to `docs/content/en/installation/playground.md`.
- The documentation builds successfully, and the FAQ layout now matches the reference page.

**Signed commits**
- [x] Yes, I signed my commits.


<img width="1415" height="781" alt="Screenshot 2026-08-06 at 2 24 39 AM" src="https://github.com/user-attachments/assets/fd68808e-9f38-43c4-ac5d-e4de1dab5394" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted the Meshery Playground FAQ for improved readability and consistency.
  * Updated question headings and answer formatting without changing the FAQ content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->