### PR TITLE
[skills] cut-release: correct it for meshery/meshery and verify the publish

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,107 +1,149 @@
 ---
 name: cut-release
 description: >-
-  Cut (publish) a release of meshery-cloud by publishing the current Release
-  Drafter draft with the gh CLI. Use this whenever the user asks to "cut a
-  release", "publish the release", "ship a release", "release meshery-cloud",
-  "do a release", "release the latest merge", or wants the recently merged PR to
-  go out to production. Handles waiting for the Release Drafter workflow to fold
-  the just-merged PR into the draft notes, then flipping the draft to published
-  so the deploy + docs + helm workflows fire. The version tag is already set by
-  Release Drafter and auto-increments after each release, so this skill never
-  creates or bumps a tag.
+  Cut (publish) a release of meshery/meshery by publishing the current Release
+  Drafter draft. Use this whenever the user asks to "cut a release", "publish the
+  release", "ship a release", "release meshery", "do a release", "release the
+  latest merge", or wants recently merged PRs to go out to users. Handles waiting
+  for the Release Drafter workflow to fold the merged PRs into the draft notes,
+  then flipping the draft to published so the stable build-and-release workflow
+  family fires. The version tag is already set by Release Drafter and
+  auto-increments after each release, so this skill never creates or bumps a tag.
 ---
 
-# Cut a meshery-cloud release
+# Cut a meshery/meshery release
 
 Publishing a release here is intentionally a one-action step: **flip the existing
 Release Drafter draft from draft to published.** Everything downstream is automated
 by GitHub Actions.
 
+Meshery has **no automatic release cadence** - nothing publishes the draft on a
+schedule. The deliberate publish in this skill *is* the release.
+
 ## How releasing works in this repo
 
-- `.github/workflows/release-drafter.yaml` runs on **every push to `master`**. As PRs
-  merge, it maintains a single **draft** GitHub Release, titled `Meshery v$NEXT_PATCH_VERSION`
-  with tag `v$NEXT_PATCH_VERSION` (the patch version auto-increments). There is always
-  exactly one draft waiting to be published.
-- Publishing that draft (the release `released` event) triggers
-  `.github/workflows/notify-release-and-deploy.yaml`, which deploys to **production** and
-  releases the Helm charts, and `.github/workflows/release-notes.yaml`, which updates the docs.
+- `.github/workflows/release-drafter.yml` runs on **every push to `master`** (except
+  pushes touching only `.github/**`, which it ignores). As PRs merge it maintains a
+  single **draft** GitHub Release, titled `Meshery v$NEXT_PATCH_VERSION` with tag
+  `v$NEXT_PATCH_VERSION` (patch auto-increments). There is always exactly one draft
+  waiting to be published. Config: `.github/release-drafter.yml`.
+- Publishing the draft creates the `v*` tag, which fires
+  `.github/workflows/build-and-release-stable.yml` (tag push). That single workflow
+  fans out to `ctlrelease` (mesheryctl via goreleaser), `call-dde-release-workflow`,
+  `call-helm-chart-releaser`, and `email-meshery-release-notes-workflow` as internal
+  jobs - those workflows are `workflow_call`/`workflow_dispatch` only and are *not*
+  separately triggered by the release event, so their absence from the run list is
+  expected, not a failure.
+- The `released`/`published` event also fires
+  `.github/workflows/release-notes.yml` (Release Notes Publisher) and Notify Remote
+  Providers.
 
-So the tag is already chosen and the notes are already drafted. Your job is only to make
-sure the just-merged PR is reflected in the draft, then publish it. **Do not create a tag,
-do not bump a version, do not write release notes by hand** - Release Drafter owns all of that.
+So the tag is already chosen and the notes are already drafted. Your job is only to
+make sure the merged PRs are reflected in the draft, then publish it. **Do not create
+a tag, do not bump a version, do not write release notes by hand** - Release Drafter
+owns all of that.
 
 ## Steps
 
 ### 1. Confirm the Release Drafter run for the latest master commit has finished
 
-The draft only includes a PR after the drafter workflow run for that merge commit completes.
-If you publish too early, the just-merged PR is missing from the notes.
+The draft only includes a PR after the drafter workflow run for that merge commit
+completes. If you publish too early, the just-merged PR is missing from the notes.
 
 ```bash
 # Latest master commit that should be in the release
 git fetch origin master --quiet && git rev-parse origin/master
 
-# Most recent Release Drafter runs (headSha should match origin/master, status "completed")
-gh run list --workflow="release-drafter.yaml" --branch master --limit 3 \
+# Most recent Release Drafter runs
+gh run list --workflow=release-drafter.yml --branch master --limit 5 \
   --json databaseId,status,conclusion,headSha,createdAt
 ```
 
-If the run for the current `origin/master` SHA is still `in_progress` (or absent because the
-push just landed), wait for it before publishing:
+The run whose `headSha` matches `origin/master` must be `completed`/`success`. If it
+is still `in_progress`, wait (`gh run watch <databaseId> --exit-status`). If it
+**failed**, stop and surface that - do not publish stale notes.
 
-```bash
-gh run watch <databaseId> --exit-status
-```
-
-A `conclusion` of `success` for the run whose `headSha` matches `origin/master` means the draft
-is up to date. If the latest run **failed**, stop and surface that - do not publish stale notes.
+Caveat: because of the `paths-ignore: '.github/**'` filter, a master HEAD whose commit
+touched only `.github/**` has **no** drafter run at all. Match against the newest
+commit that did trigger one rather than concluding the drafter is broken.
 
 ### 2. Identify and inspect the draft
 
 ```bash
-# Tag of the current draft (there is normally exactly one)
-gh release list --limit 25 --json tagName,isDraft --jq '.[] | select(.isDraft) | .tagName'
+gh api repos/meshery/meshery/releases \
+  --jq '.[] | select(.draft) | {id, tag: .tag_name, name, target: .target_commitish}'
 
-# Read the draft notes and confirm the recently merged PR appears in them
-gh release view <draftTag> --json tagName,name,isDraft,body --jq \
-  '{tag: .tagName, name: .name, isDraft: .isDraft, body: .body}'
+gh api repos/meshery/meshery/releases/<id> --jq .body
 ```
 
-Verify the merged PR the user is releasing shows up under one of the category headings. If it
-does not, the drafter run from step 1 has not yet indexed it - re-check step 1 rather than
-publishing without it.
+Verify the PRs being released show up under a category heading. If they do not, the
+drafter run from step 1 has not indexed them - re-check step 1 rather than publishing
+without them.
 
-If more than one draft is ever returned, stop and ask the user which to publish rather than
-guessing - publishing the wrong one ships an unintended version to production.
+Confirm the commit range too, not just the notes - a PR can be named in notes carried
+over from an earlier draft:
+
+```bash
+gh api repos/meshery/meshery/releases/latest --jq .tag_name   # e.g. v1.0.64
+git log <lastTag>..origin/master --oneline --grep='#<PR>'
+```
+
+If more than one draft is ever returned, stop and ask which to publish rather than
+guessing.
 
 ### 3. Publish the draft
-
-Flipping `--draft=false` publishes it and fires the `released` event that drives the production
-deploy, helm release, and docs update. Mark it `--latest` so it carries the "Latest" badge.
 
 ```bash
 gh release edit <draftTag> --draft=false --latest
 ```
 
-### 4. Confirm it published
+### 4. Confirm it published - by re-reading, never by exit status
+
+**`gh`/`gh-axi release edit --draft=false` can report success and leave the release a
+draft.** Observed on 2026-08-07 cutting v1.0.65: `edit: ok` was printed and the
+release was still `"draft": true` with a `untagged-<hash>` URL. Always re-read:
 
 ```bash
-gh release view <draftTag> --json tagName,isDraft,isLatest,publishedAt --jq \
-  '{tag: .tagName, isDraft: .isDraft, isLatest: .isLatest, publishedAt: .publishedAt}'
+gh api repos/meshery/meshery/releases/<id> \
+  --jq '{tag: .tag_name, draft, published_at, html_url}'
 ```
 
-`isDraft: false` and a non-null `publishedAt` confirm the release is out. Report the published
-version to the user and note that the production deploy + docs + helm-chart workflows have been
-triggered by the release event.
+`draft: false` and a non-null `published_at` are the only proof. If the flag silently
+failed, publish through the REST API instead:
+
+```bash
+gh api -X PATCH repos/meshery/meshery/releases/<id> -F draft=false -f make_latest=true
+```
+
+Note `-F draft=false` (typed) - `-f draft=false` sends the *string* `"false"`.
+
+Then confirm the tag was created and points where you expect:
+
+```bash
+gh api repos/meshery/meshery/git/ref/tags/<draftTag> --jq '{ref, sha: .object.sha}'
+```
+
+### 5. Confirm the release-triggered workflows actually dispatched
+
+A published release does not prove downstream ran. A release whose workflows never
+dispatched is not a cut release - report it if that happens.
+
+```bash
+gh api "repos/meshery/meshery/actions/runs?created=>$(date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)" \
+  --jq '.workflow_runs[] | {name, event, status, url: .html_url}'
+```
+
+Expect at minimum **Meshery Build and Releaser (stable)** (event `push`, branch
+`v<version>`) and **Release Notes Publisher** (event `release`). Report their run URLs.
 
 ## What to watch for
 
-- **Don't publish ahead of the drafter run.** The most common failure is publishing before the
-  Release Drafter workflow has folded the merged PR into the notes, shipping a release whose notes
-  omit the very change being released. Step 1 exists to prevent exactly this.
-- **Never hand-author the tag or notes.** If you find yourself computing a version number or
-  writing changelog entries, something is wrong - Release Drafter already did both.
-- **One draft only.** If `gh release list` shows zero drafts, no drafter run has occurred since the
-  last release; if it shows more than one, ask the user which to publish.
+- **Don't publish ahead of the drafter run.** The most common failure is publishing
+  before Release Drafter has folded the merged PR into the notes, shipping a release
+  whose notes omit the very change being released. Step 1 exists to prevent this.
+- **Never hand-author the tag or notes.** If you find yourself computing a version
+  number or writing changelog entries, something is wrong.
+- **One draft only.** Zero drafts means no drafter run since the last release; more
+  than one means ask which to publish.
+- **Trust the re-read, not the command.** Steps 4 and 5 are the verification; a
+  zero exit code from `release edit` is not evidence of anything.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,17 @@ Actions runner home). After regenerating, `git diff --stat` the docs dir, `git c
 every file whose only change is that path, and manually fix the path back to
 `/home/runner/...` in the pages you actually intended to change.
 
+### Releasing
+
+Meshery has **no automatic release cadence**. Release Drafter keeps exactly one draft
+release current on every push to `master`; publishing that draft creates the `v*` tag,
+which is what fires `build-and-release-stable.yml` and its fan-out. Follow
+`.agents/skills/cut-release/SKILL.md` - never hand-author a tag or notes.
+
+`gh release edit --draft=false` can exit 0 and leave the release a draft (seen cutting
+v1.0.65). Publication is proven only by re-reading the release for `draft: false` plus a
+non-null `published_at`, and by the release-triggered runs actually appearing.
+
 ### Docker
 
 ```bash


### PR DESCRIPTION
## Symptom

Cutting **v1.0.65** today, `gh-axi release edit v1.0.65 --draft=false --latest` printed `edit: ok` and exited 0. The release was still a draft, on an `untagged-10dcc67e9caa60183ee8` URL, with `published_at: null`. Following `.agents/skills/cut-release` as written - which ends at "run the command" - would have reported a release that never happened.

## Root cause

Two separate defects in the skill.

**1. It is meshery-cloud's skill, shipped verbatim into this repo.** It referenced `.github/workflows/release-drafter.yaml` and `.github/workflows/notify-release-and-deploy.yaml`; this repo has `release-drafter.yml` and no such deploy workflow. It described publishing as deploying to production, which Meshery does not do - here the tag push fires `build-and-release-stable.yml`. Anyone verifying against the documented filenames finds nothing and cannot tell a broken release from a mis-documented one.

**2. It treated command exit status as proof of publication.** Step 4 read back the release but the surrounding prose framed step 3 as the publish; there was no stated fallback when the flag silently no-ops.

## Fix

- Retarget the skill to this repo's real chain: `release-drafter.yml` maintains one draft -> publishing creates the `v*` tag -> the tag fires `build-and-release-stable.yml`, which fans out to `ctlrelease`, `call-dde-release-workflow`, `call-helm-chart-releaser` and `email-meshery-release-notes-workflow` as **internal jobs**. Those sibling workflows are `workflow_call`/`workflow_dispatch` only, so their absence from the post-publish run list is expected - worth stating, because it otherwise reads as a half-fired release.
- Make verification the actual gate: re-read for `draft: false` **and** non-null `published_at`, with the `gh api -X PATCH ... -F draft=false` fallback (`-F`, not `-f` - the latter sends the string `"false"`), then confirm the release-triggered runs dispatched.
- Check the commit range as well as the notes. Notes carry over between drafts, so a PR title in the body is not evidence its commits are in the range.
- Document the drafter's `paths-ignore: '.github/**'`: a master HEAD whose commit touched only `.github/**` has no drafter run at all, which looks like a stalled drafter and is not one.
- Record in `AGENTS.md` that Meshery has no automatic release cadence, plus the silent-failure trap.

## Watch for

Any other skill in `.agents/skills/` copied from a sibling repo carries the same risk of naming workflows that do not exist here. `cut-release` was the one exercised today.

## Validation

v1.0.65 is published and verified by re-read (`draft: false`, `published_at: 2026-08-07T04:49:07Z`), tag `v1.0.65` -> `d7e6acf`; **Meshery Build and Releaser (stable)** and **Release Notes Publisher** both dispatched. This PR is documentation only - no code paths change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance for the `meshery` project.
  * Documented draft-release workflows, automated stable releases, and downstream workflow triggering.
  * Added verification steps to confirm releases are published, tags are created, and follow-up workflows run.
  * Replaced CLI-based release instructions with REST API guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->