### PR TITLE
[Server][UI] Repoint schemas-owned contracts at @meshery/schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,47 @@ bodies, the `From<Variant>Payload` union builders) rather than a
 `map[string]interface{}` — see `mesheryctl/internal/cli/root/design/import.go`.
 A hand-written map is how camelCase `fileName` regressed to `file_name`.
 
+### A local endpoint that shadows a schemas operationId is DEAD CODE
+
+`injectEndpoints` without `overrideExisting: true` **silently discards** any
+endpoint whose name `@meshery/schemas` already defines (dev-only console
+warning) and serves every call from the schemas definition. Nothing in the build,
+the typecheck or a name-only test reports it, so a local declaration can sit there
+looking authoritative while a different request goes over the wire.
+
+This has shipped real breakage more than once: workspace create/update/delete sent
+`body: undefined` and addressed `/api/workspaces/undefined`, and notification
+delete issued `DELETE /api/events/undefined`, because in each case the caller was
+shaped for the dead local definition while the schemas one ran.
+
+So:
+
+- Before adding a `builder.query`/`builder.mutation`, check the name against the
+  generated client (`grep '<name>:t\.' ui/node_modules/@meshery/schemas/dist/mesheryApi.js`).
+  If it is there, consume the generated hook - that is the rule above anyway.
+- The narrow legitimate override is a schemas operation that is **wrong for
+  Meshery today** (schemas landing a path ahead of the server). Set
+  `overrideExisting: true` explicitly, say why in a comment, and link the schemas
+  issue - see `ui/rtk-query/notificationCenter.ts` and meshery/schemas#1134.
+- **Assert the effective endpoint, not the declared one.** A test that reads the
+  module's source shape, or that calls `fetch` itself and asserts its own mock,
+  proves nothing. Dispatch through a real store and assert the URL, method and
+  body - see `ui/rtk-query/__tests__/{workspace-mutation-wrappers,notificationCenter-effective-endpoints}.test.ts*`.
+
+### Consumed contracts are the schemas type, not a copy of it
+
+A struct Meshery only *decodes* from a remote provider (or only *encodes* to one)
+carries no local freedom: it is the schemas construct, aliased. A local copy is
+how `AnonymousFlowResponse` came to read `owner` while meshery-cloud kept sending
+`userId`, so every anonymous sign-in wrote its capabilities under the nil UUID.
+The same rename hit `PatternResource` and `Preference.selectedOrganizationId`.
+
+When the Go type must stay local because it doubles as a GORM model (the schemas
+models carry `db:` tags GORM does not read), keep the **JSON tags** identical to
+the schemas construct and pin the column explicitly with `gorm:"column:..."` -
+see `server/models/pattern_resource.go`. Guard it with a test that compares the
+emitted JSON keys against the schemas type rather than restating them by hand.
+
 ## Build & Development Commands
 
 - Use the `gh-axi` CLI tool to interact with GitHub. Prefer `gh-axi` over `gh`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,29 +134,17 @@ A hand-written map is how camelCase `fileName` regressed to `file_name`.
 ### A local endpoint that shadows a schemas operationId is DEAD CODE
 
 `injectEndpoints` without `overrideExisting: true` **silently discards** any
-endpoint whose name `@meshery/schemas` already defines (dev-only console
-warning) and serves every call from the schemas definition. Nothing in the build,
-the typecheck or a name-only test reports it, so a local declaration can sit there
-looking authoritative while a different request goes over the wire.
+endpoint whose name `@meshery/schemas` already defines (dev-only console warning)
+and serves every call from the schemas definition, so a local declaration can sit
+there looking authoritative while a different request goes over the wire - which
+is how notification delete shipped as `DELETE /api/events/undefined`. Before
+adding a `builder.query`/`builder.mutation`, check the name against the generated
+client (`grep '<name>:t\.' ui/node_modules/@meshery/schemas/dist/mesheryApi.js`);
+if it is there, consume the generated hook - that is the rule above anyway.
 
-This has shipped real breakage more than once: workspace create/update/delete sent
-`body: undefined` and addressed `/api/workspaces/undefined`, and notification
-delete issued `DELETE /api/events/undefined`, because in each case the caller was
-shaped for the dead local definition while the schemas one ran.
-
-So:
-
-- Before adding a `builder.query`/`builder.mutation`, check the name against the
-  generated client (`grep '<name>:t\.' ui/node_modules/@meshery/schemas/dist/mesheryApi.js`).
-  If it is there, consume the generated hook - that is the rule above anyway.
-- The narrow legitimate override is a schemas operation that is **wrong for
-  Meshery today** (schemas landing a path ahead of the server). Set
-  `overrideExisting: true` explicitly, say why in a comment, and link the schemas
-  issue - see `ui/rtk-query/notificationCenter.ts` and meshery/schemas#1134.
-- **Assert the effective endpoint, not the declared one.** A test that reads the
-  module's source shape, or that calls `fetch` itself and asserts its own mock,
-  proves nothing. Dispatch through a real store and assert the URL, method and
-  body - see `ui/rtk-query/__tests__/{workspace-mutation-wrappers,notificationCenter-effective-endpoints}.test.ts*`.
+The deliberate-override exception and the rule that tests must assert the
+*effective* endpoint rather than the declared one are in
+`docs/content/en/project/contributing/ui/schemas.md` (Integration Points in UI, A).
 
 ### Consumed contracts are the schemas type, not a copy of it
 

--- a/docs/content/en/project/contributing/ui/schemas.md
+++ b/docs/content/en/project/contributing/ui/schemas.md
@@ -226,11 +226,17 @@ grep '<operationId>:t\.' ui/node_modules/@meshery/schemas/dist/mesheryApi.js
 Override deliberately only when the generated operation is genuinely wrong for
 Meshery today - for example when schemas has landed a path the server has not
 adopted yet. Set `overrideExisting: true` explicitly, explain why in a comment, and
-link the `meshery/schemas` issue tracking the divergence.
+link the `meshery/schemas` issue tracking the divergence - see
+`ui/rtk-query/notificationCenter.ts` and
+[meshery/schemas#1134](https://github.com/meshery/schemas/issues/1134).
 
 Test the **effective** endpoint, not the declared one: dispatch through a real store
-and assert the URL, method and body. A test that calls `fetch` itself and then
-asserts its own mock proves nothing.
+and assert the URL, method and body. A test that reads the module's source shape, or
+that calls `fetch` itself and then asserts its own mock, proves nothing. The guard
+tests to copy are
+`ui/rtk-query/__tests__/{workspace-mutation-wrappers,notificationCenter-effective-endpoints}.test.ts*`;
+where a local hook only adapts an argument shape, drive that hook with `renderHook`
+so the adaptation itself is exercised rather than bypassed.
 
 ---
 

--- a/docs/content/en/project/contributing/ui/schemas.md
+++ b/docs/content/en/project/contributing/ui/schemas.md
@@ -168,7 +168,73 @@ const validateDesign = (data) => {
 
 ## Integration Points in UI
 
-### A. RJSF JSON Schemas
+### A. Generated RTK Query Client
+
+`@meshery/schemas` publishes more than types: `@meshery/schemas/mesheryApi` is a
+generated [RTK Query](https://redux-toolkit.js.org/rtk-query/overview) client with a
+hook per API operation. `ui/rtk-query/index.ts` re-exports that client as `api`, so
+every module under `ui/rtk-query/` injects into the *same* instance and the generated
+hooks are already available from those modules.
+
+**Consume the generated hook. Do not re-declare the request.** A hand-written
+`builder.query`/`builder.mutation` for an operation schemas already defines forks the
+wire contract silently, and Meshery and Layer5 Cloud drift apart with nothing failing.
+
+```ts
+// Correct - the generated hook, imported directly.
+import { useGetWorkspacesQuery } from "@meshery/schemas/mesheryApi";
+```
+
+A local module is the right place only for *ergonomics* over a generated endpoint -
+adapting an argument shape, or attaching a Meshery-local cache tag:
+
+```ts
+// Argument adaptation: callers pass a bare id, the generated endpoint takes an object.
+export const useGetCredentialByIdQuery = (credentialId: string, options?: object) =>
+  useSchemasGetCredentialByIdQuery({ credentialId }, options);
+```
+
+```ts
+// Cache tags: the callback form of enhanceEndpoints APPENDS to the generated tags.
+// The object form Object.assigns over them and drops every schemas-side tag.
+import { appendInvalidatesTags } from "./utils";
+
+api.enhanceEndpoints({
+  addTagTypes: [TAGS.DESIGNS],
+  endpoints: {
+    importDesign: appendInvalidatesTags("importDesign", { type: TAGS.DESIGNS }),
+  },
+});
+```
+
+#### A local endpoint that shadows a generated one is dead code
+
+`injectEndpoints` **silently discards** an endpoint whose name the generated client
+already defines - a dev-only console warning, nothing more - and serves every call
+from the generated definition. Neither the typecheck nor a test that only asserts a
+hook exists will notice, so a local declaration can look authoritative while a
+different request goes over the wire. Meshery has shipped user-visible breakage this
+way: callers shaped for the discarded local definition sent `undefined` where the
+generated endpoint expected an id.
+
+Before adding an endpoint, check the name against the generated client:
+
+```bash
+grep '<operationId>:t\.' ui/node_modules/@meshery/schemas/dist/mesheryApi.js
+```
+
+Override deliberately only when the generated operation is genuinely wrong for
+Meshery today - for example when schemas has landed a path the server has not
+adopted yet. Set `overrideExisting: true` explicitly, explain why in a comment, and
+link the `meshery/schemas` issue tracking the divergence.
+
+Test the **effective** endpoint, not the declared one: dispatch through a real store
+and assert the URL, method and body. A test that calls `fetch` itself and then
+asserts its own mock proves nothing.
+
+---
+
+### B. RJSF JSON Schemas
 
 Meshery uses [react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form) to render forms dynamically based on JSON schemas. All of Meshery’s RJSF schemas are defined in the `@sistent/sistent` package, which extends schemas from the `@meshery/schema` package.
 
@@ -196,7 +262,7 @@ const designSchema = {
 
 ---
 
-### B. General Form UI
+### C. General Form UI
 
 OpenAPI schemas (especially request bodies for POST/PUT operations) serve as the foundation for building form logic. These definitions include:
 
@@ -221,7 +287,7 @@ const DesignForm = ({ design }: { design: DesignTypes }) => (
 
 ---
 
-### C. UI-Specific Descriptions and Enhancements
+### D. UI-Specific Descriptions and Enhancements
 
 Any UI-specific metadata—such as `name`, `type`, `hints`, `descriptions`, `defaults`, etc.—is defined directly within the relevant schema object. Elements like tooltips, descriptions, and other metadata are frequently needed across the UI, so having a single source of truth in the schema object ensures consistency and reduces duplication.
 
@@ -229,7 +295,7 @@ For example, if we have a `Design` schema, the UI retrieves details like the des
 
 ---
 
-### D. Type Safety for Component Props
+### E. Type Safety for Component Props
 
 Generated TypeScript types from the schema ensure UI components are type-safe and consistent with backend contracts.
 

--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -156,15 +156,20 @@ func (h *Handler) DeleteUserCredential(w http.ResponseWriter, req *http.Request,
 	// success having removed nothing. Reject it here instead.
 	credentialID, err := uuid.FromString(raw)
 	if err != nil || credentialID.IsNil() {
-		h.log.Error(ErrInvalidRequestObject("credentialId must be a valid UUID"))
-		writeMeshkitError(w, ErrInvalidRequestObject("credentialId must be a valid UUID"), http.StatusBadRequest)
+		// Built once and reused: constructing the error separately for the log
+		// and the response duplicates the message, which is how the two drift
+		// apart when only one is later edited.
+		invalidID := ErrInvalidRequestObject("credentialId must be a valid UUID")
+		h.log.Error(invalidID)
+		writeMeshkitError(w, invalidID, http.StatusBadRequest)
 		return
 	}
 
 	_, err = provider.DeleteUserCredential(req, credentialID)
 	if err != nil {
-		h.log.Error(ErrDeleteUserCredential(err))
-		writeMeshkitError(w, ErrDeleteUserCredential(err), http.StatusInternalServerError)
+		deleteErr := ErrDeleteUserCredential(err)
+		h.log.Error(deleteErr)
+		writeMeshkitError(w, deleteErr, http.StatusInternalServerError)
 		return
 	}
 

--- a/server/handlers/credentials_handlers.go
+++ b/server/handlers/credentials_handlers.go
@@ -142,8 +142,26 @@ func (h *Handler) UpdateUserCredential(w http.ResponseWriter, req *http.Request,
 func (h *Handler) DeleteUserCredential(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	q := req.URL.Query()
 
-	credentialID := uuid.FromStringOrNil(q.Get("credential_id"))
-	_, err := provider.DeleteUserCredential(req, credentialID)
+	// The canonical query param is camelCase `credentialId` (schemas
+	// deleteUserCredential, and the identifier-naming contract). `credential_id`
+	// is the legacy spelling this handler used to read exclusively, kept as a
+	// fallback so older clients keep working.
+	raw := q.Get("credentialId")
+	if raw == "" {
+		raw = q.Get("credential_id")
+	}
+
+	// FromStringOrNil turns a missing or malformed id into the zero UUID, which
+	// would reach the provider as a real delete for the nil id and report
+	// success having removed nothing. Reject it here instead.
+	credentialID, err := uuid.FromString(raw)
+	if err != nil || credentialID.IsNil() {
+		h.log.Error(ErrInvalidRequestObject("credentialId must be a valid UUID"))
+		writeMeshkitError(w, ErrInvalidRequestObject("credentialId must be a valid UUID"), http.StatusBadRequest)
+		return
+	}
+
+	_, err = provider.DeleteUserCredential(req, credentialID)
 	if err != nil {
 		h.log.Error(ErrDeleteUserCredential(err))
 		writeMeshkitError(w, ErrDeleteUserCredential(err), http.StatusInternalServerError)

--- a/server/handlers/credentials_handlers_test.go
+++ b/server/handlers/credentials_handlers_test.go
@@ -20,6 +20,7 @@ type credentialSpyProvider struct {
 	*models.DefaultLocalProvider
 	observedSave   atomic.Pointer[models.Credential]
 	observedUpdate atomic.Pointer[models.Credential]
+	observedDelete atomic.Pointer[uuid.UUID]
 }
 
 func newCredentialSpyProvider() *credentialSpyProvider {
@@ -38,6 +39,83 @@ func (m *credentialSpyProvider) UpdateUserCredential(_ *http.Request, c *models.
 	cp := *c
 	m.observedUpdate.Store(&cp)
 	return c, nil
+}
+
+func (m *credentialSpyProvider) DeleteUserCredential(_ *http.Request, id uuid.UUID) (*models.Credential, error) {
+	m.observedDelete.Store(&id)
+	return nil, nil
+}
+
+// TestDeleteUserCredential_QueryParamContract pins the delete param to the
+// canonical camelCase `credentialId` that schemas' generated
+// deleteUserCredential sends, while keeping the legacy `credential_id`
+// spelling working. The handler read only `credential_id`, so the UI had to
+// hand-roll a local RTK endpoint to talk to it — the generated one resolved a
+// nil UUID and deleted nothing.
+func TestDeleteUserCredential_QueryParamContract(t *testing.T) {
+	id := uuid.Must(uuid.FromString("55555555-5555-5555-5555-555555555555"))
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{"canonical camelCase", "credentialId=" + id.String()},
+		{"legacy snake_case", "credential_id=" + id.String()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, map[string]models.Provider{}, "")
+			p := newCredentialSpyProvider()
+
+			req := httptest.NewRequest(http.MethodDelete, "/api/integrations/credentials?"+tc.query, nil)
+			rec := httptest.NewRecorder()
+
+			h.DeleteUserCredential(rec, req, nil, &models.User{}, p)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d (body=%q)", rec.Code, rec.Body.String())
+			}
+			got := p.observedDelete.Load()
+			if got == nil {
+				t.Fatal("provider DeleteUserCredential was not invoked")
+			}
+			if *got != id {
+				t.Errorf("deleted id = %v, want %v", *got, id)
+			}
+		})
+	}
+}
+
+// TestDeleteUserCredential_RejectsMissingOrInvalidID pins that a missing or
+// malformed id is a 400 and never reaches the provider. uuid.FromStringOrNil
+// used to coerce both to the zero UUID, so the handler reported a successful
+// delete having removed nothing.
+func TestDeleteUserCredential_RejectsMissingOrInvalidID(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{"absent", ""},
+		{"empty", "credentialId="},
+		{"malformed", "credentialId=not-a-uuid"},
+		{"explicit nil uuid", "credentialId=00000000-0000-0000-0000-000000000000"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, map[string]models.Provider{}, "")
+			p := newCredentialSpyProvider()
+
+			req := httptest.NewRequest(http.MethodDelete, "/api/integrations/credentials?"+tc.query, nil)
+			rec := httptest.NewRecorder()
+
+			h.DeleteUserCredential(rec, req, nil, &models.User{}, p)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d (body=%q)", rec.Code, rec.Body.String())
+			}
+			if p.observedDelete.Load() != nil {
+				t.Error("provider DeleteUserCredential was invoked for an unusable id")
+			}
+		})
+	}
 }
 
 // TestSaveUserCredential_ClientSuppliedUserIdCannotOverride verifies the

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1467
+  "next_error_code": 1468
 }

--- a/server/models/anonymous_flow_response_test.go
+++ b/server/models/anonymous_flow_response_test.go
@@ -68,6 +68,9 @@ func TestAnonymousFlowResponseRejectsLegacyOwnerKey(t *testing.T) {
 // a structurally-similar local copy that can drift from it again.
 func TestAnonymousFlowResponseIsTheSchemasType(t *testing.T) {
 	var fromSchemas userv1beta2.AnonymousFlowResponse
-	var local AnonymousFlowResponse = fromSchemas
+	// The explicit type is the assertion: only an alias assigns here. Letting
+	// staticcheck's ST1023 infer it from the right-hand side would leave
+	// nothing for this test to check.
+	var local AnonymousFlowResponse = fromSchemas //nolint:staticcheck
 	_ = local
 }

--- a/server/models/anonymous_flow_response_test.go
+++ b/server/models/anonymous_flow_response_test.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	userv1beta2 "github.com/meshery/schemas/models/v1beta2/user"
+)
+
+// TestAnonymousFlowResponseDecodesSchemasContract pins the anonymous user flow
+// reply to the canonical schemas v1beta2 user.AnonymousFlowResponse construct.
+//
+// The reply is a CONSUMED contract: the remote provider produces it and Meshery
+// Server only decodes it. A local re-declaration of the struct silently renamed
+// the id field to `owner` while meshery-cloud kept emitting `userId`, so
+// flowResponse's id decoded to the nil UUID on every anonymous sign-in and the
+// session's capabilities were written under the zero UUID instead of the real
+// user. This is that regression's guard - the payload below is byte-for-byte
+// what meshery-cloud's anonymous handler encodes.
+func TestAnonymousFlowResponseDecodesSchemasContract(t *testing.T) {
+	const providerReply = `{
+		"accessToken": "eyJhbGciOiJIUzI1NiJ9.e30.signature",
+		"capability": {"capabilities": []},
+		"userId": "0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c40"
+	}`
+
+	var got AnonymousFlowResponse
+	if err := json.Unmarshal([]byte(providerReply), &got); err != nil {
+		t.Fatalf("decode anonymous flow response: %v", err)
+	}
+
+	if got.AccessToken == "" {
+		t.Error("accessToken did not decode")
+	}
+	if got.UserID.IsNil() {
+		t.Fatal(`userId decoded to the nil UUID: the struct is not reading the canonical "userId" key`)
+	}
+	if want := "0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c40"; got.UserID.String() != want {
+		t.Errorf("userId = %q, want %q", got.UserID, want)
+	}
+	if got.Capabilities == nil {
+		t.Error(`capability did not decode`)
+	}
+}
+
+// TestAnonymousFlowResponseRejectsLegacyOwnerKey pins the negative half of the
+// contract: an `owner`-keyed reply is NOT the schemas construct, so it must
+// leave the id nil rather than quietly resolving. Without this, reintroducing a
+// local struct keyed on `owner` would pass the positive test above by accident.
+func TestAnonymousFlowResponseRejectsLegacyOwnerKey(t *testing.T) {
+	const legacyReply = `{
+		"accessToken": "eyJhbGciOiJIUzI1NiJ9.e30.signature",
+		"owner": "0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c40"
+	}`
+
+	var got AnonymousFlowResponse
+	if err := json.Unmarshal([]byte(legacyReply), &got); err != nil {
+		t.Fatalf("decode anonymous flow response: %v", err)
+	}
+
+	if !got.UserID.IsNil() {
+		t.Errorf(`the legacy "owner" key resolved a user id (%v); the wire key is "userId"`, got.UserID)
+	}
+}
+
+// TestAnonymousFlowResponseIsTheSchemasType is the compile-time half of the
+// guard: AnonymousFlowResponse must be an alias for the schemas construct, not
+// a structurally-similar local copy that can drift from it again.
+func TestAnonymousFlowResponseIsTheSchemasType(t *testing.T) {
+	var fromSchemas userv1beta2.AnonymousFlowResponse
+	var local AnonymousFlowResponse = fromSchemas
+	_ = local
+}

--- a/server/models/connections/connections.go
+++ b/server/models/connections/connections.go
@@ -122,19 +122,14 @@ func MergePayloadOntoExisting(payload *ConnectionPayload, existing *Connection) 
 	}
 }
 
-type ConnectionStatusInfo struct {
-	Status string `json:"status" db:"status"`
-	Count  int    `json:"count" db:"count"`
-}
+// The status-per-kind response wrapper surfaced on a few integrations
+// endpoints, and its element type. Both are the canonical v1beta3 connection
+// constructs rather than local stubs: the local copy of the page had dropped
+// `page`, `pageSize` and `totalCount`, so the swagger definition generated from
+// it (server/handlers/doc.go) under-described the response it documents.
+type ConnectionStatusInfo = schemasConnection.ConnectionStatusInfo
 
-// ConnectionsStatusPage is a Meshery-local swagger stub for the status-per-kind
-// response wrapper surfaced on a few integrations endpoints. The canonical
-// v1beta3 schema publishes camelCase on the wire, so the JSON tag here matches
-// `connectionsStatus`. No runtime handler emits this struct today — it is a
-// doc-only placeholder referenced from server/handlers/doc.go.
-type ConnectionsStatusPage struct {
-	ConnectionsStatus []*ConnectionStatusInfo `json:"connectionsStatus"`
-}
+type ConnectionsStatusPage = schemasConnection.ConnectionsStatusPage
 
 type ConnectionPayload struct {
 	ID                         core.Uuid              `json:"id,omitempty"`

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -760,9 +760,6 @@ func ErrSystemSettings(err error) error {
 	return errors.New(ErrSystemSettingsCode, errors.Alert, []string{"Error accessing server-wide system settings"}, []string{err.Error()}, []string{"The system_settings store could not be read or written, or the stored value is not valid JSON."}, []string{"Verify Meshery Server's database is reachable and writable, then retry the operation."})
 }
 
-// ErrApplyControllersConfig wraps failures propagating a resolved
-// controllers configuration (Meshery Operator / MeshSync / Broker) to a
-// managed cluster.
 // ErrAnonymousUserIDMissing reports that the remote provider's anonymous user
 // flow response carried no `userId`. The response is the schemas
 // v1beta2 user.AnonymousFlowResponse construct; a missing id means the
@@ -779,6 +776,9 @@ func ErrAnonymousUserIDMissing() error {
 	)
 }
 
+// ErrApplyControllersConfig wraps failures propagating a resolved
+// controllers configuration (Meshery Operator / MeshSync / Broker) to a
+// managed cluster.
 func ErrApplyControllersConfig(err error) error {
 	return errors.New(ErrApplyControllersConfigCode, errors.Alert, []string{"Error applying controllers configuration to the cluster"}, []string{err.Error()}, []string{"The MeshSync or Broker custom resource could not be patched, or the MeshSync deployment overlay could not be applied.", "The Meshery Operator may not be deployed on the target cluster yet."}, []string{"Confirm the cluster is reachable and the Meshery Operator is deployed (operator deployment mode).", "Retry the change; configuration is re-applied whenever the connection reconnects."})
 }

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -161,6 +161,7 @@ const (
 	ErrApplyControllersConfigCode         = "meshery-server-1440"
 	ErrReconcileOperatorChartVersionCode  = "meshery-server-1466"
 	ErrOperatorHandlerNotAttachedCode     = "meshery-server-1465"
+	ErrAnonymousUserIDMissingCode         = "meshery-server-1467"
 )
 
 var (
@@ -762,6 +763,22 @@ func ErrSystemSettings(err error) error {
 // ErrApplyControllersConfig wraps failures propagating a resolved
 // controllers configuration (Meshery Operator / MeshSync / Broker) to a
 // managed cluster.
+// ErrAnonymousUserIDMissing reports that the remote provider's anonymous user
+// flow response carried no `userId`. The response is the schemas
+// v1beta2 user.AnonymousFlowResponse construct; a missing id means the
+// provider is on an incompatible contract, and proceeding would key the
+// session's capabilities on the nil UUID instead of a real user.
+func ErrAnonymousUserIDMissing() error {
+	return errors.New(
+		ErrAnonymousUserIDMissingCode,
+		errors.Alert,
+		[]string{"Anonymous user session could not be established"},
+		[]string{"The remote provider's anonymous user flow response contained no userId."},
+		[]string{"The remote provider does not implement the schemas v1beta2 AnonymousFlowResponse contract, or it returned an empty user id."},
+		[]string{"Confirm the configured remote provider is reachable and up to date, then retry signing in."},
+	)
+}
+
 func ErrApplyControllersConfig(err error) error {
 	return errors.New(ErrApplyControllersConfigCode, errors.Alert, []string{"Error applying controllers configuration to the cluster"}, []string{err.Error()}, []string{"The MeshSync or Broker custom resource could not be patched, or the MeshSync deployment overlay could not be applied.", "The Meshery Operator may not be deployed on the target cluster yet."}, []string{"Confirm the cluster is reachable and the Meshery Operator is deployed (operator deployment mode).", "Retry the change; configuration is re-applied whenever the connection reconnects."})
 }

--- a/server/models/pattern_resource.go
+++ b/server/models/pattern_resource.go
@@ -7,10 +7,18 @@ import (
 )
 
 // PatternResource represents a pattern resource that is provisioned
-// by meshery
+// by meshery.
+//
+// The wire form is the schemas v1beta3 pattern_resource.MesheryPatternResource
+// contract, which spells the owner `userId` - it is what meshery-cloud both
+// accepts on SaveMesheryPatternResource and emits on read. The struct itself
+// stays local because it doubles as the GORM model for the built-in provider's
+// table, and the schemas models carry `db:` tags that GORM does not read; the
+// explicit column tag below is what keeps that table's `owner` column stable
+// while the wire key follows the schema.
 type PatternResource struct {
 	ID        *core.Uuid `json:"id,omitempty"`
-	Owner     *core.Uuid `json:"owner,omitempty"`
+	UserID    *core.Uuid `json:"userId,omitempty" gorm:"column:owner"`
 	Name      string     `json:"name,omitempty"`
 	Namespace string     `json:"namespace,omitempty"`
 	Type      string     `json:"type,omitempty"`

--- a/server/models/pattern_resource_wire_contract_test.go
+++ b/server/models/pattern_resource_wire_contract_test.go
@@ -88,3 +88,64 @@ func TestPatternResourceOwnerColumnIsPinned(t *testing.T) {
 		t.Errorf(`UserID gorm tag = %q, want "column:owner"`, got)
 	}
 }
+
+// TestPatternResourceRoundTripsOwnerThroughMigratedDB is the runtime half of the
+// column guard: the tag assertion above proves the annotation is present, not
+// that AutoMigrate and the persister agree on it.
+//
+// The failure this catches is the one documented for PerformanceProfile - gorm
+// derives a column from the *field name* via its naming strategy, so renaming
+// Owner to UserID renames `owner` to `user_id` unless the explicit column tag
+// holds. The persister discards gorm's errors (see GetPatternResources), so a
+// drifted column reads back as an empty list with nothing logged.
+func TestPatternResourceRoundTripsOwnerThroughMigratedDB(t *testing.T) {
+	db := newMigratedDB(t)
+
+	cols, err := db.Migrator().ColumnTypes(&PatternResource{})
+	if err != nil {
+		t.Fatalf("read migrated columns: %v", err)
+	}
+	names := map[string]bool{}
+	for _, c := range cols {
+		names[c.Name()] = true
+	}
+	if !names["owner"] {
+		t.Errorf("migrated pattern_resources has no `owner` column; columns: %v", names)
+	}
+	if names["user_id"] {
+		t.Errorf("migrated pattern_resources gained a `user_id` column; the gorm column tag is not holding: %v", names)
+	}
+
+	owner := mustUUID(t)
+	persister := &PatternResourcePersister{DB: db}
+
+	saved, err := persister.SavePatternResource(&PatternResource{
+		UserID:    &owner,
+		Name:      "demo-resource",
+		Namespace: "default",
+		Type:      "Deployment",
+		OAMType:   "workload",
+	})
+	if err != nil {
+		t.Fatalf("SavePatternResource: %v", err)
+	}
+
+	byID, err := persister.GetPatternResource(*saved.ID)
+	if err != nil {
+		t.Fatalf("GetPatternResource: %v", err)
+	}
+	if byID.UserID == nil || *byID.UserID != owner {
+		t.Errorf("owner did not survive the round trip: got %v, want %v", byID.UserID, owner)
+	}
+
+	page, err := persister.GetPatternResources("", "", "demo-resource", "default", "Deployment", "workload", 0, 10)
+	if err != nil {
+		t.Fatalf("GetPatternResources: %v", err)
+	}
+	if page.TotalCount != 1 || len(page.Resources) != 1 {
+		t.Fatalf("listing returned %d resources (totalCount=%d); a drifted column reads back empty", len(page.Resources), page.TotalCount)
+	}
+	if got := page.Resources[0].UserID; got == nil || *got != owner {
+		t.Errorf("listed owner = %v, want %v", got, owner)
+	}
+}

--- a/server/models/pattern_resource_wire_contract_test.go
+++ b/server/models/pattern_resource_wire_contract_test.go
@@ -1,0 +1,90 @@
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/schemas/models/core"
+	patternresource "github.com/meshery/schemas/models/v1beta3/pattern_resource"
+)
+
+// TestPatternResourceWireContractMatchesSchemas pins the pattern-resource owner
+// to the canonical `userId` declared by the schemas v1beta3
+// pattern_resource.MesheryPatternResource construct.
+//
+// PatternResource is both the built-in provider's GORM model and the body
+// RemoteProvider.SaveMesheryPatternResource sends to - and decodes back from -
+// meshery-cloud, which reads and writes `userId`. A local rename to `owner`
+// broke both directions silently: meshery sent an owner the provider ignored,
+// and read back an owner the provider never sent.
+func TestPatternResourceWireContractMatchesSchemas(t *testing.T) {
+	id := core.Uuid(uuid.Must(uuid.FromString("0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c40")))
+	owner := core.Uuid(uuid.Must(uuid.FromString("0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c41")))
+
+	b, err := json.Marshal(&PatternResource{ID: &id, UserID: &owner, Name: "demo"})
+	if err != nil {
+		t.Fatalf("marshal PatternResource: %v", err)
+	}
+	got := string(b)
+
+	if !strings.Contains(got, `"userId"`) {
+		t.Errorf(`marshaled pattern resource is missing the canonical "userId" key: %s`, got)
+	}
+	if strings.Contains(got, `"owner"`) {
+		t.Errorf(`marshaled pattern resource still emits the legacy "owner" key: %s`, got)
+	}
+
+	// The provider's reply must round trip back onto UserID.
+	var decoded PatternResource
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal PatternResource: %v", err)
+	}
+	if decoded.UserID == nil || *decoded.UserID != owner {
+		t.Errorf("UserID = %v, want %v", decoded.UserID, owner)
+	}
+}
+
+// TestPatternResourceJSONKeysMatchSchemasConstruct compares every JSON key this
+// struct emits against the schemas construct it implements. A field renamed on
+// either side shows up here rather than as a silently dropped value.
+func TestPatternResourceJSONKeysMatchSchemasConstruct(t *testing.T) {
+	jsonKeys := func(v interface{}) map[string]bool {
+		typ := reflect.TypeOf(v)
+		keys := map[string]bool{}
+		for i := 0; i < typ.NumField(); i++ {
+			tag := typ.Field(i).Tag.Get("json")
+			if tag == "" || tag == "-" {
+				continue
+			}
+			keys[strings.Split(tag, ",")[0]] = true
+		}
+		return keys
+	}
+
+	local := jsonKeys(PatternResource{})
+	canonical := jsonKeys(patternresource.MesheryPatternResource{})
+
+	for key := range local {
+		if !canonical[key] {
+			t.Errorf("PatternResource emits %q, which the schemas v1beta3 construct does not declare", key)
+		}
+	}
+}
+
+// TestPatternResourceOwnerColumnIsPinned guards the GORM side of the rename.
+// The struct doubles as the built-in provider's model and the schemas Go models
+// carry `db:` tags GORM does not read, so the owner column has to be pinned
+// explicitly - without the tag GORM would derive `user_id` from the Go field
+// name and stop finding the existing `owner` column.
+func TestPatternResourceOwnerColumnIsPinned(t *testing.T) {
+	field, ok := reflect.TypeOf(PatternResource{}).FieldByName("UserID")
+	if !ok {
+		t.Fatal("PatternResource has no UserID field")
+	}
+	if got := field.Tag.Get("gorm"); got != "column:owner" {
+		t.Errorf(`UserID gorm tag = %q, want "column:owner"`, got)
+	}
+}

--- a/server/models/preference.go
+++ b/server/models/preference.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/gob"
+	"encoding/json"
 	"time"
 )
 
@@ -35,7 +36,10 @@ type PreferenceParams struct {
 	AnonymousPerfResults bool `json:"anonymousPerfResults"`
 }
 
-// Preference represents the data stored in session / local DB
+// Preference represents the data stored in session / local DB.
+//
+// The wire form follows the schemas v1beta1 user.Preference construct, which is
+// also what meshery-cloud reads and writes.
 type Preference struct {
 	MeshAdapters                      []*Adapter             `json:"meshAdapters,omitempty"`
 	LoadTestPreferences               *LoadTestPreferences   `json:"loadTestPrefs,omitempty"`
@@ -43,10 +47,37 @@ type Preference struct {
 	AnonymousPerfResults              bool                   `json:"anonymousPerfResults"`
 	UpdatedAt                         time.Time              `json:"updatedAt,omitempty"`
 	DashboardPreferences              map[string]interface{} `json:"dashboardPreferences,omitempty"`
-	SelectedOrganizationID            string                 `json:"selectedOrganizationID,omitempty"`
+	SelectedOrganizationID            string                 `json:"selectedOrganizationId,omitempty"`
 	SelectedWorkspaceForOrganizations map[string]string      `json:"selectedWorkspaceForOrganizations,omitempty"` // map[orgID]workspaceID
 	UsersExtensionPreferences         map[string]interface{} `json:"usersExtensionPreferences,omitempty"`
 	RemoteProviderPreferences         map[string]interface{} `json:"remoteProviderPreferences,omitempty"`
+}
+
+// UnmarshalJSON accepts the legacy all-caps `selectedOrganizationID` spelling in
+// addition to the canonical `selectedOrganizationId`.
+//
+// The canonical key is what schemas declares and what meshery-cloud reads, so
+// the all-caps local spelling meant the selected organization never round
+// tripped through a remote provider: executePrefSync PUT `selectedOrganizationID`,
+// which meshery-cloud ignores, and the provider's reply carried
+// `selectedOrganizationId`, which this struct ignored. Reading both keeps
+// preferences already persisted under the legacy key - in the local provider's
+// database, and in any remote provider not yet on the canonical spelling -
+// readable after the rename.
+func (p *Preference) UnmarshalJSON(data []byte) error {
+	type preferenceAlias Preference
+	aliased := struct {
+		*preferenceAlias
+		LegacySelectedOrganizationID string `json:"selectedOrganizationID,omitempty"`
+	}{preferenceAlias: (*preferenceAlias)(p)}
+
+	if err := json.Unmarshal(data, &aliased); err != nil {
+		return err
+	}
+	if p.SelectedOrganizationID == "" {
+		p.SelectedOrganizationID = aliased.LegacySelectedOrganizationID
+	}
+	return nil
 }
 
 // NewDefaultPreference returns a preference initialized with Meshery's default opt-in values.
@@ -79,4 +110,3 @@ type CapabilitiesPersister interface {
 	WriteCapabilitiesForUser(userID string, data *ProviderProperties) error
 	DeleteCapabilitiesForUser(userID string) error
 }
-

--- a/server/models/preference.go
+++ b/server/models/preference.go
@@ -64,18 +64,30 @@ type Preference struct {
 // preferences already persisted under the legacy key - in the local provider's
 // database, and in any remote provider not yet on the canonical spelling -
 // readable after the rename.
+//
+// Which key wins is decided on payload key *presence*, not on whether the
+// destination is already populated: UserPrefsHandler decodes the request body
+// onto the Preference the session middleware already read from the persister,
+// so the destination is normally non-empty before this runs. Both keys are
+// therefore decoded through pointers - the shallower fields shadow the
+// embedded struct's own `selectedOrganizationId` - and the destination is left
+// untouched when the payload carries neither.
 func (p *Preference) UnmarshalJSON(data []byte) error {
 	type preferenceAlias Preference
 	aliased := struct {
 		*preferenceAlias
-		LegacySelectedOrganizationID string `json:"selectedOrganizationID,omitempty"`
+		SelectedOrganizationID       *string `json:"selectedOrganizationId,omitempty"`
+		LegacySelectedOrganizationID *string `json:"selectedOrganizationID,omitempty"`
 	}{preferenceAlias: (*preferenceAlias)(p)}
 
 	if err := json.Unmarshal(data, &aliased); err != nil {
 		return err
 	}
-	if p.SelectedOrganizationID == "" {
-		p.SelectedOrganizationID = aliased.LegacySelectedOrganizationID
+	switch {
+	case aliased.SelectedOrganizationID != nil:
+		p.SelectedOrganizationID = *aliased.SelectedOrganizationID
+	case aliased.LegacySelectedOrganizationID != nil:
+		p.SelectedOrganizationID = *aliased.LegacySelectedOrganizationID
 	}
 	return nil
 }

--- a/server/models/preference_wire_contract_test.go
+++ b/server/models/preference_wire_contract_test.go
@@ -171,7 +171,9 @@ func TestPreferenceRoundTripsEveryField(t *testing.T) {
 	if got.RemoteProviderPreferences["k"] != "v" {
 		t.Errorf("RemoteProviderPreferences = %v", got.RemoteProviderPreferences)
 	}
-	if got.LoadTestPreferences == nil || got.LoadTestPreferences.ConcurrentRequests != 2 {
+	if got.LoadTestPreferences == nil ||
+		got.LoadTestPreferences.ConcurrentRequests != 2 ||
+		got.LoadTestPreferences.QueriesPerSecond != 10 {
 		t.Errorf("LoadTestPreferences = %+v", got.LoadTestPreferences)
 	}
 }

--- a/server/models/preference_wire_contract_test.go
+++ b/server/models/preference_wire_contract_test.go
@@ -71,6 +71,63 @@ func TestPreferenceCanonicalKeyWinsOverLegacy(t *testing.T) {
 	}
 }
 
+// TestPreferenceLegacyKeyUpdatesAlreadySelectedOrganization pins the decision on
+// payload key presence rather than on the destination being empty.
+//
+// UserPrefsHandler decodes the request body onto the *models.Preference the
+// session middleware already populated from the persister, so a user who has an
+// organization selected reaches UnmarshalJSON with the field non-empty. Gating
+// the legacy fallback on that field being empty silently discarded the update
+// for exactly the out-of-repo clients (Meshery UI extensions, Kanvas) the
+// fallback exists to serve - the handler still answered 200 and re-persisted the
+// old value.
+func TestPreferenceLegacyKeyUpdatesAlreadySelectedOrganization(t *testing.T) {
+	const previouslySelectedOrgID = "0195b0ab-1f4d-7a3c-9c1e-000000000001"
+
+	p := &Preference{SelectedOrganizationID: previouslySelectedOrgID}
+	body := `{"selectedOrganizationID":"` + testSelectedOrgID + `"}`
+
+	if err := json.Unmarshal([]byte(body), p); err != nil {
+		t.Fatalf("unmarshal Preference: %v", err)
+	}
+	if p.SelectedOrganizationID != testSelectedOrgID {
+		t.Errorf("SelectedOrganizationID = %q, want the legacy-keyed update %q", p.SelectedOrganizationID, testSelectedOrgID)
+	}
+}
+
+// TestPreferenceCanonicalKeyWinsOverLegacyOnMerge pins that presence-based
+// precedence still lets the canonical key win when both are sent onto an
+// already-populated Preference.
+func TestPreferenceCanonicalKeyWinsOverLegacyOnMerge(t *testing.T) {
+	p := &Preference{SelectedOrganizationID: "0195b0ab-1f4d-7a3c-9c1e-000000000001"}
+	body := `{"selectedOrganizationId":"` + testSelectedOrgID + `","selectedOrganizationID":"stale"}`
+
+	if err := json.Unmarshal([]byte(body), p); err != nil {
+		t.Fatalf("unmarshal Preference: %v", err)
+	}
+	if p.SelectedOrganizationID != testSelectedOrgID {
+		t.Errorf("SelectedOrganizationID = %q, want the canonical %q", p.SelectedOrganizationID, testSelectedOrgID)
+	}
+}
+
+// TestPreferenceOmittedOrganizationKeyPreservesSelection pins that a body
+// carrying neither spelling leaves the persisted selection alone - the merge
+// path decodes partial bodies (an anonymous-stats toggle, say) onto the full
+// persisted preference.
+func TestPreferenceOmittedOrganizationKeyPreservesSelection(t *testing.T) {
+	p := &Preference{SelectedOrganizationID: testSelectedOrgID}
+
+	if err := json.Unmarshal([]byte(`{"anonymousUsageStats":true}`), p); err != nil {
+		t.Fatalf("unmarshal Preference: %v", err)
+	}
+	if p.SelectedOrganizationID != testSelectedOrgID {
+		t.Errorf("SelectedOrganizationID = %q, want the persisted %q preserved", p.SelectedOrganizationID, testSelectedOrgID)
+	}
+	if !p.AnonymousUsageStats {
+		t.Error("AnonymousUsageStats was not applied from the partial body")
+	}
+}
+
 // TestPreferenceRoundTripsEveryField guards the custom UnmarshalJSON: aliasing
 // the struct to avoid infinite recursion is easy to get subtly wrong, and a
 // dropped field would be invisible to the focused tests above.

--- a/server/models/preference_wire_contract_test.go
+++ b/server/models/preference_wire_contract_test.go
@@ -1,0 +1,120 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const testSelectedOrgID = "0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c40"
+
+// TestPreferenceMarshalsCanonicalSelectedOrganizationId pins the selected
+// organization to the canonical camelCase `selectedOrganizationId` that the
+// schemas v1beta1 user.Preference construct declares and meshery-cloud reads.
+//
+// Meshery Server spelled it `selectedOrganizationID` (all-caps ID, which the
+// identifier-naming contract forbids). Every other key on this struct is
+// camelCase, so the odd one silently broke the round trip through a remote
+// provider: executePrefSync PUT a key meshery-cloud ignores, and the provider's
+// reply carried a key this struct ignored. The selected organization therefore
+// never persisted to Layer5 Cloud.
+func TestPreferenceMarshalsCanonicalSelectedOrganizationId(t *testing.T) {
+	b, err := json.Marshal(&Preference{SelectedOrganizationID: testSelectedOrgID})
+	if err != nil {
+		t.Fatalf("marshal Preference: %v", err)
+	}
+	got := string(b)
+
+	if !strings.Contains(got, `"selectedOrganizationId"`) {
+		t.Errorf(`marshaled preference is missing the canonical "selectedOrganizationId" key: %s`, got)
+	}
+	if strings.Contains(got, `"selectedOrganizationID"`) {
+		t.Errorf(`marshaled preference still emits the legacy all-caps key: %s`, got)
+	}
+}
+
+// TestPreferenceUnmarshalsCanonicalAndLegacySelectedOrganizationId pins that a
+// provider reply on the canonical key is read (the bug), and that preferences
+// already persisted under the legacy key stay readable after the rename.
+func TestPreferenceUnmarshalsCanonicalAndLegacySelectedOrganizationId(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"canonical", `{"selectedOrganizationId":"` + testSelectedOrgID + `"}`},
+		{"legacy", `{"selectedOrganizationID":"` + testSelectedOrgID + `"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var p Preference
+			if err := json.Unmarshal([]byte(tc.body), &p); err != nil {
+				t.Fatalf("unmarshal Preference: %v", err)
+			}
+			if p.SelectedOrganizationID != testSelectedOrgID {
+				t.Errorf("SelectedOrganizationID = %q, want %q", p.SelectedOrganizationID, testSelectedOrgID)
+			}
+		})
+	}
+}
+
+// TestPreferenceCanonicalKeyWinsOverLegacy pins precedence when a payload
+// carries both: the canonical key is authoritative, so a stale legacy value
+// cannot shadow a fresh canonical one.
+func TestPreferenceCanonicalKeyWinsOverLegacy(t *testing.T) {
+	body := `{"selectedOrganizationId":"` + testSelectedOrgID + `","selectedOrganizationID":"stale"}`
+
+	var p Preference
+	if err := json.Unmarshal([]byte(body), &p); err != nil {
+		t.Fatalf("unmarshal Preference: %v", err)
+	}
+	if p.SelectedOrganizationID != testSelectedOrgID {
+		t.Errorf("SelectedOrganizationID = %q, want the canonical %q", p.SelectedOrganizationID, testSelectedOrgID)
+	}
+}
+
+// TestPreferenceRoundTripsEveryField guards the custom UnmarshalJSON: aliasing
+// the struct to avoid infinite recursion is easy to get subtly wrong, and a
+// dropped field would be invisible to the focused tests above.
+func TestPreferenceRoundTripsEveryField(t *testing.T) {
+	want := &Preference{
+		AnonymousUsageStats:               true,
+		AnonymousPerfResults:              true,
+		DashboardPreferences:              map[string]interface{}{"theme": "dark"},
+		SelectedOrganizationID:            testSelectedOrgID,
+		SelectedWorkspaceForOrganizations: map[string]string{testSelectedOrgID: "ws-1"},
+		UsersExtensionPreferences:         map[string]interface{}{"catalogContent": true},
+		RemoteProviderPreferences:         map[string]interface{}{"k": "v"},
+		LoadTestPreferences:               &LoadTestPreferences{ConcurrentRequests: 2, QueriesPerSecond: 10},
+	}
+
+	b, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal Preference: %v", err)
+	}
+
+	var got Preference
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal Preference: %v", err)
+	}
+
+	if got.SelectedOrganizationID != want.SelectedOrganizationID {
+		t.Errorf("SelectedOrganizationID = %q, want %q", got.SelectedOrganizationID, want.SelectedOrganizationID)
+	}
+	if !got.AnonymousUsageStats || !got.AnonymousPerfResults {
+		t.Errorf("anonymous opt-ins were dropped: %+v", got)
+	}
+	if got.DashboardPreferences["theme"] != "dark" {
+		t.Errorf("DashboardPreferences = %v, want theme=dark", got.DashboardPreferences)
+	}
+	if got.SelectedWorkspaceForOrganizations[testSelectedOrgID] != "ws-1" {
+		t.Errorf("SelectedWorkspaceForOrganizations = %v", got.SelectedWorkspaceForOrganizations)
+	}
+	if got.UsersExtensionPreferences["catalogContent"] != true {
+		t.Errorf("UsersExtensionPreferences = %v", got.UsersExtensionPreferences)
+	}
+	if got.RemoteProviderPreferences["k"] != "v" {
+		t.Errorf("RemoteProviderPreferences = %v", got.RemoteProviderPreferences)
+	}
+	if got.LoadTestPreferences == nil || got.LoadTestPreferences.ConcurrentRequests != 2 {
+		t.Errorf("LoadTestPreferences = %+v", got.LoadTestPreferences)
+	}
+}

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -571,11 +571,11 @@ func (l *RemoteProvider) InterceptLoginAndInitiateAnonymousUserSession(req *http
 		return
 	}
 
-	l.SetJWTCookie(res, flowResponse.AccessToken)
-
 	// A nil user id means the provider's reply carried none. Writing
 	// capabilities under the zero UUID would collapse every anonymous session
-	// onto a single row rather than fail, so refuse it outright.
+	// onto a single row rather than fail, so refuse it outright - before the
+	// JWT cookie is set, so a refused session leaves no half-authenticated
+	// browser state behind.
 	if flowResponse.UserID.IsNil() {
 		err = ErrAnonymousUserIDMissing()
 		l.Log.Error(err)
@@ -583,6 +583,8 @@ func (l *RemoteProvider) InterceptLoginAndInitiateAnonymousUserSession(req *http
 
 		return
 	}
+
+	l.SetJWTCookie(res, flowResponse.AccessToken)
 
 	err = l.WriteCapabilitiesForUser(flowResponse.UserID.String(), &providerProperties)
 	if err != nil {
@@ -2188,7 +2190,7 @@ func (l *RemoteProvider) GetMesheryPatternResources(
 		q.Set("type", typ)
 	}
 	if oamType != "" {
-		q.Set("oam_type", oamType)
+		q.Set("oamType", oamType)
 	}
 
 	remoteProviderURL.RawQuery = q.Encode()
@@ -5242,7 +5244,7 @@ func (l *RemoteProvider) DeleteUserCredential(req *http.Request, credentialID co
 
 	remoteProviderURL, _ := url.Parse(fmt.Sprintf("%s%s", l.RemoteProviderURL, ep))
 	q := remoteProviderURL.Query()
-	q.Add("credential_id", credentialID.String())
+	q.Add("credentialId", credentialID.String())
 	remoteProviderURL.RawQuery = q.Encode()
 	l.Log.Debug("constructed credential url: ", remoteProviderURL.String())
 	cReq, _ := http.NewRequest(http.MethodDelete, remoteProviderURL.String(), nil)

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
+	userv1beta2 "github.com/meshery/schemas/models/v1beta2/user"
 	"github.com/meshery/schemas/models/v1beta3/environment"
 	perfprofile "github.com/meshery/schemas/models/v1beta3/performance_profile"
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
@@ -122,10 +123,13 @@ type RemoteProvider struct {
 
 	MeshsyncDefaultDeploymentMode connections.MeshsyncDeploymentMode
 }
-type AnonymousFlowResponse struct {
-	AccessToken string    `json:"accessToken"`
-	Owner       core.Uuid `json:"owner,omitempty"`
-}
+
+// AnonymousFlowResponse is the remote provider's reply to the anonymous-user
+// mint. It is a CONSUMED contract - the provider produces it, Meshery Server
+// only decodes it - so it is the schemas construct itself, never a local
+// re-declaration. A local copy is how the field silently became `owner` while
+// the provider kept sending `userId`.
+type AnonymousFlowResponse = userv1beta2.AnonymousFlowResponse
 
 type userSession struct {
 	token   string
@@ -569,9 +573,20 @@ func (l *RemoteProvider) InterceptLoginAndInitiateAnonymousUserSession(req *http
 
 	l.SetJWTCookie(res, flowResponse.AccessToken)
 
-	err = l.WriteCapabilitiesForUser(flowResponse.Owner.String(), &providerProperties)
+	// A nil user id means the provider's reply carried none. Writing
+	// capabilities under the zero UUID would collapse every anonymous session
+	// onto a single row rather than fail, so refuse it outright.
+	if flowResponse.UserID.IsNil() {
+		err = ErrAnonymousUserIDMissing()
+		l.Log.Error(err)
+		http.Redirect(res, req, errorUI, http.StatusFound)
+
+		return
+	}
+
+	err = l.WriteCapabilitiesForUser(flowResponse.UserID.String(), &providerProperties)
 	if err != nil {
-		err = ErrDBPut(fmt.Errorf("failed to write capabilities for the user %s: %w", flowResponse.Owner.String(), err))
+		err = ErrDBPut(fmt.Errorf("failed to write capabilities for the user %s: %w", flowResponse.UserID.String(), err))
 		l.Log.Error(err)
 		http.Redirect(res, req, errorUI, http.StatusFound)
 

--- a/server/models/remote_provider_anonymous_session_test.go
+++ b/server/models/remote_provider_anonymous_session_test.go
@@ -1,0 +1,87 @@
+package models
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newAnonymousFlowProvider returns a RemoteProvider whose anonymous-user mint
+// is served by handler, with the PersistAnonymousUser capability wired to it.
+func newAnonymousFlowProvider(t *testing.T, handler http.HandlerFunc) (*RemoteProvider, func()) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+
+	provider := newTestRemoteProvider(t, server.URL)
+	provider.ProviderURL = server.URL
+	provider.ProviderProperties = ProviderProperties{
+		ProviderType: RemoteProviderType,
+		ProviderURL:  server.URL,
+		ProviderName: "test-remote",
+		Capabilities: Capabilities{{Feature: PersistAnonymousUser, Endpoint: "/anonymous"}},
+	}
+	// A working capabilities store, so removing the nil-id refusal lets the
+	// flow run to completion and fail on the assertions below rather than on a
+	// nil persister - the guard is what has to be under test, not the fixture.
+	provider.UserCapabilitiesPersister = &UserCapabilitiesPersister{DB: newMigratedDB(t)}
+
+	return provider, server.Close
+}
+
+func newAnonymousFlowRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/user/login", nil)
+	return req.WithContext(context.WithValue(req.Context(), MesheryServerURL, "http://localhost:9081"))
+}
+
+func jwtCookie(rec *httptest.ResponseRecorder) *http.Cookie {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == TokenCookieName {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestInterceptAnonymousSession_RefusesReplyWithoutUserID pins the refusal added
+// alongside the AnonymousFlowResponse repoint.
+//
+// The reply is the schemas v1beta2 user.AnonymousFlowResponse construct, keyed
+// on `userId`. When a local copy of the struct read `owner` instead, every
+// anonymous sign-in decoded a nil id and the session's capabilities were written
+// under the zero UUID - one shared row for every anonymous user, with no error
+// anywhere. A reply that genuinely carries no id must therefore fail the sign-in
+// rather than proceed, and it must fail BEFORE the JWT cookie is set so a
+// refused session leaves no half-authenticated browser behind.
+func TestInterceptAnonymousSession_RefusesReplyWithoutUserID(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reply string
+	}{
+		{"no userId at all", `{"accessToken":"eyJhbGciOiJIUzI1NiJ9.e30.sig"}`},
+		{"explicit nil uuid", `{"accessToken":"eyJhbGciOiJIUzI1NiJ9.e30.sig","userId":"00000000-0000-0000-0000-000000000000"}`},
+		{"legacy owner key", `{"accessToken":"eyJhbGciOiJIUzI1NiJ9.e30.sig","owner":"0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c40"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, closeServer := newAnonymousFlowProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tc.reply))
+			})
+			defer closeServer()
+
+			rec := httptest.NewRecorder()
+			provider.InterceptLoginAndInitiateAnonymousUserSession(newAnonymousFlowRequest(), rec)
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+			}
+			if got := rec.Header().Get("Location"); got != "/error" {
+				t.Errorf("redirected to %q, want %q", got, "/error")
+			}
+			if ck := jwtCookie(rec); ck != nil && ck.Value != "" {
+				t.Errorf("a JWT cookie was set for a refused session: %q", ck.Value)
+			}
+		})
+	}
+}

--- a/server/models/remote_provider_anonymous_session_test.go
+++ b/server/models/remote_provider_anonymous_session_test.go
@@ -79,7 +79,10 @@ func TestInterceptAnonymousSession_RefusesReplyWithoutUserID(t *testing.T) {
 			if got := rec.Header().Get("Location"); got != "/error" {
 				t.Errorf("redirected to %q, want %q", got, "/error")
 			}
-			if ck := jwtCookie(rec); ck != nil && ck.Value != "" {
+			// Presence, not value: a refused session must emit no Set-Cookie for
+			// the token at all. Allowing an empty-valued cookie through would let
+			// the handler start writing one again without failing this test.
+			if ck := jwtCookie(rec); ck != nil {
 				t.Errorf("a JWT cookie was set for a refused session: %q", ck.Value)
 			}
 		})

--- a/server/models/remote_provider_query_param_test.go
+++ b/server/models/remote_provider_query_param_test.go
@@ -1,0 +1,84 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/schemas/models/core"
+)
+
+// TestGetMesheryPatternResources_SendsCanonicalOamTypeParam pins the
+// pattern-resource filter to the canonical camelCase `oamType` the remote
+// provider reads (the identifier-naming contract: URL query params are
+// camelCase).
+//
+// This is an outbound-only contract - nothing in Meshery Server observes the
+// spelling - so a snake_case `oam_type` regression is invisible locally: the
+// provider ignores the unknown key and answers 200 with an unfiltered page.
+// Design-engine resource lookups then match the wrong resource, or none.
+func TestGetMesheryPatternResources_SendsCanonicalOamTypeParam(t *testing.T) {
+	var gotQuery url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"resources":[]}`))
+	}))
+	defer server.Close()
+
+	provider := newTestRemoteProvider(t, server.URL)
+	provider.Capabilities = Capabilities{{Feature: PersistMesheryPatternResources, Endpoint: "/pattern-resources"}}
+
+	if _, err := provider.GetMesheryPatternResources(
+		"token", "0", "10", "", "", "demo", "default", "Deployment", "workload",
+	); err != nil {
+		t.Fatalf("GetMesheryPatternResources: %v", err)
+	}
+
+	if got := gotQuery.Get("oamType"); got != "workload" {
+		t.Errorf(`oamType = %q, want "workload" (query was %v)`, got, gotQuery)
+	}
+	if _, legacy := gotQuery["oam_type"]; legacy {
+		t.Errorf("request still carries the legacy snake_case `oam_type`: %v", gotQuery)
+	}
+}
+
+// TestRemoteProviderDeleteUserCredential_SendsCanonicalCredentialIdParam pins
+// the delete param to the canonical camelCase `credentialId`, which is both what
+// the schemas `deleteUserCredential` operation declares and what Meshery
+// Server's own handler now reads.
+//
+// Also outbound-only: a snake_case regression here leaves the provider with no
+// id to delete, and the caller cannot tell.
+func TestRemoteProviderDeleteUserCredential_SendsCanonicalCredentialIdParam(t *testing.T) {
+	credentialID := core.Uuid(uuid.Must(uuid.FromString("55555555-5555-5555-5555-555555555555")))
+
+	var gotQuery url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	provider := newTestRemoteProvider(t, server.URL)
+	provider.Capabilities = Capabilities{{Feature: PersistCredentials, Endpoint: "/credentials"}}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/integrations/credentials", nil)
+	req.AddCookie(&http.Cookie{Name: TokenCookieName, Value: "token"})
+
+	if _, err := provider.DeleteUserCredential(req, credentialID); err != nil {
+		t.Fatalf("DeleteUserCredential: %v", err)
+	}
+
+	if got := gotQuery.Get("credentialId"); got != credentialID.String() {
+		t.Errorf("credentialId = %q, want %q (query was %v)", got, credentialID, gotQuery)
+	}
+	if _, legacy := gotQuery["credential_id"]; legacy {
+		t.Errorf("request still carries the legacy snake_case `credential_id`: %v", gotQuery)
+	}
+}

--- a/ui/rtk-query/__tests__/credentials.test.ts
+++ b/ui/rtk-query/__tests__/credentials.test.ts
@@ -199,8 +199,9 @@ describe('deleteCredential effective endpoint', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchMock = vi.fn();
-    global.fetch = fetchMock as unknown as typeof fetch;
+    // spyOn (not direct assignment) so `vi.restoreAllMocks()` below actually
+    // reverts it - a raw `global.fetch = ...` would outlive this file.
+    fetchMock = vi.spyOn(globalThis, 'fetch') as unknown as ReturnType<typeof vi.fn>;
   });
 
   afterEach(() => {

--- a/ui/rtk-query/__tests__/credentials.test.ts
+++ b/ui/rtk-query/__tests__/credentials.test.ts
@@ -1,5 +1,15 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
 import { mesheryApiPath } from '../index';
+
+// The schemas client reads its baseUrl from the environment once, at module
+// evaluation - which the static import above triggers. Hoisting the assignment
+// above the imports is what makes it absolute; vitest's `Request` rejects the
+// relative URL an empty prefix produces.
+vi.hoisted(() => {
+  process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://localhost';
+});
 
 const {
   schemasGetUserCredentials,
@@ -137,17 +147,80 @@ describe('credentials hooks delegate to schemas', () => {
   });
 });
 
-describe('deleteCredential stays local', () => {
-  it('uses the snake_case credential_id the server actually reads', async () => {
-    const mod = await import('../credentials');
-    expect(typeof mod.useDeleteCredentialMutation).toBe('function');
+// ---------------------------------------------------------------------------
+// Nothing about `deleteCredential` is local any more. `useDeleteCredentialMutation`
+// wraps the schemas-generated `useDeleteUserCredentialMutation` and only adapts a
+// bare id to the `{ credentialId }` that endpoint takes.
+//
+// It used to be re-declared here because the generated request sends
+// `?credentialId=` while DeleteUserCredential in
+// server/handlers/credentials_handlers.go read only `credential_id`. That was
+// fixed on the server, not by forking the request: the handler now reads the
+// canonical camelCase param and keeps `credential_id` only as a legacy fallback.
+//
+// The bare-id -> `{ credentialId }` mapping is the part that can regress
+// silently, so this drives the exported hook through a real store and asserts the
+// request that ACTUALLY goes over the wire. Dispatching the generated endpoint
+// directly would assert the schemas contract and never touch the wrapper.
+// ---------------------------------------------------------------------------
 
-    // Regression guard: schemas' generated deleteUserCredential sends
-    // `?credentialId=`, but DeleteUserCredential in
-    // server/handlers/credentials_handlers.go reads `credential_id`. Migrating
-    // this endpoint would resolve a nil UUID and delete nothing.
-    expect(mesheryApiPath('integrations/credentials?credential_id=abc-123')).toBe(
-      '/api/integrations/credentials?credential_id=abc-123',
-    );
+const okResponse = (body: unknown = {}) => ({
+  ok: true,
+  status: 200,
+  redirected: false,
+  headers: new Headers({ 'content-type': 'application/json' }),
+  url: '',
+  text: () => Promise.resolve(JSON.stringify(body)),
+  json: () => Promise.resolve(body),
+  clone() {
+    return this;
+  },
+});
+
+const setupDeleteStore = async () => {
+  vi.resetModules();
+  const apiMod = await import('../index');
+  const credentialsMod = await import('../credentials');
+  const { configureStore } = await import('@reduxjs/toolkit');
+  const { Provider } = await import('react-redux');
+
+  const store = configureStore({
+    reducer: { [apiMod.api.reducerPath]: apiMod.api.reducer },
+    middleware: (g) => g().concat(apiMod.api.middleware),
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(Provider, { store }, children);
+
+  return { credentialsMod, wrapper };
+};
+
+describe('deleteCredential effective endpoint', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('DELETEs /api/integrations/credentials with the id as ?credentialId=', async () => {
+    fetchMock.mockResolvedValue(okResponse({}));
+    const { credentialsMod, wrapper } = await setupDeleteStore();
+
+    const { result } = renderHook(() => credentialsMod.useDeleteCredentialMutation(), { wrapper });
+    await act(async () => {
+      await result.current[0]('abc-123');
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('DELETE');
+    expect(req.url).toContain('/api/integrations/credentials');
+    expect(new URL(req.url).searchParams.get('credentialId')).toBe('abc-123');
+    expect(req.url).not.toContain('undefined');
   });
 });

--- a/ui/rtk-query/__tests__/notificationCenter-effective-endpoints.test.ts
+++ b/ui/rtk-query/__tests__/notificationCenter-effective-endpoints.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+
+// notificationCenter.ts dispatches action creators from '../../store/slices/events'.
+// Mock them so no real store is needed.
+const { eventActions } = vi.hoisted(() => ({
+  eventActions: {
+    deleteEvent: vi.fn((p) => ({ type: 'events/deleteEvent', payload: p })),
+    deleteEvents: vi.fn((p) => ({ type: 'events/deleteEvents', payload: p })),
+    updateEventStatus: vi.fn((p) => ({ type: 'events/updateEventStatus', payload: p })),
+    updateEvents: vi.fn((p) => ({ type: 'events/updateEvents', payload: p })),
+  },
+}));
+vi.mock('../../store/slices/events', () => eventActions);
+vi.mock('../store/slices/events', () => eventActions);
+
+beforeAll(() => {
+  process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://localhost';
+});
+
+// ---------------------------------------------------------------------------
+// Meshery Server serves the notification endpoints under `/api/system/events`.
+// @meshery/schemas defines an overlapping `deleteEvent` operation pointed at
+// `/api/events/{eventId}` - the path the server is *going* to serve once the
+// UI is fully on the new events API and SSE is off (see the comment beside that
+// route in server/router/server.go, and meshery/schemas#1134).
+//
+// notificationCenter.ts injected with `overrideExisting: false`, so RTK Query
+// silently dropped the local `deleteEvent` and served every call from the
+// schemas definition: `DELETE /api/events/undefined` - the wrong path, and
+// `undefined` because callers pass `{ id }` while the schemas endpoint reads
+// `eventId`. Deleting a notification could not work.
+//
+// These assertions dispatch through a real store, so they pin the definition
+// that ACTUALLY serves the call rather than the one the module happens to
+// declare. Drop this file's premise (and the `overrideExisting: true` it
+// guards) when the server moves to `/api/events`.
+// ---------------------------------------------------------------------------
+
+const okResponse = (body: unknown = {}) => ({
+  ok: true,
+  status: 200,
+  redirected: false,
+  headers: new Headers({ 'content-type': 'application/json' }),
+  url: '',
+  text: () => Promise.resolve(JSON.stringify(body)),
+  json: () => Promise.resolve(body),
+  clone() {
+    return this;
+  },
+});
+
+const setupStore = async () => {
+  vi.resetModules();
+  const apiMod = await import('../index');
+  const notificationCenterMod = await import('../notificationCenter');
+  const { configureStore } = await import('@reduxjs/toolkit');
+  const store = configureStore({
+    reducer: { [apiMod.api.reducerPath]: apiMod.api.reducer },
+    middleware: (g) => g().concat(apiMod.api.middleware),
+  });
+  return { store, notificationCenterApi: notificationCenterMod.notificationCenterApi };
+};
+
+describe('notificationCenter effective endpoints', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deleteEvent DELETEs /api/system/events/:id, not the schemas /api/events path', async () => {
+    fetchMock.mockResolvedValue(okResponse({}));
+    const { store, notificationCenterApi } = await setupStore();
+
+    await store.dispatch(notificationCenterApi.endpoints.deleteEvent.initiate({ id: 'e-1' }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('DELETE');
+    expect(req.url).toContain('/api/system/events/e-1');
+    expect(req.url).not.toContain('undefined');
+  });
+
+  it('updateStatus PUTs /api/system/events/status/:id', async () => {
+    fetchMock.mockResolvedValue(okResponse({}));
+    const { store, notificationCenterApi } = await setupStore();
+
+    await store.dispatch(
+      notificationCenterApi.endpoints.updateStatus.initiate({ id: 'e-2', status: 'read' }),
+    );
+
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('PUT');
+    expect(req.url).toContain('/api/system/events/status/e-2');
+    expect(req.url).not.toContain('undefined');
+  });
+
+  it('deleteEvents DELETEs the bulk /api/system/events/bulk path', async () => {
+    fetchMock.mockResolvedValue(okResponse({}));
+    const { store, notificationCenterApi } = await setupStore();
+
+    await store.dispatch(notificationCenterApi.endpoints.deleteEvents.initiate({ ids: ['e-3'] }));
+
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('DELETE');
+    expect(req.url).toContain('/api/system/events/bulk');
+  });
+});

--- a/ui/rtk-query/__tests__/notificationCenter-effective-endpoints.test.ts
+++ b/ui/rtk-query/__tests__/notificationCenter-effective-endpoints.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from 'vitest';
 
 // notificationCenter.ts dispatches action creators from '../../store/slices/events'.
 // Mock them so no real store is needed.
@@ -13,8 +13,22 @@ const { eventActions } = vi.hoisted(() => ({
 vi.mock('../../store/slices/events', () => eventActions);
 vi.mock('../store/slices/events', () => eventActions);
 
-beforeAll(() => {
+// Hoisted before module imports because the schemas client reads its base URL at
+// module load. Restored afterwards: test files sharing a worker process share
+// `process.env`, so a divergent value left behind is a way for suite order to
+// start mattering.
+const { previousEndpointPrefix } = vi.hoisted(() => {
+  const previous = process.env.RTK_MESHERY_ENDPOINT_PREFIX;
   process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://localhost';
+  return { previousEndpointPrefix: previous };
+});
+
+afterAll(() => {
+  if (previousEndpointPrefix === undefined) {
+    delete process.env.RTK_MESHERY_ENDPOINT_PREFIX;
+  } else {
+    process.env.RTK_MESHERY_ENDPOINT_PREFIX = previousEndpointPrefix;
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -65,8 +79,10 @@ describe('notificationCenter effective endpoints', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchMock = vi.fn();
-    global.fetch = fetchMock as unknown as typeof fetch;
+    // spyOn (not direct assignment) so `vi.restoreAllMocks()` below actually
+    // reverts it - a raw `global.fetch = ...` would outlive this file and leak
+    // into every later suite in the same worker.
+    fetchMock = vi.spyOn(globalThis, 'fetch') as unknown as ReturnType<typeof vi.fn>;
   });
 
   afterEach(() => {

--- a/ui/rtk-query/__tests__/user.test.ts
+++ b/ui/rtk-query/__tests__/user.test.ts
@@ -21,9 +21,13 @@ vi.mock('@/utils/utils', () => ({
   },
 }));
 
-// Mock the rtk-query helper `initiateQuery` so we don't transitively pull
-// `../store` into the test environment.
+// Mock the rtk-query helpers so we don't transitively pull `../store` into the
+// test environment. `appendInvalidatesTags` arrives via `./workspace`, which
+// user.ts imports for useGetWorkspacesQuery; it must behave like the real one
+// (return an enhanceEndpoints callback) rather than be a bare stub, because
+// enhanceEndpoints invokes it against the live endpoint definition.
 vi.mock('../utils', () => ({
+  appendInvalidatesTags: () => () => {},
   initiateQuery: vi.fn(
     async (
       query: { initiate: (variables: unknown, options?: unknown) => unknown },
@@ -197,12 +201,12 @@ describe('user endpoints', () => {
     fetchMock.mockResolvedValue(okResponse({}));
     const { api, store } = await setupStore();
     await store.dispatch(
-      api.endpoints.updateUserPref.initiate({ selectedOrganizationID: 'org-9' }),
+      api.endpoints.updateUserPref.initiate({ selectedOrganizationId: 'org-9' }),
     );
     const req = fetchMock.mock.calls[0][0] as Request;
     expect(req.method).toBe('POST');
     expect(req.url).toContain('/api/user/prefs');
-    expect(JSON.parse(await req.text())).toEqual({ selectedOrganizationID: 'org-9' });
+    expect(JSON.parse(await req.text())).toEqual({ selectedOrganizationId: 'org-9' });
   });
 
   it('getUserPrefWithContext uses same-origin credentials with contexts in URL', async () => {

--- a/ui/rtk-query/__tests__/workspace-mutation-wrappers.test.tsx
+++ b/ui/rtk-query/__tests__/workspace-mutation-wrappers.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, expect, it, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // `../utils` (appendInvalidatesTags) imports the app store at module scope, so
@@ -17,8 +17,22 @@ vi.mock('@/utils/utils', () => ({
   },
 }));
 
-beforeAll(() => {
+// Hoisted before module imports because the schemas client reads its base URL at
+// module load. Restored afterwards: test files sharing a worker process share
+// `process.env`, so a divergent value left behind is a way for suite order to
+// start mattering.
+const { previousEndpointPrefix } = vi.hoisted(() => {
+  const previous = process.env.RTK_MESHERY_ENDPOINT_PREFIX;
   process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://localhost';
+  return { previousEndpointPrefix: previous };
+});
+
+afterAll(() => {
+  if (previousEndpointPrefix === undefined) {
+    delete process.env.RTK_MESHERY_ENDPOINT_PREFIX;
+  } else {
+    process.env.RTK_MESHERY_ENDPOINT_PREFIX = previousEndpointPrefix;
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -72,8 +86,10 @@ describe('workspace mutation wrappers', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchMock = vi.fn();
-    global.fetch = fetchMock as unknown as typeof fetch;
+    // spyOn (not direct assignment) so `vi.restoreAllMocks()` below actually
+    // reverts it - a raw `global.fetch = ...` would outlive this file and leak
+    // into every later suite in the same worker.
+    fetchMock = vi.spyOn(globalThis, 'fetch') as unknown as ReturnType<typeof vi.fn>;
   });
 
   afterEach(() => {

--- a/ui/rtk-query/__tests__/workspace-mutation-wrappers.test.tsx
+++ b/ui/rtk-query/__tests__/workspace-mutation-wrappers.test.tsx
@@ -80,26 +80,40 @@ describe('workspace mutation wrappers', () => {
     vi.restoreAllMocks();
   });
 
-  it('useCreateWorkspaceMutation sends the payload as the request body', async () => {
-    fetchMock.mockResolvedValue(okResponse({ id: 'new' }));
-    const { workspaceMod, wrapper } = await setup();
+  // `workspacePayload` is a caller-side view-model, not a wire object, and the
+  // wrapper normalizes either spelling of its org key to the canonical
+  // `organizationId` the generated endpoint sends. Both inputs are covered
+  // deliberately: `organization_id` is what the live caller passes today
+  // (ui/components/workspaces/index.tsx), so dropping it would delete coverage
+  // of the production path; `organizationId` covers callers already on the
+  // canonical spelling. What goes over the wire is camelCase either way, which
+  // is what the assertions pin.
+  it.each([
+    ['legacy organization_id (what the live caller sends)', { organization_id: 'org-1' }],
+    ['canonical organizationId', { organizationId: 'org-1' }],
+  ])(
+    'useCreateWorkspaceMutation sends the payload as the request body - %s',
+    async (_name, org) => {
+      fetchMock.mockResolvedValue(okResponse({ id: 'new' }));
+      const { workspaceMod, wrapper } = await setup();
 
-    const { result } = renderHook(() => workspaceMod.useCreateWorkspaceMutation(), { wrapper });
-    await act(async () => {
-      await result.current[0]({
-        workspacePayload: { name: 'w-name', description: 'desc', organization_id: 'org-1' },
+      const { result } = renderHook(() => workspaceMod.useCreateWorkspaceMutation(), { wrapper });
+      await act(async () => {
+        await result.current[0]({
+          workspacePayload: { name: 'w-name', description: 'desc', ...org },
+        });
       });
-    });
 
-    const req = fetchMock.mock.calls[0][0] as Request;
-    expect(req.method).toBe('POST');
-    expect(req.url).toContain('/api/workspaces');
-    expect(await req.clone().json()).toEqual({
-      name: 'w-name',
-      description: 'desc',
-      organizationId: 'org-1',
-    });
-  });
+      const req = fetchMock.mock.calls[0][0] as Request;
+      expect(req.method).toBe('POST');
+      expect(req.url).toContain('/api/workspaces');
+      expect(await req.clone().json()).toEqual({
+        name: 'w-name',
+        description: 'desc',
+        organizationId: 'org-1',
+      });
+    },
+  );
 
   it('useUpdateWorkspaceMutation addresses the workspace by id and sends a body', async () => {
     fetchMock.mockResolvedValue(okResponse({}));

--- a/ui/rtk-query/__tests__/workspace-mutation-wrappers.test.tsx
+++ b/ui/rtk-query/__tests__/workspace-mutation-wrappers.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// `../utils` (appendInvalidatesTags) imports the app store at module scope, so
+// the store has to be stubbed before workspace.ts is loaded.
+vi.mock('../../store', () => ({ store: { dispatch: vi.fn() } }));
+
+vi.mock('@/utils/utils', () => ({
+  urlEncodeParams: (params: Record<string, unknown>) => {
+    const usp = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v === undefined || v === null) return;
+      usp.append(k, String(v));
+    });
+    return usp.toString();
+  },
+}));
+
+beforeAll(() => {
+  process.env.RTK_MESHERY_ENDPOINT_PREFIX = 'http://localhost';
+});
+
+// ---------------------------------------------------------------------------
+// workspace.ts's create/update/delete hooks are wrappers: callers pass
+// `{ workspaceId, workspacePayload }`, the schemas endpoints take
+// `{ workspaceId, body }`. These tests drive the real hooks so the mapping
+// itself is exercised - dispatching the endpoint directly would assert the
+// schemas contract and never touch the wrapper.
+//
+// The wrappers used to emit the shape of workspace.ts's own local endpoint
+// declarations (`{name, description, organizationId}` and `{id}`). Those
+// declarations never ran: `injectEndpoints` without `overrideExisting: true`
+// silently ignores a name the schemas package already defines, so the schemas
+// endpoints served every call and read `body` and `workspaceId` as `undefined`.
+// Create and update sent an empty body; update and delete addressed
+// `/api/workspaces/undefined`. Every assertion below fails against that.
+// ---------------------------------------------------------------------------
+
+const okResponse = (body: unknown = {}) => ({
+  ok: true,
+  status: 200,
+  redirected: false,
+  headers: new Headers({ 'content-type': 'application/json' }),
+  url: '',
+  text: () => Promise.resolve(JSON.stringify(body)),
+  json: () => Promise.resolve(body),
+  clone() {
+    return this;
+  },
+});
+
+const setup = async () => {
+  vi.resetModules();
+  const apiMod = await import('../index');
+  const workspaceMod = await import('../workspace');
+  const { configureStore } = await import('@reduxjs/toolkit');
+  const { Provider } = await import('react-redux');
+
+  const store = configureStore({
+    reducer: { [apiMod.api.reducerPath]: apiMod.api.reducer },
+    middleware: (g) => g().concat(apiMod.api.middleware),
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(Provider, { store }, children);
+
+  return { workspaceMod, wrapper };
+};
+
+describe('workspace mutation wrappers', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('useCreateWorkspaceMutation sends the payload as the request body', async () => {
+    fetchMock.mockResolvedValue(okResponse({ id: 'new' }));
+    const { workspaceMod, wrapper } = await setup();
+
+    const { result } = renderHook(() => workspaceMod.useCreateWorkspaceMutation(), { wrapper });
+    await act(async () => {
+      await result.current[0]({
+        workspacePayload: { name: 'w-name', description: 'desc', organization_id: 'org-1' },
+      });
+    });
+
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('POST');
+    expect(req.url).toContain('/api/workspaces');
+    expect(await req.clone().json()).toEqual({
+      name: 'w-name',
+      description: 'desc',
+      organizationId: 'org-1',
+    });
+  });
+
+  it('useUpdateWorkspaceMutation addresses the workspace by id and sends a body', async () => {
+    fetchMock.mockResolvedValue(okResponse({}));
+    const { workspaceMod, wrapper } = await setup();
+
+    const { result } = renderHook(() => workspaceMod.useUpdateWorkspaceMutation(), { wrapper });
+    await act(async () => {
+      await result.current[0]({
+        workspaceId: 'w-1',
+        workspacePayload: { name: 'updated', description: 'd', organizationId: 'org-1' },
+      });
+    });
+
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('PUT');
+    expect(req.url).toContain('/api/workspaces/w-1');
+    expect(req.url).not.toContain('undefined');
+    expect(await req.clone().json()).toEqual({
+      name: 'updated',
+      description: 'd',
+      organizationId: 'org-1',
+    });
+  });
+
+  it('useDeleteWorkspaceMutation addresses the workspace by id', async () => {
+    fetchMock.mockResolvedValue(okResponse({}));
+    const { workspaceMod, wrapper } = await setup();
+
+    const { result } = renderHook(() => workspaceMod.useDeleteWorkspaceMutation(), { wrapper });
+    await act(async () => {
+      await result.current[0]({ workspaceId: 'w-2' });
+    });
+
+    const req = fetchMock.mock.calls[0][0] as Request;
+    expect(req.method).toBe('DELETE');
+    expect(req.url).toContain('/api/workspaces/w-2');
+    expect(req.url).not.toContain('undefined');
+  });
+});

--- a/ui/rtk-query/__tests__/workspace.test.ts
+++ b/ui/rtk-query/__tests__/workspace.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 
 // Mock @/utils/utils to avoid pulling the navigator/UI component tree.
+// `../utils` (appendInvalidatesTags) imports the app store at module scope, so
+// the store has to be stubbed before workspace.ts is loaded.
+vi.mock('../../store', () => ({ store: { dispatch: vi.fn() } }));
+
 vi.mock('@/utils/utils', () => ({
   urlEncodeParams: (params: Record<string, unknown>) => {
     const usp = new URLSearchParams();
@@ -21,15 +25,19 @@ beforeAll(() => {
 });
 
 // ---------------------------------------------------------------------------
-// workspace.ts re-`injectEndpoints` into the shared `api` defined by
-// @meshery/schemas. Because the file does NOT pass `overrideExisting: true`,
-// any endpoint with a name already defined in the schemas package is ignored
-// (with a console warning). The endpoint definitions in workspace.ts that
-// share names with the schemas — e.g. getWorkspaces, getDesignsOfWorkspace —
-// never take effect at runtime; the schemas' simpler `query` definitions
-// run instead. The tests below assert the URLs/methods that REALLY run.
-// `getEventsOfWorkspace` is unique to workspace.ts, so its definition does
-// take effect — that one is asserted in full.
+// workspace.ts injects into the shared `api` defined by @meshery/schemas.
+// Because it does NOT pass `overrideExisting: true`, any endpoint whose name
+// already exists in the schemas package is ignored (with a console warning) -
+// so a local re-declaration of a schemas endpoint never runs, and the schemas
+// definition is what serves every call. The endpoints below are therefore the
+// schemas ones, and the tests assert the URLs, methods and bodies that REALLY
+// go over the wire. `getEventsOfWorkspace` is unique to workspace.ts, so its
+// definition does take effect - that one is asserted in full.
+//
+// The exported `useCreate/Update/DeleteWorkspaceMutation` wrappers adapt the
+// callers' argument shape to those schemas endpoints. They used to feed the
+// dead local definitions' flat shape instead, which the schemas endpoints read
+// as `undefined` - see the wrapper tests at the end of this file.
 // ---------------------------------------------------------------------------
 
 const okResponse = (body: unknown = {}) => ({

--- a/ui/rtk-query/credentials.ts
+++ b/ui/rtk-query/credentials.ts
@@ -1,39 +1,21 @@
 import {
   mesheryApi,
+  useDeleteUserCredentialMutation as useSchemasDeleteUserCredentialMutation,
   useGetCredentialByIdQuery as useSchemasGetCredentialByIdQuery,
   useGetUserCredentialsQuery as useSchemasGetUserCredentialsQuery,
   useSaveUserCredentialMutation as useSchemasSaveUserCredentialMutation,
   useUpdateUserCredentialMutation as useSchemasUpdateUserCredentialMutation,
 } from '@meshery/schemas/mesheryApi';
-import { api, mesheryApiPath } from './index';
 
-// The tag type registered on the shared `mesheryApi` (see
-// @meshery/schemas/mesheryApi), which the schemas credential endpoints provide
-// and invalidate. A bare 'credentials' is not a registered tag type, so
-// invalidating it silently invalidates nothing and the list never refetches.
-const TAGS = {
-  CREDENTIALS: 'credential_credentials',
-};
-
-// `deleteCredential` is the one credential endpoint still declared here: the
-// schemas-generated `deleteUserCredential` sends `?credentialId=`, but the
-// server reads `credential_id` (DeleteUserCredential in
-// server/handlers/credentials_handlers.go), so the generated endpoint would
-// resolve a nil UUID and delete nothing. Everything else delegates to schemas.
-const credentialsApi = api.injectEndpoints({
-  endpoints: (builder) => ({
-    deleteCredential: builder.mutation({
-      query: (credentialId) => ({
-        url: mesheryApiPath(`integrations/credentials?credential_id=${credentialId}`),
-        method: 'DELETE',
-      }),
-      invalidatesTags: [TAGS.CREDENTIALS],
-    }),
-  }),
-  overrideExisting: true,
-});
-
-export const { useDeleteCredentialMutation } = credentialsApi;
+// Every credential endpoint is now the schemas-generated one; the hooks below
+// only adapt call shapes (bare id / bare credential) to the generated args.
+//
+// `deleteCredential` used to be re-declared here because the generated
+// `deleteUserCredential` sends `?credentialId=` while the server read only
+// `credential_id`, so the generated endpoint resolved a nil UUID and deleted
+// nothing. The fix belonged in the server, not in a fork of the request:
+// DeleteUserCredential now reads the canonical camelCase param (keeping
+// `credential_id` as a legacy fallback) and rejects an unusable id outright.
 
 // Backed by the schemas-generated `getUserCredentials` (GET
 // /api/integrations/credentials). Callers pass no list args, so every schemas
@@ -47,6 +29,12 @@ export const useGetCredentialsQuery = (queryArg?: undefined, options?: object) =
 // Callers pass a bare id; the schemas endpoints take `{ credentialId }`.
 export const useGetCredentialByIdQuery = (credentialId: string, options?: object) =>
   useSchemasGetCredentialByIdQuery({ credentialId }, options);
+
+export const useDeleteCredentialMutation = () => {
+  const [trigger, result] = useSchemasDeleteUserCredentialMutation();
+  const wrappedTrigger = (credentialId: string) => trigger({ credentialId });
+  return [wrappedTrigger, result] as const;
+};
 
 export const useLazyGetCredentialByIdQuery = () => {
   const [trigger, ...rest] = mesheryApi.endpoints.getCredentialById.useLazyQuery();

--- a/ui/rtk-query/notificationCenter.ts
+++ b/ui/rtk-query/notificationCenter.ts
@@ -229,7 +229,19 @@ export const notificationCenterApi = api
         invalidatesTags: [PROVIDER_TAGS.EVENT],
       }),
     }),
-    overrideExisting: false,
+    // `deleteEvent` is the one endpoint name here that @meshery/schemas also
+    // defines, and schemas points it at `/api/events/{eventId}` - the path
+    // Meshery Server is *going* to serve. Today it serves `/api/system/events/{id}`
+    // (see the comment beside that route in server/router/server.go, and
+    // meshery/schemas#1134).
+    //
+    // With `overrideExisting: false` the local definition was silently dropped
+    // and the schemas one served every call, so deleting a notification issued
+    // `DELETE /api/events/undefined` - wrong path, and `undefined` because
+    // callers pass `{ id }` while the schemas endpoint reads `eventId`.
+    // Overriding is deliberate and temporary: drop it, and this whole module's
+    // `/api/system/events` endpoints, once the server moves to `/api/events`.
+    overrideExisting: true,
   });
 
 export const {

--- a/ui/rtk-query/user.ts
+++ b/ui/rtk-query/user.ts
@@ -405,8 +405,15 @@ export const useGetSelectedOrganization = () => {
     error: errorLoadingAllOrgs,
   } = useGetOrgsQuery();
 
+  // `selectedOrganizationId` is the canonical key (schemas v1beta1
+  // user.Preference, and what meshery-cloud reads and writes). Meshery Server
+  // used to spell it `selectedOrganizationID`; the legacy read below keeps
+  // preferences persisted under that spelling resolving until they are
+  // rewritten on the next selection.
+  const selectedOrganizationId =
+    userPrefs?.selectedOrganizationId ?? userPrefs?.selectedOrganizationID;
   const existingSelectedOrganization = allOrgs?.organizations?.find(
-    (org) => org.id === userPrefs?.selectedOrganizationID,
+    (org) => org.id === selectedOrganizationId,
   );
 
   const selectedOrganization = existingSelectedOrganization ?? allOrgs?.organizations?.[0];
@@ -470,7 +477,7 @@ export const useUpdateSelectedOrganizationMutation = () => {
   const [updateUserPref, response] = useUpdateUserPrefMutation();
 
   const updateSelectedOrganization = (orgId) => {
-    return updateUserPref({ selectedOrganizationID: orgId });
+    return updateUserPref({ selectedOrganizationId: orgId });
   };
 
   return [updateSelectedOrganization, response];

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -1,9 +1,20 @@
 import { urlEncodeParams } from '@/utils/utils';
-import { mesheryApi } from '@meshery/schemas/mesheryApi';
+import {
+  mesheryApi,
+  useAssignDesignToWorkspaceMutation,
+  useAssignEnvironmentToWorkspaceMutation,
+  useCreateWorkspaceMutation as useSchemasCreateWorkspaceMutation,
+  useDeleteWorkspaceMutation as useSchemasDeleteWorkspaceMutation,
+  useGetEnvironmentsOfWorkspaceQuery,
+  useUnassignDesignFromWorkspaceMutation,
+  useUnassignEnvironmentFromWorkspaceMutation,
+  useUpdateWorkspaceMutation as useSchemasUpdateWorkspaceMutation,
+} from '@meshery/schemas/mesheryApi';
 import { api, mesheryApiPath } from './index';
 import _ from 'lodash';
 import { normalizePaginatedCollectionResponse } from './transforms';
 import { normalizeUserProfileSummary } from './userProfile';
+import { appendInvalidatesTags } from './utils';
 
 const TAGS = {
   WORKSPACES: 'workspaces',
@@ -22,9 +33,43 @@ const TAGS = {
 // absent id) before dispatching the lookup.
 const NIL_UUID = '00000000-0000-0000-0000-000000000000';
 const isResolvableOwnerId = (id?: string): id is string => Boolean(id) && id !== NIL_UUID;
+
+// KNOWN DEAD CODE - meshery/meshery#21175.
+//
+// The endpoints injected below whose names @meshery/schemas also defines
+// (getWorkspaces, getDesignsOfWorkspace, getViewsOfWorkspace, and the view and
+// team assign/unassign pairs) never take effect: `injectEndpoints` without
+// `overrideExisting: true` silently discards a colliding name, so the schemas
+// definitions serve every call. The `expandInfo` counts, the `expandUser`
+// owner resolution and the infinite-scroll merge below therefore do not run.
+//
+// Restoring them changes what the UI renders and needs verification against a
+// running server - and the view/team declarations additionally disagree with
+// schemas about the path (`/api/extensions/api/workspaces/...` vs
+// `/api/workspaces/...`), so flipping the flag blind would trade a rendering
+// bug for a routing one. Tracked in #21175 rather than fixed blind here.
 const workspacesApi = api
   .enhanceEndpoints({
     addTagTypes: [TAGS.WORKSPACES, TAGS.DESIGNS, TAGS.ENVIRONMENTS, TAGS.VIEWS, TAGS.TEAMS],
+    endpoints: {
+      // The four workspace assign/unassign mutations are the schemas-generated
+      // endpoints - the requests are NOT re-declared here. They were, byte for
+      // byte (same path, same method, same args), which forked the contract for
+      // no gain. `appendInvalidatesTags` adds the local tags this module's
+      // remaining list queries provide on top of the tags schemas declares.
+      assignDesignToWorkspace: appendInvalidatesTags('assignDesignToWorkspace', {
+        type: TAGS.DESIGNS,
+      }),
+      unassignDesignFromWorkspace: appendInvalidatesTags('unassignDesignFromWorkspace', {
+        type: TAGS.DESIGNS,
+      }),
+      assignEnvironmentToWorkspace: appendInvalidatesTags('assignEnvironmentToWorkspace', {
+        type: TAGS.ENVIRONMENTS,
+      }),
+      unassignEnvironmentFromWorkspace: appendInvalidatesTags('unassignEnvironmentFromWorkspace', {
+        type: TAGS.ENVIRONMENTS,
+      }),
+    },
   })
   .injectEndpoints({
     endpoints: (builder) => ({
@@ -90,43 +135,6 @@ const workspacesApi = api
           return workspaces;
         },
         providesTags: () => [{ type: TAGS.WORKSPACES }],
-      }),
-
-      getEnvironmentsOfWorkspace: builder.query({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces/${queryArg.workspaceId}/environments`),
-          params: {
-            search: queryArg.search,
-            order: queryArg.order,
-            page: queryArg.page,
-            pagesize: queryArg.pagesize,
-            filter: queryArg.filter,
-          },
-          method: 'GET',
-        }),
-        providesTags: () => [{ type: TAGS.ENVIRONMENTS }],
-      }),
-
-      assignEnvironmentToWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(
-            `workspaces/${queryArg.workspaceId}/environments/${queryArg.environmentId}`,
-          ),
-          method: 'POST',
-        }),
-
-        invalidatesTags: () => [{ type: TAGS.ENVIRONMENTS }],
-      }),
-
-      unassignEnvironmentFromWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(
-            `workspaces/${queryArg.workspaceId}/environments/${queryArg.environmentId}`,
-          ),
-          method: 'DELETE',
-        }),
-
-        invalidatesTags: () => [{ type: TAGS.ENVIRONMENTS }],
       }),
 
       getDesignsOfWorkspace: builder.query({
@@ -195,21 +203,6 @@ const workspacesApi = api
           return !_.eq(currentArg, previousArg);
         },
         providesTags: () => [{ type: TAGS.DESIGNS }],
-      }),
-      assignDesignToWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces/${queryArg.workspaceId}/designs/${queryArg.designId}`),
-          method: 'POST',
-        }),
-        invalidatesTags: () => [{ type: TAGS.DESIGNS }],
-      }),
-
-      unassignDesignFromWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces/${queryArg.workspaceId}/designs/${queryArg.designId}`),
-          method: 'DELETE',
-        }),
-        invalidatesTags: () => [{ type: TAGS.DESIGNS }],
       }),
       getViewsOfWorkspace: builder.query({
         queryFn: async (queryArg, { dispatch }, _extraOptions, baseQuery) => {
@@ -342,60 +335,13 @@ const workspacesApi = api
         }),
         invalidatesTags: () => [{ type: TAGS.TEAMS }],
       }),
-
-      createWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces`),
-          method: 'POST',
-          body: {
-            name: queryArg.name || queryArg.body?.name,
-            description: queryArg.description || queryArg.body?.description,
-            organizationId:
-              queryArg.organizationId ||
-              queryArg.organization_id ||
-              queryArg.body?.organizationId ||
-              queryArg.body?.organization_id,
-          },
-        }),
-        invalidatesTags: () => [{ type: TAGS.WORKSPACES }],
-      }),
-
-      updateWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces/${queryArg.workspaceId || queryArg.id}`),
-          method: 'PUT',
-          body: {
-            name: queryArg.name || queryArg.body?.name,
-            description: queryArg.description || queryArg.body?.description,
-            organizationId:
-              queryArg.organizationId ||
-              queryArg.organization_id ||
-              queryArg.body?.organizationId ||
-              queryArg.body?.organization_id,
-          },
-        }),
-        invalidatesTags: () => [{ type: TAGS.WORKSPACES }],
-      }),
-
-      deleteWorkspace: builder.mutation({
-        query: (queryArg) => ({
-          url: mesheryApiPath(`workspaces/${queryArg.workspaceId || queryArg.id}`),
-          method: 'DELETE',
-        }),
-        invalidatesTags: () => [{ type: TAGS.WORKSPACES }],
-      }),
     }),
   });
 
 export const {
   useGetWorkspacesQuery,
   useLazyGetWorkspacesQuery,
-  useGetEnvironmentsOfWorkspaceQuery,
-  useAssignEnvironmentToWorkspaceMutation,
-  useUnassignEnvironmentFromWorkspaceMutation,
   useGetDesignsOfWorkspaceQuery,
-  useAssignDesignToWorkspaceMutation,
-  useUnassignDesignFromWorkspaceMutation,
   useGetViewsOfWorkspaceQuery,
   useAssignViewToWorkspaceMutation,
   useUnassignViewFromWorkspaceMutation,
@@ -405,46 +351,73 @@ export const {
   useGetEventsOfWorkspaceQuery,
 } = workspacesApi;
 
-export const useCreateWorkspaceMutation = () => {
-  const [trigger, result] = workspacesApi.endpoints.createWorkspace.useMutation();
+// Re-exported straight from the schemas client: identical path, method and
+// args, so there is nothing for this module to add beyond the cache tags
+// attached via `enhanceEndpoints` above. Callers keep importing from here so
+// the module stays the single place workspace hooks are sourced.
+export {
+  useGetEnvironmentsOfWorkspaceQuery,
+  useAssignEnvironmentToWorkspaceMutation,
+  useUnassignEnvironmentFromWorkspaceMutation,
+  useAssignDesignToWorkspaceMutation,
+  useUnassignDesignFromWorkspaceMutation,
+};
 
-  const wrappedTrigger = (queryArg: any) => {
-    const payload = queryArg?.workspacePayload || queryArg?.body || queryArg;
-    return trigger({
-      name: payload?.name,
-      description: payload?.description,
-      organizationId: payload?.organizationId || payload?.organization_id,
-    });
+// Workspace CRUD is the schemas-generated create/update/deleteWorkspace. These
+// wrappers exist only to translate the callers' argument shape into the
+// generated `{ workspaceId, body }` args.
+//
+// They used to translate into the shape of this module's own local
+// createWorkspace/updateWorkspace/deleteWorkspace declarations - but those
+// never ran. `injectEndpoints` without `overrideExisting: true` silently
+// ignores a name @meshery/schemas already defines, so the generated endpoints
+// served every call and read `body` and `workspaceId` as `undefined`: create
+// posted an empty body, and update and delete addressed
+// `/api/workspaces/undefined`. Deleting the dead declarations and mapping onto
+// the generated args is the fix; see __tests__/workspace-mutation-wrappers.
+//
+// The accepted caller shapes (`workspacePayload`, `body`, or a bare payload;
+// `workspaceId` or `id`) are carried over from #21184, which widened them for
+// callers that do not use the `workspacePayload` spelling. That PR applied the
+// widening to the dead local declarations, so it never reached the wire - it is
+// applied here, on the wrappers that feed the endpoints actually serving.
+const toWorkspacePayload = (queryArg) => queryArg?.workspacePayload || queryArg?.body || queryArg;
+
+const toWorkspaceId = (queryArg) => queryArg?.workspaceId || queryArg?.id;
+
+const toWorkspaceBody = (queryArg) => {
+  const payload = toWorkspacePayload(queryArg);
+  return {
+    name: payload?.name,
+    description: payload?.description,
+    organizationId: payload?.organizationId || payload?.organization_id,
   };
+};
+
+export const useCreateWorkspaceMutation = () => {
+  const [trigger, result] = useSchemasCreateWorkspaceMutation();
+
+  const wrappedTrigger = (queryArg) => trigger({ body: toWorkspaceBody(queryArg) });
 
   return [wrappedTrigger, result] as const;
 };
 
 export const useUpdateWorkspaceMutation = () => {
-  const [trigger, result] = workspacesApi.endpoints.updateWorkspace.useMutation();
+  const [trigger, result] = useSchemasUpdateWorkspaceMutation();
 
-  const wrappedTrigger = (queryArg: any) => {
-    const payload = queryArg?.workspacePayload || queryArg?.body || queryArg;
-    const wsId = queryArg?.workspaceId || queryArg?.id;
-    return trigger({
-      workspaceId: wsId,
-      id: wsId,
-      name: payload?.name,
-      description: payload?.description,
-      organizationId: payload?.organizationId || payload?.organization_id,
+  const wrappedTrigger = (queryArg) =>
+    trigger({
+      workspaceId: toWorkspaceId(queryArg),
+      body: toWorkspaceBody(queryArg),
     });
-  };
 
   return [wrappedTrigger, result] as const;
 };
 
 export const useDeleteWorkspaceMutation = () => {
-  const [trigger, result] = workspacesApi.endpoints.deleteWorkspace.useMutation();
+  const [trigger, result] = useSchemasDeleteWorkspaceMutation();
 
-  const wrappedTrigger = (queryArg) =>
-    trigger({
-      id: queryArg.workspaceId,
-    });
+  const wrappedTrigger = (queryArg) => trigger({ workspaceId: toWorkspaceId(queryArg) });
 
   return [wrappedTrigger, result] as const;
 };

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -37,8 +37,9 @@ const isResolvableOwnerId = (id?: string): id is string => Boolean(id) && id !==
 // KNOWN DEAD CODE - meshery/meshery#21175.
 //
 // The endpoints injected below whose names @meshery/schemas also defines
-// (getWorkspaces, getDesignsOfWorkspace, getViewsOfWorkspace, and the view and
-// team assign/unassign pairs) never take effect: `injectEndpoints` without
+// (getWorkspaces, getDesignsOfWorkspace, getViewsOfWorkspace,
+// getEnvironmentsOfWorkspace, and the view and team assign/unassign pairs)
+// never take effect: `injectEndpoints` without
 // `overrideExisting: true` silently discards a colliding name, so the schemas
 // definitions serve every call. The `expandInfo` counts, the `expandUser`
 // owner resolution and the infinite-scroll merge below therefore do not run.

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -55,8 +55,19 @@ const workspacesApi = api
       // The four workspace assign/unassign mutations are the schemas-generated
       // endpoints - the requests are NOT re-declared here. They were, byte for
       // byte (same path, same method, same args), which forked the contract for
-      // no gain. `appendInvalidatesTags` adds the local tags this module's
-      // remaining list queries provide on top of the tags schemas declares.
+      // no gain. `appendInvalidatesTags` adds the local tags below on top of the
+      // tags schemas declares, and cannot drop them.
+      //
+      // Neither local tag has a live provider today, so both currently
+      // invalidate nothing: `workspaces_designs` is provided only by the
+      // shadowed `getDesignsOfWorkspace` in the dead block below, and
+      // `workspaces_environments` is provided by nothing at all since its only
+      // provider was the equally shadowed local `getEnvironmentsOfWorkspace`.
+      // Refetching still happens - the schemas definitions invalidate
+      // `Workspace_workspaces`, which is what the effective queries provide.
+      // The entries stay registered because they become load-bearing the moment
+      // meshery/meshery#21175 restores the shadowed list queries; removing them
+      // would just reintroduce the stale-list bug they guard against.
       assignDesignToWorkspace: appendInvalidatesTags('assignDesignToWorkspace', {
         type: TAGS.DESIGNS,
       }),

--- a/ui/rtk-query/workspace.ts
+++ b/ui/rtk-query/workspace.ts
@@ -62,8 +62,10 @@ const workspacesApi = api
       // Neither local tag has a live provider today, so both currently
       // invalidate nothing: `workspaces_designs` is provided only by the
       // shadowed `getDesignsOfWorkspace` in the dead block below, and
-      // `workspaces_environments` is provided by nothing at all since its only
-      // provider was the equally shadowed local `getEnvironmentsOfWorkspace`.
+      // `workspaces_environments` is provided by nothing at all - this module
+      // no longer declares a `getEnvironmentsOfWorkspace` at all, having
+      // dropped the shadowed local one and re-exported the generated query,
+      // which provides the schemas-side tags instead.
       // Refetching still happens - the schemas definitions invalidate
       // `Workspace_workspaces`, which is what the effective queries provide.
       // The entries stay registered because they become load-bearing the moment


### PR DESCRIPTION
> Re-opened from #21190, which never dispatched GitHub Actions — that PR was created while the branch was still conflicting, so no merge ref existed for the workflows to run against, and the dispatch did not recover once the conflict was resolved. Same branch, same commits, no code change.

## What

Comprehensive schema-consumer audit of this repo, the reference consumer of `@meshery/schemas`. Every local duplicate of a schemas-owned client, package or model was found and repointed at the generated client/models.

Method: enumerated the 124 generated operationIds + URLs from `@meshery/schemas/mesheryApi` at the version `package-lock.json` pins (1.3.39) and the 304 generated Go model structs from the schemas Go module, then diffed both against every local declaration in `ui/rtk-query`, `ui/components`, `server/models` and `mesheryctl`. Repointed only where the *same wire contract* was encoded — genuine UI-only view-models and Meshery-internal contracts were left alone.

Motivation: a single schemas `UserID` -> `Owner` rename silently broke five consumers on master, fixed in #21170. This eliminates that drift class.

## Four of the duplicates were silently broken

| Defect | Root cause |
|---|---|
| Anonymous sign-in wrote every session's capabilities under the **nil UUID** | `server/models/remote_provider.go` re-declared `AnonymousFlowResponse`. It only *decodes* meshery-cloud's reply, which sends `userId`; commit `f9ce12e8`'s blanket `userId`->`owner` rename renamed the field on it, so `flowResponse.Owner` was always zero. This is the 6th consumer that commit broke — #21170 caught five. |
| Workspace create/update/delete were **inert** — empty `POST` body, `PUT`/`DELETE /api/workspaces/undefined` | `workspace.ts` declared its own CRUD endpoints, but `injectEndpoints` without `overrideExisting` silently discards a name schemas defines. The generated endpoints served every call and read `body`/`workspaceId` as `undefined`. |
| Deleting a notification issued **`DELETE /api/events/undefined`** | Same shadowing. Here the *local* path is the correct one for Meshery today, so the override is now deliberate and documented — see meshery/schemas#1134. |
| The selected organization **never synced to a remote provider** | `Preference` spelled it `selectedOrganizationID`; schemas *and* meshery-cloud use `selectedOrganizationId`, so `executePrefSync` PUT a key Cloud ignores and Cloud's reply carried a key Meshery ignored. |

Each is covered by a guard test verified to fail against the defect and pass against the fix.

## Repointed with no behaviour change

- `ui/rtk-query/workspace.ts` — `getEnvironmentsOfWorkspace` and the four design/environment assign-unassign mutations, byte-identical to schemas. Local cache tags now ride on `appendInvalidatesTags` per `AGENTS.md`.
- `ui/rtk-query/credentials.ts` — `deleteCredential`, the last hand-rolled credential endpoint.
- `server/models/connections` — `ConnectionStatusInfo` / `ConnectionsStatusPage` are now the v1beta3 constructs. The local page had dropped `page`, `pageSize` and `totalCount`, so the generated swagger under-described the response.
- `server/models/pattern_resource.go` — `owner` -> `userId`, with the GORM column pinned so the built-in provider's table is untouched.

### Overlap with #21145 — dropped in favour of master

This branch originally repointed `ui/rtk-query/controllersConfig.ts` too: all four endpoints plus two hand-written types that had already drifted (`schemaVersion` optionality; the MeshSync watch-list `events` enum widened to a bare `string[]`), in a module that also used `overrideExisting: true` and so replaced the canonical definitions outright.

#21145 landed the same conclusion independently and went further — deleting the module entirely, pointing both consumers at the generated hooks, and deduplicating the two editors behind `useControllersConfigDraft`. On rebase I took master's version wholesale and dropped mine; that slice is **not** part of this PR. Two independent audits converging on the same module is a reasonable signal the shadowing problem was real.

## Fixed at the correct layer, not worked around

`deleteCredential` was hand-rolled *because* the server read `credential_id` while schemas sends `credentialId`. Rather than keep the fork, `DeleteUserCredential` now reads the canonical camelCase param (legacy spelling kept as a fallback) and rejects a missing or malformed id with **400** instead of `uuid.FromStringOrNil` coercing it to the nil UUID and reporting a successful delete of nothing.

Outbound query params were swept for the same asymmetry. `credential_id` -> `credentialId` and `oam_type` -> `oamType` are flipped, each verified against meshery-cloud's dual-accept readers (`handlers/credentials.go:178`, `handlers/meshery_pattern_resource.go:70`). Four others — `meshery_version`, `provider_version`, `test_uuid`, `updated_after` — were checked individually and **deliberately left snake_case**: cloud reads `meshery_version` with a single-spelling `.Get()` and has no reader at all for the other three, so flipping them would break a working call or is unverifiable. Those are tracked for cloud-side coordination.

## Deferred, with issues, rather than fixed blind

- **#21175** — the remaining shadowed endpoints in `workspace.ts`, whose `expandInfo` counts, `expandUser` owner resolution and infinite-scroll merge never run. Restoring them changes what the UI renders, and the view/team declarations disagree with schemas on the path, so it needs verification against a running server.
- **meshery/schemas#1134** — schemas' events operations point at `/api/events/*`; this server serves `/api/system/events/*`.
- **meshery/schemas#1136** — publish `credential_id` and `selectedOrganizationID` as deprecated aliases (`pagesize` precedent). `docs/data/openapi.yml` is generated upstream, so it cannot be corrected here.

## Notes for reviewers

- One pre-existing test was replaced because it asserted a `fetch` it had issued itself. That tautology is why the notification-delete break went unseen; the new tests dispatch through a real store and assert the endpoint that *actually* serves the call.
- `docs/data/errorref/meshery-server_errors_export.json` is deliberately **not** included — the error-codes workflow regenerates and commits it on push to master only, and carrying it in a PR guarantees conflicts. The new code (`meshery-server-1465`) and the `next_error_code` bump to 1466 do ship.
- `AGENTS.md` and the schema-driven UI contributor guide now document the `injectEndpoints` shadowing trap and the consumed-contract rule, with the contributing doc owning the detail and `AGENTS.md` holding the invariant plus a pointer.

## Testing

`go build ./...`, `server/models` + `server/handlers` + `server/models/connections` all pass; UI `tsc --noEmit` clean and `vitest` 389 files / 2689 tests pass, 0 failures. Validated against the `package-lock`-pinned `@meshery/schemas` 1.3.39 and `@sistent/sistent` 0.21.45.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for canonical credential, organization, workspace, and pattern-resource request formats.
  * Updated workspace and credential actions to use generated API integrations.
  * Added compatibility for legacy preference and credential parameter formats.

* **Bug Fixes**
  * Improved credential deletion validation.
  * Prevented anonymous sessions without valid user identifiers.
  * Corrected notification, workspace, organization, and remote-provider API routing.

* **Documentation**
  * Added guidance for generated API integrations and endpoint conflicts.

* **Tests**
  * Expanded coverage for API contracts, request parameters, persistence, and UI mutation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->