### PR TITLE
[mesheryctl] Guard GetDeploymentVersion against malformed image tags

### DIFF
--- a/mesheryctl/pkg/utils/platform.go
+++ b/mesheryctl/pkg/utils/platform.go
@@ -249,11 +249,22 @@ func GetDeploymentVersion(filePath string) (string, error) {
 		return "", fmt.Errorf("unable to unmarshal config %s | %s", MesheryDeployment, err)
 	}
 
+	if len(compose.Spec.Template.Spec.Containers) == 0 {
+		return "", fmt.Errorf("unable to determine deployment version: no containers found in %s", filePath)
+	}
+
 	image := compose.Spec.Template.Spec.Containers[0].Image
 	spliter := strings.Split(image, ":")
-	version := strings.Split(spliter[1], "-")[1]
+	if len(spliter) < 2 {
+		return "", fmt.Errorf("unable to determine deployment version: image %q has no tag", image)
+	}
 
-	return version, nil
+	tagParts := strings.Split(spliter[1], "-")
+	if len(tagParts) < 2 {
+		return "", fmt.Errorf("unable to determine deployment version: image tag %q does not match the expected version-build format", spliter[1])
+	}
+
+	return tagParts[1], nil
 }
 
 // CanUseCachedOperatorManifests returns an error if it is not possible to use cached operator manifests

--- a/mesheryctl/pkg/utils/platform.go
+++ b/mesheryctl/pkg/utils/platform.go
@@ -254,14 +254,24 @@ func GetDeploymentVersion(filePath string) (string, error) {
 	}
 
 	image := compose.Spec.Template.Spec.Containers[0].Image
-	spliter := strings.Split(image, ":")
-	if len(spliter) < 2 {
+	if strings.Contains(image, "@") {
+		return "", fmt.Errorf("unable to determine deployment version: image %q is a digest reference, expected a tag", image)
+	}
+
+	lastSlash := strings.LastIndex(image, "/")
+	lastColon := strings.LastIndex(image, ":")
+	if lastColon == -1 || lastColon < lastSlash {
 		return "", fmt.Errorf("unable to determine deployment version: image %q has no tag", image)
 	}
 
-	tagParts := strings.Split(spliter[1], "-")
-	if len(tagParts) < 2 {
-		return "", fmt.Errorf("unable to determine deployment version: image tag %q does not match the expected version-build format", spliter[1])
+	tag := image[lastColon+1:]
+	if tag == "" {
+		return "", fmt.Errorf("unable to determine deployment version: image %q has an empty tag", image)
+	}
+
+	tagParts := strings.SplitN(tag, "-", 2)
+	if len(tagParts) < 2 || tagParts[0] == "" || tagParts[1] == "" {
+		return "", fmt.Errorf("unable to determine deployment version: image tag %q does not match the expected version-build format", tag)
 	}
 
 	return tagParts[1], nil

--- a/mesheryctl/pkg/utils/platform_test.go
+++ b/mesheryctl/pkg/utils/platform_test.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -27,6 +29,82 @@ func TestListManifests(t *testing.T) {
 		_, err := ListManifests(url)
 		if err != nil {
 			t.Errorf("ListManifests failed: %v", err)
+		}
+	})
+}
+func TestGetDeploymentVersion(t *testing.T) {
+	writeDeploymentFile := func(t *testing.T, contents string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "meshery-deployment.yaml")
+		if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+			t.Fatalf("failed to write fixture: %v", err)
+		}
+		return path
+	}
+
+	t.Run("valid version-build tag returns the build version", func(t *testing.T) {
+		path := writeDeploymentFile(t, `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: meshery
+          image: layer5/meshery:v0.7.65-abc123
+`)
+		version, err := GetDeploymentVersion(path)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if version != "abc123" {
+			t.Errorf("expected version %q, got %q", "abc123", version)
+		}
+	})
+
+	t.Run("plain tag without a hyphen returns an error instead of panicking", func(t *testing.T) {
+		path := writeDeploymentFile(t, `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: meshery
+          image: layer5/meshery:v0.7.65
+`)
+		if _, err := GetDeploymentVersion(path); err == nil {
+			t.Fatal("expected an error for a tag without a hyphen, got nil")
+		}
+	})
+
+	t.Run("image with no tag returns an error instead of panicking", func(t *testing.T) {
+		path := writeDeploymentFile(t, `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: meshery
+          image: layer5/meshery
+`)
+		if _, err := GetDeploymentVersion(path); err == nil {
+			t.Fatal("expected an error for an image with no tag, got nil")
+		}
+	})
+
+	t.Run("empty containers list returns an error instead of panicking", func(t *testing.T) {
+		path := writeDeploymentFile(t, `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers: []
+`)
+		if _, err := GetDeploymentVersion(path); err == nil {
+			t.Fatal("expected an error for an empty containers list, got nil")
 		}
 	})
 }

--- a/mesheryctl/pkg/utils/platform_test.go
+++ b/mesheryctl/pkg/utils/platform_test.go
@@ -107,4 +107,84 @@ spec:
 			t.Fatal("expected an error for an empty containers list, got nil")
 		}
 	})
+	t.Run("registry host with a port is not mistaken for the tag", func(t *testing.T) {
+		content := `
+spec:
+  template:
+    spec:
+      containers:
+        - image: "registry.example.com:5000/meshery/meshery:stable-v0.7.0"
+`
+		path := writeDeploymentFile(t, content)
+		got, err := GetDeploymentVersion(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "v0.7.0" {
+			t.Errorf("got %q, want %q", got, "v0.7.0")
+		}
+	})
+
+	t.Run("tag with multiple hyphens keeps the full build component", func(t *testing.T) {
+		content := `
+spec:
+  template:
+    spec:
+      containers:
+        - image: "meshery/meshery:stable-v0.7.0-rc1"
+`
+		path := writeDeploymentFile(t, content)
+		got, err := GetDeploymentVersion(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "v0.7.0-rc1" {
+			t.Errorf("got %q, want %q", got, "v0.7.0-rc1")
+		}
+	})
+
+	t.Run("tag with an empty build component returns an error", func(t *testing.T) {
+		content := `
+spec:
+  template:
+    spec:
+      containers:
+        - image: "meshery/meshery:stable-"
+`
+		path := writeDeploymentFile(t, content)
+		_, err := GetDeploymentVersion(path)
+		if err == nil {
+			t.Fatal("expected an error for empty build component, got nil")
+		}
+	})
+
+	t.Run("tag with an empty version component returns an error", func(t *testing.T) {
+		content := `
+spec:
+  template:
+    spec:
+      containers:
+        - image: "meshery/meshery:-v0.7.0"
+`
+		path := writeDeploymentFile(t, content)
+		_, err := GetDeploymentVersion(path)
+		if err == nil {
+			t.Fatal("expected an error for empty version component, got nil")
+		}
+	})
+
+	t.Run("digest reference returns an error instead of panicking", func(t *testing.T) {
+		content := `
+spec:
+  template:
+    spec:
+      containers:
+        - image: "meshery/meshery@sha256:abc123"
+`
+		path := writeDeploymentFile(t, content)
+		_, err := GetDeploymentVersion(path)
+		if err == nil {
+			t.Fatal("expected an error for digest reference, got nil")
+		}
+	})
 }


### PR DESCRIPTION

- This PR fixes #20991

## Root cause
"GetDeploymentVersion" pulled the version out of the container image string
with two chained, unguarded "strings.Split" calls, plus an unchecked empty
"Containers" slice. Any of the following would panic instead of returning
an error:
- a plain release tag with no "-" (e.g. "v0.7.65", "latest")
- an image string with no ":" at all
- an empty "Containers" slice

Panic reproduction is documented in the issue (#20991) via
"TestGetDeploymentVersion_PanicsOnPlainTag".

## Fix
Added explicit length checks before each index access, so the function
now returns a descriptive error instead of panicking, per the issue's
desired behavior.

Design note for reviewers: tags without a hyphen now return an error
rather than a value — matching the issue's stated spec, but worth flagging
since plain release tags are common in practice. Happy to switch to a
permissive fallback (treat the whole tag as the version) if preferred.

Dead code note:
Grepped the full "mesheryctl" tree and found no caller of
"CanUseCachedManifests" (the only caller of "GetDeploymentVersion"). This
fix currently has no live call path, but is still worth fixing correctly
per the issue.

## Before / After (terminal output)

**Before** (from the issue's repro test):

--- FAIL: TestGetDeploymentVersion_PanicsOnPlainTag (0.00s)
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
testing.tRunner.func1()
strings.Split(...)
github.com/meshery/meshery/mesheryctl/pkg/utils.GetDeploymentVersion(...)
FAIL    github.com/meshery/meshery/mesheryctl/pkg/utils
** After** 

=== RUN   TestGetDeploymentVersion
=== RUN   TestGetDeploymentVersion/valid_version-build_tag_returns_the_build_version
=== RUN   TestGetDeploymentVersion/plain_tag_without_a_hyphen_returns_an_error_instead_of_panicking
=== RUN   TestGetDeploymentVersion/image_with_no_tag_returns_an_error_instead_of_panicking
=== RUN   TestGetDeploymentVersion/empty_containers_list_returns_an_error_instead_of_panicking
--- PASS: TestGetDeploymentVersion (0.01s)
    --- PASS: TestGetDeploymentVersion/valid_version-build_tag_returns_the_build_version (0.00s)
    --- PASS: TestGetDeploymentVersion/plain_tag_without_a_hyphen_returns_an_error_instead_of_panicking (0.00s)
    --- PASS: TestGetDeploymentVersion/image_with_no_tag_returns_an_error_instead_of_panicking (0.00s)
    --- PASS: TestGetDeploymentVersion/empty_containers_list_returns_an_error_instead_of_panicking (0.00s)
PASS
ok      github.com/meshery/meshery/mesheryctl/pkg/utils 0.132s




## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment version detection for incomplete or malformed deployment images.
  * Added clear error handling instead of failures when containers, image tags, or expected version details are missing.

* **Tests**
  * Added coverage for valid version extraction and invalid deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment version detection for incomplete or incorrectly formatted container image data.
  * Added clear error handling instead of failures when deployment containers or image tags are missing, empty, malformed, or use unsupported digest references.
  * Improved handling for image references containing registry ports and multiple hyphens.

* **Tests**
  * Added coverage for valid version extraction and malformed deployment scenarios, including missing containers, invalid tags, empty version or build values, and digest-based references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->