### PR TITLE
[mesheryctl] Fix broken doc links in organization commands

### DIFF
--- a/mesheryctl/internal/cli/root/organizations/list.go
+++ b/mesheryctl/internal/cli/root/organizations/list.go
@@ -24,8 +24,8 @@ var listOrgCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List registered organizations",
 	Long: `List all registered organizations with their id, name and date of creation. Organization will be returned based on provider you logged in.
-Find more information at: https://docs.meshery.io/reference/references/mesheryctl/organizations/list
-	`, // TODO: need to find correct link for this one
+Find more information at: https://docs.meshery.io/reference/references/mesheryctl/organization/list
+	`,
 	Example: `
 // list all organizations
 mesheryctl organization list

--- a/mesheryctl/internal/cli/root/organizations/organization.go
+++ b/mesheryctl/internal/cli/root/organizations/organization.go
@@ -21,7 +21,7 @@ var OrgCmd = &cobra.Command{
 	Use:   "organization",
 	Short: "Interact with registered organizations",
 	Long: `Interact with registered organizations to display detailed information
-Find more information at: https://docs.meshery.io/reference/references/mesheryctl/organizations`, // TODO: need to find correct link for this one
+Find more information at: https://docs.meshery.io/reference/references/mesheryctl/organization`,
 	Example: `
 // Number of  registered orgs
 mesheryctl organization --count


### PR DESCRIPTION
Fixes #21185

**Notes for Reviewers**

- This PR fixes #21185 by updating the hardcoded documentation URLs in the `mesheryctl organization` and `mesheryctl organization list` command descriptions.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the organization command documentation links to use the correct singular URL path.
  * Removed outdated TODO references from the organization command documentation.
  * Improved consistency and reliability when accessing help documentation for organization listing and related commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->