### PR TITLE
[UI][CLI][Server] Complete the design-import canonical-sourcing audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,25 @@ across `meshery/meshery` and `meshery-cloud`.
 - MUST NOT change wire casing/field names only in this repo — change the schema
   and regenerate (see the naming conventions above).
 
+### Attaching local cache tags to a generated endpoint
+
+`ui/rtk-query/index.js` re-exports the schemas client itself (`mesheryApi as api`),
+so every `ui/rtk-query/*` module injects into that same API instance — generated
+hooks are therefore already available from those local modules and need no
+re-declaration. To give a generated endpoint a local cache tag, pass it through
+`enhanceEndpoints({ endpoints: { <operationId>: { invalidatesTags: [...] } } })`
+and re-export the generated hook; list the generated tag alongside the local one
+so the schemas-side invalidation is not dropped. See the `importDesign`
+enhancement in `ui/rtk-query/design.ts`. Re-declaring the endpoint with
+`builder.mutation` to get a tag is the forbidden path above — it forks the wire
+contract silently.
+
+On the Go side, schemas ships **models only, no generated HTTP client**, so
+`mesheryctl` builds request bodies from the generated structs (and, for `oneOf`
+bodies, the `From<Variant>Payload` union builders) rather than a
+`map[string]interface{}` — see `mesheryctl/internal/cli/root/design/import.go`.
+A hand-written map is how camelCase `fileName` regressed to `file_name`.
+
 ## Build & Development Commands
 
 - Use the `gh-axi` CLI tool to interact with GitHub. Prefer `gh-axi` over `gh`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,16 +108,22 @@ across `meshery/meshery` and `meshery-cloud`.
 
 ### Attaching local cache tags to a generated endpoint
 
-`ui/rtk-query/index.js` re-exports the schemas client itself (`mesheryApi as api`),
-so every `ui/rtk-query/*` module injects into that same API instance — generated
+`ui/rtk-query/index.ts` re-exports the schemas client itself (`mesheryApi as api`),
+so every `ui/rtk-query/*` module injects into that same API instance - generated
 hooks are therefore already available from those local modules and need no
-re-declaration. To give a generated endpoint a local cache tag, pass it through
-`enhanceEndpoints({ endpoints: { <operationId>: { invalidatesTags: [...] } } })`
-and re-export the generated hook; list the generated tag alongside the local one
-so the schemas-side invalidation is not dropped. See the `importDesign`
-enhancement in `ui/rtk-query/design.ts`. Re-declaring the endpoint with
-`builder.mutation` to get a tag is the forbidden path above — it forks the wire
-contract silently.
+re-declaration. To give a generated endpoint a local cache tag, use the **callback
+form** of `enhanceEndpoints` via `appendInvalidatesTags` from `ui/rtk-query/utils`,
+then re-export the generated hook - see the `importDesign` enhancement in
+`ui/rtk-query/design.ts`. Do **not** use the object form
+(`{ <operationId>: { invalidatesTags: [...] } }`): `enhanceEndpoints` applies an
+object partial with `Object.assign(getEndpointDefinition(...) || {}, partial)`, so
+it REPLACES `invalidatesTags` wholesale and every schemas-side tag has to be
+hand-relisted - drift the moment schemas adds one. The callback form is handed the
+live definition by reference, so the local tag is appended to the generated ones
+and cannot drop them; that same lookup has no fallback, so `appendInvalidatesTags`
+fails loudly and by name when the operationId is gone from schemas rather than
+enhancing a throwaway object. Re-declaring the endpoint with `builder.mutation` to
+get a tag is the forbidden path above - it forks the wire contract silently.
 
 On the Go side, schemas ships **models only, no generated HTTP client**, so
 `mesheryctl` builds request bodies from the generated structs (and, for `oneOf`

--- a/mesheryctl/internal/cli/root/design/deploy.go
+++ b/mesheryctl/internal/cli/root/design/deploy.go
@@ -138,7 +138,7 @@ mesheryctl design deploy -f [filepath] -s [source type]
 				return err
 			}
 			patternImportURL := fmt.Sprintf("%s/%s/import", mctlCfg.GetBaseMesheryURL(), patternURLPath)
-			pattern, err := importPattern(designDeployFlags.SourceType, designDeployFlags.File, patternImportURL, !designDeployFlags.SkipSave)
+			pattern, err := importPattern(designDeployFlags.SourceType, designDeployFlags.File, patternImportURL)
 			if err != nil {
 				return err
 			}

--- a/mesheryctl/internal/cli/root/design/import.go
+++ b/mesheryctl/internal/cli/root/design/import.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"net/http"
 	"os"
 	"path"
 
@@ -96,7 +95,7 @@ mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name
 			sourceType = string(core.DockerCompose)
 		}
 
-		pattern, err := importPattern(sourceType, file, patternURL, true)
+		pattern, err := importPattern(sourceType, file, patternURL)
 		if err != nil {
 			return err
 		}
@@ -107,10 +106,30 @@ mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name
 	},
 }
 
-func importPattern(sourceType string, file string, patternURL string, save bool) (*models.MesheryPattern, error) {
-	var req *http.Request
-	var pattern *models.MesheryPattern
+// marshalDesignImportBody builds the `POST /api/pattern/import` request body
+// through the schemas-generated union type rather than a hand-written
+// map[string]interface{}. The wire field names - notably camelCase `fileName` -
+// then come from the generated struct tags, so they cannot drift from the
+// contract: sending the legacy snake_case `file_name` leaves the server's oneOf
+// unmatched and the request is rejected with "Invalid design import request"
+// (meshery-server-1422), the bug this endpoint regressed with before.
+//
+// `variant` selects the oneOf arm via the generated
+// FromMesheryPatternImport{File,URL}Payload builders.
+func marshalDesignImportBody(variant func(*pattern.MesheryPatternImportRequestBody) error) ([]byte, error) {
+	var body pattern.MesheryPatternImportRequestBody
+	if err := variant(&body); err != nil {
+		return nil, utils.ErrMarshal(err)
+	}
 
+	jsonValues, err := json.Marshal(body)
+	if err != nil {
+		return nil, utils.ErrMarshal(err)
+	}
+	return jsonValues, nil
+}
+
+func importPattern(sourceType string, file string, patternURL string) (*models.MesheryPattern, error) {
 	// If design name is not provided
 	// use file name as default
 	var patternName string
@@ -121,93 +140,86 @@ func importPattern(sourceType string, file string, patternURL string, save bool)
 		patternName = name
 	}
 
-	validURL := utils.IsValidUrl(file)
-	// Check if the pattern is file or URL
-	if !validURL {
+	// Check if the design is a file or a URL and build the matching oneOf arm.
+	if !utils.IsValidUrl(file) {
 		content, err := os.ReadFile(file)
 		if err != nil {
 			return nil, utils.ErrFileRead(err)
 		}
 
-		// The /api/pattern/import File-import variant expects camelCase `fileName`
-		// (the canonical wire form per the schemas naming conventions). Sending the
-		// legacy snake_case `file_name` leaves the server's oneOf unmatched and the
-		// request is rejected with "Invalid design import request" (meshery-server-1422).
-		jsonValues, err := json.Marshal(map[string]interface{}{
-			"name":     patternName,
-			"file":     content,
-			"fileName": fileName,
-			"save":     save,
+		jsonValues, err := marshalDesignImportBody(func(body *pattern.MesheryPatternImportRequestBody) error {
+			return body.FromMesheryPatternImportFilePayload(pattern.MesheryPatternImportFilePayload{
+				Name:     &patternName,
+				File:     content,
+				FileName: fileName,
+			})
 		})
-		if err != nil {
-			return nil, utils.ErrMarshal(err)
-		}
-		req, err = utils.NewRequest("POST", patternURL, bytes.NewBuffer(jsonValues))
 		if err != nil {
 			return nil, err
 		}
 
-		resp, err := utils.MakeRequest(req)
+		imported, err := postDesignImport(patternURL, jsonValues)
 		if err != nil {
 			return nil, err
 		}
 		utils.Log.Debug("design file saved")
-		var response []*models.MesheryPattern
-		defer func() { _ = resp.Body.Close() }()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			utils.Log.Debug("failed to read response body")
-			return nil, utils.ErrReadResponseBody(err)
-		}
-		err = json.Unmarshal(body, &response)
-		if err != nil {
-			utils.Log.Debug("failed to unmarshal JSON response")
-			return nil, utils.ErrUnmarshal(err)
-		}
-		// set pattern
-		pattern = response[0]
-	} else {
-		var jsonValues []byte
-
-		jsonValues, err := json.Marshal(map[string]interface{}{
-			"url":  file,
-			"name": patternName,
-			"save": save,
-		})
-		if err != nil {
-			return nil, utils.ErrMarshal(err)
-		}
-
-		req, err := utils.NewRequest("POST", patternURL, bytes.NewBuffer(jsonValues))
-		if err != nil {
-			return nil, utils.ErrCreatingRequest(err)
-		}
-
-		resp, err := utils.MakeRequest(req)
-		if err != nil {
-			return nil, utils.ErrRequestResponse(err)
-		}
-		utils.Log.Debug("Fetched the design from the remote host")
-		var response []*models.MesheryPattern
-		defer func() { _ = resp.Body.Close() }()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			utils.Log.Debug("failed to read response body")
-			return nil, utils.ErrReadResponseBody(err)
-		}
-		err = json.Unmarshal(body, &response)
-		if err != nil {
-			utils.Log.Debug("failed to unmarshal JSON response")
-			return nil, utils.ErrUnmarshal(err)
-		}
-
-		// set pattern
-		pattern = response[0]
+		return imported, nil
 	}
 
-	return pattern, nil
+	jsonValues, err := marshalDesignImportBody(func(body *pattern.MesheryPatternImportRequestBody) error {
+		return body.FromMesheryPatternImportURLPayload(pattern.MesheryPatternImportURLPayload{
+			Name: &patternName,
+			Url:  file,
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	imported, err := postDesignImport(patternURL, jsonValues)
+	if err != nil {
+		return nil, err
+	}
+	utils.Log.Debug("Fetched the design from the remote host")
+	return imported, nil
+}
+
+// postDesignImport POSTs an already-marshalled import body and returns the
+// first design from the response collection. Both oneOf arms share it so the
+// response handling cannot drift between them - the divergence that let the
+// snake_case `file_name` bug survive in only one arm.
+func postDesignImport(patternURL string, jsonValues []byte) (*models.MesheryPattern, error) {
+	req, err := utils.NewRequest("POST", patternURL, bytes.NewBuffer(jsonValues))
+	if err != nil {
+		return nil, utils.ErrCreatingRequest(err)
+	}
+
+	resp, err := utils.MakeRequest(req)
+	if err != nil {
+		return nil, utils.ErrRequestResponse(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		utils.Log.Debug("failed to read response body")
+		return nil, utils.ErrReadResponseBody(err)
+	}
+
+	var response []*models.MesheryPattern
+	if err := json.Unmarshal(body, &response); err != nil {
+		utils.Log.Debug("failed to unmarshal JSON response")
+		return nil, utils.ErrUnmarshal(err)
+	}
+
+	// The server returns the saved design(s) as a collection. Guard the index
+	// so an empty (or null) collection surfaces as a structured error instead
+	// of panicking with an out-of-range index.
+	if len(response) == 0 || response[0] == nil {
+		return nil, ErrDesignInvalidApiResponse("design import returned no design")
+	}
+
+	return response[0], nil
 }
 
 func init() {

--- a/mesheryctl/internal/cli/root/design/import_test.go
+++ b/mesheryctl/internal/cli/root/design/import_test.go
@@ -11,38 +11,58 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_importPattern_DisplayErrorsMissingFlags(t *testing.T) {
-	type args struct {
-		sourceType string
-		file       string
-		patternURL string
-	}
-
+// Test_designImport_FlagValidation covers the two validation paths
+// `mesheryctl design import` actually has, and asserts the error each one
+// returns is the expected one.
+//
+// It previously called importPattern directly. importPattern performs no flag
+// validation at all - the source type is checked in RunE via
+// retrieveProvidedSourceType, and the required -f flag in the command's Args -
+// so both cases were passing on an incidental "no such file or directory" from
+// os.ReadFile while the declared `want` was never compared to anything. Both
+// assertions below fail if that error identity regresses.
+func Test_designImport_FlagValidation(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    args
-		want    error
-		wantErr bool
+		name string
+		run  func(t *testing.T) error
+		want error
 	}{
 		{
-			name:    "given invalid source type when design import then error is thrown",
-			args:    args{"invalid source type", "file.yaml", ""},
-			want:    ErrInValidSource("invalid source type", validDesignSourceTypes),
-			wantErr: true,
+			name: "given invalid source type when design import then error is thrown",
+			run: func(_ *testing.T) error {
+				_, err := retrieveProvidedSourceType("invalid source type", validDesignSourceTypes)
+				return err
+			},
+			want: ErrInValidSource("invalid source type", validDesignSourceTypes),
 		},
 		{
-			name:    "given missing file flag when design import then error is thrown",
-			args:    args{"helm", "", ""},
-			want:    ErrDesignFileNotProvided(),
-			wantErr: true,
+			name: "given missing file flag when design import then error is thrown",
+			run: func(t *testing.T) error {
+				// `file` is a package-level flag target shared by every design
+				// subcommand, so restore it rather than leaving it blank for
+				// whatever test runs next.
+				previous := file
+				file = ""
+				t.Cleanup(func() { file = previous })
+
+				return importCmd.Args(importCmd, nil)
+			},
+			want: ErrDesignFileNotProvided(),
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := importPattern(tt.args.sourceType, tt.args.file, tt.args.patternURL)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("importPattern() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			// The Args validator logs before returning; without this the
+			// nil logger panics.
+			_ = utils.SetupMeshkitLoggerTesting(t, false)
+
+			err := tt.run(t)
+			if err == nil {
+				t.Fatalf("expected error %v, got nil", tt.want)
+			}
+			if err.Error() != tt.want.Error() {
+				t.Fatalf("error mismatch\n got: %v\nwant: %v", err, tt.want)
 			}
 		})
 	}

--- a/mesheryctl/internal/cli/root/design/import_test.go
+++ b/mesheryctl/internal/cli/root/design/import_test.go
@@ -16,7 +16,6 @@ func Test_importPattern_DisplayErrorsMissingFlags(t *testing.T) {
 		sourceType string
 		file       string
 		patternURL string
-		save       bool
 	}
 
 	tests := []struct {
@@ -27,20 +26,20 @@ func Test_importPattern_DisplayErrorsMissingFlags(t *testing.T) {
 	}{
 		{
 			name:    "given invalid source type when design import then error is thrown",
-			args:    args{"invalid source type", "file.yaml", "", false},
+			args:    args{"invalid source type", "file.yaml", ""},
 			want:    ErrInValidSource("invalid source type", validDesignSourceTypes),
 			wantErr: true,
 		},
 		{
 			name:    "given missing file flag when design import then error is thrown",
-			args:    args{"helm", "", "", false},
+			args:    args{"helm", "", ""},
 			want:    ErrDesignFileNotProvided(),
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := importPattern(tt.args.sourceType, tt.args.file, tt.args.patternURL, tt.args.save)
+			_, err := importPattern(tt.args.sourceType, tt.args.file, tt.args.patternURL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("importPattern() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/mesheryctl/internal/cli/root/design/import_test.go
+++ b/mesheryctl/internal/cli/root/design/import_test.go
@@ -89,6 +89,79 @@ func Test_importPattern_SendsCamelCaseFileName(t *testing.T) {
 	assert.Equal(t, "sampleDesign.golden", capturedBody["fileName"])
 }
 
+// Test_importPattern_SendsContractUrlPayload covers the URL oneOf arm, the one
+// the camelCase regression test above cannot reach. Both arms are now built from
+// the same generated MesheryPatternImportRequestBody, so the URL arm has to carry
+// exactly the contract's `url`/`name` fields - and specifically NOT the legacy
+// `save` key, which was never part of the request contract and which the server's
+// DesignFileImportHandler never read.
+func Test_importPattern_SendsContractUrlPayload(t *testing.T) {
+	testContext := utils.InitTestEnvironment(t)
+	output := utils.SetupMeshkitLoggerTesting(t, false)
+	defer utils.StopMockery(t)
+	defer resetVariables()
+	defer utils.ResetCommandFlags(DesignCmd, t)
+
+	utils.TokenFlag = utils.GetToken(t)
+
+	var capturedBody map[string]interface{}
+	httpmock.RegisterResponder(
+		"POST",
+		testContext.BaseURL+"/api/pattern/import",
+		func(req *http.Request) (*http.Response, error) {
+			raw, err := io.ReadAll(req.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, json.Unmarshal(raw, &capturedBody))
+			t.Logf("Captured URL-import request body: %s", raw)
+			return httpmock.NewStringResponse(
+				200,
+				`[{"id":"3817ec9a-1d83-4f6f-9154-0fd4408ba9f0","name":"RemoteApp"}]`,
+			), nil
+		},
+	)
+
+	DesignCmd.SetArgs([]string{
+		"import", "-f", "https://example.com/design.yaml", "-n", "RemoteApp",
+	})
+	assert.NoError(t, DesignCmd.Execute())
+
+	assert.Equal(t, "https://example.com/design.yaml", capturedBody["url"])
+	assert.Equal(t, "RemoteApp", capturedBody["name"])
+	assert.NotContains(t, capturedBody, "save", "`save` is not part of the import request contract")
+	assert.ElementsMatch(t, []string{"url", "name"}, mapKeys(capturedBody))
+	t.Logf("mesheryctl output: %s", output.String())
+}
+
+// Test_importPattern_EmptyResponseCollection pins the guard added when both oneOf
+// arms were folded into postDesignImport: the server returns the saved design(s)
+// as a collection, and both arms previously indexed response[0] unguarded, so an
+// empty collection panicked with an index-out-of-range instead of surfacing an
+// error the user can act on.
+func Test_importPattern_EmptyResponseCollection(t *testing.T) {
+	testContext := utils.InitTestEnvironment(t)
+	_ = utils.SetupMeshkitLoggerTesting(t, false)
+	defer utils.StopMockery(t)
+	defer resetVariables()
+	defer utils.ResetCommandFlags(DesignCmd, t)
+
+	utils.TokenFlag = utils.GetToken(t)
+
+	httpmock.RegisterResponder(
+		"POST",
+		testContext.BaseURL+"/api/pattern/import",
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(200, `[]`), nil
+		},
+	)
+
+	DesignCmd.SetArgs([]string{"import", "-f", "fixtures/sampleDesign.golden", "-n", "SampleApp"})
+
+	err := DesignCmd.Execute()
+	assert.Error(t, err, "an empty design collection must surface as an error, not a panic")
+	assert.Equal(t, ErrDesignInvalidApiResponse("design import returned no design").Error(), err.Error())
+	t.Logf("structured error returned instead of panicking: %v", err)
+}
+
 func mapKeys(m map[string]interface{}) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/server/handlers/design_import.go
+++ b/server/handlers/design_import.go
@@ -77,9 +77,9 @@ func resolveImportVariant(body pattern.MesheryPatternImportRequestBody) (importV
 				Name: stringFromPtr(filePayload.Name),
 				File: FileToImport{FileName: filePayload.FileName},
 			},
-			ErrInvalidImportRequest(errors.New("request body must contain exactly one of File Import (file + file_name) or URL Import (url), not both"))
+			ErrInvalidImportRequest(errors.New("request body must contain exactly one of File Import (file + fileName) or URL Import (url), not both"))
 	case !hasFile && !hasURL:
-		return importVariant{}, ErrInvalidImportRequest(errors.New("request body must contain either a File Import (file + file_name) or a URL Import (url)"))
+		return importVariant{}, ErrInvalidImportRequest(errors.New("request body must contain either a File Import (file + fileName) or a URL Import (url)"))
 	case hasFile:
 		return importVariant{
 			Name: stringFromPtr(filePayload.Name),

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -1045,7 +1045,7 @@ func ErrInvalidBase64Data(err error) error {
 // set, or neither. Emitted with HTTP 400 because the caller needs to
 // correct the request shape, not the server to recover.
 func ErrInvalidImportRequest(err error) error {
-	return errors.New(ErrInvalidImportRequestCode, errors.Alert, []string{"Invalid design import request"}, []string{err.Error()}, []string{"The request body did not match exactly one variant of the import oneOf — the File variant requires `file` and `file_name`, the URL variant requires `url`.", "Both variants were provided, or neither was."}, []string{"Send a request body with exactly one variant set: either {\"file\": <bytes>, \"file_name\": \"design.yml\"} or {\"url\": \"https://...\"}."})
+	return errors.New(ErrInvalidImportRequestCode, errors.Alert, []string{"Invalid design import request"}, []string{err.Error()}, []string{"The request body did not match exactly one variant of the import oneOf — the File variant requires `file` and `fileName`, the URL variant requires `url`.", "Both variants were provided, or neither was."}, []string{"Send a request body with exactly one variant set: either {\"file\": <bytes>, \"fileName\": \"design.yml\"} or {\"url\": \"https://...\"}."})
 }
 
 // ErrConvertToDesign wraps failures in the conversion pipeline that

--- a/ui/assets/jsonschema/uiSchemaDesignImport.json
+++ b/ui/assets/jsonschema/uiSchemaDesignImport.json
@@ -1,5 +1,0 @@
-{
-  "uploadType": {
-    "ui:widget": "radio"
-  }
-}

--- a/ui/components/designs/import-design-request.test.ts
+++ b/ui/components/designs/import-design-request.test.ts
@@ -26,15 +26,15 @@ describe('buildImportDesignRequestBody', () => {
         file: 'data:text/plain;base64,QQ==',
       }),
     ).resolves.toEqual({
-      requestBody: JSON.stringify({
+      requestBody: {
         name: 'Imported design',
         fileName: 'imported-design.yaml',
         file: [1, 2, 3],
-      }),
+      },
     });
   });
 
-  it('builds the URL import request body with contract-ordered fields', async () => {
+  it('builds the URL import request body from the contract fields', async () => {
     await expect(
       buildImportDesignRequestBody({
         uploadType: 'URL Import',
@@ -42,10 +42,10 @@ describe('buildImportDesignRequestBody', () => {
         url: 'https://example.com/design.yaml',
       }),
     ).resolves.toEqual({
-      requestBody: JSON.stringify({
+      requestBody: {
         url: 'https://example.com/design.yaml',
         name: 'Imported design',
-      }),
+      },
     });
 
     expect(resolveImportedDesignFile).not.toHaveBeenCalled();

--- a/ui/components/designs/import-design-request.ts
+++ b/ui/components/designs/import-design-request.ts
@@ -8,8 +8,6 @@ export type ImportDesignFormData = {
   file?: string;
 };
 
-export type ImportDesignRequestResult = { requestBody: string } | { errorMessage: string };
-
 /**
  * Wire contract for `POST /api/pattern/import`, sourced from the schemas
  * generated client (`ImportDesignApiArg`, produced from
@@ -23,14 +21,15 @@ type ImportDesignFileVariant = Extract<ImportDesignRequestBody, { fileName: stri
 type ImportDesignUrlVariant = Extract<ImportDesignRequestBody, { url: string }>;
 
 /**
- * File-Upload variant as this client emits it. The fields are pinned to the
- * contract via `ImportDesignFileVariant`; only `file` is widened: the openapi
- * contract types it as a base64 string (`format: byte`), while the browser
- * sends the decoded byte array produced after reading the upload. The server's
- * Go `[]byte` decoder accepts either representation, so the byte array is a
- * conformant alternative and is preserved here unchanged.
+ * Result union of the builder. `requestBody` is the generated wire body itself
+ * - not a pre-serialized string - so it can be handed straight to the
+ * schemas-generated `importDesign` mutation, which serializes it. `errorMessage`
+ * is UI copy for the notification shown when the form data cannot produce a
+ * valid body.
  */
-type ImportDesignFileWireBody = Omit<ImportDesignFileVariant, 'file'> & { file: number[] };
+export type ImportDesignRequestResult =
+  | { requestBody: ImportDesignRequestBody }
+  | { errorMessage: string };
 
 export const buildImportDesignRequestBody = async (
   data: ImportDesignFormData,
@@ -45,12 +44,19 @@ export const buildImportDesignRequestBody = async (
           return { errorMessage: 'Please choose a design file before continuing.' };
         }
 
-        const requestBody: ImportDesignFileWireBody = {
+        const requestBody: ImportDesignFileVariant = {
           name,
           fileName: importedFile.fileName,
-          file: importedFile.fileData,
+          // The contract types `file` as a base64 string (`format: byte`);
+          // this client sends the decoded byte array produced after reading
+          // the upload. The server's Go `[]byte` decoder accepts either
+          // representation and yields identical bytes, so the byte array is a
+          // conformant alternative and is preserved here unchanged. The cast is
+          // confined to this single property so every other field stays pinned
+          // to the generated contract.
+          file: importedFile.fileData as unknown as ImportDesignFileVariant['file'],
         };
-        return { requestBody: JSON.stringify(requestBody) };
+        return { requestBody };
       } catch (error) {
         console.error('Error resolving design import file:', error);
         return { errorMessage: 'Unable to read the selected design file. Please try again.' };
@@ -66,7 +72,7 @@ export const buildImportDesignRequestBody = async (
       }
 
       const requestBody: ImportDesignUrlVariant = { url, name };
-      return { requestBody: JSON.stringify(requestBody) };
+      return { requestBody };
     }
     default:
       return { errorMessage: 'Please choose a valid design import source before continuing.' };

--- a/ui/components/designs/patterns/MesheryPatterns.tsx
+++ b/ui/components/designs/patterns/MesheryPatterns.tsx
@@ -36,7 +36,7 @@ import {
   useDeletePatternMutation,
   useDeployPatternMutation,
   useGetPatternsQuery,
-  useImportPatternMutation,
+  useImportDesignMutation,
   usePublishPatternMutation,
   useUndeployPatternMutation,
   useUnpublishPatternMutation,
@@ -145,7 +145,7 @@ function MesheryPatterns({
   const [publishCatalog] = usePublishPatternMutation();
   const [unpublishCatalog] = useUnpublishPatternMutation();
   const [deletePattern] = useDeletePatternMutation();
-  const [importPattern] = useImportPatternMutation();
+  const [importDesign] = useImportDesignMutation();
   const [updatePattern] = useUpdatePatternFileMutation();
   const [uploadPatternFile] = useUploadPatternFileMutation();
   const [deletePatternFile] = useDeletePatternFileMutation();
@@ -230,7 +230,7 @@ function MesheryPatterns({
     unpublishCatalog,
     deletePattern,
     deletePatternFile,
-    importPattern,
+    importDesign,
     updatePattern,
     uploadPatternFile,
     deployPatternMutation,

--- a/ui/components/designs/patterns/patterns-actions.test.tsx
+++ b/ui/components/designs/patterns/patterns-actions.test.tsx
@@ -63,7 +63,7 @@ const baseDeps = () => {
     unpublishCatalog: vi.fn(),
     deletePattern: vi.fn(),
     deletePatternFile: vi.fn(),
-    importPattern: vi.fn(),
+    importDesign: vi.fn(),
     updatePattern: vi.fn(),
     uploadPatternFile: vi.fn(),
     deployPatternMutation: vi.fn().mockResolvedValue({}),
@@ -222,13 +222,13 @@ describe('createPatternsActions', () => {
 
   it('handleImportDesign uploads file imports using the resolved file metadata', async () => {
     const deps = baseDeps();
-    deps.importPattern.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    deps.importDesign.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     buildImportDesignRequestBody.mockResolvedValue({
-      requestBody: JSON.stringify({
+      requestBody: {
         name: 'Imported design',
         fileName: 'imported-design.yaml',
         file: [1, 2, 3],
-      }),
+      },
     });
 
     const actions = createPatternsActions(deps);
@@ -243,12 +243,12 @@ describe('createPatternsActions', () => {
       name: 'Imported design',
       file: 'data:text/plain;base64,QQ==',
     });
-    expect(deps.importPattern).toHaveBeenCalledWith({
-      importBody: JSON.stringify({
+    expect(deps.importDesign).toHaveBeenCalledWith({
+      body: {
         name: 'Imported design',
         fileName: 'imported-design.yaml',
         file: [1, 2, 3],
-      }),
+      },
     });
   });
 
@@ -265,7 +265,7 @@ describe('createPatternsActions', () => {
       file: undefined,
     });
 
-    expect(deps.importPattern).not.toHaveBeenCalled();
+    expect(deps.importDesign).not.toHaveBeenCalled();
     expect(deps.notify).toHaveBeenCalledWith({
       message: 'Please choose a design file before continuing.',
       event_type: 'error',

--- a/ui/components/designs/patterns/patterns-actions.ts
+++ b/ui/components/designs/patterns/patterns-actions.ts
@@ -24,7 +24,7 @@ export function createPatternsActions(deps) {
     unpublishCatalog,
     deletePattern,
     deletePatternFile,
-    importPattern,
+    importDesign,
     updatePattern,
     uploadPatternFile,
     deployPatternMutation,
@@ -321,8 +321,8 @@ export function createPatternsActions(deps) {
       return;
     }
 
-    return importPattern({
-      importBody: importRequest.requestBody,
+    return importDesign({
+      body: importRequest.requestBody,
     })
       .unwrap()
       .then(() => {

--- a/ui/components/workspaces/SpacesSwitcher/components.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/components.tsx
@@ -34,7 +34,7 @@ import { ImportDesignModal } from '@/components/designs/ImportDesignModal';
 import { buildImportDesignRequestBody } from '@/components/designs/import-design-request';
 import { useNotification } from '@/utils/hooks/useNotification';
 import { EVENT_TYPES } from 'lib/event-types';
-import { useImportPatternMutation } from '@/rtk-query/design';
+import { useImportDesignMutation } from '@/rtk-query/design';
 import { updateProgress } from '@/store/slices/mesheryUi';
 import { WorkspaceModalContext } from '@/utils/context/WorkspaceModalContextProvider';
 import { useAssignDesignToWorkspaceMutation } from '@/rtk-query/workspace';
@@ -324,7 +324,7 @@ export const ImportButton = ({ workspaceId, disabled = false, refetch, permissio
   const handleImportModalClose = () => {
     setImportModal(false);
   };
-  const [importPattern] = useImportPatternMutation();
+  const [importDesign] = useImportDesignMutation();
   const { notify } = useNotification();
   const theme = useTheme();
   async function handleImportDesign(data) {
@@ -341,8 +341,8 @@ export const ImportButton = ({ workspaceId, disabled = false, refetch, permissio
       return;
     }
 
-    return importPattern({
-      importBody: importRequest.requestBody,
+    return importDesign({
+      body: importRequest.requestBody,
     })
       .unwrap()
       .then((data) => {

--- a/ui/rtk-query/__tests__/design-import-invalidation.test.ts
+++ b/ui/rtk-query/__tests__/design-import-invalidation.test.ts
@@ -1,12 +1,26 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';
 
 // The schemas client reads its base URL from the environment at module-load
 // time, and the app relies on a relative base in the browser. Under the test
 // runner a relative base has no origin to resolve against, so pin an absolute
 // one before the client is imported (vi.hoisted runs ahead of the imports).
-vi.hoisted(() => {
-  process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://meshery.test';
+//
+// Use the same value every other rtk-query suite uses, and restore whatever was
+// there afterwards: test files sharing a worker process share `process.env`, so
+// a divergent value left behind here is a way for suite order to start mattering.
+const { previousEndpointPrefix } = vi.hoisted(() => {
+  const previous = process.env.RTK_MESHERY_ENDPOINT_PREFIX;
+  process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://localhost';
+  return { previousEndpointPrefix: previous };
+});
+
+afterAll(() => {
+  if (previousEndpointPrefix === undefined) {
+    delete process.env.RTK_MESHERY_ENDPOINT_PREFIX;
+  } else {
+    process.env.RTK_MESHERY_ENDPOINT_PREFIX = previousEndpointPrefix;
+  }
 });
 
 // design.ts pulls in @/utils/utils + @/utils/multi-ctx, which transitively

--- a/ui/rtk-query/__tests__/design-import-invalidation.test.ts
+++ b/ui/rtk-query/__tests__/design-import-invalidation.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../store', () => ({ store: { dispatch } }));
 
 import { api } from '../index';
 import { designsApi } from '../design';
+import { appendInvalidatesTags } from '../utils';
 
 // Nothing in the generated client provides the schemas-side `Design_designs`
 // tag, so this stands in for any future consumer of it: it is the only way to
@@ -58,13 +59,16 @@ const methodOf = (call: unknown[]) =>
     : (call[0] as Request).method;
 
 /**
- * `enhanceEndpoints` applies a partial definition with
- * `Object.assign(getEndpointDefinition(context, name) || {}, partial)`. When the
- * named endpoint is absent at enhance time the assignment lands on a throwaway
- * object and the enhancement is a SILENT no-op. These tests pin both halves of
- * the design-import wiring: that `importDesign` really is the generated endpoint
- * being enhanced, and that an import actually invalidates the local `designs`
- * tag the design lists provide.
+ * `design.ts` attaches the local `designs` cache tag to the schemas-generated
+ * `importDesign` endpoint through the callback form of `enhanceEndpoints`, which
+ * is handed the live definition from `getEndpointDefinition(context, name)`. That
+ * lookup has no fallback, so a missing endpoint fails at module load instead of
+ * enhancing a throwaway object the way the object form
+ * (`Object.assign(getEndpointDefinition(...) || {}, partial)`) silently would.
+ * These tests pin the three parts of that wiring: that `importDesign` is the
+ * generated endpoint and no local duplicate has come back, that an import
+ * invalidates the local `designs` tag the design lists provide, and that the tags
+ * schemas itself declares are still invalidated alongside it.
  */
 describe('importDesign — schemas-generated endpoint with local cache tag', () => {
   const setup = () => {
@@ -105,12 +109,17 @@ describe('importDesign — schemas-generated endpoint with local cache tag', () 
 
   it('is the schemas-generated endpoint, never a locally re-declared one', () => {
     // `enhanceEndpoints` only ever mutates an existing definition, so a defined
-    // `importDesign` proves the generated endpoint was there to enhance. If this
-    // fails, the enhancement in design.ts is a no-op and the local `designs` tag
-    // silently stops being invalidated on import.
+    // `importDesign` is the generated one design.ts enhanced.
     expect(api.endpoints.importDesign).toBeDefined();
     // The local duplicate that used to declare POST /api/pattern/import.
     expect(designsApi.endpoints.importPattern).toBeUndefined();
+  });
+
+  it('names the endpoint and the package if schemas stops generating it', () => {
+    const attachTag = appendInvalidatesTags('importDesign', { type: 'designs' });
+    expect(() => attachTag(undefined)).toThrow(/importDesign/);
+    expect(() => attachTag(undefined)).toThrow(/@meshery\/schemas/);
+    expect(() => attachTag(undefined)).toThrow(/renamed or removed/);
   });
 
   it('POSTs the generated /api/pattern/import request and refetches the designs list', async () => {

--- a/ui/rtk-query/__tests__/design-import-invalidation.test.ts
+++ b/ui/rtk-query/__tests__/design-import-invalidation.test.ts
@@ -27,6 +27,18 @@ vi.mock('../../store', () => ({ store: { dispatch } }));
 import { api } from '../index';
 import { designsApi } from '../design';
 
+// Nothing in the generated client provides the schemas-side `Design_designs`
+// tag, so this stands in for any future consumer of it: it is the only way to
+// observe from the outside that the enhancement kept the generated tag.
+const schemasTaggedApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    designsTaggedBySchemas: builder.query({
+      query: () => '/api/test/schemas-tagged-designs',
+      providesTags: ['Design_designs'],
+    }),
+  }),
+});
+
 const jsonResponse = (body: unknown) =>
   Promise.resolve(
     new Response(JSON.stringify(body), {
@@ -55,22 +67,7 @@ const methodOf = (call: unknown[]) =>
  * tag the design lists provide.
  */
 describe('importDesign — schemas-generated endpoint with local cache tag', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('is already present on the schemas client before design.ts enhances it', () => {
-    // If this ever fails, the enhanceEndpoints call in design.ts is a no-op and
-    // the local `designs` tag silently stops being invalidated on import.
-    expect(api.endpoints.importDesign).toBeDefined();
-    expect(designsApi.endpoints.importDesign).toBe(api.endpoints.importDesign);
-  });
-
-  it('POSTs the generated /api/pattern/import request and refetches the designs list', async () => {
+  const setup = () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : (input as Request).url;
       if (url.includes('/api/pattern/import')) {
@@ -85,6 +82,40 @@ describe('importDesign — schemas-generated endpoint with local cache tag', () 
       middleware: (getDefault) => getDefault().concat(api.middleware),
     });
 
+    return { fetchMock, store };
+  };
+
+  const importDesign = (store: ReturnType<typeof setup>['store']) =>
+    store
+      .dispatch(
+        designsApi.endpoints.importDesign.initiate({
+          body: { url: 'https://example.com/design.yaml', name: 'Imported design' },
+        }),
+      )
+      .unwrap();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('is the schemas-generated endpoint, never a locally re-declared one', () => {
+    // `enhanceEndpoints` only ever mutates an existing definition, so a defined
+    // `importDesign` proves the generated endpoint was there to enhance. If this
+    // fails, the enhancement in design.ts is a no-op and the local `designs` tag
+    // silently stops being invalidated on import.
+    expect(api.endpoints.importDesign).toBeDefined();
+    // The local duplicate that used to declare POST /api/pattern/import.
+    expect(designsApi.endpoints.importPattern).toBeUndefined();
+  });
+
+  it('POSTs the generated /api/pattern/import request and refetches the designs list', async () => {
+    const { fetchMock, store } = setup();
+
     // Subscribe to the designs list so RTK will act on the invalidation.
     const listSub = store.dispatch(
       designsApi.endpoints.getPatterns.initiate({ page: 0, pagesize: 10 }),
@@ -92,13 +123,7 @@ describe('importDesign — schemas-generated endpoint with local cache tag', () 
     await listSub;
     const fetchesAfterList = fetchMock.mock.calls.length;
 
-    await store
-      .dispatch(
-        designsApi.endpoints.importDesign.initiate({
-          body: { url: 'https://example.com/design.yaml', name: 'Imported design' },
-        }),
-      )
-      .unwrap();
+    await importDesign(store);
 
     const importCall = fetchMock.mock.calls.find((call) =>
       urlOf(call).includes('/api/pattern/import'),
@@ -115,5 +140,25 @@ describe('importDesign — schemas-generated endpoint with local cache tag', () 
     expect(listRefetches.length, 'designs list refetched after import').toBeGreaterThan(0);
 
     listSub.unsubscribe();
+  });
+
+  it('keeps the tags the generated definition declares, not just the local one', async () => {
+    const { fetchMock, store } = setup();
+
+    const schemasTagSub = store.dispatch(
+      schemasTaggedApi.endpoints.designsTaggedBySchemas.initiate(undefined),
+    );
+    await schemasTagSub;
+    const fetchesAfterSubscribe = fetchMock.mock.calls.length;
+
+    await importDesign(store);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const refetches = fetchMock.mock.calls
+      .slice(fetchesAfterSubscribe)
+      .filter((call) => urlOf(call).includes('/api/test/schemas-tagged-designs'));
+    expect(refetches.length, 'Design_designs consumer refetched after import').toBeGreaterThan(0);
+
+    schemasTagSub.unsubscribe();
   });
 });

--- a/ui/rtk-query/__tests__/design-import-invalidation.test.ts
+++ b/ui/rtk-query/__tests__/design-import-invalidation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+
+// The schemas client reads its base URL from the environment at module-load
+// time, and the app relies on a relative base in the browser. Under the test
+// runner a relative base has no origin to resolve against, so pin an absolute
+// one before the client is imported (vi.hoisted runs ahead of the imports).
+vi.hoisted(() => {
+  process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://meshery.test';
+});
+
+// design.ts pulls in @/utils/utils + @/utils/multi-ctx, which transitively
+// import non-test-safe modules (SVG-in-JS). Mock the small surface it uses.
+vi.mock('@/utils/utils', () => ({
+  urlEncodeParams: (params: Record<string, unknown>) => {
+    const sp = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v != null) sp.append(k, String(v));
+    });
+    return sp.toString();
+  },
+}));
+vi.mock('@/utils/multi-ctx', () => ({ ctxUrl: (url: string) => url }));
+const { dispatch } = vi.hoisted(() => ({ dispatch: vi.fn() }));
+vi.mock('../../store', () => ({ store: { dispatch } }));
+
+import { api } from '../index';
+import { designsApi } from '../design';
+
+const jsonResponse = (body: unknown) =>
+  Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+
+// fetchBaseQuery calls fetch() with a Request object, so both the URL and the
+// method come off argument 0 rather than an init bag.
+const urlOf = (call: unknown[]) =>
+  typeof call[0] === 'string' ? call[0] : (call[0] as Request).url;
+
+const methodOf = (call: unknown[]) =>
+  typeof call[0] === 'string'
+    ? ((call[1] as RequestInit)?.method ?? 'GET')
+    : (call[0] as Request).method;
+
+/**
+ * `enhanceEndpoints` applies a partial definition with
+ * `Object.assign(getEndpointDefinition(context, name) || {}, partial)`. When the
+ * named endpoint is absent at enhance time the assignment lands on a throwaway
+ * object and the enhancement is a SILENT no-op. These tests pin both halves of
+ * the design-import wiring: that `importDesign` really is the generated endpoint
+ * being enhanced, and that an import actually invalidates the local `designs`
+ * tag the design lists provide.
+ */
+describe('importDesign — schemas-generated endpoint with local cache tag', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is already present on the schemas client before design.ts enhances it', () => {
+    // If this ever fails, the enhanceEndpoints call in design.ts is a no-op and
+    // the local `designs` tag silently stops being invalidated on import.
+    expect(api.endpoints.importDesign).toBeDefined();
+    expect(designsApi.endpoints.importDesign).toBe(api.endpoints.importDesign);
+  });
+
+  it('POSTs the generated /api/pattern/import request and refetches the designs list', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/api/pattern/import')) {
+        return jsonResponse([{ id: 'design-1', name: 'Imported design' }]);
+      }
+      return jsonResponse({ patterns: [], total_count: 0 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const store = configureStore({
+      reducer: { [api.reducerPath]: api.reducer },
+      middleware: (getDefault) => getDefault().concat(api.middleware),
+    });
+
+    // Subscribe to the designs list so RTK will act on the invalidation.
+    const listSub = store.dispatch(
+      designsApi.endpoints.getPatterns.initiate({ page: 0, pagesize: 10 }),
+    );
+    await listSub;
+    const fetchesAfterList = fetchMock.mock.calls.length;
+
+    await store
+      .dispatch(
+        designsApi.endpoints.importDesign.initiate({
+          body: { url: 'https://example.com/design.yaml', name: 'Imported design' },
+        }),
+      )
+      .unwrap();
+
+    const importCall = fetchMock.mock.calls.find((call) =>
+      urlOf(call).includes('/api/pattern/import'),
+    );
+    expect(importCall, 'import request was issued').toBeDefined();
+    expect(methodOf(importCall!)).toBe('POST');
+
+    // Let the invalidation-driven refetch settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const listRefetches = fetchMock.mock.calls
+      .slice(fetchesAfterList)
+      .filter((call) => urlOf(call).includes('/api/pattern?'));
+    expect(listRefetches.length, 'designs list refetched after import').toBeGreaterThan(0);
+
+    listSub.unsubscribe();
+  });
+});

--- a/ui/rtk-query/__tests__/design.test.ts
+++ b/ui/rtk-query/__tests__/design.test.ts
@@ -38,7 +38,9 @@ describe('design – module surface', () => {
     expect(designsApi.endpoints.publishPattern).toBeDefined();
     expect(designsApi.endpoints.unpublishPattern).toBeDefined();
     expect(designsApi.endpoints.deletePattern).toBeDefined();
-    expect(designsApi.endpoints.importPattern).toBeDefined();
+    // `importDesign` comes from the schemas-generated client, enhanced here
+    // with the local `designs` cache tag rather than re-declared.
+    expect(designsApi.endpoints.importDesign).toBeDefined();
     expect(designsApi.endpoints.deletePatternFile).toBeDefined();
     expect(designsApi.endpoints.updatePatternFile).toBeDefined();
     expect(designsApi.endpoints.uploadPatternFile).toBeDefined();
@@ -57,7 +59,7 @@ describe('design – module surface', () => {
     expect(typeof mod.usePublishPatternMutation).toBe('function');
     expect(typeof mod.useUnpublishPatternMutation).toBe('function');
     expect(typeof mod.useDeletePatternMutation).toBe('function');
-    expect(typeof mod.useImportPatternMutation).toBe('function');
+    expect(typeof mod.useImportDesignMutation).toBe('function');
     expect(typeof mod.useUpdatePatternFileMutation).toBe('function');
     expect(typeof mod.useUploadPatternFileMutation).toBe('function');
     expect(typeof mod.useDeletePatternFileMutation).toBe('function');

--- a/ui/rtk-query/design.ts
+++ b/ui/rtk-query/design.ts
@@ -1,7 +1,7 @@
 import { urlEncodeParams } from '@/utils/utils';
 import { api, mesheryApiPath } from './index';
 import { ctxUrl } from '@/utils/multi-ctx';
-import { initiateQuery } from './utils';
+import { appendInvalidatesTags, initiateQuery } from './utils';
 import _ from 'lodash';
 
 const TAGS = {
@@ -13,21 +13,11 @@ export const designsApi = api
     addTagTypes: [TAGS.DESIGNS],
     endpoints: {
       // `importDesign` (POST /api/pattern/import) is the schemas-generated
-      // endpoint - the request is NOT re-declared here. The callback form of
-      // `enhanceEndpoints` hands over the generated definition, so the local
-      // `designs` tag the design lists provide is appended to whatever tags
-      // schemas declares; the object form would `Object.assign` over them. This
-      // is the cache-tag ergonomics wrapper AGENTS.md permits, not a second
-      // declaration of the request.
-      importDesign: (definition) => {
-        const generatedTags = definition.invalidatesTags;
-        definition.invalidatesTags = (result, error, arg, meta) => [
-          ...(typeof generatedTags === 'function'
-            ? generatedTags(result, error, arg, meta)
-            : (generatedTags ?? [])),
-          { type: TAGS.DESIGNS },
-        ];
-      },
+      // endpoint - the request is NOT re-declared here. `appendInvalidatesTags`
+      // adds the local `designs` tag the design lists provide on top of the tags
+      // schemas already declares. This is the cache-tag ergonomics wrapper
+      // AGENTS.md permits, not a second declaration of the request.
+      importDesign: appendInvalidatesTags('importDesign', { type: TAGS.DESIGNS }),
     },
   })
   .injectEndpoints({

--- a/ui/rtk-query/design.ts
+++ b/ui/rtk-query/design.ts
@@ -6,20 +6,27 @@ import _ from 'lodash';
 
 const TAGS = {
   DESIGNS: 'designs',
-};
+} as const;
 
 export const designsApi = api
   .enhanceEndpoints({
     addTagTypes: [TAGS.DESIGNS],
     endpoints: {
       // `importDesign` (POST /api/pattern/import) is the schemas-generated
-      // endpoint - the request is NOT re-declared here. It already invalidates
-      // the schemas tag `Design_designs`; the local design lists provide the
-      // `designs` tag, so both are listed to keep every design cache entry
-      // refreshed after an import. This is the cache-tag ergonomics wrapper
-      // AGENTS.md permits, not a second declaration of the request.
-      importDesign: {
-        invalidatesTags: ['Design_designs', { type: TAGS.DESIGNS }],
+      // endpoint - the request is NOT re-declared here. The callback form of
+      // `enhanceEndpoints` hands over the generated definition, so the local
+      // `designs` tag the design lists provide is appended to whatever tags
+      // schemas declares; the object form would `Object.assign` over them. This
+      // is the cache-tag ergonomics wrapper AGENTS.md permits, not a second
+      // declaration of the request.
+      importDesign: (definition) => {
+        const generatedTags = definition.invalidatesTags;
+        definition.invalidatesTags = (result, error, arg, meta) => [
+          ...(typeof generatedTags === 'function'
+            ? generatedTags(result, error, arg, meta)
+            : (generatedTags ?? [])),
+          { type: TAGS.DESIGNS },
+        ];
       },
     },
   })

--- a/ui/rtk-query/design.ts
+++ b/ui/rtk-query/design.ts
@@ -11,6 +11,17 @@ const TAGS = {
 export const designsApi = api
   .enhanceEndpoints({
     addTagTypes: [TAGS.DESIGNS],
+    endpoints: {
+      // `importDesign` (POST /api/pattern/import) is the schemas-generated
+      // endpoint - the request is NOT re-declared here. It already invalidates
+      // the schemas tag `Design_designs`; the local design lists provide the
+      // `designs` tag, so both are listed to keep every design cache entry
+      // refreshed after an import. This is the cache-tag ergonomics wrapper
+      // AGENTS.md permits, not a second declaration of the request.
+      importDesign: {
+        invalidatesTags: ['Design_designs', { type: TAGS.DESIGNS }],
+      },
+    },
   })
   .injectEndpoints({
     endpoints: (builder) => ({
@@ -148,14 +159,6 @@ export const designsApi = api
         }),
         invalidatesTags: [{ type: TAGS.DESIGNS }],
       }),
-      importPattern: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`pattern/import`),
-          method: 'POST',
-          body: queryArg.importBody,
-        }),
-        invalidatesTags: [{ type: TAGS.DESIGNS }],
-      }),
       deletePatternFile: builder.mutation({
         query: (queryArg) => ({
           url: mesheryApiPath(`pattern/${queryArg.id}`),
@@ -207,7 +210,10 @@ export const {
   usePublishPatternMutation,
   useUnpublishPatternMutation,
   useDeletePatternMutation,
-  useImportPatternMutation,
+  // Re-exported from the schemas-generated client (see the `importDesign`
+  // enhancement above) so design-import callers stay on the canonical
+  // `@meshery/schemas` mutation instead of a locally declared one.
+  useImportDesignMutation,
   useUpdatePatternFileMutation,
   useUploadPatternFileMutation,
   useDeletePatternFileMutation,

--- a/ui/rtk-query/utils.ts
+++ b/ui/rtk-query/utils.ts
@@ -1,6 +1,36 @@
 import { store } from '../store';
 
 /**
+ * Builds the callback form of an `enhanceEndpoints` partial that appends local
+ * cache tags to a schemas-generated endpoint. The callback is handed the live
+ * generated definition, so the tags schemas declares are kept; the object form
+ * of `enhanceEndpoints` would `Object.assign` over them.
+ * @param {string} operationId - The generated operationId being enhanced, used in the failure message.
+ * @param {...(string|Object)} localTags - Tag descriptions to invalidate in addition to the generated ones.
+ * @returns {(definition: Object) => void} - An `enhanceEndpoints` endpoint callback.
+ * @throws {Error} If the operationId is absent from the generated client.
+ */
+export const appendInvalidatesTags =
+  (operationId, ...localTags) =>
+  (definition) => {
+    if (!definition) {
+      throw new Error(
+        `RTK Query endpoint "${operationId}" is not present on the @meshery/schemas generated client, ` +
+          `so its local cache tags could not be attached. @meshery/schemas most likely renamed or removed ` +
+          `the operation - update the enhanceEndpoints call in ui/rtk-query to the current operationId.`,
+      );
+    }
+
+    const generatedTags = definition.invalidatesTags;
+    definition.invalidatesTags = (result, error, arg, meta) => [
+      ...(typeof generatedTags === 'function'
+        ? generatedTags(result, error, arg, meta)
+        : (generatedTags ?? [])),
+      ...localTags,
+    ];
+  };
+
+/**
  * Initiates a query using specified query and variables via store.dispatch.
  * @param {Object} query - The query object containing the initiate function.
  * @param {any} variables - Variables to be passed to the query initiate function.


### PR DESCRIPTION
## Description

Completes the design-import canonical-sourcing audit begun in #21114.

#21114 pinned the design-import **request body** in the UI to `@meshery/schemas`' generated `ImportDesignApiArg`. This PR audits every remaining design-import consumer in this repo and repoints the ones that still carried a local copy of the wire contract.

### What was still duplicating the contract

**1. `ui/rtk-query/design.ts` hand-rolled the import mutation.**

A local `importPattern: builder.mutation` re-declared `POST /api/pattern/import` alongside the generated `importDesign` — exactly the forbidden path in `AGENTS.md`. It is removed; callers now use the generated `useImportDesignMutation`.

The endpoint still needs the local `designs` cache tag, so it is attached with `enhanceEndpoints`. Worth noting **which** form, because the obvious one is a trap: the object form does `Object.assign(definition, partial)` and so **replaces** `invalidatesTags` wholesale, silently dropping whatever tags schemas declares. The callback form receives the live definition, so the new `appendInvalidatesTags` helper appends the local tag to the generated ones and any tag schemas adds later flows through automatically.

If schemas ever renames or removes `importDesign`, that callback would previously have thrown a bare `Cannot read properties of undefined (reading 'invalidatesTags')` at module load — taking down every page importing the module (`MesheryPatterns`, `SpacesSwitcher`, the rest of the designs surface) with no clue as to the cause. It now fails fast with a named error identifying the operation, `@meshery/schemas` as the source, and the likely cause.

**2. `mesheryctl design import` built its body from a hand-written map.**

`map[string]interface{}{"file": …, "fileName": …}` is precisely how camelCase `fileName` regressed to `file_name` before (#21105). It now builds the body from the schemas-generated `v1beta3` `oneOf` union builders (`FromMesheryPatternImport{File,URL}Payload`), so the wire field names come from the generated struct tags and cannot drift. The two arms also now share one response path, since the divergence between them is what let the bug survive in only one.

`save` is dropped from the body: the server never reads it (`DesignFileImportHandler` always saves), so it was already inert on the wire.

**3. An orphaned local copy of the import form schema.**

`ui/assets/jsonschema/uiSchemaDesignImport.json` duplicated the design-import RJSF uiSchema, and had drifted to a stale subset of the canonical `DesignImportRjsfUiSchemaV1Beta3`. Zero references repo-wide; the live consumer already sources it canonically via sistent. Deleted.

### Out-of-scope fix included: the 1422 error told callers to reproduce the bug

`meshery-server-1422` ("Invalid design import request") instructed callers to send the exact snake_case that causes it:

> Send a request body with exactly one variant set: either `{"file": <bytes>, "file_name": "design.yml"}` …

A caller who hit 1422 and followed its own remediation verbatim reproduced 1422 forever. Corrected to camelCase `fileName` across all three strings a rendered 1422 shows — the detail line (`design_import.go:80,82`), the probable cause, and the remediation (`error.go:1048`).

No error code is added or renumbered, and no generated export is committed: `error-codes-updater.yaml` runs `errorutil update` before `analyze` in the same step, so the PR stays green, and `docs/data/errorref/meshery-server_errors_export.json` self-heals via the push-to-master auto-commit.

## Defects found during the audit, filed rather than fixed here

Each is real and reproducible, but none belongs in a wire-contract audit:

| Issue | Summary |
|---|---|
| meshery/schemas#1128 | `ImportDesignApiResponse` is `{ message?: string }`, but `/api/pattern/import` returns an **array of designs**. Runtime-correct here and gated by nothing (`noImplicitAny: false`), so latent — but it is a wrong contract for every repo that sources it. |
| #21162 | **`ui/tsconfig.json` include globs match no files** — they resolve to `ui/ui/**` because the tsconfig already lives in `ui/`. `tsc --noEmit --listFiles` yields exactly one non-`node_modules` file, so the UI typecheck is vacuous. Correcting it surfaces 2,933 errors across 527 files. |
| #21163 | `mesheryctl design import --source-type` is inert (never reaches the server), and its title-cased mapping switch is unreachable because the value is lower-cased first. |
| #21164 | `initiateQuery` silently drops its third argument, so `getDesign`'s `forceRefetch: true` is discarded and the design info modal can render a stale design. |

## Testing

- `ui`: vitest suites for `import-design-request`, `patterns-actions`, `design`, and a new `design-import-invalidation` suite covering the generated request, the local refetch, and a guard that the generated tags survive the enhancement
- `mesheryctl`: `go test --short ./...`, including a regression test asserting the request body does **not** carry snake_case `file_name`
- `make golangci` and `make ui-lint` clean

## Documentation

`AGENTS.md` gains the cache-tag rule this PR establishes: attach local tags to a generated endpoint with the **callback** form of `enhanceEndpoints`, never by re-declaring the endpoint, and never with the object form that overwrites the generated tags.

Signed-off-by: Mohd Hamza Shaikh <mohd.hamza@tata-consulting.co.uk>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Design imports now use a consistent generated API contract for file and URL requests.
  * Successful imports refresh the design list while preserving existing cache behavior.
* **Bug Fixes**
  * Corrected file field naming to `fileName` in import errors and examples.
  * Prevented malformed URL payload fields from being sent.
  * Improved validation and handling of invalid or empty import responses.
* **Documentation**
  * Added guidance for request body construction and cache-tag enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->