### PR TITLE
[Docs] Fix broken image references in notification-center.md and models

### DIFF
--- a/docs/content/en/project/contributing/models/models.md
+++ b/docs/content/en/project/contributing/models/models.md
@@ -34,7 +34,7 @@ The schema defines the structure of the model, including the entities it contain
 
 > See [Registry]({{< ref "concepts/logical/registry.md" >}}) to learn more about Meshery's internal registry and how to use it.
 
-[![Model Entity Classification](images/model-architecture.svg)](../images/meshery-models.png)
+[![Model Entity Classification](../images/model-architecture.svg)](../images/meshery-models.png)
 _Figure: Model Entity Classification_
 
 ## Meshery Entities and their Lifecycle

--- a/docs/content/en/project/contributing/ui/notification-center.md
+++ b/docs/content/en/project/contributing/ui/notification-center.md
@@ -213,7 +213,7 @@ The `ErrorMetadataFormatter` is used for formatting error-related notifications 
 />
 ```
 
-<a href="images/error-formatter.png"><img alt="Error Formatter" style="width:500px;height:auto;" src="images/error-formatter.png" /></a>
+<a href="../images/error-formatter.png"><img alt="Error Formatter" style="width:500px;height:auto;" src="../images/error-formatter.png" /></a>
 
 **When to Use:**
 
@@ -240,7 +240,7 @@ The `Model Registration Formatter` formats and displays model registration detai
 
    - `modelDetails` (object) – Contains model import data.
 
-<a href="images/model-register-formatter.png"><img alt="Model Register Formatter" style="width:500px;height:auto;" src="images/model-register-formatter.png" /></a>
+<a href="../images/model-register-formatter.png"><img alt="Model Register Formatter" style="width:500px;height:auto;" src="../images/model-register-formatter.png" /></a>
 
 ### Relationship Evaluation Formatter
 
@@ -265,7 +265,7 @@ The **Relationship Evaluation Formatter** is responsible for rendering notificat
     - `relationshipsUpdated` (Array)
     - `relationshipsRemoved` (Array)
 
-<a href="images/relationship-evaluation-formatter.png"><img alt="Relationship Evaluation Formatter" style="width:500px;height:auto;" src="images/relationship-evaluation-formatter.png" /></a>
+<a href="../images/relationship-evaluation-formatter.png"><img alt="Relationship Evaluation Formatter" style="width:500px;height:auto;" src="../images/relationship-evaluation-formatter.png" /></a>
 
 #### When to Use
 
@@ -330,7 +330,7 @@ The **Dry Run Formatter** is responsible for rendering notifications related to 
 - **validationMachine** (object): The state machine handling the dry run validation process.
 - **currentComponentName** (string): The name of the component currently being validated.
 
-<a href="images/dry-run-formatter.png"><img alt="Dry Run Formatter" style="width:500px;height:auto;" src="images/dry-run-formatter.png" /></a>
+<a href="../images/dry-run-formatter.png"><img alt="Dry Run Formatter" style="width:500px;height:auto;" src="../images/dry-run-formatter.png" /></a>
 
 #### When to Use
 

--- a/docs/content/en/project/contributing/ui/widgets.md
+++ b/docs/content/en/project/contributing/ui/widgets.md
@@ -158,8 +158,8 @@ Meshery stores user layout preferences either in local storage or via the provid
 
 This is how your default widget would appear in the dashboard:
 
-<a href="images/dashboard-widgets.png">
-<img style= "width: 600px;" src="images/dashboard-widgets.png" />
+<a href="../images/dashboard-widgets.png">
+<img style= "width: 600px;" src="../images/dashboard-widgets.png" />
 </a>
 
 ---


### PR DESCRIPTION

**Notes for Reviewers**
Corrected relative image paths in `docs/content/en/project/contributing/ui/notification-center.md` and in `docs/content/en/project/contributing/models/models.md`


**After SS**
<img width="1440" height="813" alt="Screenshot 2026-08-06 at 11 31 56 AM" src="https://github.com/user-attachments/assets/2e526916-0ec3-48fb-85bd-86d24608dff7" />
<img width="1440" height="812" alt="Screenshot 2026-08-06 at 11 31 37 AM" src="https://github.com/user-attachments/assets/b5081b2f-e2d2-4428-8934-0c60e25c7bdf" />
<img width="1440" height="814" alt="Screenshot 2026-08-06 at 11 31 05 AM" src="https://github.com/user-attachments/assets/741dbc2e-3580-4d31-8cf4-c4cc3bc02cc6" />
<img width="1440" height="816" alt="Screenshot 2026-08-06 at 11 31 47 AM" src="https://github.com/user-attachments/assets/29db0209-7f2e-4eb6-a779-3f4187a27b22" />
<img width="1435" height="813" alt="Screenshot 2026-08-06 at 11 28 52 AM" src="https://github.com/user-attachments/assets/95854a77-5639-453c-adef-120f011e80b0" />


- This PR fixes #20919 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed the model architecture image link.
  * Corrected formatter screenshot links in the notification center documentation.
  * Updated dashboard widget image links.
  * Documentation images now display correctly across contributing guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->