### PR TITLE
[Server] Pin operator deployment to a published Meshery Operator chart

### DIFF
--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -41,6 +41,11 @@ jobs:
       id: install
     - name: validate meshery
       run: helm lint install/kubernetes/helm/meshery --with-subcharts
+    # helm lint does not compare a parent chart's appVersion with its subcharts',
+    # so a subchart left behind at an older operator release passes lint while
+    # advertising an application it was not published alongside.
+    - name: validate meshery-operator subchart appVersions
+      run: ./install/scripts/check-operator-chart-appversions.sh install/kubernetes/helm/meshery-operator
     - name: validate meshery-operator
       run: helm lint install/kubernetes/helm/meshery-operator --with-subcharts
   release-chart:

--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -45,7 +45,9 @@ jobs:
     # so a subchart left behind at an older operator release passes lint while
     # advertising an application it was not published alongside.
     - name: validate meshery-operator subchart appVersions
-      run: ./install/scripts/check-operator-chart-appversions.sh install/kubernetes/helm/meshery-operator
+      run: |
+        ./install/scripts/check-operator-chart-appversions.sh --self-test
+        ./install/scripts/check-operator-chart-appversions.sh install/kubernetes/helm/meshery-operator
     - name: validate meshery-operator
       run: helm lint install/kubernetes/helm/meshery-operator --with-subcharts
   release-chart:

--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -43,7 +43,10 @@ jobs:
       run: helm lint install/kubernetes/helm/meshery --with-subcharts
     # helm lint does not compare a parent chart's appVersion with its subcharts',
     # so a subchart left behind at an older operator release passes lint while
-    # advertising an application it was not published alongside.
+    # advertising an application it was not published alongside. This also
+    # reports - as a warning, not a failure; see the script header - the same
+    # drift inside the operator archive the meshery chart vendors, which is what
+    # `helm install meshery/meshery` actually deploys.
     - name: validate meshery-operator subchart appVersions
       run: |
         ./install/scripts/check-operator-chart-appversions.sh --self-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,15 @@ make helm-docs      # Generate Helm chart docs
   `mesheryctl/helpers/component_info.json` (`next_error_code`) and that value bumped in the
   same commit. `.github/workflows/error-codes-updater.yaml` re-runs errorutil and fails the
   PR if its analysis reports anything.
+  The server side has the same contract in `server/helpers/component_info.json`: errorutil
+  refuses to run at all ("next_error_code is lower than or equal to highest used code") until
+  `next_error_code` is bumped past every code you added, so bump it in the same commit.
+  Name each constant `<BuilderFuncName>Code` - errorutil keys the export off that pairing.
+  `server/helpers/errorutil_errors_export.json` is gitignored, but the reference data at
+  `docs/data/errorref/meshery-server_errors_export.json` is tracked: regenerate it with the
+  `jq --slurpfile` wrapper the workflow uses, or the docs reference silently omits the new
+  codes. Adding a constant longer than the block's current widest name makes gofmt realign
+  the entire `error.go` const block - prefer a shorter name over a 300-line whitespace diff.
 - Only `utils.Log.Error(err)` renders a MeshKit error's code, cause and remediation; cobra's
   default print shows just the message. In `mesheryctl` commands, log the structured error
   for the user *and* return it for the exit path.

--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,11 @@ check-go:
 ## Generate all Meshery Helm Chart documentation in markdown format.
 helm-docs: helm-operator-docs helm-meshery-docs
 
-## Generate Meshery Operator Helm Chart documentation in markdown format.
+# WARNING: this overwrites install/kubernetes/helm/meshery-operator/README.md, which is
+# hand-maintained. values.yaml has no `# --` comments and there is no README.md.gotmpl,
+# so helm-docs would delete that README's "CRD lifecycle" section and every per-value
+# description. Read the note at the top of that file before running this.
+## Generate Meshery Operator Helm Chart docs. WARNING: overwrites the hand-maintained meshery-operator README - read the note at its top first.
 helm-operator-docs: dep-check
 	GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs
 	$(GOPATH)/bin/helm-docs -c install/kubernetes/helm/meshery-operator

--- a/Makefile
+++ b/Makefile
@@ -435,6 +435,7 @@ helm-operator-lint: helm-operator-appversion-check
 
 ## Assert the Meshery Operator chart and its subcharts advertise the same appVersion
 helm-operator-appversion-check:
+	./install/scripts/check-operator-chart-appversions.sh --self-test
 	./install/scripts/check-operator-chart-appversions.sh install/kubernetes/helm/meshery-operator
 ## Lint Meshery Server and Adapter Helm Charts
 helm-meshery-lint:

--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ check-go:
 #-----------------------------------------------------------------------------
 # Meshery Helm Charts
 #-----------------------------------------------------------------------------
-.PHONY: helm-docs helm-operator-docs helm-meshery-docs helm-operator-lint helm-lint
+.PHONY: helm-docs helm-operator-docs helm-meshery-docs helm-operator-lint helm-operator-appversion-check helm-lint
 ## Generate all Meshery Helm Chart documentation in markdown format.
 helm-docs: helm-operator-docs helm-meshery-docs
 
@@ -430,8 +430,12 @@ helm-meshery-docs: dep-check
 helm-lint: helm-operator-lint helm-meshery-lint
 
 ## Lint Meshery Operator Helm Chart
-helm-operator-lint:
+helm-operator-lint: helm-operator-appversion-check
 	helm lint install/kubernetes/helm/meshery-operator --with-subcharts
+
+## Assert the Meshery Operator chart and its subcharts advertise the same appVersion
+helm-operator-appversion-check:
+	./install/scripts/check-operator-chart-appversions.sh install/kubernetes/helm/meshery-operator
 ## Lint Meshery Server and Adapter Helm Charts
 helm-meshery-lint:
 	helm lint install/kubernetes/helm/meshery --with-subcharts

--- a/docs/content/en/concepts/architecture/operator/index.md
+++ b/docs/content/en/concepts/architecture/operator/index.md
@@ -33,7 +33,8 @@ It is recommended to deploy one Meshery Operator per cluster.
 Meshery Server installs the `meshery-operator` Helm chart from
 [meshery.io/charts](https://meshery.io/charts) into the `meshery` namespace of
 each managed cluster, requesting the chart version that **matches the Meshery
-Server release**. Upgrading Meshery Server is therefore what upgrades the
+Server release** and resolving it against the versions the repository actually
+publishes. Upgrading Meshery Server is therefore what upgrades the
 Operator: the Server re-applies the newer chart, the chart's CRD update Job
 refreshes the CRD schemas, and the Operator Deployment rolls to the operator
 version pinned in that chart. Manual operator upgrades on Server-managed

--- a/docs/content/en/guides/infrastructure-management/configuring-operator-meshsync-broker.md
+++ b/docs/content/en/guides/infrastructure-management/configuring-operator-meshsync-broker.md
@@ -65,10 +65,10 @@ Meshery Operator itself has little to configure by design: it is a controller wh
 | Setting | Mechanism | Default | Behavioral impact |
 | --- | --- | --- | --- |
 | Deploy or do not deploy | Per-connection deployment mode; Settings page Operator switch; `DISABLE_OPERATOR=true` on the server | Deployed for operator-mode connections | Without the Operator, no Broker or MeshSync runs in-cluster; embedded mode (or no discovery) applies |
-| Operator version | Tracks the Meshery Server release via the `meshery-operator` Helm chart | Matches your server version | Upgrading Meshery Server upgrades the Operator; manual operator upgrades on server-managed clusters are reverted by the server's reconciliation |
+| Operator version | Tracks the Meshery Server release via the `meshery-operator` Helm chart, or `operator.version` on the connection | The published chart for your server release | Upgrading Meshery Server upgrades the Operator; manual operator upgrades on server-managed clusters are reverted by the server's reconciliation |
 | Namespace | Fixed | `meshery` | Operator, Broker, and MeshSync objects live in the `meshery` namespace |
 
-Meshery Server installs the Operator from the `meshery-operator` Helm chart at [meshery.io/charts](https://meshery.io/charts), pinned to the chart version matching the server release. To upgrade the Operator, upgrade Meshery Server; see [How Meshery Server manages Meshery Operator]({{< ref "installation/upgrades/index.md#how-meshery-server-manages-meshery-operator" >}}).
+Meshery Server installs the Operator from the `meshery-operator` Helm chart at [meshery.io/charts](https://meshery.io/charts), always at a version the repository publishes. To upgrade the Operator, upgrade Meshery Server; for how the version is chosen, when it is substituted, and how to pin one yourself, see [How Meshery Server manages Meshery Operator]({{< ref "installation/upgrades/index.md#how-meshery-server-manages-meshery-operator" >}}).
 
 You can also toggle the Operator per cluster without disconnecting the cluster: the Meshery Operator section of **Settings** in Meshery UI provides an on/off switch, and `kubectl` shows you what the Operator has deployed:
 

--- a/docs/content/en/guides/infrastructure-management/configuring-operator-meshsync-broker.md
+++ b/docs/content/en/guides/infrastructure-management/configuring-operator-meshsync-broker.md
@@ -89,7 +89,7 @@ MeshSync's configuration spans three mechanisms: fields on the `MeshSync` custom
 | Secret value redaction | `MESHSYNC_REDACT_SECRETS` env var | Off | Rollout (env change restarts pods) |
 | Broker content deduplication | `MESHSYNC_BROKER_CONTENT_DEDUP` env var | Off | Rollout (env change restarts pods) |
 | Log verbosity | `DEBUG` env var | Info level | Rollout (env change restarts pods) |
-| Image version | `MeshSync` CR `spec.version` | `stable-latest` | Operator rolls the Deployment |
+| Image version | `MeshSync` CR `spec.version` | `1.0.3` - the pinned MeshSync release the Operator ships with | Operator rolls the Deployment |
 | Replica count | `MeshSync` CR `spec.size` (1-10) | `1` | Operator scales the Deployment |
 | Broker to publish to | `MeshSync` CR `spec.broker.native` or `spec.broker.custom.url` | The cluster's `meshery-broker` | Operator re-reconciles `BROKER_URL` |
 
@@ -215,7 +215,7 @@ metadata:
   name: meshery-meshsync
   namespace: meshery
 spec:
-  version: stable-latest   # image tag for meshery/meshsync
+  version: 1.0.3           # image tag for meshery/meshsync; omit to take the Operator's pinned default
   size: 1                  # replicas, 1-10
   broker:
     native:
@@ -223,7 +223,7 @@ spec:
       namespace: meshery
 ```
 
-- **`spec.version`** maps to the container image `meshery/meshsync:<version>`. The default is `stable-latest`. Tags ending in `-latest` are pulled on every pod start (`imagePullPolicy: Always`); pinned tags are pulled only if not present. Pin a specific version in production if you need to control exactly when MeshSync behavior changes.
+- **`spec.version`** maps to the container image `meshery/meshsync:<version>`. Leaving it unset takes the Operator's own pinned default, `1.0.3` - never a moving channel tag. A leading `v` is dropped when the rest of the value parses as a semantic version, so `v1.0.3` and `1.0.3` both resolve to `meshery/meshsync:1.0.3`, while a non-semver value is passed through unchanged. The pull policy follows the tag's mutability, not the field: a moving tag (`latest`, or anything ending in `-latest`) is pulled on every pod start (`imagePullPolicy: Always`) so it tracks its channel, while a pinned tag is pulled only if not already present. Because the default is already pinned, set `spec.version` explicitly when you want a *different* MeshSync version - not to escape a moving tag.
 - **`spec.size`** sets Deployment replicas, validated to the range 1-10, defaulting to 1. MeshSync replicas do not coordinate: there is no leader election or work sharding, so every replica watches the entire cluster and publishes its own copy of every event, multiplying API server watch load, Broker traffic, and Meshery Server's ingest and database write load without adding discovery capacity. Keep `size: 1` for normal operation; the [work-queue design](#what-is-coming) is the roadmap direction for scaling discovery throughput.
 - **`spec.broker`** selects where MeshSync publishes: `native` points at a `Broker` resource by name and namespace (the Operator resolves its endpoint and injects `BROKER_URL`), while `custom.url` points MeshSync at an externally managed NATS verbatim.
 

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -154,6 +154,10 @@ Meshery Server normally deploys the operator chart that matches its own release,
 
 The value must be a chart version that the repository publishes, for example `v1.0.64` (the leading `v` is optional - `1.0.64` names the same chart). A moving tag such as `stable-latest`, or a version that is not published, is rejected with a visible error rather than being silently replaced. Clear the field to go back to tracking the Meshery Server release.
 
+Release candidates are the one thing Meshery will never pick for you: when it falls back to the newest published chart, or raises an old one to the oldest chart known to deploy, it skips any version carrying a prerelease suffix such as `v1.0.66-rc.1`. Naming a prerelease in `operator.version` deploys it exactly as asked.
+
+If the chart repository cannot be reached, Meshery still reports the operator's status and image version for an operator that is already installed - only installing or upgrading it is withheld, and the reason appears in the connection's diagnostics and in the events feed.
+
 ## Operating Meshery without Meshery Operator
 
 Meshery Operator, MeshSync, and Broker are crucial components in a Meshery deployment. Meshery can function without them, but some functions of Meshery will be disable / unusable. Whether Meshery Operator is initially deployed via `mesheryctl` command or via Meshery Server, you can monitor the health of the Meshery Operator deployment using either the CLI or UI clients.

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -100,16 +100,16 @@ kubectl -n meshery logs deploy/meshery-operator -c manager
 # open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory
 ```
 
-**Cause.** Both symptoms come from one thing: an **old `meshery-operator` Helm chart**, from before `v1.0.63`.
+**Cause.** Both symptoms come from one thing: an **old `meshery-operator` Helm chart**, from before `v1.0.51`.
 
 - Those charts ship a `gcr.io/kubebuilder/kube-rbac-proxy` sidecar. That registry has been retired, so the image can no longer be pulled and the Pod never becomes ready.
 - They also set no `ENABLE_WEBHOOKS` on the manager and mount no serving certificate. Current operator images treat an unset `ENABLE_WEBHOOKS` as *enabled*, so the manager looks for a certificate that the old chart never created and crash-loops.
 
-Charts `v1.0.63` and later drop the sidecar and ship `ENABLE_WEBHOOKS=false` with the conversion webhook opt-in and off by default.
+`v1.0.51` is the oldest published chart confirmed to render without the sidecar and with `ENABLE_WEBHOOKS=false` - the conversion webhook opt-in, off by default - and every chart above it does the same. Both symptoms were reproduced from the published archives of `v1.0.40` and of the contiguous run `v1.0.41` through `v1.0.50` (`v1.0.47` was never published); charts older than `v1.0.40` were not checked, so treat "older than `v1.0.51`" as the boundary rather than a claim about any specific ancient release.
 
-**Remedy.** Get a chart at or above `v1.0.63` into the cluster.
+**Remedy.** Get a chart at or above `v1.0.51` into the cluster.
 
-If Meshery Server deployed the operator for you (the usual case: you added a kubeconfig and Meshery installed the operator), simply **upgrade Meshery Server**. Meshery Server will not install a chart below `v1.0.63`: it resolves the chart version against what the repository actually publishes and raises anything older to the oldest working chart, telling you it did so in the events feed. Then reconnect the cluster.
+If Meshery Server deployed the operator for you (the usual case: you added a kubeconfig and Meshery installed the operator), simply **upgrade Meshery Server**. Meshery Server will not install a chart below `v1.0.51`: it resolves the chart version against what the repository actually publishes and raises anything older to the oldest published chart at or above that boundary, telling you it did so in the events feed. Then reconnect the cluster.
 
 If you installed the operator chart yourself with Helm:
 
@@ -141,7 +141,7 @@ kubectl -n meshery get deploy meshery-operator \
 helm -n meshery list --filter meshery-operator
 ```
 
-A `kube-rbac-proxy` container in the output of the following command means the chart predates `v1.0.63`, whatever version it claims:
+A `kube-rbac-proxy` container in the output of the following command means the chart predates `v1.0.51`, whatever version it claims:
 
 ```bash
 kubectl -n meshery get deploy meshery-operator \

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -152,7 +152,7 @@ kubectl -n meshery get deploy meshery-operator \
 
 Meshery Server normally deploys the operator chart that matches its own release, falling back to the newest published chart when that one is not published yet (chart publishing trails Meshery Server releases). To pin a specific chart version for one connection, set **`operator.version`** in the connection's controllers configuration.
 
-The value must be a chart version that the repository publishes, for example `v1.0.64`. A moving tag such as `stable-latest`, or a version that is not published, is rejected with a visible error rather than being silently replaced. Clear the field to go back to tracking the Meshery Server release.
+The value must be a chart version that the repository publishes, for example `v1.0.64` (the leading `v` is optional - `1.0.64` names the same chart). A moving tag such as `stable-latest`, or a version that is not published, is rejected with a visible error rather than being silently replaced. Clear the field to go back to tracking the Meshery Server release.
 
 ## Operating Meshery without Meshery Operator
 

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -81,6 +81,78 @@ Some common failure situations that Meshery users might face are described below
    5. **Broker unreachable / not authenticated (out-of-cluster Meshery):** the Broker is `ClusterIP`-only and unreachable, or Meshery is not presenting the NATS token. See [Out-of-Cluster Deployment](#out-of-cluster-deployment); the connection's [Diagnostics](#diagnostics-in-the-connection-detail-view) will report `broker_unreachable` with remediation.
 1. **Situation:** The `meshery-nats` (Broker) pod is in `CrashLoopBackOff` and never becomes ready.
    1. **Probable cause:** Some Meshery Operator versions inject the NATS token into `nats.conf` **unquoted** (`token: $NATS_TOKEN`). When the generated token happens to look like a number, the NATS config parser rejects it and the pod crash-loops. Confirm with `kubectl logs -n meshery meshery-nats-0 -c nats` (look for a `variable reference for 'NATS_TOKEN' ... could not be parsed` error). The fix belongs in the Operator (quote it: `token: "$NATS_TOKEN"`); redeploying often generates a token that parses.
+1. **Situation:** The `meshery-operator` pod never becomes ready after connecting a cluster. Its `kube-rbac-proxy` container is in `ImagePullBackOff`, and/or its `manager` container crash-loops with `open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory`.
+   1. **Probable cause:** An old Meshery Operator Helm chart was installed. See [Meshery Operator will not start: ImagePullBackOff and a missing webhook certificate](#meshery-operator-will-not-start-imagepullbackoff-and-a-missing-webhook-certificate).
+
+## Meshery Operator will not start: ImagePullBackOff and a missing webhook certificate
+
+**Signature.** After adding a Kubernetes connection, the operator never reaches **DEPLOYED**. Both of these appear together:
+
+```bash
+kubectl -n meshery get pods
+# meshery-operator-...   1/2   ImagePullBackOff   (kube-rbac-proxy)
+#                              CrashLoopBackOff   (manager)
+
+kubectl -n meshery describe pod -l app=meshery-operator | grep -A2 kube-rbac-proxy
+# Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0"
+
+kubectl -n meshery logs deploy/meshery-operator -c manager
+# open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory
+```
+
+**Cause.** Both symptoms come from one thing: an **old `meshery-operator` Helm chart**, from before `v1.0.63`.
+
+- Those charts ship a `gcr.io/kubebuilder/kube-rbac-proxy` sidecar. That registry has been retired, so the image can no longer be pulled and the Pod never becomes ready.
+- They also set no `ENABLE_WEBHOOKS` on the manager and mount no serving certificate. Current operator images treat an unset `ENABLE_WEBHOOKS` as *enabled*, so the manager looks for a certificate that the old chart never created and crash-loops.
+
+Charts `v1.0.63` and later drop the sidecar and ship `ENABLE_WEBHOOKS=false` with the conversion webhook opt-in and off by default.
+
+**Remedy.** Get a chart at or above `v1.0.63` into the cluster.
+
+If Meshery Server deployed the operator for you (the usual case: you added a kubeconfig and Meshery installed the operator), simply **upgrade Meshery Server**. Meshery Server will not install a chart below `v1.0.63`: it resolves the chart version against what the repository actually publishes and raises anything older to the oldest working chart, telling you it did so in the events feed. Then reconnect the cluster.
+
+If you installed the operator chart yourself with Helm:
+
+```bash
+helm repo add meshery https://meshery.github.io/meshery.io/charts
+helm repo update
+helm upgrade --install meshery-operator meshery/meshery-operator \
+  --namespace meshery --create-namespace
+```
+
+`helm repo update` matters on its own: a stale local repository cache will happily reinstall the same broken chart.
+
+If the operator Pod is still wedged after the upgrade, delete it so the new spec takes effect immediately:
+
+```bash
+kubectl -n meshery rollout restart deploy/meshery-operator
+```
+
+### Confirming which Meshery Operator version is deployed
+
+The chart version and the operator image tag are different numbers; the image tag is what tells you which operator is actually running:
+
+```bash
+# The operator image actually running in the cluster
+kubectl -n meshery get deploy meshery-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+
+# The Helm chart release that installed it (chart version and app version)
+helm -n meshery list --filter meshery-operator
+```
+
+A `kube-rbac-proxy` container in the output of the following command means the chart predates `v1.0.63`, whatever version it claims:
+
+```bash
+kubectl -n meshery get deploy meshery-operator \
+  -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n"}{end}'
+```
+
+### Choosing the chart version yourself
+
+Meshery Server normally deploys the operator chart that matches its own release, falling back to the newest published chart when that one is not published yet (chart publishing trails Meshery Server releases). To pin a specific chart version for one connection, set **`operator.version`** in the connection's controllers configuration.
+
+The value must be a chart version that the repository publishes, for example `v1.0.64`. A moving tag such as `stable-latest`, or a version that is not published, is rejected with a visible error rather than being silently replaced. Clear the field to go back to tracking the Meshery Server release.
 
 ## Operating Meshery without Meshery Operator
 

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -94,6 +94,8 @@ kubectl -n meshery get pods
 #                              CrashLoopBackOff   (manager)
 
 kubectl -n meshery describe pod -l app=meshery-operator | grep -A2 kube-rbac-proxy
+# Failed to pull image "registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0"
+# ...older charts name the same sidecar under the other registry:
 # Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0"
 
 kubectl -n meshery logs deploy/meshery-operator -c manager
@@ -102,10 +104,11 @@ kubectl -n meshery logs deploy/meshery-operator -c manager
 
 **Cause.** Both symptoms come from one thing: an **old `meshery-operator` Helm chart**, from before `v1.0.51`.
 
-- Those charts ship a `gcr.io/kubebuilder/kube-rbac-proxy` sidecar. That registry has been retired, so the image can no longer be pulled and the Pod never becomes ready.
+- Those charts ship a `kube-rbac-proxy` sidecar next to the manager. Charts around `v0.8.214` and above - including the chart a helm-installed Meshery Server asks for, which is the usual case - name it `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0`; older charts such as `v0.8.180` name the same image as `gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0`. Match on either. When that image does not pull, the container sits in `ImagePullBackOff` and the Pod never becomes ready.
+  - Why the pull fails is not the same story for both registries, and only one of them is settled: the `gcr.io` copy of `v0.16.0` is gone (the repository's tag list is empty and the tag returns `404`), while the `registry.k8s.io` copy still resolves from an unrestricted network. So if your cluster reports the pull failing on `registry.k8s.io`, treat it as something about that cluster's access to the registry rather than as the image having been withdrawn. The remedy below does not depend on which it is.
 - They also set no `ENABLE_WEBHOOKS` on the manager and mount no serving certificate. Current operator images treat an unset `ENABLE_WEBHOOKS` as *enabled*, so the manager looks for a certificate that the old chart never created and crash-loops.
 
-`v1.0.51` is the oldest published chart confirmed to render without the sidecar and with `ENABLE_WEBHOOKS=false` - the conversion webhook opt-in, off by default - and every chart above it does the same. Both symptoms were reproduced from the published archives of `v1.0.40` and of the contiguous run `v1.0.41` through `v1.0.50` (`v1.0.47` was never published); charts older than `v1.0.40` were not checked, so treat "older than `v1.0.51`" as the boundary rather than a claim about any specific ancient release.
+`v1.0.51` is the oldest published chart confirmed to render without the sidecar and with `ENABLE_WEBHOOKS=false` - the conversion webhook opt-in, off by default - and every chart above it does the same. Both conditions behind the symptoms - the sidecar, and the absent `ENABLE_WEBHOOKS` - were confirmed by rendering the published archives of `v1.0.40` and of the contiguous run `v1.0.41` through `v1.0.50` (`v1.0.47` was never published); charts older than `v1.0.40` were not rendered, so treat "older than `v1.0.51`" as the boundary rather than a claim about any specific ancient release.
 
 **Remedy.** Get a chart at or above `v1.0.51` into the cluster.
 

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -40,6 +40,10 @@ Each Meshery Operator controller offers a health status that you can use to unde
 - **UNDEPLOYED:** Custom Resource not deployed.
 - **CONNECTED:** Deployed, sending data to Meshery Server.
 
+### When a controller reports UNKOWN
+
+Any of the three can instead report **UNKOWN** (spelled that way on the wire). It is not a health state: it means Meshery made no observation of that controller on this cluster, so it is asserting nothing about it. All three report it at once when the connection's kubeconfig could not be read or its Kubernetes client could not be created, since nothing about the cluster was observable. The cards stay visible on purpose - the reason is in the connection's [Diagnostics](#diagnostics-in-the-connection-detail-view) and in the events feed, not in the status itself.
+
 ## Meshery Operator Deployment Scenarios
 
 Because Meshery is versatile in its deployment models, there are different scenarios in which you may need to troubleshoot the health of Meshery Operator. Identify the deployment model fitting your environment and follow the guidance under the respective scenario to troubleshoot accordingly.

--- a/docs/content/en/installation/production/networking-and-connectivity.md
+++ b/docs/content/en/installation/production/networking-and-connectivity.md
@@ -28,7 +28,7 @@ current releases.
 
 In addition, optional [Meshery Adapters]({{< ref "concepts/architecture/adapters.md" >}}) listen
 on their own ports (for example `10000/tcp` and up), and the Meshery Operator's
-`kube-rbac-proxy` listens on `8443/tcp` in-cluster. Inside the pod, Meshery
+authn/authz-filtered metrics endpoint listens on `8443/tcp` in-cluster. Inside the pod, Meshery
 Server listens on `8080/tcp`, which the Kubernetes Service exposes as
 `9081/tcp`.
 

--- a/docs/content/en/installation/upgrades/index.md
+++ b/docs/content/en/installation/upgrades/index.md
@@ -96,9 +96,33 @@ and what you should — and should not — touch by hand.
 **Installation.** When Meshery Server connects to a Kubernetes cluster (in
 operator deployment mode), it installs the `meshery-operator` Helm chart from
 [meshery.io/charts](https://meshery.io/charts) into the `meshery` namespace.
-The chart version it requests **matches the Meshery Server release version** —
+The chart version it asks for **matches the Meshery Server release version** -
 each Server release snapshots the operator chart (and the operator version
 pinned inside it) as of that release.
+
+**What actually gets deployed is always a published chart.** The Server reads
+the repository's index before installing and never hands Helm a version the
+repository does not carry, so two everyday cases are corrected rather than
+failed:
+
+- **Not published yet.** Chart publishing trails Server releases, so a current
+  Server routinely names a chart that does not exist yet. The newest published
+  release is deployed instead.
+- **Too old to run.** A Server old enough to name a chart below `v1.0.51`, the
+  oldest chart verified to deploy successfully, gets the oldest published chart
+  at or above that boundary. Every chart checked below it leaves the Operator
+  Pod unable to become ready; the symptoms and the reasoning are in
+  [Meshery Operator will not start]({{< ref "guides/troubleshooting/meshery-operator-meshsync.md#meshery-operator-will-not-start-imagepullbackoff-and-a-missing-webhook-certificate" >}}).
+
+Neither substitution is silent: it is reported in the events feed, naming the
+version that was deployed and why. Release candidates are never chosen for you.
+If the chart repository cannot be reached at all, installation is withheld with
+a visible error rather than attempted at an unverified version, while an
+already-installed Operator keeps reporting its status and version as usual.
+
+To choose the chart version yourself instead of tracking the Server release,
+set `operator.version` on the connection - see
+[Choosing the chart version yourself]({{< ref "guides/troubleshooting/meshery-operator-meshsync.md#choosing-the-chart-version-yourself" >}}).
 
 **Upgrades.** Upgrading Meshery Server is what upgrades the Operator: on
 (re)connection, the Server re-applies the operator chart at its own (new)
@@ -113,9 +137,11 @@ the Operator is missing or unhealthy. Two practical consequences:
 
 - **Manual operator changes are temporary.** A hand-run
   `helm upgrade meshery-operator --version <x>` or an edited image tag on a
-  Server-managed cluster will be reverted to the Server's pinned chart version
-  by the next reconciliation. Standalone/manual operator installs are only
-  durable on clusters that Meshery Server does not manage.
+  Server-managed cluster will be reverted to the chart version the Server
+  resolves (above) by the next reconciliation. `operator.version` on the
+  connection is the durable way to choose a version on a managed cluster;
+  standalone/manual operator installs are only durable on clusters that Meshery
+  Server does not manage.
 - **Operator versions are pinned, not floating.** The operator image is a
   fixed version per chart release (no `stable-latest` drift): an Operator pod
   restart never silently changes the operator version. Upgrades happen only

--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -252,6 +252,8 @@ The charts lint check, charts build, and charts release workflows are all trigge
 
 Every PR which includes changes to the files under `install/kubernetes/` directory in the `meshery/meshery` will trigger a Github Action to check for any mistakes in Helm charts using the `helm lint` command.
 
+The same job additionally runs `install/scripts/check-operator-chart-appversions.sh`, which fails the PR when the `meshery-operator` chart and its `meshery-broker` and `meshery-meshsync` subcharts advertise different `appVersion` values. `helm lint` does not compare a parent chart's `appVersion` with its subcharts', so a subchart left behind on an older operator release passes lint while advertising an application it was never published alongside. Run the same check locally with `make helm-operator-lint`; the script's header explains what it accepts and why.
+
 ### Release Helm Charts to Github and Artifact Hub
 
 New Meshery Helm charts are published upon trigger of a release event in the `meshery/meshery` repo. New versions of Meshery's Helm charts are published to [Meshery's Helm charts release page](https://github.com/meshery/meshery.io/tree/master/charts). [Artifact Hub] (https://artifacthub.io/packages/helm/meshery/meshery) syncs with these updated Meshery Helm charts.

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -211,6 +211,19 @@ instead of falling through to a `Deploy`. The FSM paths need no equivalent
 because they always run straight after a fresh `AddCtxControllerHandlers`, and
 `ReconcileOperatorChartVersion` re-resolves before it installs.
 
+"Only as a consequence of a resolution that succeeded" is where the clear
+physically sits, and it has to stay there. `AddCtxControllerHandlers` clears
+`lastOperatorError` at the top but clears `operatorChartError` on the success
+path, beside the handler built from the resolved config. Both of its early
+returns - an unreadable kubeconfig and a failed Kubernetes client - leave the
+*previously attached* operator handler in place so the operator card keeps
+reporting status, and that handler still carries whatever chart version it was
+built with. Clearing the refusal at the top therefore produced the one state the
+install guard cannot see: a stale handler holding an unresolved version with
+`GetOperatorChartError()` reading nil, which the very next
+`DeployUndeployedOperators` in an FSM chain would hand to Helm. Do not move that
+clear back up.
+
 `UndeployDeployedOperators` is deliberately **not** gated on the chart error:
 removal is the direction to attempt rather than refuse, since refusing would
 leave the operator running on a cluster the user asked to have it taken off.
@@ -479,10 +492,18 @@ Unit coverage that exists today:
   no chart version resolves; all three install paths - the FSM reconcile, the
   chart-version reconcile, and the user-initiated `SetOperatorDeployment` -
   refuse through the shared guard; a latched chart error is re-resolved on a
-  user-initiated retry and only clears when resolution actually succeeds;
-  undeploy does not refuse, a missing handler is reported by name with its
-  context id rather than passed over, teardown of a never-connected connection
-  stays quiet, and the kubeconfig/client diagnostic survives that teardown).
+  user-initiated retry, survives a re-attach that never reached resolution, and
+  clears only when resolution actually succeeds; undeploy does not refuse, a
+  missing handler is reported by name with its context id rather than passed
+  over, teardown of a never-connected connection stays quiet, and the
+  kubeconfig/client diagnostic survives that teardown).
+
+  These are unit tests and none of them may reach a meshkit `Deploy` or
+  `Undeploy`. `reachableK8sContext` yields real meshkit handlers, and meshkit
+  downloads the chart archive before it touches the cluster - so a test that
+  reaches an install performs live Helm I/O, and really installs the operator
+  wherever `127.0.0.1:6443` answers (Docker Desktop Kubernetes, k3s). Assert
+  through `operatorInstallTarget`, or swap a `stubController` in first.
 - `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
   version extraction, structured failures, TTL reuse, stale-while-revalidate on
   expiry (including through a failing refresh), that only a cold cache blocks,

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -136,11 +136,18 @@ An unreadable repository index fails rather than guessing: without the index
 there is no way to know which versions exist. Operator lifecycle is then
 withheld for that connection (no `MesheryOperator` handler is attached) while
 the Broker and MeshSync handlers, which need no chart version, still attach.
-`collectControllersStatus` synthesizes an `OPERATOR` row carrying `UNKOWN`
-whenever no operator handler is attached, so the Operator card stays visible
-rather than disappearing from a snapshot the client applies wholesale; the
-reason is carried by the `operator_deploy_failed` diagnostic, which reads
-`GetOperatorError`.
+
+The controller-status snapshot is built from `models.MesheryControllers`, not
+from the attached-handler map, so a connection with a ready FSM context always
+reports exactly one row per controller. A controller with no handler behind it
+reports `UNKOWN` and no version - Meshery made no observation of the cluster, so
+any other value would assert something it did not check. Without that the card
+disappears from the UI, because the client replaces its controller state with
+each snapshot wholesale: withheld operator lifecycle would drop the Operator
+card, and an unreadable kubeconfig or a failed Kubernetes client (a pre-existing
+gap, since no handlers attach at all in those paths) would drop all three. The
+reason a row is unknown belongs to the connection diagnostics -
+`operator_deploy_failed` reads `GetOperatorError` - not to the status payload.
 
 `NewOperatorDeploymentConfig` consequently leaves the chart version empty for an
 unstamped build instead of asking the GitHub releases API for the newest server
@@ -362,11 +369,11 @@ Unit coverage that exists today:
 - `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
   version extraction, structured failures, TTL reuse, that failures are not
   cached, that the lock is not held across the fetch, that concurrent misses
-  single-flight, and that the cached catalogue is never handed out by
-  reference.
-- `server/handlers/controllers_status_handler_test.go` - that the `OPERATOR`
-  row is present in the status snapshot even when no operator handler is
-  attached.
+  single-flight, that a panicking fetch leaves the cache usable, and that the
+  cached catalogue is never handed out by reference.
+- `server/handlers/controllers_status_handler_test.go` - that the status
+  snapshot carries one row per controller, sorted, even when no handlers are
+  attached at all.
 - `ui/components/configuration/__tests__/deploymentMode.test.ts` - which
   settings each deployment mode can apply, and how the mode governing each
   editor is resolved and attributed to a layer.

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -172,18 +172,55 @@ or `GetVersion` - so all three handlers still attach and the operator card keeps
 reporting a healthy operator's status and image tag, which is exactly the value
 [the troubleshooting guide](/guides/troubleshooting/meshery-operator-meshsync)
 tells users to read. The failure is recorded on `operatorChartError`
-(`GetOperatorChartError`) as well as `setOperatorError`, and
-`DeployUndeployedOperators` refuses on it rather than handing Helm a version the
-repository does not publish, which would surface as an opaque chart-not-found
-error instead. `UndeployDeployedOperators` is deliberately **not** gated on it:
-removal must always be attempted, since refusing it would leave the operator
-running on a cluster the user asked to have it taken off.
+(`GetOperatorChartError`) as well as `setOperatorError`, and every install path
+refuses on it rather than handing Helm a version the repository does not
+publish, which would surface as an opaque chart-not-found error instead.
 
-A missing `MesheryOperator` handler - which now means only that the kubeconfig
-or the Kubernetes client failed - is never a silent no-op either. Both
-`DeployUndeployedOperators` and `UndeployDeployedOperators` report it through
-`ErrOperatorHandlerNotAttached` (recorded, logged, and emitted), so a lifecycle
-request that did nothing does not read to the user as one that succeeded.
+**Every install path** means exactly that, and it is enforced by a single
+function rather than by convention. `operatorInstallTarget` is the one guard;
+the FSM's `DeployUndeployedOperators` and the user-initiated
+`SetOperatorDeployment` both go through it, so they cannot drift into one
+refusing an unpublishable version while the other installs it. The GraphQL
+`changeOperatorStatus` mutation is the second entry point and calls
+`SetOperatorDeployment` through the connection's helper (resolved via the state
+machine, the same route resync and controller-status take). It previously read
+a `MesheryControllerHandlersKey` context value that nothing ever populated -
+that key is now retired; do not reintroduce it.
+
+`UndeployDeployedOperators` is deliberately **not** gated on the chart error:
+removal is the direction to attempt rather than refuse, since refusing would
+leave the operator running on a cluster the user asked to have it taken off.
+Attempted is all it is, though - meshkit's `ApplyHelmChart` downloads and loads
+the chart archive before dispatching `UNINSTALL` exactly as it does for
+`INSTALL`, from the same repository whose index could not be read, so in the very
+case that motivates not refusing, `Undeploy` fails at chart download, the
+operator stays on the cluster, and the user gets a Helm error. A removal path
+that does not need the archive would have to come from meshkit.
+
+A missing `MesheryOperator` handler - which means only that the kubeconfig or
+the Kubernetes client failed - is reported through `ErrOperatorHandlerNotAttached`
+rather than passed over in silence, so a lifecycle request that did nothing does
+not read to the user as one that succeeded. Two things bound that report:
+
+- The context identifier is threaded in from the call site (every one has the
+  `K8sContext`) rather than read from `MesheryControllersHelper.contextID`, which
+  nothing assigns. That field's emptiness is a separate latent bug - it makes
+  `UpdateOperatorsStatusMap`'s `ot.IsUndeployed(mch.contextID)` probe the
+  empty-string key forever - and is documented at its declaration rather than
+  fixed here, because assigning it would silently change operator-undeploy
+  behavior.
+- Teardown of a connection whose cluster was never reached stays quiet.
+  `UndeployDeployedOperators` reports a missing handler only when the operator
+  status was ever genuinely observed (not the `controllers.Unknown` the
+  constructor seeds), so deleting a connection that never had an operator does
+  not alert about failing to remove one. User-initiated deploy and undeploy are
+  not gated this way - those always report.
+
+Relatedly, the missing-handler error never overwrites a more specific one:
+`setOperatorErrorIfUnset` records it only when nothing is already recorded. "No
+handler is attached" is the *consequence* of the unreadable kubeconfig or failed
+Kubernetes client that `AddCtxControllerHandlers` already recorded by name, and
+letting the consequence replace the cause degraded the diagnostic on teardown.
 
 The controller-status snapshot is built from `models.MesheryControllers`, not
 from the attached-handler map, so a connection with a ready FSM context always
@@ -415,8 +452,11 @@ Unit coverage that exists today:
   excluded from every automatic selection but honored when named, the
   pinned-against-pinned reconcile comparison, and the split between withholding
   installation and withholding observation (all three handlers still attach when
-  no chart version resolves; deploy refuses, undeploy does not, and a missing
-  handler is reported rather than passed over).
+  no chart version resolves; deploy refuses through the shared guard on both the
+  reconcile and the user-initiated `SetOperatorDeployment` path, undeploy does
+  not refuse, a missing handler is reported by name with its context id rather
+  than passed over, teardown of a never-connected connection stays quiet, and the
+  kubeconfig/client diagnostic survives that teardown).
 - `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
   version extraction, structured failures, TTL reuse, stale-while-revalidate on
   expiry (including through a failing refresh), that only a cold cache blocks,

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -117,9 +117,8 @@ guarantees such a chart exists, and two everyday cases guarantee it does not:
 
 `MesheryControllersHelper.pinnedOperatorDeploymentConfig` is therefore the only
 deployment config allowed to reach Helm. It lists what the repository publishes
-(`helpers/utils.PublishedChartVersions`, a TTL-cached `index.yaml` read) and
-hands that to `models.ResolveOperatorChartVersion`, which distinguishes two
-sources:
+(`helpers/utils.PublishedChartVersions`) and hands that to
+`models.ResolveOperatorChartVersion`, which distinguishes two sources:
 
 - **Derived** (`OperatorChartVersionDerived`) - the boot-time server release.
   Nobody chose it, so it may be corrected: unpinned or unpublished falls back to
@@ -133,6 +132,18 @@ sources:
   events feed surface to the user. The floor does not apply, so deliberately
   pinning an old chart still works.
 
+Both corrections above - the newest-published fallback and the floor raise -
+draw only from **stable** releases. The repository publishes prerelease charts
+(`v0.6.0-rc.6`, `v0.5.0-rc-5g` are real entries), and by semver a release
+candidate outranks every stable chart below it, so an rc published ahead of its
+release would otherwise become what every server whose own chart is not yet
+published installs onto production clusters. A prerelease is still fully
+reachable by name: an explicit `operator.version` naming one is honored exactly,
+as is a derived version that already matches a published prerelease - a
+prerelease server asking for its own prerelease chart chose nothing. A
+repository that publishes *only* prereleases fails resolution
+(`ErrNoOperatorChartPublished`) rather than having one selected for it.
+
 Membership in the published set is decided by semver comparison, not by string
 equality, because Helm treats `1.0.64` and `v1.0.64` as the same version.
 Resolution always returns the repository's own spelling of the matched release -
@@ -140,10 +151,39 @@ that is the string handed to Helm and the string
 `attachedOperatorChartVersion` is compared against - and a spelling difference
 is not a substitution, so it produces no reason.
 
+`PublishedChartVersions` reads `index.yaml` through a per-repository cache in
+`server/helpers/utils/helm_chart_repo.go`. That read happens inside the
+cluster-connect request handler and the Meshery index is several megabytes, so
+expiry is **stale-while-revalidate, not a miss**: an expired catalogue is served
+immediately while a single-flighted refresh runs behind the caller, and only a
+cold cache with nothing to serve blocks. Published charts are append-mostly, so
+the worst a stale list costs is not yet knowing about the newest chart - which
+the resolver already handles - whereas blocking would put a full
+`chartIndexTimeout` in front of every connect whenever the TTL lapsed against a
+slow repository. Failures are never cached as successes, so a repository outage
+is retried on the next call rather than pinned in for a TTL.
+
 An unreadable repository index fails rather than guessing: without the index
-there is no way to know which versions exist. Operator lifecycle is then
-withheld for that connection (no `MesheryOperator` handler is attached) while
-the Broker and MeshSync handlers, which need no chart version, still attach.
+there is no way to know which versions exist. What that failure costs is
+deliberately narrow. A chart version is what it takes to **install** the
+operator, not to **observe** one - meshkit's `mesheryOperator` reads its
+`OperatorDeploymentConfig` in `Deploy` and `Undeploy` only, never in `GetStatus`
+or `GetVersion` - so all three handlers still attach and the operator card keeps
+reporting a healthy operator's status and image tag, which is exactly the value
+[the troubleshooting guide](/guides/troubleshooting/meshery-operator-meshsync)
+tells users to read. The failure is recorded on `operatorChartError`
+(`GetOperatorChartError`) as well as `setOperatorError`, and
+`DeployUndeployedOperators` refuses on it rather than handing Helm a version the
+repository does not publish, which would surface as an opaque chart-not-found
+error instead. `UndeployDeployedOperators` is deliberately **not** gated on it:
+removal must always be attempted, since refusing it would leave the operator
+running on a cluster the user asked to have it taken off.
+
+A missing `MesheryOperator` handler - which now means only that the kubeconfig
+or the Kubernetes client failed - is never a silent no-op either. Both
+`DeployUndeployedOperators` and `UndeployDeployedOperators` report it through
+`ErrOperatorHandlerNotAttached` (recorded, logged, and emitted), so a lifecycle
+request that did nothing does not read to the user as one that succeeded.
 
 The controller-status snapshot is built from `models.MesheryControllers`, not
 from the attached-handler map, so a connection with a ready FSM context always
@@ -151,11 +191,10 @@ reports exactly one row per controller. A controller with no handler behind it
 reports `UNKOWN` and no version - Meshery made no observation of the cluster, so
 any other value would assert something it did not check. Without that the card
 disappears from the UI, because the client replaces its controller state with
-each snapshot wholesale: withheld operator lifecycle would drop the Operator
-card, and an unreadable kubeconfig or a failed Kubernetes client (a pre-existing
-gap, since no handlers attach at all in those paths) would drop all three. The
-reason a row is unknown belongs to the connection diagnostics -
-`operator_deploy_failed` reads `GetOperatorError` - not to the status payload.
+each snapshot wholesale: an unreadable kubeconfig or a failed Kubernetes client,
+where no handlers attach at all, would drop all three cards. The reason a row is
+unknown belongs to the connection diagnostics - `operator_deploy_failed` reads
+`GetOperatorError` - not to the status payload.
 
 `NewOperatorDeploymentConfig` consequently leaves the chart version empty for an
 unstamped build instead of asking the GitHub releases API for the newest server
@@ -372,13 +411,18 @@ Unit coverage that exists today:
   cases where a chart-version reconcile must not touch the cluster.
 - `server/models/operator_chart_pinning_test.go` - pinning the resolved version
   to one the repository publishes: the floor, the unpublished-release fallback,
-  moving tags never reaching Helm, explicit requests failing loudly, and the
-  pinned-against-pinned reconcile comparison.
+  moving tags never reaching Helm, explicit requests failing loudly, prereleases
+  excluded from every automatic selection but honored when named, the
+  pinned-against-pinned reconcile comparison, and the split between withholding
+  installation and withholding observation (all three handlers still attach when
+  no chart version resolves; deploy refuses, undeploy does not, and a missing
+  handler is reported rather than passed over).
 - `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
-  version extraction, structured failures, TTL reuse, that failures are not
-  cached, that the lock is not held across the fetch, that concurrent misses
-  single-flight, that a panicking fetch leaves the cache usable, and that the
-  cached catalogue is never handed out by reference.
+  version extraction, structured failures, TTL reuse, stale-while-revalidate on
+  expiry (including through a failing refresh), that only a cold cache blocks,
+  that failures are not cached, that the lock is not held across the fetch, that
+  concurrent misses single-flight, that a panicking fetch leaves the cache
+  usable, and that the cached catalogue is never handed out by reference.
 - `server/handlers/controllers_status_handler_test.go` - that the status
   snapshot carries one row per controller, sorted, even when no handlers are
   attached at all.

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -503,7 +503,22 @@ Unit coverage that exists today:
   downloads the chart archive before it touches the cluster - so a test that
   reaches an install performs live Helm I/O, and really installs the operator
   wherever `127.0.0.1:6443` answers (Docker Desktop Kubernetes, k3s). Assert
-  through `operatorInstallTarget`, or swap a `stubController` in first.
+  through `operatorInstallTarget`, or swap a `stubController` in first. The two
+  context helpers are a matched pair and say so at their declarations:
+  `reachableK8sContext` enables real handlers, `unresolvableK8sContext` reliably
+  prevents them - and because the latter depends on meshkit rejecting the
+  kubeconfig rather than falling back to the ambient one, every test built on it
+  calls `requireUnresolvableK8sContext` so a meshkit change surfaces as a
+  failure rather than as a real install.
+
+  `reattachControllerHandlers` is injected on the helper for the same reason
+  `chartVersions` is. `AddCtxControllerHandlers` clears the chart refusal exactly
+  where it resolves, so it can never return having both succeeded and left one
+  standing - which makes the guard's refusal branch unreachable, and would leave
+  an install site that stopped consulting the guard entirely unobserved. The
+  seam lets `TestReconcileInstallGoesThroughTheSharedGuard` produce that state
+  with a stub handler attached, so dropping the guard call fails the test by
+  construction instead of silently.
 - `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
   version extraction, structured failures, TTL reuse, stale-while-revalidate on
   expiry (including through a failing refresh), that only a cold cache blocks,

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -125,8 +125,22 @@ sources:
   events feed surface to the user. The floor does not apply, so deliberately
   pinning an old chart still works.
 
+Membership in the published set is decided by semver comparison, not by string
+equality, because Helm treats `1.0.64` and `v1.0.64` as the same version.
+Resolution always returns the repository's own spelling of the matched release -
+that is the string handed to Helm and the string
+`attachedOperatorChartVersion` is compared against - and a spelling difference
+is not a substitution, so it produces no reason.
+
 An unreadable repository index fails rather than guessing: without the index
-there is no way to know which versions exist.
+there is no way to know which versions exist. Operator lifecycle is then
+withheld for that connection (no `MesheryOperator` handler is attached) while
+the Broker and MeshSync handlers, which need no chart version, still attach.
+`collectControllersStatus` synthesizes an `OPERATOR` row carrying `UNKOWN`
+whenever no operator handler is attached, so the Operator card stays visible
+rather than disappearing from a snapshot the client applies wholesale; the
+reason is carried by the `operator_deploy_failed` diagnostic, which reads
+`GetOperatorError`.
 
 `NewOperatorDeploymentConfig` consequently leaves the chart version empty for an
 unstamped build instead of asking the GitHub releases API for the newest server
@@ -346,8 +360,13 @@ Unit coverage that exists today:
   moving tags never reaching Helm, explicit requests failing loudly, and the
   pinned-against-pinned reconcile comparison.
 - `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
-  version extraction, structured failures, TTL reuse, and that failures are not
-  cached.
+  version extraction, structured failures, TTL reuse, that failures are not
+  cached, that the lock is not held across the fetch, that concurrent misses
+  single-flight, and that the cached catalogue is never handed out by
+  reference.
+- `server/handlers/controllers_status_handler_test.go` - that the `OPERATOR`
+  row is present in the status snapshot even when no operator handler is
+  attached.
 - `ui/components/configuration/__tests__/deploymentMode.test.ts` - which
   settings each deployment mode can apply, and how the mode governing each
   editor is resolved and attributed to a layer.

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -103,8 +103,9 @@ guarantees such a chart exists, and two everyday cases guarantee it does not:
   published. Helm then fails with a chart-not-found error and the operator never
   deploys.
 - Charts below `models.MinimumOperatorChartVersion` are published but are not
-  known to run: every one that was rendered from its published archive ships the
-  retired `kube-rbac-proxy` image and no webhook certificate. Because the derived
+  known to run: every one that was rendered from its published archive ships a
+  `kube-rbac-proxy` sidecar that affected clusters report as `ImagePullBackOff`,
+  and no webhook certificate. Because the derived
   version tracks the server's own release, an old server would install one of
   those on every cluster it is ever pointed at, forever.
 

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -93,6 +93,53 @@ Leaving the field unset at every layer resolves to `""`, and the boot-time chart
 version applies unchanged: a connection on Inherit behaves exactly as it did
 before the field was wired up.
 
+### The chart version that reaches Helm is pinned, not assumed
+
+`operatorDeploymentConfig` returns the version that was *asked for*. Nothing yet
+guarantees such a chart exists, and two everyday cases guarantee it does not:
+
+- Chart publishing is decoupled from Meshery Server releases and trails them, so
+  a current server routinely names a chart version the repository has not
+  published. Helm then fails with a chart-not-found error and the operator never
+  deploys.
+- Charts below `models.MinimumOperatorChartVersion` are published but cannot run
+  (retired `kube-rbac-proxy` image, no webhook certificate). Because the derived
+  version tracks the server's own release, an old server would install one of
+  those on every cluster it is ever pointed at, forever.
+
+`MesheryControllersHelper.pinnedOperatorDeploymentConfig` is therefore the only
+deployment config allowed to reach Helm. It lists what the repository publishes
+(`helpers/utils.PublishedChartVersions`, a TTL-cached `index.yaml` read) and
+hands that to `models.ResolveOperatorChartVersion`, which distinguishes two
+sources:
+
+- **Derived** (`OperatorChartVersionDerived`) - the boot-time server release.
+  Nobody chose it, so it may be corrected: unpinned or unpublished falls back to
+  the newest published chart, and anything below the floor is raised to the
+  oldest published chart at or above the floor. Every correction returns a
+  one-sentence reason that is logged and emitted as a warning event, so no
+  substitution is silent.
+- **Requested** (`OperatorChartVersionRequested`) - an explicit
+  `operator.version`. Never substituted. A moving tag or an unpublished version
+  fails through `setOperatorError`, which the connection-diagnostics API and the
+  events feed surface to the user. The floor does not apply, so deliberately
+  pinning an old chart still works.
+
+An unreadable repository index fails rather than guessing: without the index
+there is no way to know which versions exist.
+
+`NewOperatorDeploymentConfig` consequently leaves the chart version empty for an
+unstamped build instead of asking the GitHub releases API for the newest server
+tag. The newest GitHub release is not the newest published chart, so that call
+spent a rate-limited request to produce a version that frequently does not exist
+in the chart repository; an empty version resolves to the newest published chart,
+which is what was wanted.
+
+`ReconcileOperatorChartVersion` compares **pinned against pinned**.
+`attachedOperatorChartVersion` always records a published version, so comparing
+the raw request against it would differ forever whenever the request is being
+substituted - re-running the Helm upgrade on every reconcile.
+
 ### MeshSync
 
 | Setting | Wire path | Propagates to | Observable as |
@@ -294,6 +341,13 @@ Unit coverage that exists today:
 - `server/models/operator_chart_version_test.go` - `operator.version` selecting
   the operator Helm chart version, the layering it resolves through, and the
   cases where a chart-version reconcile must not touch the cluster.
+- `server/models/operator_chart_pinning_test.go` - pinning the resolved version
+  to one the repository publishes: the floor, the unpublished-release fallback,
+  moving tags never reaching Helm, explicit requests failing loudly, and the
+  pinned-against-pinned reconcile comparison.
+- `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
+  version extraction, structured failures, TTL reuse, and that failures are not
+  cached.
 - `ui/components/configuration/__tests__/deploymentMode.test.ts` - which
   settings each deployment mode can apply, and how the mode governing each
   editor is resolved and attributed to a layer.

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -177,15 +177,39 @@ refuses on it rather than handing Helm a version the repository does not
 publish, which would surface as an opaque chart-not-found error instead.
 
 **Every install path** means exactly that, and it is enforced by a single
-function rather than by convention. `operatorInstallTarget` is the one guard;
-the FSM's `DeployUndeployedOperators` and the user-initiated
-`SetOperatorDeployment` both go through it, so they cannot drift into one
-refusing an unpublishable version while the other installs it. The GraphQL
-`changeOperatorStatus` mutation is the second entry point and calls
+function rather than by convention. `operatorInstallTarget` is the one guard, and
+there are exactly three callers of `Deploy` on an operator handler in the whole
+server - the FSM's `DeployUndeployedOperators`, the user-initiated
+`SetOperatorDeployment`, and `ReconcileOperatorChartVersion` - all three of which
+go through it. None can drift into installing an unpublishable version while the
+others refuse it. `ReconcileOperatorChartVersion` was the last one to reach
+`Deploy` by reading the handler out of the map directly; it was guarded only
+incidentally, because `AddCtxControllerHandlers` happens to write
+`lastOperatorError` and `operatorChartError` together, and five other writers of
+`lastOperatorError` could have broken that coupling. If you add a fourth caller,
+route it through the guard or this paragraph becomes false.
+
+The GraphQL `changeOperatorStatus` mutation is the second entry point and calls
 `SetOperatorDeployment` through the connection's helper (resolved via the state
 machine, the same route resync and controller-status take). It previously read
 a `MesheryControllerHandlersKey` context value that nothing ever populated -
 that key is now retired; do not reintroduce it.
+
+A latched `operatorChartError` is not permanent. It is written only where
+handlers are attached, so a connect that landed during a chart-repository outage
+would otherwise refuse every later install for the life of that connection, long
+after the repository came back - while `ErrHelmChartIndex` tells the user to
+confirm the repository is reachable and *retry*. `SetOperatorDeployment`
+therefore re-runs `AddCtxControllerHandlers` when a chart error is latched, which
+makes that instruction true: clicking deploy again genuinely re-resolves.
+Clearing the latch on its own would not be enough - the handler the failure path
+attached still carries the raw unresolved chart version, so the latch and the
+handler have to be corrected together, which is exactly what re-attaching does.
+The latch clears only as a consequence of a resolution that succeeded; one that
+fails again replaces it with the fresh error and the guard refuses on that
+instead of falling through to a `Deploy`. The FSM paths need no equivalent
+because they always run straight after a fresh `AddCtxControllerHandlers`, and
+`ReconcileOperatorChartVersion` re-resolves before it installs.
 
 `UndeployDeployedOperators` is deliberately **not** gated on the chart error:
 removal is the direction to attempt rather than refuse, since refusing would
@@ -452,11 +476,13 @@ Unit coverage that exists today:
   excluded from every automatic selection but honored when named, the
   pinned-against-pinned reconcile comparison, and the split between withholding
   installation and withholding observation (all three handlers still attach when
-  no chart version resolves; deploy refuses through the shared guard on both the
-  reconcile and the user-initiated `SetOperatorDeployment` path, undeploy does
-  not refuse, a missing handler is reported by name with its context id rather
-  than passed over, teardown of a never-connected connection stays quiet, and the
-  kubeconfig/client diagnostic survives that teardown).
+  no chart version resolves; all three install paths - the FSM reconcile, the
+  chart-version reconcile, and the user-initiated `SetOperatorDeployment` -
+  refuse through the shared guard; a latched chart error is re-resolved on a
+  user-initiated retry and only clears when resolution actually succeeds;
+  undeploy does not refuse, a missing handler is reported by name with its
+  context id rather than passed over, teardown of a never-connected connection
+  stays quiet, and the kubeconfig/client diagnostic survives that teardown).
 - `server/helpers/utils/helm_chart_repo_test.go` - the `index.yaml` read: chart
   version extraction, structured failures, TTL reuse, stale-while-revalidate on
   expiry (including through a failing refresh), that only a cold cache blocks,

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -102,10 +102,18 @@ guarantees such a chart exists, and two everyday cases guarantee it does not:
   a current server routinely names a chart version the repository has not
   published. Helm then fails with a chart-not-found error and the operator never
   deploys.
-- Charts below `models.MinimumOperatorChartVersion` are published but cannot run
-  (retired `kube-rbac-proxy` image, no webhook certificate). Because the derived
+- Charts below `models.MinimumOperatorChartVersion` are published but are not
+  known to run: every one that was rendered from its published archive ships the
+  retired `kube-rbac-proxy` image and no webhook certificate. Because the derived
   version tracks the server's own release, an old server would install one of
   those on every cluster it is ever pointed at, forever.
+
+  The floor means only "below this, the chart cannot deploy at all" - it is not a
+  preference for newer charts. Setting it above a chart that provably works would
+  substitute a working release and tell the user, falsely, that theirs cannot
+  deploy. Its doc comment in `server/models/operator_chart_version.go` records
+  exactly which archives were rendered to establish the boundary; raise the
+  constant only with the same evidence.
 
 `MesheryControllersHelper.pinnedOperatorDeploymentConfig` is therefore the only
 deployment config allowed to reach Helm. It lists what the repository publishes

--- a/docs/data/errorref/meshery-server_errors_export.json
+++ b/docs/data/errorref/meshery-server_errors_export.json
@@ -4105,7 +4105,7 @@
         "long_description": "",
         "short_description": "No Meshery Operator Helm chart is published",
         "probable_cause": "The chart repository index was served from an unexpected location, its published charts were removed, or it currently carries only prerelease charts, which Meshery never selects on its own.",
-        "suggested_remediation": ""
+        "suggested_remediation": "To deploy a prerelease chart deliberately, set operator.version on the Kubernetes connection to that exact version."
       },
       "1469": {
         "name": "ErrOperatorChartNotPinnedCode",
@@ -4114,7 +4114,7 @@
         "long_description": "",
         "short_description": "Meshery Operator chart version is not a released version",
         "probable_cause": "A moving tag (for example stable-latest or edge-latest) or a non-version string was configured as the operator chart version.",
-        "suggested_remediation": ""
+        "suggested_remediation": "Set operator.version to a released chart version, or clear it to track this Meshery Server release. This error's cause names the newest released version."
       },
       "1470": {
         "name": "ErrOperatorChartNotPublishedCode",
@@ -4123,7 +4123,7 @@
         "long_description": "",
         "short_description": "Meshery Operator chart version is not published",
         "probable_cause": "The configured chart version was mistyped, or it was never published to the Meshery Helm chart repository.",
-        "suggested_remediation": ""
+        "suggested_remediation": "Set operator.version to a published chart version, or clear it to track this Meshery Server release. This error's cause names the newest published version."
       },
       "1471": {
         "name": "ErrOperatorChartSubstitutedCode",
@@ -4149,8 +4149,8 @@
         "severity": "Alert",
         "long_description": "",
         "short_description": "Unable to read the Helm chart repository index.",
-        "probable_cause": "",
-        "suggested_remediation": ""
+        "probable_cause": "The Helm chart repository is unreachable, returned an error, or served an index that is not valid YAML. Meshery Server may have no outbound network access, or the repository may be temporarily unavailable.",
+        "suggested_remediation": "Confirm that the chart repository named in this error's cause is reachable from the Meshery Server pod or container, then retry. If Meshery runs behind a proxy, confirm the proxy environment variables are set on the server."
       },
       "1474": {
         "name": "ErrOperatorControllersHelperCode",
@@ -4159,7 +4159,7 @@
         "long_description": "",
         "short_description": "Unable to reach Meshery Operator lifecycle for this Kubernetes connection",
         "probable_cause": "The connection is not connected yet, or its state machine has not finished initializing.",
-        "suggested_remediation": ""
+        "suggested_remediation": "Wait for the Kubernetes connection to reach the connected state, then retry.\nIf it stays disconnected, check the connection's diagnostics for why its Kubernetes client could not be created."
       }
     }
   }

--- a/docs/data/errorref/meshery-server_errors_export.json
+++ b/docs/data/errorref/meshery-server_errors_export.json
@@ -4104,7 +4104,7 @@
         "severity": "Alert",
         "long_description": "",
         "short_description": "No Meshery Operator Helm chart is published",
-        "probable_cause": "The chart repository index was served from an unexpected location, or its published charts were removed.",
+        "probable_cause": "The chart repository index was served from an unexpected location, its published charts were removed, or it currently carries only prerelease charts, which Meshery never selects on its own.",
         "suggested_remediation": ""
       },
       "1469": {

--- a/docs/data/errorref/meshery-server_errors_export.json
+++ b/docs/data/errorref/meshery-server_errors_export.json
@@ -4097,6 +4097,60 @@
         "short_description": "Anonymous user session could not be established",
         "probable_cause": "The remote provider does not implement the schemas v1beta2 AnonymousFlowResponse contract, or it returned an empty user id.",
         "suggested_remediation": "Confirm the configured remote provider is reachable and up to date, then retry signing in."
+      },
+      "1468": {
+        "name": "ErrNoOperatorChartPublishedCode",
+        "code": "1468",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "No Meshery Operator Helm chart is published",
+        "probable_cause": "The chart repository index was served from an unexpected location, or its published charts were removed.",
+        "suggested_remediation": ""
+      },
+      "1469": {
+        "name": "ErrOperatorChartNotPinnedCode",
+        "code": "1469",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Meshery Operator chart version is not a released version",
+        "probable_cause": "A moving tag (for example stable-latest or edge-latest) or a non-version string was configured as the operator chart version.",
+        "suggested_remediation": ""
+      },
+      "1470": {
+        "name": "ErrOperatorChartNotPublishedCode",
+        "code": "1470",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Meshery Operator chart version is not published",
+        "probable_cause": "The configured chart version was mistyped, or it was never published to the Meshery Helm chart repository.",
+        "suggested_remediation": ""
+      },
+      "1471": {
+        "name": "ErrOperatorChartSubstitutedCode",
+        "code": "1471",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Meshery Operator was deployed at a different chart version than this server's release",
+        "probable_cause": "The chart version matching this Meshery Server release is either not published yet or is too old to deploy successfully.",
+        "suggested_remediation": "No action is required. To choose the chart version yourself, set operator.version on the Kubernetes connection."
+      },
+      "1472": {
+        "name": "ErrNoMesheryReleasesFoundCode",
+        "code": "1472",
+        "severity": "Alert",
+        "long_description": "The GitHub releases listing for meshery/meshery returned no tags.",
+        "short_description": "No Meshery releases were found",
+        "probable_cause": "GitHub returned an empty or filtered release listing, possibly because the request was rate-limited.",
+        "suggested_remediation": "Retry later. This only affects the reported latest-version comparison; Meshery continues to run."
+      },
+      "1473": {
+        "name": "ErrHelmChartIndexCode",
+        "code": "1473",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Unable to read the Helm chart repository index.",
+        "probable_cause": "",
+        "suggested_remediation": ""
       }
     }
   }

--- a/docs/data/errorref/meshery-server_errors_export.json
+++ b/docs/data/errorref/meshery-server_errors_export.json
@@ -4151,6 +4151,15 @@
         "short_description": "Unable to read the Helm chart repository index.",
         "probable_cause": "",
         "suggested_remediation": ""
+      },
+      "1474": {
+        "name": "ErrOperatorControllersHelperCode",
+        "code": "1474",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Unable to reach Meshery Operator lifecycle for this Kubernetes connection",
+        "probable_cause": "The connection is not connected yet, or its state machine has not finished initializing.",
+        "suggested_remediation": ""
       }
     }
   }

--- a/install/docker-extension/ui/src/components/utils/constants.js
+++ b/install/docker-extension/ui/src/components/utils/constants.js
@@ -28,7 +28,7 @@ export const REMOTE_PROVIDERS = [
         url: "https://cloud.layer5.io",
     },
     {
-        name: "TCS Labs",
+        name: "TATA Labs",
         url: "https://platform.tata-consulting.co.uk",
     },
     {

--- a/install/kubernetes/helm/meshery-operator/README.md
+++ b/install/kubernetes/helm/meshery-operator/README.md
@@ -1,6 +1,17 @@
+<!--
+  HAND-MAINTAINED - do NOT regenerate with `make helm-operator-docs` (helm-docs).
+  values.yaml carries no `# --` description comments and there is no
+  README.md.gotmpl here, so the generator would delete the extended chart
+  description, the "CRD lifecycle" section, and every Description cell below.
+  Regenerating is safe only after that migration (curated prose -> README.md.gotmpl,
+  descriptions -> `# --` comments in values.yaml); until then edit by hand and keep
+  the badges, Requirements and Values defaults in step with Chart.yaml/values.yaml.
+  The two subchart READMEs under charts/ are pure helm-docs output and are safe.
+-->
+
 # meshery-operator
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.5](https://img.shields.io/badge/AppVersion-1.0.5-informational?style=flat-square)
 
 Meshery Operator chart. Deploys the [meshery-operator](https://github.com/meshery/meshery-operator) manager, which reconciles the `Broker` (NATS) and `MeshSync` custom resources.
 
@@ -59,7 +70,7 @@ The chart's `version`/`appVersion` and the CRD bundles under `crds/` and
 | fullnameOverride | string | `"meshery-operator"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"meshery/meshery-operator"` |  |
-| image.tag | string | `"1.0.0"` | Pinned operator release, stamped by the sync workflow. Kept explicit because server-release chart publishing re-stamps appVersion with the server tag; empty falls back to the chart appVersion |
+| image.tag | string | `"1.0.5"` | Pinned operator release, stamped by the sync workflow. Kept explicit because server-release chart publishing re-stamps appVersion with the server tag; empty falls back to the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-broker/Chart.yaml
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-broker/Chart.yaml
@@ -4,7 +4,14 @@ description: Meshery Broker
 icon: https://meshery.io/images/logos/meshery-logo.png
 type: application
 version: 0.5.0
-appVersion: stable-latest
+# This chart ships only the Broker custom resource; the Meshery Operator that
+# reconciles it is what chooses the NATS image. appVersion therefore names the
+# operator release this subchart is published alongside, and must stay in step
+# with the parent chart's appVersion. It must never be a moving tag: the parent
+# is republished at every Meshery Server release, so a moving appVersion here
+# advertises a different application from one publish to the next while the
+# archive itself is immutable.
+appVersion: "1.0.4"
 
 maintainers:
   - name: Meshery Authors

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-broker/Chart.yaml
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-broker/Chart.yaml
@@ -5,12 +5,20 @@ icon: https://meshery.io/images/logos/meshery-logo.png
 type: application
 version: 0.5.0
 # This chart ships only the Broker custom resource; the Meshery Operator that
-# reconciles it is what chooses the NATS image. appVersion therefore names the
-# operator release this subchart is published alongside, and must stay in step
-# with the parent chart's appVersion. It must never be a moving tag: the parent
-# is republished at every Meshery Server release, so a moving appVersion here
-# advertises a different application from one publish to the next while the
-# archive itself is immutable.
+# reconciles it is what chooses the NATS image. appVersion therefore names a
+# real, published Meshery Operator release - the one this subchart is published
+# alongside - and is kept equal to the parent chart's in-repo appVersion, which
+# install/scripts/check-operator-chart-appversions.sh enforces.
+#
+# That agreement holds in this repository only. helm-chart-releaser packages the
+# chart with app_version set to the Meshery Server tag, and that rewrites just
+# the top-level Chart.yaml, so the published parent advertises a Meshery Server
+# release while this file advertises a Meshery Operator release. The two are
+# separate numbering lines and are not expected to match in the shipped archive.
+#
+# It must never be a moving tag such as stable-latest: the published archive is
+# immutable, so a moving appVersion here would advertise a different application
+# from one publish to the next.
 appVersion: "1.0.5"
 
 maintainers:

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-broker/Chart.yaml
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-broker/Chart.yaml
@@ -11,7 +11,7 @@ version: 0.5.0
 # is republished at every Meshery Server release, so a moving appVersion here
 # advertises a different application from one publish to the next while the
 # archive itself is immutable.
-appVersion: "1.0.4"
+appVersion: "1.0.5"
 
 maintainers:
   - name: Meshery Authors

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-broker/README.md
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-broker/README.md
@@ -1,6 +1,6 @@
 # meshery-broker
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: stable-latest](https://img.shields.io/badge/AppVersion-stable--latest-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.5](https://img.shields.io/badge/AppVersion-1.0.5-informational?style=flat-square)
 
 Meshery Broker
 

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/Chart.yaml
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/Chart.yaml
@@ -11,7 +11,7 @@ version: 0.5.0
 # parent is republished at every Meshery Server release, so a moving appVersion
 # here advertises a different application from one publish to the next while
 # the archive itself is immutable.
-appVersion: "1.0.4"
+appVersion: "1.0.5"
 
 maintainers:
   - name: Meshery Authors

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/Chart.yaml
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/Chart.yaml
@@ -5,12 +5,20 @@ icon: https://meshery.io/images/logos/meshery-logo.png
 type: application
 version: 0.5.0
 # This chart ships only the MeshSync custom resource; the Meshery Operator that
-# reconciles it is what chooses the MeshSync image. appVersion therefore names
-# the operator release this subchart is published alongside, and must stay in
-# step with the parent chart's appVersion. It must never be a moving tag: the
-# parent is republished at every Meshery Server release, so a moving appVersion
-# here advertises a different application from one publish to the next while
-# the archive itself is immutable.
+# reconciles it is what chooses the MeshSync image. appVersion therefore names a
+# real, published Meshery Operator release - the one this subchart is published
+# alongside - and is kept equal to the parent chart's in-repo appVersion, which
+# install/scripts/check-operator-chart-appversions.sh enforces.
+#
+# That agreement holds in this repository only. helm-chart-releaser packages the
+# chart with app_version set to the Meshery Server tag, and that rewrites just
+# the top-level Chart.yaml, so the published parent advertises a Meshery Server
+# release while this file advertises a Meshery Operator release. The two are
+# separate numbering lines and are not expected to match in the shipped archive.
+#
+# It must never be a moving tag such as stable-latest: the published archive is
+# immutable, so a moving appVersion here would advertise a different application
+# from one publish to the next.
 appVersion: "1.0.5"
 
 maintainers:

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/Chart.yaml
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/Chart.yaml
@@ -4,7 +4,14 @@ description: Meshery MeshSync
 icon: https://meshery.io/images/logos/meshery-logo.png
 type: application
 version: 0.5.0
-appVersion: stable-latest
+# This chart ships only the MeshSync custom resource; the Meshery Operator that
+# reconciles it is what chooses the MeshSync image. appVersion therefore names
+# the operator release this subchart is published alongside, and must stay in
+# step with the parent chart's appVersion. It must never be a moving tag: the
+# parent is republished at every Meshery Server release, so a moving appVersion
+# here advertises a different application from one publish to the next while
+# the archive itself is immutable.
+appVersion: "1.0.4"
 
 maintainers:
   - name: Meshery Authors

--- a/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/README.md
+++ b/install/kubernetes/helm/meshery-operator/charts/meshery-meshsync/README.md
@@ -1,6 +1,6 @@
 # meshery-meshsync
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: stable-latest](https://img.shields.io/badge/AppVersion-stable--latest-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.5](https://img.shields.io/badge/AppVersion-1.0.5-informational?style=flat-square)
 
 Meshery MeshSync
 

--- a/install/scripts/check-operator-chart-appversions.sh
+++ b/install/scripts/check-operator-chart-appversions.sh
@@ -16,14 +16,14 @@
 
 set -euo pipefail
 
-CHART_DIR="${1:-install/kubernetes/helm/meshery-operator}"
-
-PARENT_CHART="${CHART_DIR}/Chart.yaml"
-BROKER_CHART="${CHART_DIR}/charts/meshery-broker/Chart.yaml"
-MESHSYNC_CHART="${CHART_DIR}/charts/meshery-meshsync/Chart.yaml"
-
-# read_app_version prints the top-level appVersion of a Chart.yaml, with any
-# surrounding quotes stripped.
+# read_app_version prints the top-level appVersion of a Chart.yaml as a bare
+# version string.
+#
+# The trailing comment goes first, then trailing whitespace, then the quotes.
+# Any other order defeats itself: stripping quotes from `"1.0.5" # stamped`
+# finds no quote at the end of the line, so the closing one survives into the
+# comparison and the check fails against a subchart that reads identically.
+# --self-test pins that ordering.
 read_app_version() {
   local file="$1" value
   if [ ! -f "$file" ]; then
@@ -31,19 +31,64 @@ read_app_version() {
     exit 1
   fi
   value="$(sed -n 's/^appVersion:[[:space:]]*//p' "$file" | head -n 1)"
+  # YAML requires whitespace before an inline comment, so anchoring on that
+  # leaves a '#' inside the value alone.
+  value="$(printf '%s' "$value" | sed -e 's/[[:space:]]#.*$//' -e 's/[[:space:]]*$//')"
   value="${value%\"}"
   value="${value#\"}"
   value="${value%\'}"
   value="${value#\'}"
-  # Trim a trailing comment and any trailing whitespace.
-  value="${value%%#*}"
-  value="$(printf '%s' "$value" | sed 's/[[:space:]]*$//')"
   if [ -z "$value" ]; then
     echo "check-operator-chart-appversions: $file declares no appVersion" >&2
     exit 1
   fi
   printf '%s' "$value"
 }
+
+# self_test asserts read_app_version against every spelling a Chart.yaml may
+# legitimately use, so the strip ordering above cannot silently regress.
+self_test() {
+  local dir failures=0 case_line expected got
+  dir="$(mktemp -d)"
+
+  # Each case is "<expected>|<appVersion line>".
+  local cases=(
+    '1.0.4|appVersion: 1.0.4'
+    '1.0.4|appVersion: "1.0.4"'
+    "1.0.4|appVersion: '1.0.4'"
+    '1.0.4|appVersion: "1.0.4" # stamped by sync-downstream'
+    '1.0.4|appVersion: 1.0.4 # stamped by sync-downstream'
+    "1.0.4|appVersion: '1.0.4'   "
+    '1.0.4|appVersion:    1.0.4'
+  )
+
+  for case_line in "${cases[@]}"; do
+    expected="${case_line%%|*}"
+    printf '%s\n' "${case_line#*|}" > "${dir}/Chart.yaml"
+    got="$(read_app_version "${dir}/Chart.yaml")"
+    if [ "$got" != "$expected" ]; then
+      echo "check-operator-chart-appversions: self-test failed for '${case_line#*|}': parsed '${got}', want '${expected}'" >&2
+      failures=$((failures + 1))
+    fi
+  done
+
+  rm -rf "$dir"
+  if [ "$failures" -ne 0 ]; then
+    exit 1
+  fi
+  echo "check-operator-chart-appversions: self-test passed (${#cases[@]} cases)"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit 0
+fi
+
+CHART_DIR="${1:-install/kubernetes/helm/meshery-operator}"
+
+PARENT_CHART="${CHART_DIR}/Chart.yaml"
+BROKER_CHART="${CHART_DIR}/charts/meshery-broker/Chart.yaml"
+MESHSYNC_CHART="${CHART_DIR}/charts/meshery-meshsync/Chart.yaml"
 
 parent="$(read_app_version "$PARENT_CHART")"
 broker="$(read_app_version "$BROKER_CHART")"

--- a/install/scripts/check-operator-chart-appversions.sh
+++ b/install/scripts/check-operator-chart-appversions.sh
@@ -1,20 +1,66 @@
 #!/usr/bin/env bash
 #
-# Assert that the meshery-operator chart and its two subcharts advertise the
-# same appVersion.
+# Assert that every meshery-operator subchart in this repository advertises the
+# same Meshery Operator release as the parent chart it ships under.
+#
+# WHAT THIS IS FOR
 #
 # The subcharts ship only the Broker and MeshSync custom resources; the operator
-# release that reconciles them is what their appVersion names. That value is
-# baked into an immutable published archive, so a subchart left behind
-# advertises an operator release it was not published alongside - which is what
-# "appVersion: stable-latest" did before it was pinned.
+# release that reconciles them is what their appVersion names. Left at a moving
+# tag - "appVersion: stable-latest", which is what both carried before they were
+# pinned - an immutable published archive advertises whatever happened to be
+# newest at some unrelated later moment. This check keeps the subcharts pinned to
+# a real, published Meshery Operator release and keeps the in-repo values
+# consistent with one another. `helm lint` does not compare a parent's appVersion
+# with its subcharts', so nothing else catches the drift.
 #
-# The parent's version/appVersion are stamped by hack/sync-downstream.sh in
-# meshery/meshery-operator on every operator release, and that mechanism touches
-# only the parent. `helm lint` does not compare a parent's appVersion with its
-# subcharts', so nothing else catches the drift. This check does.
+# WHAT THIS IS NOT FOR
+#
+# It does not assert - and must not be read as asserting - that the *published*
+# archive has a parent and subcharts that agree. They do not, by design:
+# .github/workflows/helm-chart-releaser.yml packages the chart through
+# helm-gh-pages with `app_version: <Meshery Server tag>`, and that rewrites only
+# the top-level Chart.yaml. So the published parent advertises a Meshery Server
+# release while the subcharts advertise a Meshery Operator release - two separate
+# numbering lines. Confirmed against the published meshery-operator-v1.0.65.tgz,
+# whose parent reads v1.0.65 while its subcharts read what the repository said.
+#
+# WHAT IS INSPECTED
+#
+#   1. The standalone chart at install/kubernetes/helm/meshery-operator. Its
+#      parent version/appVersion are stamped by hack/sync-downstream.sh in
+#      meshery/meshery-operator on every operator release, and that mechanism
+#      touches only the parent. This repository owns these files, so drift here
+#      is a HARD FAILURE.
+#
+#   2. The packaged copy the meshery chart vendors at
+#      install/kubernetes/helm/meshery/charts/meshery-operator-*.tgz - the
+#      artifact `helm install meshery/meshery` actually deploys, and the
+#      deployment shape the original operator-image bug report came from. It is
+#      vendored from the published chart repository, so it cannot be corrected in
+#      place: hand-repacking it would diverge from upstream and be reverted by
+#      the next `helm dependency update`. Its subcharts can carry the pin only
+#      once a meshery-operator chart built from the pinned sources in (1) has
+#      been published and re-vendored here. Until then drift is reported LOUDLY
+#      but NON-FATALLY, because a hard failure would block the very change that
+#      makes the fix possible.
+#
+#      TO PROMOTE (2) TO A HARD FAILURE: set BUNDLED_CHART_DRIFT_IS_FATAL to
+#      true, below. Do that once - and only once - a published meshery-operator
+#      chart carrying pinned subchart appVersions has been re-vendored into
+#      install/kubernetes/helm/meshery/charts/. Nothing else needs to change.
 
 set -euo pipefail
+
+# BUNDLED_CHART_DRIFT_IS_FATAL promotes the vendored-archive check from a warning
+# to a build failure. See "WHAT IS INSPECTED" (2) for the condition that makes
+# flipping this safe.
+BUNDLED_CHART_DRIFT_IS_FATAL="${BUNDLED_CHART_DRIFT_IS_FATAL:-false}"
+
+# BUNDLED_CHART_GLOB locates the vendored operator archive. The version is
+# globbed rather than named so a `helm dependency update` that bumps it does not
+# silently take the archive out of this check's reach.
+BUNDLED_CHART_GLOB="${BUNDLED_CHART_GLOB:-install/kubernetes/helm/meshery/charts/meshery-operator-*.tgz}"
 
 # read_app_version prints the top-level appVersion of a Chart.yaml as a bare
 # version string.
@@ -24,11 +70,15 @@ set -euo pipefail
 # finds no quote at the end of the line, so the closing one survives into the
 # comparison and the check fails against a subchart that reads identically.
 # --self-test pins that ordering.
+#
+# A malformed or missing chart exits 2 rather than 1, so a caller can tell "this
+# tree could not be read" from "this tree disagrees with itself" and report the
+# one that actually happened.
 read_app_version() {
   local file="$1" value
   if [ ! -f "$file" ]; then
     echo "check-operator-chart-appversions: $file does not exist" >&2
-    exit 1
+    exit 2
   fi
   value="$(sed -n 's/^appVersion:[[:space:]]*//p' "$file" | head -n 1)"
   # YAML requires whitespace before an inline comment, so anchoring on that
@@ -40,9 +90,41 @@ read_app_version() {
   value="${value#\'}"
   if [ -z "$value" ]; then
     echo "check-operator-chart-appversions: $file declares no appVersion" >&2
-    exit 1
+    exit 2
   fi
   printf '%s' "$value"
+}
+
+# compare_chart_tree reports the parent and subchart appVersions of an unpacked
+# chart directory on stdout, one "  <path>: <version>" line each. It returns 1
+# when a subchart disagrees with the parent and 2 when the tree could not be
+# read at all.
+#
+# Subcharts are discovered rather than named, so a third one added later is
+# covered the day it appears instead of passing unexamined.
+compare_chart_tree() {
+  local chart_dir="$1"
+  local parent subchart_dir subchart_yaml subchart_version drift=0 found=0
+
+  parent="$(read_app_version "${chart_dir}/Chart.yaml")"
+  printf '  %s: %s\n' "${chart_dir}/Chart.yaml" "$parent"
+
+  for subchart_dir in "${chart_dir}"/charts/*/; do
+    subchart_yaml="${subchart_dir}Chart.yaml"
+    [ -f "$subchart_yaml" ] || continue
+    found=1
+    subchart_version="$(read_app_version "$subchart_yaml")"
+    printf '  %s: %s\n' "$subchart_yaml" "$subchart_version"
+    if [ "$subchart_version" != "$parent" ]; then
+      drift=1
+    fi
+  done
+
+  if [ "$found" -eq 0 ]; then
+    echo "check-operator-chart-appversions: ${chart_dir} has no subcharts to check" >&2
+    return 2
+  fi
+  return "$drift"
 }
 
 # self_test asserts read_app_version against every spelling a Chart.yaml may
@@ -60,6 +142,7 @@ self_test() {
     '1.0.4|appVersion: 1.0.4 # stamped by sync-downstream'
     "1.0.4|appVersion: '1.0.4'   "
     '1.0.4|appVersion:    1.0.4'
+    'stable-latest|appVersion: stable-latest'
   )
 
   for case_line in "${cases[@]}"; do
@@ -72,11 +155,89 @@ self_test() {
     fi
   done
 
+  # compare_chart_tree must call agreement agreement and drift drift, on the
+  # same shapes the two real chart trees take.
+  mkdir -p "${dir}/tree/charts/meshery-broker" "${dir}/tree/charts/meshery-meshsync"
+  printf 'appVersion: "1.0.5"\n' > "${dir}/tree/Chart.yaml"
+  printf 'appVersion: "1.0.5"\n' > "${dir}/tree/charts/meshery-broker/Chart.yaml"
+  printf 'appVersion: "1.0.5"\n' > "${dir}/tree/charts/meshery-meshsync/Chart.yaml"
+  if ! compare_chart_tree "${dir}/tree" > /dev/null; then
+    echo "check-operator-chart-appversions: self-test failed: agreeing charts reported as drift" >&2
+    failures=$((failures + 1))
+  fi
+  printf 'appVersion: stable-latest\n' > "${dir}/tree/charts/meshery-meshsync/Chart.yaml"
+  if compare_chart_tree "${dir}/tree" > /dev/null; then
+    echo "check-operator-chart-appversions: self-test failed: a subchart on stable-latest reported as agreement" >&2
+    failures=$((failures + 1))
+  fi
+
   rm -rf "$dir"
   if [ "$failures" -ne 0 ]; then
     exit 1
   fi
-  echo "check-operator-chart-appversions: self-test passed (${#cases[@]} cases)"
+  echo "check-operator-chart-appversions: self-test passed (${#cases[@]} parse cases, 2 tree cases)"
+}
+
+# check_bundled_chart inspects the vendored packaged operator chart. It never
+# fails the build on its own; the caller decides, so that the promotion
+# described in the header is a one-line change.
+check_bundled_chart() {
+  local archive="$1" work root report status=0
+
+  if ! command -v tar > /dev/null 2>&1; then
+    echo "check-operator-chart-appversions: tar is unavailable, skipping ${archive}" >&2
+    return 0
+  fi
+
+  work="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '${work}'" RETURN
+
+  if ! tar -xzf "$archive" -C "$work" 2> /dev/null; then
+    echo "check-operator-chart-appversions: could not unpack ${archive}, skipping it" >&2
+    return 0
+  fi
+
+  root="$(find "$work" -mindepth 2 -maxdepth 2 -name Chart.yaml -print 2> /dev/null | head -n 1)"
+  if [ -z "$root" ]; then
+    echo "check-operator-chart-appversions: ${archive} contains no chart, skipping it" >&2
+    return 0
+  fi
+  root="$(dirname "$root")"
+
+  report="$(compare_chart_tree "$root")" || status=$?
+  # The report names the temporary extraction path, which means nothing to a
+  # reader; rewrite it to the archive it came out of.
+  report="${report//${work}\//${archive}!}"
+
+  if [ "$status" -eq 0 ]; then
+    echo "check-operator-chart-appversions: ${archive} and its subcharts agree on appVersion"
+    return 0
+  fi
+  if [ "$status" -ne 1 ]; then
+    echo "check-operator-chart-appversions: ${archive} could not be read, skipping it" >&2
+    return 0
+  fi
+
+  cat >&2 <<EOF
+
+================================================================================
+check-operator-chart-appversions: WARNING - the vendored Meshery Operator chart
+disagrees with its own subcharts on appVersion.
+
+  ${archive}
+
+${report}
+
+This archive is vendored from the published chart repository, so it cannot be
+corrected here: it will carry the pin only after a meshery-operator chart built
+from install/kubernetes/helm/meshery-operator is published and re-vendored. This
+is a warning, not a failure, for exactly that reason - see the header of
+$0 for how to promote it once that has happened.
+================================================================================
+
+EOF
+  return 1
 }
 
 if [ "${1:-}" = "--self-test" ]; then
@@ -86,26 +247,43 @@ fi
 
 CHART_DIR="${1:-install/kubernetes/helm/meshery-operator}"
 
-PARENT_CHART="${CHART_DIR}/Chart.yaml"
-BROKER_CHART="${CHART_DIR}/charts/meshery-broker/Chart.yaml"
-MESHSYNC_CHART="${CHART_DIR}/charts/meshery-meshsync/Chart.yaml"
+standalone_report=""
+standalone_status=0
+standalone_report="$(compare_chart_tree "$CHART_DIR")" || standalone_status=$?
 
-parent="$(read_app_version "$PARENT_CHART")"
-broker="$(read_app_version "$BROKER_CHART")"
-meshsync="$(read_app_version "$MESHSYNC_CHART")"
+if [ "$standalone_status" -ne 0 ] && [ "$standalone_status" -ne 1 ]; then
+  # read_app_version or compare_chart_tree already named the exact problem on
+  # stderr; restating it as an appVersion disagreement would misdescribe it.
+  exit "$standalone_status"
+fi
 
-if [ "$parent" != "$broker" ] || [ "$parent" != "$meshsync" ]; then
+if [ "$standalone_status" -ne 0 ]; then
   cat >&2 <<EOF
 check-operator-chart-appversions: the meshery-operator chart and its subcharts disagree on appVersion.
 
-  ${PARENT_CHART}: ${parent}
-  ${BROKER_CHART}: ${broker}
-  ${MESHSYNC_CHART}: ${meshsync}
+${standalone_report}
 
-All three must name the same Meshery Operator release. The parent's appVersion is
-stamped automatically on every operator release; update both subcharts to match it.
+All of them must name the same published Meshery Operator release. The parent's
+appVersion is stamped automatically on every operator release and that stamping
+touches only the parent, so update the subcharts to match it. A moving tag such
+as stable-latest is never acceptable here: the archive is immutable, so the
+application it advertises would change out from under it.
 EOF
   exit 1
 fi
 
-echo "check-operator-chart-appversions: meshery-operator and both subcharts agree on appVersion ${parent}"
+echo "check-operator-chart-appversions: ${CHART_DIR} and its subcharts agree on appVersion"
+
+bundled_drift=0
+shopt -s nullglob
+for bundled_archive in $BUNDLED_CHART_GLOB; do
+  check_bundled_chart "$bundled_archive" || bundled_drift=1
+done
+shopt -u nullglob
+
+if [ "$bundled_drift" -ne 0 ] && [ "$BUNDLED_CHART_DRIFT_IS_FATAL" = "true" ]; then
+  echo "check-operator-chart-appversions: vendored chart drift is configured as fatal" >&2
+  exit 1
+fi
+
+exit 0

--- a/install/scripts/check-operator-chart-appversions.sh
+++ b/install/scripts/check-operator-chart-appversions.sh
@@ -71,14 +71,18 @@ BUNDLED_CHART_GLOB="${BUNDLED_CHART_GLOB:-install/kubernetes/helm/meshery/charts
 # comparison and the check fails against a subchart that reads identically.
 # --self-test pins that ordering.
 #
-# A malformed or missing chart exits 2 rather than 1, so a caller can tell "this
-# tree could not be read" from "this tree disagrees with itself" and report the
-# one that actually happened.
+# A malformed or missing chart RETURNS 2 rather than 1, so a caller can tell
+# "this tree could not be read" from "this tree disagrees with itself" and report
+# the one that actually happened. It must be return, not exit: every call site
+# is a command substitution, so an exit would end only that nested subshell and
+# leave the caller comparing an empty string - which reports drift, the wrong
+# answer, and makes the read-failure branch unreachable. Callers must therefore
+# check the status of each read rather than only its output.
 read_app_version() {
   local file="$1" value
   if [ ! -f "$file" ]; then
     echo "check-operator-chart-appversions: $file does not exist" >&2
-    exit 2
+    return 2
   fi
   value="$(sed -n 's/^appVersion:[[:space:]]*//p' "$file" | head -n 1)"
   # YAML requires whitespace before an inline comment, so anchoring on that
@@ -90,7 +94,7 @@ read_app_version() {
   value="${value#\'}"
   if [ -z "$value" ]; then
     echo "check-operator-chart-appversions: $file declares no appVersion" >&2
-    exit 2
+    return 2
   fi
   printf '%s' "$value"
 }
@@ -106,14 +110,18 @@ compare_chart_tree() {
   local chart_dir="$1"
   local parent subchart_dir subchart_yaml subchart_version drift=0 found=0
 
-  parent="$(read_app_version "${chart_dir}/Chart.yaml")"
+  if ! parent="$(read_app_version "${chart_dir}/Chart.yaml")"; then
+    return 2
+  fi
   printf '  %s: %s\n' "${chart_dir}/Chart.yaml" "$parent"
 
   for subchart_dir in "${chart_dir}"/charts/*/; do
     subchart_yaml="${subchart_dir}Chart.yaml"
     [ -f "$subchart_yaml" ] || continue
     found=1
-    subchart_version="$(read_app_version "$subchart_yaml")"
+    if ! subchart_version="$(read_app_version "$subchart_yaml")"; then
+      return 2
+    fi
     printf '  %s: %s\n' "$subchart_yaml" "$subchart_version"
     if [ "$subchart_version" != "$parent" ]; then
       drift=1
@@ -170,6 +178,28 @@ self_test() {
     echo "check-operator-chart-appversions: self-test failed: a subchart on stable-latest reported as agreement" >&2
     failures=$((failures + 1))
   fi
+
+  # An unreadable tree must report 2, not 1. read_app_version runs inside a
+  # command substitution, so returning instead of exiting is the only way that
+  # status reaches here; when it regressed to exit, the caller compared an empty
+  # string and this tree was reported as ordinary drift.
+  printf 'appVersion: "1.0.5"\n' > "${dir}/tree/charts/meshery-meshsync/Chart.yaml"
+  printf 'name: no-appversion-here\n' > "${dir}/tree/Chart.yaml"
+  compare_chart_tree "${dir}/tree" > /dev/null 2>&1
+  case $? in
+    2) : ;;
+    *) echo "check-operator-chart-appversions: self-test failed: a parent with no appVersion must report 2 (unreadable), not drift" >&2
+       failures=$((failures + 1)) ;;
+  esac
+  printf 'appVersion: "1.0.5"\n' > "${dir}/tree/Chart.yaml"
+  rm -f "${dir}/tree/charts/meshery-broker/Chart.yaml"
+  printf 'name: broken\n' > "${dir}/tree/charts/meshery-broker/Chart.yaml"
+  compare_chart_tree "${dir}/tree" > /dev/null 2>&1
+  case $? in
+    2) : ;;
+    *) echo "check-operator-chart-appversions: self-test failed: a subchart with no appVersion must report 2 (unreadable), not drift" >&2
+       failures=$((failures + 1)) ;;
+  esac
 
   rm -rf "$dir"
   if [ "$failures" -ne 0 ]; then

--- a/install/scripts/check-operator-chart-appversions.sh
+++ b/install/scripts/check-operator-chart-appversions.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Assert that the meshery-operator chart and its two subcharts advertise the
+# same appVersion.
+#
+# The subcharts ship only the Broker and MeshSync custom resources; the operator
+# release that reconciles them is what their appVersion names. That value is
+# baked into an immutable published archive, so a subchart left behind
+# advertises an operator release it was not published alongside - which is what
+# "appVersion: stable-latest" did before it was pinned.
+#
+# The parent's version/appVersion are stamped by hack/sync-downstream.sh in
+# meshery/meshery-operator on every operator release, and that mechanism touches
+# only the parent. `helm lint` does not compare a parent's appVersion with its
+# subcharts', so nothing else catches the drift. This check does.
+
+set -euo pipefail
+
+CHART_DIR="${1:-install/kubernetes/helm/meshery-operator}"
+
+PARENT_CHART="${CHART_DIR}/Chart.yaml"
+BROKER_CHART="${CHART_DIR}/charts/meshery-broker/Chart.yaml"
+MESHSYNC_CHART="${CHART_DIR}/charts/meshery-meshsync/Chart.yaml"
+
+# read_app_version prints the top-level appVersion of a Chart.yaml, with any
+# surrounding quotes stripped.
+read_app_version() {
+  local file="$1" value
+  if [ ! -f "$file" ]; then
+    echo "check-operator-chart-appversions: $file does not exist" >&2
+    exit 1
+  fi
+  value="$(sed -n 's/^appVersion:[[:space:]]*//p' "$file" | head -n 1)"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  # Trim a trailing comment and any trailing whitespace.
+  value="${value%%#*}"
+  value="$(printf '%s' "$value" | sed 's/[[:space:]]*$//')"
+  if [ -z "$value" ]; then
+    echo "check-operator-chart-appversions: $file declares no appVersion" >&2
+    exit 1
+  fi
+  printf '%s' "$value"
+}
+
+parent="$(read_app_version "$PARENT_CHART")"
+broker="$(read_app_version "$BROKER_CHART")"
+meshsync="$(read_app_version "$MESHSYNC_CHART")"
+
+if [ "$parent" != "$broker" ] || [ "$parent" != "$meshsync" ]; then
+  cat >&2 <<EOF
+check-operator-chart-appversions: the meshery-operator chart and its subcharts disagree on appVersion.
+
+  ${PARENT_CHART}: ${parent}
+  ${BROKER_CHART}: ${broker}
+  ${MESHSYNC_CHART}: ${meshsync}
+
+All three must name the same Meshery Operator release. The parent's appVersion is
+stamped automatically on every operator release; update both subcharts to match it.
+EOF
+  exit 1
+fi
+
+echo "check-operator-chart-appversions: meshery-operator and both subcharts agree on appVersion ${parent}"

--- a/install/scripts/check-operator-chart-appversions.sh
+++ b/install/scripts/check-operator-chart-appversions.sh
@@ -138,7 +138,7 @@ compare_chart_tree() {
 # self_test asserts read_app_version against every spelling a Chart.yaml may
 # legitimately use, so the strip ordering above cannot silently regress.
 self_test() {
-  local dir failures=0 case_line expected got
+  local dir failures=0 case_line expected got tree_status
   dir="$(mktemp -d)"
 
   # Each case is "<expected>|<appVersion line>".
@@ -179,33 +179,38 @@ self_test() {
     failures=$((failures + 1))
   fi
 
-  # An unreadable tree must report 2, not 1. read_app_version runs inside a
-  # command substitution, so returning instead of exiting is the only way that
-  # status reaches here; when it regressed to exit, the caller compared an empty
-  # string and this tree was reported as ordinary drift.
+  # An unreadable tree must report 2, not 1. What this pins is that
+  # compare_chart_tree CHECKS the status of every read: drop either guard and an
+  # unreadable chart is silently downgraded to ordinary drift (status 1), which
+  # is what shipped before and what made the read-failure branch unreachable.
+  # It does not distinguish read_app_version returning from exiting - with the
+  # caller's guard in place both propagate - so do not read it as pinning that.
+  # These two cases expect a NON-ZERO status, so each call must be written in a
+  # form errexit tolerates. A bare `compare_chart_tree ...` followed by `case $?`
+  # aborts the whole script under `set -e` before the status is ever inspected -
+  # the assertion never runs and the self-test exits 2 instead of reporting.
   printf 'appVersion: "1.0.5"\n' > "${dir}/tree/charts/meshery-meshsync/Chart.yaml"
   printf 'name: no-appversion-here\n' > "${dir}/tree/Chart.yaml"
-  compare_chart_tree "${dir}/tree" > /dev/null 2>&1
-  case $? in
-    2) : ;;
-    *) echo "check-operator-chart-appversions: self-test failed: a parent with no appVersion must report 2 (unreadable), not drift" >&2
-       failures=$((failures + 1)) ;;
-  esac
+  tree_status=0
+  compare_chart_tree "${dir}/tree" > /dev/null 2>&1 || tree_status=$?
+  if [ "$tree_status" -ne 2 ]; then
+    echo "check-operator-chart-appversions: self-test failed: a parent with no appVersion must report 2 (unreadable), got ${tree_status}" >&2
+    failures=$((failures + 1))
+  fi
   printf 'appVersion: "1.0.5"\n' > "${dir}/tree/Chart.yaml"
-  rm -f "${dir}/tree/charts/meshery-broker/Chart.yaml"
   printf 'name: broken\n' > "${dir}/tree/charts/meshery-broker/Chart.yaml"
-  compare_chart_tree "${dir}/tree" > /dev/null 2>&1
-  case $? in
-    2) : ;;
-    *) echo "check-operator-chart-appversions: self-test failed: a subchart with no appVersion must report 2 (unreadable), not drift" >&2
-       failures=$((failures + 1)) ;;
-  esac
+  tree_status=0
+  compare_chart_tree "${dir}/tree" > /dev/null 2>&1 || tree_status=$?
+  if [ "$tree_status" -ne 2 ]; then
+    echo "check-operator-chart-appversions: self-test failed: a subchart with no appVersion must report 2 (unreadable), got ${tree_status}" >&2
+    failures=$((failures + 1))
+  fi
 
   rm -rf "$dir"
   if [ "$failures" -ne 0 ]; then
     exit 1
   fi
-  echo "check-operator-chart-appversions: self-test passed (${#cases[@]} parse cases, 2 tree cases)"
+  echo "check-operator-chart-appversions: self-test passed (${#cases[@]} parse cases, 4 tree cases)"
 }
 
 # check_bundled_chart inspects the vendored packaged operator chart. It never

--- a/server/handlers/connection_action_handler.go
+++ b/server/handlers/connection_action_handler.go
@@ -325,7 +325,7 @@ func (h *Handler) reconcileMeshsyncDeploymentMode(ctx context.Context, connectio
 	// Undeploy the previous MeshSync setup for this context.
 	ctrlHelper.
 		UpdateOperatorsStatusMap(machineCtx.OperatorTracker).
-		UndeployDeployedOperators(machineCtx.OperatorTracker).
+		UndeployDeployedOperators(machineCtx.OperatorTracker, contextID).
 		RemoveCtxControllerHandler(ctx, contextID)
 	ctrlHelper.RemoveMeshSyncDataHandler(ctx, contextID)
 
@@ -339,7 +339,7 @@ func (h *Handler) reconcileMeshsyncDeploymentMode(ctx context.Context, connectio
 		SetMeshsyncDeploymentMode(newMode).
 		AddCtxControllerHandlers(machineCtx.K8sContext).
 		UpdateOperatorsStatusMap(machineCtx.OperatorTracker).
-		DeployUndeployedOperators(machineCtx.OperatorTracker).
+		DeployUndeployedOperators(machineCtx.OperatorTracker, contextID).
 		AddMeshsyncDataHandlers(ctx, machineCtx.K8sContext, userID, mesheryInstanceID, provider)
 
 	return nil

--- a/server/handlers/connections_handlers.go
+++ b/server/handlers/connections_handlers.go
@@ -734,7 +734,7 @@ func (h *Handler) handleMeshSyncDeploymentModeChange(
 			contextID := machineCtx.K8sContext.ID
 			ctrlHelper.
 				UpdateOperatorsStatusMap(machineCtx.OperatorTracker).
-				UndeployDeployedOperators(machineCtx.OperatorTracker).
+				UndeployDeployedOperators(machineCtx.OperatorTracker, contextID).
 				RemoveCtxControllerHandler(ctx, contextID)
 			ctrlHelper.RemoveMeshSyncDataHandler(ctx, contextID)
 		}
@@ -750,7 +750,7 @@ func (h *Handler) handleMeshSyncDeploymentModeChange(
 				SetMeshsyncDeploymentMode(newMeshSyncMode).
 				AddCtxControllerHandlers(machineCtx.K8sContext).
 				UpdateOperatorsStatusMap(machineCtx.OperatorTracker).
-				DeployUndeployedOperators(machineCtx.OperatorTracker).
+				DeployUndeployedOperators(machineCtx.OperatorTracker, machineCtx.K8sContext.ID).
 				AddMeshsyncDataHandlers(ctx, machineCtx.K8sContext, userID, mesheryInstanceID, provider)
 		}
 

--- a/server/handlers/controllers_status_handler.go
+++ b/server/handlers/controllers_status_handler.go
@@ -182,6 +182,17 @@ func deriveControllerStatus(controller models.MesheryController, status system.C
 // collectControllersStatus builds the full status list for the requested
 // connections. The result is sorted (connectionId, controller) so callers can
 // compare successive snapshots byte-for-byte to detect changes.
+//
+// Every connection with a ready FSM context reports an operator row, whether or
+// not an operator controller handler is attached. A handler is absent whenever
+// Meshery could not build one - the Kubernetes client failed, or no publishable
+// Meshery Operator chart version could be resolved - and the client replaces
+// its controller state with each snapshot wholesale, so omitting the row makes
+// the Operator card vanish from the UI at exactly the moment it has something
+// to report. The synthesized row carries controllersStatusUnknown (Meshery did
+// not probe the cluster, so it does not know whether an operator is installed)
+// and no version; why the handler is missing is carried by the
+// operator_deploy_failed diagnostic, which is fed from GetOperatorError.
 func (h *Handler) collectControllersStatus(connectionIDs []string) []system.ControllerStatus {
 	items := make([]system.ControllerStatus, 0)
 	for _, connectionID := range connectionIDs {
@@ -192,6 +203,9 @@ func (h *Handler) collectControllersStatus(connectionIDs []string) []system.Cont
 		ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
 		brokerConnected := h.mesheryHoldsLiveBrokerConnection(machinectx)
 		for controller, ctrlHandler := range ctrlHandlers {
+			if ctrlHandler == nil {
+				continue
+			}
 			version, err := ctrlHandler.GetVersion()
 			if err != nil {
 				h.log.Debugf("controllers status: version for %s on %s: %v", internalControllerName(controller), connectionID, err)
@@ -204,6 +218,13 @@ func (h *Handler) collectControllersStatus(connectionIDs []string) []system.Cont
 				Controller:   internalControllerName(controller),
 				Status:       status,
 				Version:      version,
+			})
+		}
+		if ctrlHandlers[models.MesheryOperator] == nil {
+			items = append(items, system.ControllerStatus{
+				ConnectionId: uuid.FromStringOrNil(connectionID),
+				Controller:   internalControllerName(models.MesheryOperator),
+				Status:       controllersStatusUnknown,
 			})
 		}
 	}

--- a/server/handlers/controllers_status_handler.go
+++ b/server/handlers/controllers_status_handler.go
@@ -188,10 +188,11 @@ func deriveControllerStatus(controller models.MesheryController, status system.C
 // that set rather than from the handler map, which is missing entries precisely
 // when something went wrong: AddCtxControllerHandlers attaches no handlers at
 // all when the kubeconfig is unreadable or the Kubernetes client cannot be
-// built, and no operator handler when no publishable Meshery Operator chart
-// version can be resolved. Since the client replaces its controller state with
-// each snapshot wholesale, dropping a row makes that controller's card vanish
-// from the UI at exactly the moment it has something to report.
+// built. (An unresolvable chart version is not one of those cases - the
+// operator handler is still attached and still observes, only installation is
+// withheld.) Since the client replaces its controller state with each snapshot
+// wholesale, dropping a row makes that controller's card vanish from the UI at
+// exactly the moment it has something to report.
 //
 // A row with no handler behind it carries controllersStatusUnknown - Meshery
 // made no observation of the cluster, so any other value would assert something

--- a/server/handlers/controllers_status_handler.go
+++ b/server/handlers/controllers_status_handler.go
@@ -183,16 +183,21 @@ func deriveControllerStatus(controller models.MesheryController, status system.C
 // connections. The result is sorted (connectionId, controller) so callers can
 // compare successive snapshots byte-for-byte to detect changes.
 //
-// Every connection with a ready FSM context reports an operator row, whether or
-// not an operator controller handler is attached. A handler is absent whenever
-// Meshery could not build one - the Kubernetes client failed, or no publishable
-// Meshery Operator chart version could be resolved - and the client replaces
-// its controller state with each snapshot wholesale, so omitting the row makes
-// the Operator card vanish from the UI at exactly the moment it has something
-// to report. The synthesized row carries controllersStatusUnknown (Meshery did
-// not probe the cluster, so it does not know whether an operator is installed)
-// and no version; why the handler is missing is carried by the
-// operator_deploy_failed diagnostic, which is fed from GetOperatorError.
+// A connection with a ready FSM context reports exactly one row per controller
+// in models.MesheryControllers - never a partial list. The rows are built from
+// that set rather than from the handler map, which is missing entries precisely
+// when something went wrong: AddCtxControllerHandlers attaches no handlers at
+// all when the kubeconfig is unreadable or the Kubernetes client cannot be
+// built, and no operator handler when no publishable Meshery Operator chart
+// version can be resolved. Since the client replaces its controller state with
+// each snapshot wholesale, dropping a row makes that controller's card vanish
+// from the UI at exactly the moment it has something to report.
+//
+// A row with no handler behind it carries controllersStatusUnknown - Meshery
+// made no observation of the cluster, so any other value would assert something
+// it did not check - and no version. Why the handler is missing has its own
+// home: the connection diagnostics, including operator_deploy_failed, which is
+// fed from GetOperatorError.
 func (h *Handler) collectControllersStatus(connectionIDs []string) []system.ControllerStatus {
 	items := make([]system.ControllerStatus, 0)
 	for _, connectionID := range connectionIDs {
@@ -202,30 +207,23 @@ func (h *Handler) collectControllersStatus(connectionIDs []string) []system.Cont
 		}
 		ctrlHandlers := machinectx.MesheryCtrlsHelper.GetControllerHandlersForEachContext()
 		brokerConnected := h.mesheryHoldsLiveBrokerConnection(machinectx)
-		for controller, ctrlHandler := range ctrlHandlers {
-			if ctrlHandler == nil {
-				continue
-			}
-			version, err := ctrlHandler.GetVersion()
-			if err != nil {
-				h.log.Debugf("controllers status: version for %s on %s: %v", internalControllerName(controller), connectionID, err)
-			}
-			status := deriveControllerStatus(controller, internalControllerStatus(ctrlHandler.GetStatus()), brokerConnected)
-			items = append(items, system.ControllerStatus{
+		for _, controller := range models.MesheryControllers {
+			item := system.ControllerStatus{
 				// machineCtxForConnection only resolves valid UUIDs, so the parse
 				// cannot yield the zero UUID here.
 				ConnectionId: uuid.FromStringOrNil(connectionID),
 				Controller:   internalControllerName(controller),
-				Status:       status,
-				Version:      version,
-			})
-		}
-		if ctrlHandlers[models.MesheryOperator] == nil {
-			items = append(items, system.ControllerStatus{
-				ConnectionId: uuid.FromStringOrNil(connectionID),
-				Controller:   internalControllerName(models.MesheryOperator),
 				Status:       controllersStatusUnknown,
-			})
+			}
+			if ctrlHandler := ctrlHandlers[controller]; ctrlHandler != nil {
+				version, err := ctrlHandler.GetVersion()
+				if err != nil {
+					h.log.Debugf("controllers status: version for %s on %s: %v", internalControllerName(controller), connectionID, err)
+				}
+				item.Status = deriveControllerStatus(controller, internalControllerStatus(ctrlHandler.GetStatus()), brokerConnected)
+				item.Version = version
+			}
+			items = append(items, item)
 		}
 	}
 	sort.Slice(items, func(i, j int) bool {

--- a/server/handlers/controllers_status_handler_test.go
+++ b/server/handlers/controllers_status_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/meshery/meshery/server/machines/kubernetes"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/schemas/models/core"
+	system "github.com/meshery/schemas/models/v1beta1/system"
 )
 
 // trackerWith builds an instance tracker holding a single connection->machine
@@ -113,6 +114,61 @@ func TestMachineCtxForConnection(t *testing.T) {
 				t.Fatalf("expected the tracked machine context to be returned, got %#v", ctx)
 			}
 		})
+	}
+}
+
+// TestCollectControllersStatus_OperatorRowSurvivesAMissingHandler: the SSE
+// snapshot is the complete controller list and the client replaces its state
+// with it wholesale, so a controller that is missing from the snapshot is a
+// card that disappears from the UI rather than one that reports a problem.
+//
+// No operator handler is attached whenever Meshery could not build one - the
+// Kubernetes client failed, or no publishable Meshery Operator chart version
+// could be resolved - which is exactly when the Operator card has something to
+// say. The row must be present and carry an existing status value; the reason
+// belongs to the operator_deploy_failed diagnostic, not to this payload.
+func TestCollectControllersStatus_OperatorRowSurvivesAMissingHandler(t *testing.T) {
+	connID := uuid.Must(uuid.NewV4())
+	// A controllers helper with no attached handlers at all: the widest case,
+	// covering both client-creation failure and withheld operator lifecycle.
+	mctx := &kubernetes.MachineCtx{MesheryCtrlsHelper: &models.MesheryControllersHelper{}}
+
+	h := &Handler{
+		config:                                  &models.HandlerConfig{},
+		log:                                     newTestLogger(t),
+		ConnectionToStateMachineInstanceTracker: trackerWith(connID, &machines.StateMachine{ID: connID, Context: mctx}),
+	}
+
+	items := h.collectControllersStatus([]string{connID.String()})
+
+	var operator *system.ControllerStatus
+	for i := range items {
+		if items[i].Controller == system.ControllerStatusControllerOPERATOR {
+			operator = &items[i]
+		}
+	}
+	if operator == nil {
+		t.Fatalf("no OPERATOR row in the snapshot %+v: the Operator card vanishes from the UI", items)
+	}
+	if operator.ConnectionId != connID {
+		t.Fatalf("connectionId = %s, want %s", operator.ConnectionId, connID)
+	}
+	if operator.Status != controllersStatusUnknown {
+		t.Fatalf("status = %q, want %q - Meshery did not probe the cluster, so it does not know", operator.Status, controllersStatusUnknown)
+	}
+	if operator.Version != "" {
+		t.Fatalf("version = %q, want it empty for a synthesized row", operator.Version)
+	}
+}
+
+// A connection with no ready FSM instance still reports nothing: there is no
+// context to read, and inventing rows for it would report on connections
+// Meshery is not tracking.
+func TestCollectControllersStatus_UnresolvedConnectionReportsNothing(t *testing.T) {
+	h := newControllersStatusTestHandler(t)
+
+	if items := h.collectControllersStatus([]string{uuid.Must(uuid.NewV4()).String()}); len(items) != 0 {
+		t.Fatalf("snapshot = %+v, want it empty for a connection with no ready instance", items)
 	}
 }
 

--- a/server/handlers/controllers_status_handler_test.go
+++ b/server/handlers/controllers_status_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -117,20 +118,22 @@ func TestMachineCtxForConnection(t *testing.T) {
 	}
 }
 
-// TestCollectControllersStatus_OperatorRowSurvivesAMissingHandler: the SSE
-// snapshot is the complete controller list and the client replaces its state
-// with it wholesale, so a controller that is missing from the snapshot is a
-// card that disappears from the UI rather than one that reports a problem.
+// TestCollectControllersStatus_EveryControllerRowSurvivesMissingHandlers: the
+// SSE snapshot is the complete controller list and the client replaces its
+// state with it wholesale, so a controller missing from the snapshot is a card
+// that disappears from the UI rather than one that reports a problem.
 //
-// No operator handler is attached whenever Meshery could not build one - the
-// Kubernetes client failed, or no publishable Meshery Operator chart version
-// could be resolved - which is exactly when the Operator card has something to
-// say. The row must be present and carry an existing status value; the reason
-// belongs to the operator_deploy_failed diagnostic, not to this payload.
-func TestCollectControllersStatus_OperatorRowSurvivesAMissingHandler(t *testing.T) {
+// No handler is attached whenever Meshery could not build one - an unreadable
+// kubeconfig or a failed Kubernetes client take out all three, and an
+// unresolvable Meshery Operator chart version takes out the operator - which is
+// exactly when those cards have something to say. Every controller must get a
+// row carrying an existing status value; the reason belongs to the connection
+// diagnostics, not to this payload.
+func TestCollectControllersStatus_EveryControllerRowSurvivesMissingHandlers(t *testing.T) {
 	connID := uuid.Must(uuid.NewV4())
 	// A controllers helper with no attached handlers at all: the widest case,
-	// covering both client-creation failure and withheld operator lifecycle.
+	// covering kubeconfig failure, client-creation failure, and withheld
+	// operator lifecycle alike.
 	mctx := &kubernetes.MachineCtx{MesheryCtrlsHelper: &models.MesheryControllersHelper{}}
 
 	h := &Handler{
@@ -141,23 +144,43 @@ func TestCollectControllersStatus_OperatorRowSurvivesAMissingHandler(t *testing.
 
 	items := h.collectControllersStatus([]string{connID.String()})
 
-	var operator *system.ControllerStatus
-	for i := range items {
-		if items[i].Controller == system.ControllerStatusControllerOPERATOR {
-			operator = &items[i]
+	if len(items) != len(models.MesheryControllers) {
+		t.Fatalf("snapshot has %d rows, want one per controller (%d): %+v",
+			len(items), len(models.MesheryControllers), items)
+	}
+	seen := map[system.ControllerStatusController]bool{}
+	for _, item := range items {
+		if item.ConnectionId != connID {
+			t.Fatalf("connectionId = %s, want %s", item.ConnectionId, connID)
+		}
+		if item.Status != controllersStatusUnknown {
+			t.Fatalf("%s status = %q, want %q - Meshery did not probe the cluster, so it does not know",
+				item.Controller, item.Status, controllersStatusUnknown)
+		}
+		if item.Version != "" {
+			t.Fatalf("%s version = %q, want it empty for a synthesized row", item.Controller, item.Version)
+		}
+		if seen[item.Controller] {
+			t.Fatalf("%s reported twice: duplicate rows break the snapshot's sort key", item.Controller)
+		}
+		seen[item.Controller] = true
+	}
+	for _, want := range []system.ControllerStatusController{
+		system.ControllerStatusControllerBROKER,
+		system.ControllerStatusControllerMESHSYNC,
+		system.ControllerStatusControllerOPERATOR,
+	} {
+		if !seen[want] {
+			t.Fatalf("no %s row in the snapshot %+v: that card vanishes from the UI", want, items)
 		}
 	}
-	if operator == nil {
-		t.Fatalf("no OPERATOR row in the snapshot %+v: the Operator card vanishes from the UI", items)
-	}
-	if operator.ConnectionId != connID {
-		t.Fatalf("connectionId = %s, want %s", operator.ConnectionId, connID)
-	}
-	if operator.Status != controllersStatusUnknown {
-		t.Fatalf("status = %q, want %q - Meshery did not probe the cluster, so it does not know", operator.Status, controllersStatusUnknown)
-	}
-	if operator.Version != "" {
-		t.Fatalf("version = %q, want it empty for a synthesized row", operator.Version)
+	if !sort.SliceIsSorted(items, func(i, j int) bool {
+		if items[i].ConnectionId != items[j].ConnectionId {
+			return items[i].ConnectionId.String() < items[j].ConnectionId.String()
+		}
+		return items[i].Controller < items[j].Controller
+	}) {
+		t.Fatalf("snapshot is not sorted by (connectionId, controller); SSE change detection compares it byte-for-byte: %+v", items)
 	}
 }
 

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1474
+  "next_error_code": 1475
 }

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1468
+  "next_error_code": 1474
 }

--- a/server/helpers/utils/error.go
+++ b/server/helpers/utils/error.go
@@ -16,8 +16,12 @@ func ErrHelmChartIndex(url, cause string) error {
 		ErrHelmChartIndexCode,
 		errors.Alert,
 		[]string{"Unable to read the Helm chart repository index."},
-		[]string{cause},
-		[]string{"The Helm repository at " + url + " is unreachable, returned an error, or served an index that is not valid YAML. Meshery Server may have no outbound network access, or the repository may be temporarily unavailable."},
-		[]string{"Confirm that " + url + " is reachable from the Meshery Server pod or container, then retry. If Meshery runs behind a proxy, confirm the proxy environment variables are set on the server."},
+		[]string{cause + " (chart repository: " + url + ")"},
+		// Probable cause and remediation must be static literals: errorutil cannot
+		// statically extract a concatenated string, and a code whose exported
+		// entry is blank is a code the published error reference cannot explain.
+		// The repository URL travels in the cause instead.
+		[]string{"The Helm chart repository is unreachable, returned an error, or served an index that is not valid YAML. Meshery Server may have no outbound network access, or the repository may be temporarily unavailable."},
+		[]string{"Confirm that the chart repository named in this error's cause is reachable from the Meshery Server pod or container, then retry. If Meshery runs behind a proxy, confirm the proxy environment variables are set on the server."},
 	)
 }

--- a/server/helpers/utils/error.go
+++ b/server/helpers/utils/error.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"github.com/meshery/meshkit/errors"
+)
+
+const (
+	ErrHelmChartIndexCode = "meshery-server-1473"
+)
+
+// ErrHelmChartIndex is returned when a Helm repository's index.yaml cannot be
+// fetched or parsed. Without the index there is no way to know which chart
+// versions exist, so callers must fail rather than guess at a version.
+func ErrHelmChartIndex(url, cause string) error {
+	return errors.New(
+		ErrHelmChartIndexCode,
+		errors.Alert,
+		[]string{"Unable to read the Helm chart repository index."},
+		[]string{cause},
+		[]string{"The Helm repository at " + url + " is unreachable, returned an error, or served an index that is not valid YAML. Meshery Server may have no outbound network access, or the repository may be temporarily unavailable."},
+		[]string{"Confirm that " + url + " is reachable from the Meshery Server pod or container, then retry. If Meshery runs behind a proxy, confirm the proxy environment variables are set on the server."},
+	)
+}

--- a/server/helpers/utils/helm_chart_repo.go
+++ b/server/helpers/utils/helm_chart_repo.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"net/http"
 	"slices"
 	"strconv"
@@ -113,28 +114,53 @@ func (c *chartIndexCache) index(repo string) (map[string][]string, error) {
 	c.inflight[repo] = pending
 	c.mu.Unlock()
 
-	versions, err := c.fetch(repo)
+	return c.runFetch(repo, pending)
+}
 
-	c.mu.Lock()
-	pending.versions, pending.err = versions, err
-	delete(c.inflight, repo)
-	if err == nil {
-		if c.entries == nil {
-			c.entries = map[string]chartIndexCacheEntry{}
+// runFetch performs the one fetch that waiters on pending are blocked behind,
+// and publishes its outcome.
+//
+// Releasing the in-flight slot and closing pending.done are deferred because
+// they must happen on every exit path. A panic that skipped them would wedge
+// this repository permanently: the slot would still be occupied, so every later
+// caller would block forever on a done channel nobody can close, leaking a
+// goroutine each until the server is restarted. A panic is therefore converted
+// into a structured failure, which the normal error path already handles
+// (operator lifecycle is withheld, the cause is recorded for diagnostics, and
+// the next call retries because failures are not cached).
+func (c *chartIndexCache) runFetch(repo string, pending *chartIndexFetch) (versions map[string][]string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			versions = nil
+			err = ErrHelmChartIndex(chartIndexURL(repo), fmt.Sprintf("reading the repository index panicked: %v", r))
 		}
-		c.entries[repo] = chartIndexCacheEntry{versions: versions, fetchedAt: c.now()}
-	}
-	c.mu.Unlock()
-	close(pending.done)
 
-	return versions, err
+		c.mu.Lock()
+		pending.versions, pending.err = versions, err
+		delete(c.inflight, repo)
+		if err == nil {
+			if c.entries == nil {
+				c.entries = map[string]chartIndexCacheEntry{}
+			}
+			c.entries[repo] = chartIndexCacheEntry{versions: versions, fetchedAt: c.now()}
+		}
+		c.mu.Unlock()
+		close(pending.done)
+	}()
+
+	return c.fetch(repo)
+}
+
+// chartIndexURL is where a Helm repository serves its index.
+func chartIndexURL(repo string) string {
+	return strings.TrimSuffix(repo, "/") + "/index.yaml"
 }
 
 // fetchChartIndexVersions downloads repo's index.yaml and reduces it to
 // chart name -> published versions. It decodes into MeshKit's HelmIndex rather
 // than a local copy of the same shape, so the index contract keeps one owner.
 func fetchChartIndexVersions(repo string) (map[string][]string, error) {
-	url := strings.TrimSuffix(repo, "/") + "/index.yaml"
+	url := chartIndexURL(repo)
 
 	// The repository URL is server configuration, never user input. #nosec G107
 	client := &http.Client{Timeout: chartIndexTimeout}

--- a/server/helpers/utils/helm_chart_repo.go
+++ b/server/helpers/utils/helm_chart_repo.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,10 +27,18 @@ const (
 // chartIndexCache memoizes Helm repository indexes, keyed by repository URL.
 //
 // Only successful fetches are cached: a transient repository outage is retried
-// on the next call rather than being pinned in for the whole TTL.
+// on the next call rather than being pinned in for the whole TTL. The fetch
+// itself runs without the lock held and is single-flighted per repository, so
+// an unreachable repository costs all concurrent callers one chartIndexTimeout
+// between them rather than one each, serially.
 type chartIndexCache struct {
 	mu      sync.Mutex
 	entries map[string]chartIndexCacheEntry
+
+	// inflight tracks the fetch currently in progress for a repository, so
+	// callers that miss the cache at the same time share its result instead of
+	// each issuing their own request.
+	inflight map[string]*chartIndexFetch
 
 	// now and fetch are injectable so tests can drive expiry and serve a fixed
 	// index without touching the network.
@@ -42,11 +51,20 @@ type chartIndexCacheEntry struct {
 	fetchedAt time.Time
 }
 
+// chartIndexFetch is one in-progress fetch. done is closed once versions and
+// err are final, and neither field is read before that.
+type chartIndexFetch struct {
+	done     chan struct{}
+	versions map[string][]string
+	err      error
+}
+
 func newChartIndexCache() *chartIndexCache {
 	return &chartIndexCache{
-		entries: map[string]chartIndexCacheEntry{},
-		now:     time.Now,
-		fetch:   fetchChartIndexVersions,
+		entries:  map[string]chartIndexCacheEntry{},
+		inflight: map[string]*chartIndexFetch{},
+		now:      time.Now,
+		fetch:    fetchChartIndexVersions,
 	}
 }
 
@@ -54,7 +72,9 @@ var defaultChartIndexCache = newChartIndexCache()
 
 // PublishedChartVersions returns every version of chart published in the Helm
 // repository at repo, in the order that repository's index.yaml lists them
-// (newest first by convention; callers that depend on ordering must sort).
+// (newest first by convention). The slice is a fresh copy the caller owns and
+// may sort or otherwise modify; the cached catalogue behind it is shared across
+// goroutines and is never handed out.
 //
 // A reachable repository that publishes no such chart yields an empty slice and
 // no error: "the repository has nothing under that name" is a different
@@ -65,19 +85,49 @@ func PublishedChartVersions(repo, chart string) ([]string, error) {
 }
 
 func (c *chartIndexCache) list(repo, chart string) ([]string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	entry, ok := c.entries[repo]
-	if !ok || c.now().Sub(entry.fetchedAt) > chartIndexTTL {
-		versions, err := c.fetch(repo)
-		if err != nil {
-			return nil, err
-		}
-		entry = chartIndexCacheEntry{versions: versions, fetchedAt: c.now()}
-		c.entries[repo] = entry
+	versions, err := c.index(repo)
+	if err != nil {
+		return nil, err
 	}
-	return entry.versions[chart], nil
+	return slices.Clone(versions[chart]), nil
+}
+
+// index returns repo's chart catalogue, fetching it when the cache holds no
+// unexpired copy. The lock is held only around the cache and the in-flight
+// bookkeeping, never across the fetch.
+func (c *chartIndexCache) index(repo string) (map[string][]string, error) {
+	c.mu.Lock()
+	if entry, ok := c.entries[repo]; ok && c.now().Sub(entry.fetchedAt) <= chartIndexTTL {
+		c.mu.Unlock()
+		return entry.versions, nil
+	}
+	if pending, ok := c.inflight[repo]; ok {
+		c.mu.Unlock()
+		<-pending.done
+		return pending.versions, pending.err
+	}
+	pending := &chartIndexFetch{done: make(chan struct{})}
+	if c.inflight == nil {
+		c.inflight = map[string]*chartIndexFetch{}
+	}
+	c.inflight[repo] = pending
+	c.mu.Unlock()
+
+	versions, err := c.fetch(repo)
+
+	c.mu.Lock()
+	pending.versions, pending.err = versions, err
+	delete(c.inflight, repo)
+	if err == nil {
+		if c.entries == nil {
+			c.entries = map[string]chartIndexCacheEntry{}
+		}
+		c.entries[repo] = chartIndexCacheEntry{versions: versions, fetchedAt: c.now()}
+	}
+	c.mu.Unlock()
+	close(pending.done)
+
+	return versions, err
 }
 
 // fetchChartIndexVersions downloads repo's index.yaml and reduces it to

--- a/server/helpers/utils/helm_chart_repo.go
+++ b/server/helpers/utils/helm_chart_repo.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// chartIndexTTL is how long a fetched repository index is reused. Charts
+	// are published at release cadence, so minutes of staleness are harmless,
+	// while re-downloading a multi-megabyte index.yaml on every cluster
+	// connection is not.
+	chartIndexTTL = 15 * time.Minute
+
+	// chartIndexTimeout bounds the index fetch. Without it an unresponsive
+	// repository stalls every caller indefinitely.
+	chartIndexTimeout = 30 * time.Second
+)
+
+// chartIndexCache memoizes Helm repository indexes, keyed by repository URL.
+//
+// Only successful fetches are cached: a transient repository outage is retried
+// on the next call rather than being pinned in for the whole TTL.
+type chartIndexCache struct {
+	mu      sync.Mutex
+	entries map[string]chartIndexCacheEntry
+
+	// now and fetch are injectable so tests can drive expiry and serve a fixed
+	// index without touching the network.
+	now   func() time.Time
+	fetch func(repo string) (map[string][]string, error)
+}
+
+type chartIndexCacheEntry struct {
+	versions  map[string][]string
+	fetchedAt time.Time
+}
+
+func newChartIndexCache() *chartIndexCache {
+	return &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     time.Now,
+		fetch:   fetchChartIndexVersions,
+	}
+}
+
+var defaultChartIndexCache = newChartIndexCache()
+
+// PublishedChartVersions returns every version of chart published in the Helm
+// repository at repo, in the order that repository's index.yaml lists them
+// (newest first by convention; callers that depend on ordering must sort).
+//
+// A reachable repository that publishes no such chart yields an empty slice and
+// no error: "the repository has nothing under that name" is a different
+// condition from "the repository could not be read", and callers act on them
+// differently.
+func PublishedChartVersions(repo, chart string) ([]string, error) {
+	return defaultChartIndexCache.list(repo, chart)
+}
+
+func (c *chartIndexCache) list(repo, chart string) ([]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[repo]
+	if !ok || c.now().Sub(entry.fetchedAt) > chartIndexTTL {
+		versions, err := c.fetch(repo)
+		if err != nil {
+			return nil, err
+		}
+		entry = chartIndexCacheEntry{versions: versions, fetchedAt: c.now()}
+		c.entries[repo] = entry
+	}
+	return entry.versions[chart], nil
+}
+
+// fetchChartIndexVersions downloads repo's index.yaml and reduces it to
+// chart name -> published versions. It decodes into MeshKit's HelmIndex rather
+// than a local copy of the same shape, so the index contract keeps one owner.
+func fetchChartIndexVersions(repo string) (map[string][]string, error) {
+	url := strings.TrimSuffix(repo, "/") + "/index.yaml"
+
+	// The repository URL is server configuration, never user input. #nosec G107
+	client := &http.Client{Timeout: chartIndexTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, ErrHelmChartIndex(url, err.Error())
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, ErrHelmChartIndex(url, "the repository responded with HTTP "+strconv.Itoa(resp.StatusCode))
+	}
+
+	var index mesherykube.HelmIndex
+	if err := yaml.NewDecoder(resp.Body).Decode(&index); err != nil {
+		return nil, ErrHelmChartIndex(url, err.Error())
+	}
+
+	versions := make(map[string][]string, len(index.Entries))
+	for name, entries := range index.Entries {
+		for _, entry := range entries {
+			if entry.Version != "" {
+				versions[name] = append(versions[name], entry.Version)
+			}
+		}
+	}
+	return versions, nil
+}

--- a/server/helpers/utils/helm_chart_repo.go
+++ b/server/helpers/utils/helm_chart_repo.go
@@ -32,6 +32,15 @@ const (
 // itself runs without the lock held and is single-flighted per repository, so
 // an unreachable repository costs all concurrent callers one chartIndexTimeout
 // between them rather than one each, serially.
+//
+// Expiry is stale-while-revalidate, not a miss. This index is read on the
+// cluster-connect request path, and index.yaml is several megabytes: treating
+// an expired entry as absent puts a full chartIndexTimeout in front of a
+// connect every time the TTL happens to lapse against a slow or unreachable
+// repository. Published charts are append-mostly, so the worst a stale
+// catalogue costs is not yet knowing about the newest chart - a case the
+// version resolver already handles - which is strictly better than stalling the
+// request. Only a cold cache, with no catalogue to serve at all, blocks.
 type chartIndexCache struct {
 	mu      sync.Mutex
 	entries map[string]chartIndexCacheEntry
@@ -93,28 +102,46 @@ func (c *chartIndexCache) list(repo, chart string) ([]string, error) {
 	return slices.Clone(versions[chart]), nil
 }
 
-// index returns repo's chart catalogue, fetching it when the cache holds no
-// unexpired copy. The lock is held only around the cache and the in-flight
-// bookkeeping, never across the fetch.
+// index returns repo's chart catalogue. A fresh entry is served as-is, an
+// expired one is served while a refresh runs behind the caller, and only a
+// caller that finds no entry at all waits for a fetch. The lock is held around
+// the cache and the in-flight bookkeeping, never across the fetch.
 func (c *chartIndexCache) index(repo string) (map[string][]string, error) {
 	c.mu.Lock()
-	if entry, ok := c.entries[repo]; ok && c.now().Sub(entry.fetchedAt) <= chartIndexTTL {
+	entry, cached := c.entries[repo]
+	if cached && c.now().Sub(entry.fetchedAt) <= chartIndexTTL {
 		c.mu.Unlock()
 		return entry.versions, nil
 	}
+	pending := c.startFetchLocked(repo)
+	c.mu.Unlock()
+
+	if cached {
+		return entry.versions, nil
+	}
+	<-pending.done
+	return pending.versions, pending.err
+}
+
+// startFetchLocked returns the fetch in progress for repo, starting one when
+// none is. c.mu must be held.
+//
+// The fetch runs on its own goroutine whether or not anyone waits for it, which
+// is what lets an expired entry be refreshed without a caller paying for it,
+// and keeps every caller - waiting or not - behind the same single flight.
+func (c *chartIndexCache) startFetchLocked(repo string) *chartIndexFetch {
 	if pending, ok := c.inflight[repo]; ok {
-		c.mu.Unlock()
-		<-pending.done
-		return pending.versions, pending.err
+		return pending
 	}
 	pending := &chartIndexFetch{done: make(chan struct{})}
 	if c.inflight == nil {
 		c.inflight = map[string]*chartIndexFetch{}
 	}
 	c.inflight[repo] = pending
-	c.mu.Unlock()
-
-	return c.runFetch(repo, pending)
+	go func() {
+		_, _ = c.runFetch(repo, pending)
+	}()
+	return pending
 }
 
 // runFetch performs the one fetch that waiters on pending are blocked behind,
@@ -124,10 +151,12 @@ func (c *chartIndexCache) index(repo string) (map[string][]string, error) {
 // they must happen on every exit path. A panic that skipped them would wedge
 // this repository permanently: the slot would still be occupied, so every later
 // caller would block forever on a done channel nobody can close, leaking a
-// goroutine each until the server is restarted. A panic is therefore converted
-// into a structured failure, which the normal error path already handles
-// (operator lifecycle is withheld, the cause is recorded for diagnostics, and
-// the next call retries because failures are not cached).
+// goroutine each until the server is restarted. It would also take the process
+// with it: this runs on its own goroutine, where an unrecovered panic is fatal
+// with no handler above it to absorb it. A panic is therefore converted into a
+// structured failure, which the normal error path already handles (installation
+// is withheld, the cause is recorded for diagnostics, and the next call retries
+// because failures are not cached).
 func (c *chartIndexCache) runFetch(repo string, pending *chartIndexFetch) (versions map[string][]string, err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/server/helpers/utils/helm_chart_repo_test.go
+++ b/server/helpers/utils/helm_chart_repo_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -157,6 +159,149 @@ func TestChartIndexCacheDoesNotCacheFailures(t *testing.T) {
 	}
 	if len(versions) != 1 {
 		t.Fatalf("versions = %v, want the successfully fetched catalogue", versions)
+	}
+}
+
+// waitFor spins until cond holds, failing the test if it has not within a
+// generous deadline. Used instead of a fixed sleep so the tests below do not
+// encode a timing guess.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestChartIndexCacheDoesNotHoldTheLockAcrossAFetch is the reason the fetch
+// moved out from under the mutex. The fetch is an HTTP GET bounded only by
+// chartIndexTimeout, so holding the lock across it stalled every other caller -
+// including callers for an entirely different repository - for the full
+// timeout, one after another. On an egress-blocked server that turned several
+// simultaneous cluster connections into minutes of blocked request handlers.
+func TestChartIndexCacheDoesNotHoldTheLockAcrossAFetch(t *testing.T) {
+	inFlight := make(chan struct{})
+	release := make(chan struct{})
+
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     time.Now,
+		fetch: func(repo string) (map[string][]string, error) {
+			if repo == "slow" {
+				close(inFlight)
+				<-release
+			}
+			return map[string][]string{"meshery-operator": {"v1.0.64"}}, nil
+		},
+	}
+
+	slowDone := make(chan struct{})
+	go func() {
+		defer close(slowDone)
+		if _, err := cache.list("slow", "meshery-operator"); err != nil {
+			t.Errorf("slow repository: unexpected error: %v", err)
+		}
+	}()
+	<-inFlight
+
+	fastDone := make(chan struct{})
+	go func() {
+		defer close(fastDone)
+		if _, err := cache.list("fast", "meshery-operator"); err != nil {
+			t.Errorf("fast repository: unexpected error: %v", err)
+		}
+	}()
+
+	select {
+	case <-fastDone:
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("a lookup for another repository blocked behind an in-flight fetch: the cache lock is held across the fetch")
+	}
+
+	close(release)
+	<-slowDone
+}
+
+// TestChartIndexCacheSingleFlightsConcurrentMisses asserts concurrent callers
+// that miss the cache share one fetch instead of each issuing their own.
+//
+// The fetch here fails, which is the case that matters: failures are
+// deliberately not cached, so without single-flight every caller pays its own
+// full chartIndexTimeout - N cluster connections against an unreachable
+// repository cost N timeouts rather than one.
+func TestChartIndexCacheSingleFlightsConcurrentMisses(t *testing.T) {
+	const callers = 8
+
+	release := make(chan struct{})
+	var fetches atomic.Int32
+	outage := errors.New("repository unreachable")
+
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     time.Now,
+		fetch: func(string) (map[string][]string, error) {
+			fetches.Add(1)
+			<-release
+			return nil, outage
+		},
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = cache.list("repo", "meshery-operator")
+		}()
+	}
+
+	// The first caller is now inside the blocked fetch; the rest are joining it.
+	waitFor(t, "the first fetch to start", func() bool { return fetches.Load() >= 1 })
+	time.Sleep(200 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	// Serializing on the mutex instead of sharing the result costs exactly one
+	// fetch per caller.
+	if got := fetches.Load(); got >= callers {
+		t.Fatalf("fetched %d times for %d concurrent callers: each caller paid its own timeout", got, callers)
+	}
+	for i := range callers {
+		if !errors.Is(errs[i], outage) {
+			t.Fatalf("caller %d: err = %v, want the shared fetch failure", i, errs[i])
+		}
+	}
+}
+
+// TestChartIndexCacheReturnsACopyOfTheCatalogue: the cached catalogue is shared
+// across goroutines for a full TTL. Handing out its own slice lets any caller
+// that sorts or appends corrupt it for everyone else, with no lock held.
+func TestChartIndexCacheReturnsACopyOfTheCatalogue(t *testing.T) {
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     time.Now,
+		fetch: func(string) (map[string][]string, error) {
+			return map[string][]string{"meshery-operator": {"v1.0.64", "v1.0.63"}}, nil
+		},
+	}
+
+	first, err := cache.list("repo", "meshery-operator")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	first[0] = "tampered"
+
+	second, err := cache.list("repo", "meshery-operator")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if second[0] != "v1.0.64" {
+		t.Fatalf("versions = %v, want the cached catalogue to be unaffected by a caller mutating its result", second)
 	}
 }
 

--- a/server/helpers/utils/helm_chart_repo_test.go
+++ b/server/helpers/utils/helm_chart_repo_test.go
@@ -1,0 +1,182 @@
+package utils
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	meshkiterrors "github.com/meshery/meshkit/errors"
+)
+
+const testIndexYAML = `apiVersion: v1
+entries:
+  meshery-operator:
+    - apiVersion: v2
+      appVersion: v1.0.64
+      name: meshery-operator
+      version: v1.0.64
+    - apiVersion: v2
+      appVersion: v1.0.63
+      name: meshery-operator
+      version: v1.0.63
+  meshery:
+    - apiVersion: v2
+      name: meshery
+      version: v1.0.64
+`
+
+func TestFetchChartIndexVersionsReadsEveryChart(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/index.yaml" {
+			t.Errorf("requested %q, want /index.yaml", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(testIndexYAML))
+	}))
+	defer srv.Close()
+
+	versions, err := fetchChartIndexVersions(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := versions["meshery-operator"]; len(got) != 2 || got[0] != "v1.0.64" || got[1] != "v1.0.63" {
+		t.Fatalf("meshery-operator versions = %v, want the index order [v1.0.64 v1.0.63]", got)
+	}
+	if got := versions["meshery"]; len(got) != 1 {
+		t.Fatalf("meshery versions = %v, want one entry", got)
+	}
+}
+
+// TestFetchChartIndexVersionsToleratesATrailingSlash guards the URL join: a
+// repository configured with a trailing slash must not produce
+// ".../charts//index.yaml".
+func TestFetchChartIndexVersionsToleratesATrailingSlash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/index.yaml" {
+			t.Errorf("requested %q, want /index.yaml", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(testIndexYAML))
+	}))
+	defer srv.Close()
+
+	if _, err := fetchChartIndexVersions(srv.URL + "/"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchChartIndexVersionsReportsStructuredFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name:    "an error status",
+			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
+		},
+		{
+			name:    "a body that is not an index",
+			handler: func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("\t- not: [yaml")) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			_, err := fetchChartIndexVersions(srv.URL)
+			if err == nil {
+				t.Fatal("expected a failure")
+			}
+			if code := meshkiterrors.GetCode(err); code != ErrHelmChartIndexCode {
+				t.Fatalf("error code = %q, want %q (from %v)", code, ErrHelmChartIndexCode, err)
+			}
+		})
+	}
+}
+
+// TestChartIndexCacheServesFromCacheUntilTheTTLExpires keeps the index off the
+// wire on the hot path: it is fetched on every cluster connection, and the
+// Meshery index is several megabytes.
+func TestChartIndexCacheServesFromCacheUntilTheTTLExpires(t *testing.T) {
+	now := time.Unix(0, 0)
+	fetches := 0
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     func() time.Time { return now },
+		fetch: func(string) (map[string][]string, error) {
+			fetches++
+			return map[string][]string{"meshery-operator": {"v1.0.64"}}, nil
+		},
+	}
+
+	for range 3 {
+		if _, err := cache.list("repo", "meshery-operator"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if fetches != 1 {
+		t.Fatalf("fetched %d times within the TTL, want 1", fetches)
+	}
+
+	now = now.Add(chartIndexTTL + time.Second)
+	if _, err := cache.list("repo", "meshery-operator"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fetches != 2 {
+		t.Fatalf("fetched %d times after the TTL expired, want 2", fetches)
+	}
+}
+
+// TestChartIndexCacheDoesNotCacheFailures asserts a transient repository outage
+// is retried on the next connection instead of being pinned in for a full TTL,
+// which would extend a momentary blip into fifteen minutes of failed operator
+// deployments.
+func TestChartIndexCacheDoesNotCacheFailures(t *testing.T) {
+	now := time.Unix(0, 0)
+	calls := 0
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     func() time.Time { return now },
+		fetch: func(string) (map[string][]string, error) {
+			calls++
+			if calls == 1 {
+				return nil, errors.New("transient outage")
+			}
+			return map[string][]string{"meshery-operator": {"v1.0.64"}}, nil
+		},
+	}
+
+	if _, err := cache.list("repo", "meshery-operator"); err == nil {
+		t.Fatal("expected the first call to report the outage")
+	}
+	versions, err := cache.list("repo", "meshery-operator")
+	if err != nil {
+		t.Fatalf("the retry must not be served from a cached failure: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("versions = %v, want the successfully fetched catalogue", versions)
+	}
+}
+
+// TestChartIndexCacheDistinguishesEmptyFromUnreadable: a repository that is
+// reachable but publishes no such chart is not an error. Callers decide what an
+// empty catalogue means; only an unreadable index is a failure.
+func TestChartIndexCacheDistinguishesEmptyFromUnreadable(t *testing.T) {
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     time.Now,
+		fetch: func(string) (map[string][]string, error) {
+			return map[string][]string{"meshery": {"v1.0.64"}}, nil
+		},
+	}
+
+	versions, err := cache.list("repo", "meshery-operator")
+	if err != nil {
+		t.Fatalf("an absent chart is not a read failure: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("versions = %v, want none", versions)
+	}
+}

--- a/server/helpers/utils/helm_chart_repo_test.go
+++ b/server/helpers/utils/helm_chart_repo_test.go
@@ -278,6 +278,56 @@ func TestChartIndexCacheSingleFlightsConcurrentMisses(t *testing.T) {
 	}
 }
 
+// TestChartIndexCacheSurvivesAPanickingFetch: the in-flight slot must be
+// released on every exit path. Leaving it behind after a panic wedges the
+// repository permanently - the done channel nobody can close blocks every
+// later caller forever, leaking a goroutine each - and net/http recovers the
+// panic in the handler goroutine, so the process stays up to keep hanging.
+func TestChartIndexCacheSurvivesAPanickingFetch(t *testing.T) {
+	calls := 0
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     time.Now,
+		fetch: func(string) (map[string][]string, error) {
+			calls++
+			if calls == 1 {
+				panic("index decode blew up")
+			}
+			return map[string][]string{"meshery-operator": {"v1.0.64"}}, nil
+		},
+	}
+
+	// The panicking flight reports a structured failure rather than escaping as
+	// a panic or handing back a nil catalogue with a nil error.
+	versions, err := cache.list("repo", "meshery-operator")
+	if err == nil {
+		t.Fatalf("a panicking fetch must be reported as a failure, got versions %v", versions)
+	}
+	if code := meshkiterrors.GetCode(err); code != ErrHelmChartIndexCode {
+		t.Fatalf("error code = %q, want %q (from %v)", code, ErrHelmChartIndexCode, err)
+	}
+
+	// And the cache is still usable: no slot left occupied, so this neither
+	// blocks nor is served from a cached failure.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		versions, err := cache.list("repo", "meshery-operator")
+		if err != nil {
+			t.Errorf("the cache is wedged after a panicking fetch: %v", err)
+			return
+		}
+		if len(versions) != 1 || versions[0] != "v1.0.64" {
+			t.Errorf("versions = %v, want the successfully fetched catalogue", versions)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a lookup after a panicking fetch blocked forever: the in-flight slot was never released")
+	}
+}
+
 // TestChartIndexCacheReturnsACopyOfTheCatalogue: the cached catalogue is shared
 // across goroutines for a full TTL. Handing out its own slice lets any caller
 // that sorts or appends corrupt it for everyone else, with no lock held.

--- a/server/helpers/utils/helm_chart_repo_test.go
+++ b/server/helpers/utils/helm_chart_repo_test.go
@@ -102,13 +102,18 @@ func TestFetchChartIndexVersionsReportsStructuredFailures(t *testing.T) {
 // wire on the hot path: it is fetched on every cluster connection, and the
 // Meshery index is several megabytes.
 func TestChartIndexCacheServesFromCacheUntilTheTTLExpires(t *testing.T) {
+	var mu sync.Mutex
 	now := time.Unix(0, 0)
-	fetches := 0
+	var fetches atomic.Int32
 	cache := &chartIndexCache{
 		entries: map[string]chartIndexCacheEntry{},
-		now:     func() time.Time { return now },
+		now: func() time.Time {
+			mu.Lock()
+			defer mu.Unlock()
+			return now
+		},
 		fetch: func(string) (map[string][]string, error) {
-			fetches++
+			fetches.Add(1)
 			return map[string][]string{"meshery-operator": {"v1.0.64"}}, nil
 		},
 	}
@@ -118,16 +123,151 @@ func TestChartIndexCacheServesFromCacheUntilTheTTLExpires(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	}
-	if fetches != 1 {
-		t.Fatalf("fetched %d times within the TTL, want 1", fetches)
+	if got := fetches.Load(); got != 1 {
+		t.Fatalf("fetched %d times within the TTL, want 1", got)
 	}
 
+	mu.Lock()
 	now = now.Add(chartIndexTTL + time.Second)
+	mu.Unlock()
 	if _, err := cache.list("repo", "meshery-operator"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fetches != 2 {
-		t.Fatalf("fetched %d times after the TTL expired, want 2", fetches)
+	waitFor(t, "the expired entry to be refreshed", func() bool { return fetches.Load() == 2 })
+}
+
+// TestChartIndexCacheServesStaleWhileRefreshing is the reason expiry is not a
+// miss. This index is read inside the cluster-connect request handler; blocking
+// that request on a multi-megabyte fetch bounded only by chartIndexTimeout
+// turned a slow or unreachable repository into a 30-second connect (and every
+// concurrent connect joined the same wait) every time the TTL happened to
+// lapse. Published charts are append-mostly, so a stale catalogue costs at most
+// not knowing about the newest chart, which the resolver already handles.
+func TestChartIndexCacheServesStaleWhileRefreshing(t *testing.T) {
+	var mu sync.Mutex
+	now := time.Unix(0, 0)
+	release := make(chan struct{})
+	var fetches atomic.Int32
+
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now: func() time.Time {
+			mu.Lock()
+			defer mu.Unlock()
+			return now
+		},
+		fetch: func(string) (map[string][]string, error) {
+			if fetches.Add(1) > 1 {
+				<-release
+				return map[string][]string{"meshery-operator": {"v1.0.65", "v1.0.64"}}, nil
+			}
+			return map[string][]string{"meshery-operator": {"v1.0.64"}}, nil
+		},
+	}
+
+	// Warm the cache, then expire it. The refresh that the next call kicks off
+	// is blocked for the rest of the test.
+	if _, err := cache.list("repo", "meshery-operator"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mu.Lock()
+	now = now.Add(chartIndexTTL + time.Second)
+	mu.Unlock()
+
+	served := make(chan []string, 1)
+	go func() {
+		versions, err := cache.list("repo", "meshery-operator")
+		if err != nil {
+			t.Errorf("serving a stale catalogue must not fail: %v", err)
+		}
+		served <- versions
+	}()
+
+	select {
+	case versions := <-served:
+		if len(versions) != 1 || versions[0] != "v1.0.64" {
+			t.Fatalf("versions = %v, want the stale catalogue served while the refresh runs", versions)
+		}
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("an expired entry blocked the caller on a refetch instead of being served stale")
+	}
+
+	// The refresh really was started, and its result replaces the stale entry.
+	waitFor(t, "the background refresh to start", func() bool { return fetches.Load() == 2 })
+	close(release)
+	waitFor(t, "the refreshed catalogue to be installed", func() bool {
+		versions, err := cache.list("repo", "meshery-operator")
+		return err == nil && len(versions) == 2
+	})
+}
+
+// TestChartIndexCacheBlocksOnlyOnAColdCache: with no catalogue to serve there
+// is nothing to be stale about, so a first caller does wait - and gets the
+// failure rather than an empty slice that would read as "no chart published".
+func TestChartIndexCacheBlocksOnlyOnAColdCache(t *testing.T) {
+	outage := errors.New("repository unreachable")
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now:     time.Now,
+		fetch:   func(string) (map[string][]string, error) { return nil, outage },
+	}
+
+	versions, err := cache.list("repo", "meshery-operator")
+	if !errors.Is(err, outage) {
+		t.Fatalf("err = %v, want the fetch failure reported to the first caller", err)
+	}
+	if versions != nil {
+		t.Fatalf("versions = %v, want none: an unreadable index is not an empty catalogue", versions)
+	}
+}
+
+// TestChartIndexCacheServesStaleThroughAnOutage: failures are not cached, so a
+// refresh that keeps failing must neither poison the stale entry nor start
+// blocking callers again.
+func TestChartIndexCacheServesStaleThroughAnOutage(t *testing.T) {
+	var mu sync.Mutex
+	now := time.Unix(0, 0)
+	var fetches atomic.Int32
+
+	cache := &chartIndexCache{
+		entries: map[string]chartIndexCacheEntry{},
+		now: func() time.Time {
+			mu.Lock()
+			defer mu.Unlock()
+			return now
+		},
+		fetch: func(string) (map[string][]string, error) {
+			if fetches.Add(1) > 1 {
+				return nil, errors.New("repository unreachable")
+			}
+			return map[string][]string{"meshery-operator": {"v1.0.64"}}, nil
+		},
+	}
+
+	if _, err := cache.list("repo", "meshery-operator"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mu.Lock()
+	now = now.Add(chartIndexTTL + time.Second)
+	mu.Unlock()
+
+	for range 3 {
+		versions, err := cache.list("repo", "meshery-operator")
+		if err != nil {
+			t.Fatalf("a failing refresh must not fail the caller that could be served stale: %v", err)
+		}
+		if len(versions) != 1 || versions[0] != "v1.0.64" {
+			t.Fatalf("versions = %v, want the stale catalogue", versions)
+		}
+		waitFor(t, "the failing refresh to finish", func() bool {
+			cache.mu.Lock()
+			defer cache.mu.Unlock()
+			return len(cache.inflight) == 0
+		})
+	}
+	if got := fetches.Load(); got < 2 {
+		t.Fatalf("fetched %d times, want the refresh retried rather than a failure cached", got)
 	}
 }
 

--- a/server/internal/graphql/model/helpers.go
+++ b/server/internal/graphql/model/helpers.go
@@ -6,19 +6,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshkit/broker"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/controllers"
-	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-)
-
-// to be moved elsewhere
-const (
-	chartRepo = "https://meshery.github.io/meshery.io/charts"
 )
 
 var (
@@ -50,55 +41,6 @@ var (
 		MeshTypeCiliumServiceMesh: {"cilium"},
 	}
 )
-
-// installs operator
-// To be depricated
-func installUsingHelm(client *mesherykube.Client, delete bool, _ models.AdaptersTrackerInterface) error {
-	// retrieving meshery's version to apply the appropriate chart
-	mesheryReleaseVersion := viper.GetString("BUILD")
-	if mesheryReleaseVersion == "" || mesheryReleaseVersion == "Not Set" || mesheryReleaseVersion == "edge-latest" {
-		_, latestRelease, err := handlers.CheckLatestVersion(mesheryReleaseVersion)
-		// if unable to fetch latest release tag, meshkit helm functions handle
-		// this automatically fetch the latest one
-		if err != nil {
-			logrus.Errorf("Couldn't check release tag: %s. Will use latest version", err)
-			mesheryReleaseVersion = ""
-		} else {
-			mesheryReleaseVersion = latestRelease
-		}
-	}
-	var (
-		act   = mesherykube.INSTALL
-		chart = "meshery-operator"
-	)
-	if delete {
-		act = mesherykube.UNINSTALL
-	}
-	// a basic check to see if meshery is installed in cluster
-	// this helps decide what chart should be used for installing operator
-	if viper.GetString("KUBERNETES_SERVICE_HOST") != "" {
-		// act = mesherykube.UPGRADE
-		chart = "meshery"
-	}
-
-	err := client.ApplyHelmChart(mesherykube.ApplyHelmChartConfig{
-		Namespace:   "meshery",
-		ReleaseName: "meshery-operator",
-		ChartLocation: mesherykube.HelmChartLocation{
-			Repository: chartRepo,
-			Chart:      chart,
-			Version:    mesheryReleaseVersion,
-		},
-		// CreateNamespace doesn't have any effect when the action is UNINSTALL
-		CreateNamespace: true,
-		Action:          act,
-	})
-	if err != nil {
-		return ErrApplyHelmChart(err)
-	}
-
-	return nil
-}
 
 // SetOverrideValues detects the currently insalled adapters and sets appropriate
 // overrides so as to not uninstall them. It also sets override values for

--- a/server/internal/graphql/model/operator_helper.go
+++ b/server/internal/graphql/model/operator_helper.go
@@ -38,16 +38,6 @@ type connection struct {
 	Name string `json:"name"`
 }
 
-func Initialize(client *mesherykube.Client, delete bool, adapterTracker models.AdaptersTrackerInterface) error {
-	// installOperator
-	err := installUsingHelm(client, delete, adapterTracker)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func GetOperator(kubeclient *mesherykube.Client) (string, string, error) {
 	if kubeclient == nil || kubeclient.KubeClient == nil {
 		return "", "", ErrMesheryClientNil

--- a/server/internal/graphql/resolver/error.go
+++ b/server/internal/graphql/resolver/error.go
@@ -31,6 +31,7 @@ const (
 	ErrAdapterInsufficientInformationCode   = "meshery-server-1210"
 	ErrGormDatabaseCode                     = "meshery-server-1213"
 	ErrResyncClusterCode                    = "meshery-server-1369"
+	ErrOperatorControllersHelperCode        = "meshery-server-1474"
 
 	// Retired with the removal of every GraphQL subscription (subscribeConfiguration,
 	// subscribeClusterResources, subscribeMeshModelSummary, subscribePerfProfiles,
@@ -138,4 +139,11 @@ func ErrAdapterInsufficientInformation(err error) error {
 
 func ErrResyncCluster(err error) error {
 	return errors.New(ErrResyncClusterCode, errors.Alert, []string{"Unable to process resync cluster request"}, []string{err.Error()}, []string{}, []string{})
+}
+
+// ErrOperatorControllersHelper reports that the controllers helper that owns
+// Meshery Operator lifecycle for a Kubernetes connection could not be reached,
+// so an operator install or removal cannot be performed through it.
+func ErrOperatorControllersHelper(cause string) error {
+	return errors.New(ErrOperatorControllersHelperCode, errors.Alert, []string{"Unable to reach Meshery Operator lifecycle for this Kubernetes connection"}, []string{cause}, []string{"The connection is not connected yet, or its state machine has not finished initializing."}, []string{"Wait for the Kubernetes connection to reach the connected state, then retry.", "If it stays disconnected, check the connection's diagnostics for why its Kubernetes client could not be created."})
 }

--- a/server/internal/graphql/resolver/operator.go
+++ b/server/internal/graphql/resolver/operator.go
@@ -158,8 +158,10 @@ func (r *Resolver) changeOperatorStatus(ctx context.Context, provider models.Pro
 
 		// SetOperatorDeployment carries the same guard the connect-time path
 		// uses, so an unresolvable chart version is refused identically here
-		// rather than being handed to Helm as an opaque chart-not-found.
-		err := ctrlHelper.SetOperatorDeployment(k8scontext.ID, !del)
+		// rather than being handed to Helm as an opaque chart-not-found. It also
+		// re-resolves that version first, so clicking deploy again after the
+		// chart repository recovers is a retry that can actually succeed.
+		err := ctrlHelper.SetOperatorDeployment(k8scontext, !del)
 		if err != nil {
 			r.Log.Error(err)
 			r.Broadcast.Submit(broadcast.BroadcastMessage{

--- a/server/internal/graphql/resolver/operator.go
+++ b/server/internal/graphql/resolver/operator.go
@@ -3,9 +3,13 @@ package resolver
 import (
 	"context"
 
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/internal/graphql/model"
+	mhelpers "github.com/meshery/meshery/server/machines/helpers"
+	"github.com/meshery/meshery/server/machines/kubernetes"
 	"github.com/meshery/meshery/server/models"
-	"github.com/meshery/meshkit/models/controllers"
+	"github.com/meshery/meshkit/utils"
 	"github.com/meshery/meshkit/utils/broadcast"
 	mesherykube "github.com/meshery/meshkit/utils/kubernetes"
 )
@@ -24,6 +28,43 @@ import (
 type operatorStatusK8sContext struct {
 	ctxID      string
 	processing interface{}
+}
+
+// operatorControllersHelper resolves the controllers helper that owns Meshery
+// Operator lifecycle for a Kubernetes context, by way of that connection's
+// state machine - the same route the resync and controller-status paths take.
+//
+// Operator install and removal go through the helper rather than a meshkit
+// handler read straight out of the request context, because the helper is what
+// holds the resolved Helm chart version and refuses an install when no
+// published version could be pinned. Reaching around it is how an unresolvable
+// version would reach Helm from this entry point while every other one refused.
+func operatorControllersHelper(ctx context.Context, k8scontext models.K8sContext) (*models.MesheryControllersHelper, error) {
+	connectionDetail := "Kubernetes context " + k8scontext.ID + " (connection " + k8scontext.ConnectionID + ")"
+
+	h, ok := ctx.Value(models.HandlerKey).(*handlers.Handler)
+	if !ok || h == nil {
+		return nil, ErrOperatorControllersHelper("No Meshery handler is present in the request context.")
+	}
+	tracker := h.ConnectionToStateMachineInstanceTracker
+	if tracker == nil {
+		return nil, ErrOperatorControllersHelper("No connection state machine tracker is available on the Meshery handler.")
+	}
+	if k8scontext.ConnectionID == "" {
+		return nil, ErrOperatorControllersHelper("Kubernetes context " + k8scontext.ID + " carries no connection id.")
+	}
+	inst, ok := tracker.Get(uuid.FromStringOrNil(k8scontext.ConnectionID))
+	if !ok || inst == nil || !mhelpers.HasMachineContext(inst) {
+		return nil, ErrOperatorControllersHelper(connectionDetail + " has no ready state machine.")
+	}
+	machinectx, castErr := utils.Cast[*kubernetes.MachineCtx](inst.Context)
+	if castErr != nil {
+		return nil, ErrOperatorControllersHelper(castErr.Error())
+	}
+	if machinectx.MesheryCtrlsHelper == nil {
+		return nil, ErrOperatorControllersHelper(connectionDetail + " has no controllers helper attached.")
+	}
+	return machinectx.MesheryCtrlsHelper, nil
 }
 
 func (r *Resolver) changeOperatorStatus(ctx context.Context, provider models.Provider, status model.Status, ctxID string) (model.Status, error) {
@@ -92,19 +133,33 @@ func (r *Resolver) changeOperatorStatus(ctx context.Context, provider models.Pro
 		return model.StatusUnknown, ErrNilClient
 	}
 
+	// Resolve the lifecycle owner before reporting the request as accepted, so a
+	// connection that cannot be acted on fails the mutation outright instead of
+	// reporting "processing" and then going quiet.
+	ctrlHelper, err := operatorControllersHelper(ctx, k8scontext)
+	if err != nil {
+		r.Log.Error(err)
+		r.Broadcast.Submit(broadcast.BroadcastMessage{
+			Source: broadcast.OperatorSyncChannel,
+			Data: operatorStatusK8sContext{
+				processing: err,
+				ctxID:      ctxID,
+			},
+			Type: "error",
+		})
+		return model.StatusUnknown, err
+	}
+
 	go func(del bool, kubeclient *mesherykube.Client) {
 		if r.Config.OperatorTracker.DisableOperator { //Do not deploy operator is explicitly in disabled mode
 			r.Log.Info("skipping operator deployment (in disabled mode)")
 			return
 		}
-		op, _ := ctx.Value(models.MesheryControllerHandlersKey).(map[string]map[models.MesheryController]controllers.IMesheryController)
 
-		var err error
-		if del {
-			err = op[ctxID][models.MesheryOperator].Undeploy()
-		} else {
-			err = op[ctxID][models.MesheryOperator].Deploy(true)
-		}
+		// SetOperatorDeployment carries the same guard the connect-time path
+		// uses, so an unresolvable chart version is refused identically here
+		// rather than being handed to Helm as an opaque chart-not-found.
+		err := ctrlHelper.SetOperatorDeployment(k8scontext.ID, !del)
 		if err != nil {
 			r.Log.Error(err)
 			r.Broadcast.Submit(broadcast.BroadcastMessage{

--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -102,7 +102,7 @@ func (ca *ConnectAction) Execute(ctx context.Context, machineCtx interface{}, da
 			SetMeshsyncDeploymentMode(meshsyncDeploymentMode).
 			AddCtxControllerHandlers(machinectx.K8sContext).
 			UpdateOperatorsStatusMap(machinectx.OperatorTracker).
-			DeployUndeployedOperators(machinectx.OperatorTracker)
+			DeployUndeployedOperators(machinectx.OperatorTracker, machinectx.K8sContext.ID)
 		ctrlHelper.AddMeshsyncDataHandlers(ctx, machinectx.K8sContext, userUUID, *sysID, provider)
 
 		// Operator mode: best-effort apply of the explicitly-set

--- a/server/machines/kubernetes/delete.go
+++ b/server/machines/kubernetes/delete.go
@@ -52,7 +52,7 @@ func (da *DeleteAction) Execute(ctx context.Context, machineCtx interface{}, dat
 	go func() {
 
 		machinectx.MesheryCtrlsHelper.UpdateOperatorsStatusMap(machinectx.OperatorTracker).
-			UndeployDeployedOperators(machinectx.OperatorTracker).
+			UndeployDeployedOperators(machinectx.OperatorTracker, contextID).
 			RemoveCtxControllerHandler(ctx, contextID)
 
 		machinectx.MesheryCtrlsHelper.RemoveMeshSyncDataHandler(ctx, contextID)

--- a/server/machines/kubernetes/disconnect.go
+++ b/server/machines/kubernetes/disconnect.go
@@ -33,7 +33,7 @@ func (da *DisconnectAction) Execute(ctx context.Context, machineCtx interface{},
 	go func() {
 		machinectx.MesheryCtrlsHelper.
 			UpdateOperatorsStatusMap(machinectx.OperatorTracker).
-			UndeployDeployedOperators(machinectx.OperatorTracker).
+			UndeployDeployedOperators(machinectx.OperatorTracker, contextID).
 			RemoveCtxControllerHandler(ctx, contextID)
 		machinectx.MesheryCtrlsHelper.RemoveMeshSyncDataHandler(ctx, contextID)
 

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -810,7 +810,10 @@ func ErrNoOperatorChartPublished(chart, repo string) error {
 // deployed from one cannot be reproduced or reasoned about; Meshery deploys
 // only versions it can name.
 func ErrOperatorChartNotPinned(requested, newest string) error {
-	return errors.New(ErrOperatorChartNotPinnedCode, errors.Alert, []string{"Meshery Operator chart version is not a released version"}, []string{"operator.version is set to " + requested + ", which is not a released chart version."}, []string{"A moving tag (for example stable-latest or edge-latest) or a non-version string was configured as the operator chart version."}, []string{"Set operator.version to a released chart version such as " + newest + ", or clear it to track this Meshery Server release."})
+	// Probable cause and remediation are static literals so errorutil can export
+	// them into the published error reference; the version-specific detail lives
+	// in the cause, which is runtime-only.
+	return errors.New(ErrOperatorChartNotPinnedCode, errors.Alert, []string{"Meshery Operator chart version is not a released version"}, []string{"operator.version is set to " + requested + ", which is not a released chart version. The newest released chart version is " + newest + "."}, []string{"A moving tag (for example stable-latest or edge-latest) or a non-version string was configured as the operator chart version."}, []string{"Set operator.version to a released chart version, or clear it to track this Meshery Server release. This error's cause names the newest released version."})
 }
 
 // ErrOperatorChartNotPublished reports that an explicitly configured
@@ -818,7 +821,9 @@ func ErrOperatorChartNotPinned(requested, newest string) error {
 // This is never substituted silently: deploying a different version than the
 // one asked for would hide the mistake.
 func ErrOperatorChartNotPublished(requested, newest string) error {
-	return errors.New(ErrOperatorChartNotPublishedCode, errors.Alert, []string{"Meshery Operator chart version is not published"}, []string{"operator.version is set to " + requested + ", which the Meshery chart repository does not publish. The newest published version is " + newest + "."}, []string{"The configured chart version was mistyped, or it was never published to the Meshery Helm chart repository."}, []string{"Set operator.version to a published chart version such as " + newest + ", or clear it to track this Meshery Server release."})
+	// Static probable cause and remediation, as above: the concrete versions are
+	// carried by the cause so the exported reference is not blank.
+	return errors.New(ErrOperatorChartNotPublishedCode, errors.Alert, []string{"Meshery Operator chart version is not published"}, []string{"operator.version is set to " + requested + ", which the Meshery chart repository does not publish. The newest published version is " + newest + "."}, []string{"The configured chart version was mistyped, or it was never published to the Meshery Helm chart repository."}, []string{"Set operator.version to a published chart version, or clear it to track this Meshery Server release. This error's cause names the newest published version."})
 }
 
 // ErrNoMesheryReleasesFound reports that the GitHub releases listing for

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -162,6 +162,11 @@ const (
 	ErrReconcileOperatorChartVersionCode  = "meshery-server-1466"
 	ErrOperatorHandlerNotAttachedCode     = "meshery-server-1465"
 	ErrAnonymousUserIDMissingCode         = "meshery-server-1467"
+	ErrNoOperatorChartPublishedCode       = "meshery-server-1468"
+	ErrOperatorChartNotPinnedCode         = "meshery-server-1469"
+	ErrOperatorChartNotPublishedCode      = "meshery-server-1470"
+	ErrOperatorChartSubstitutedCode       = "meshery-server-1471"
+	ErrNoMesheryReleasesFoundCode         = "meshery-server-1472"
 )
 
 var (
@@ -788,6 +793,47 @@ func ErrApplyControllersConfig(err error) error {
 // asks for (`operator.version`).
 func ErrReconcileOperatorChartVersion(err error) error {
 	return errors.New(ErrReconcileOperatorChartVersionCode, errors.Alert, []string{"Error deploying Meshery Operator at the configured chart version"}, []string{err.Error()}, []string{"The requested Meshery Operator Helm chart version does not exist in the chart repository, or the cluster rejected the Helm release."}, []string{"Confirm the chart version exists in the Meshery Operator Helm repository, or clear operator.version to track the Meshery Server release.", "Confirm the cluster is reachable and the Meshery namespace is writable."})
+}
+
+// ErrNoOperatorChartPublished reports that the Helm repository was read but
+// advertises no usable version of the Meshery Operator chart, so there is no
+// version that could be deployed.
+func ErrNoOperatorChartPublished(chart, repo string) error {
+	return errors.New(ErrNoOperatorChartPublishedCode, errors.Alert, []string{"No Meshery Operator Helm chart is published"}, []string{"The chart repository " + repo + " advertises no released version of the " + chart + " chart."}, []string{"The chart repository index was served from an unexpected location, or its published charts were removed."}, []string{"Confirm " + repo + "/index.yaml lists the " + chart + " chart, then reconnect the Kubernetes connection."})
+}
+
+// ErrOperatorChartNotPinned reports that an explicitly configured
+// `operator.version` is not a specific chart release. Moving tags such as
+// stable-latest name whatever was published most recently, so a cluster
+// deployed from one cannot be reproduced or reasoned about; Meshery deploys
+// only versions it can name.
+func ErrOperatorChartNotPinned(requested, newest string) error {
+	return errors.New(ErrOperatorChartNotPinnedCode, errors.Alert, []string{"Meshery Operator chart version is not a released version"}, []string{"operator.version is set to " + requested + ", which is not a released chart version."}, []string{"A moving tag (for example stable-latest or edge-latest) or a non-version string was configured as the operator chart version."}, []string{"Set operator.version to a released chart version such as " + newest + ", or clear it to track this Meshery Server release."})
+}
+
+// ErrOperatorChartNotPublished reports that an explicitly configured
+// `operator.version` names a chart version the repository does not publish.
+// This is never substituted silently: deploying a different version than the
+// one asked for would hide the mistake.
+func ErrOperatorChartNotPublished(requested, newest string) error {
+	return errors.New(ErrOperatorChartNotPublishedCode, errors.Alert, []string{"Meshery Operator chart version is not published"}, []string{"operator.version is set to " + requested + ", which the Meshery chart repository does not publish. The newest published version is " + newest + "."}, []string{"The configured chart version was mistyped, or it was never published to the Meshery Helm chart repository."}, []string{"Set operator.version to a published chart version such as " + newest + ", or clear it to track this Meshery Server release."})
+}
+
+// ErrNoMesheryReleasesFound reports that the GitHub releases listing for
+// Meshery was fetched successfully but was empty, so there is no latest version
+// to compare against.
+func ErrNoMesheryReleasesFound() error {
+	return errors.New(ErrNoMesheryReleasesFoundCode, errors.Alert, []string{"No Meshery releases were found"}, []string{"The GitHub releases listing for meshery/meshery returned no tags."}, []string{"GitHub returned an empty or filtered release listing, possibly because the request was rate-limited."}, []string{"Retry later. This only affects the reported latest-version comparison; Meshery continues to run."})
+}
+
+// ErrOperatorChartSubstituted reports that the Meshery Operator chart
+// version derived from this Meshery Server's release was replaced by one the
+// chart repository publishes and that can actually run. It is a warning, not a
+// failure: the operator was deployed. It exists so the substitution is visible
+// in the events feed and the logs rather than being inferred from a version
+// number that does not match the server's.
+func ErrOperatorChartSubstituted(reason string) error {
+	return errors.New(ErrOperatorChartSubstitutedCode, errors.Alert, []string{"Meshery Operator was deployed at a different chart version than this server's release"}, []string{reason}, []string{"The chart version matching this Meshery Server release is either not published yet or is too old to deploy successfully."}, []string{"No action is required. To choose the chart version yourself, set operator.version on the Kubernetes connection."})
 }
 
 // ErrOperatorHandlerNotAttached reports that no Meshery Operator controller

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -796,10 +796,12 @@ func ErrReconcileOperatorChartVersion(err error) error {
 }
 
 // ErrNoOperatorChartPublished reports that the Helm repository was read but
-// advertises no usable version of the Meshery Operator chart, so there is no
-// version that could be deployed.
+// advertises no version of the Meshery Operator chart that Meshery may choose
+// on the user's behalf, so there is no version to deploy. Release candidates do
+// not count: Meshery never selects a prerelease chart by itself, though an
+// explicit operator.version naming one is honored.
 func ErrNoOperatorChartPublished(chart, repo string) error {
-	return errors.New(ErrNoOperatorChartPublishedCode, errors.Alert, []string{"No Meshery Operator Helm chart is published"}, []string{"The chart repository " + repo + " advertises no released version of the " + chart + " chart."}, []string{"The chart repository index was served from an unexpected location, or its published charts were removed."}, []string{"Confirm " + repo + "/index.yaml lists the " + chart + " chart, then reconnect the Kubernetes connection."})
+	return errors.New(ErrNoOperatorChartPublishedCode, errors.Alert, []string{"No Meshery Operator Helm chart is published"}, []string{"The chart repository " + repo + " advertises no released (non-prerelease) version of the " + chart + " chart."}, []string{"The chart repository index was served from an unexpected location, its published charts were removed, or it currently carries only prerelease charts, which Meshery never selects on its own."}, []string{"Confirm " + repo + "/index.yaml lists a released version of the " + chart + " chart, then reconnect the Kubernetes connection.", "To deploy a prerelease chart deliberately, set operator.version on the Kubernetes connection to that exact version."})
 }
 
 // ErrOperatorChartNotPinned reports that an explicitly configured

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -119,6 +119,16 @@ type MesheryControllersHelper struct {
 	// from the connect goroutine and read from the diagnostics HTTP handler.
 	opErrMu           sync.RWMutex
 	lastOperatorError error
+
+	// operatorChartError records that no publishable Meshery Operator chart
+	// version could be resolved for this context. It is narrower than
+	// lastOperatorError, which also carries deploy and client failures: this one
+	// answers exactly "may Meshery install the operator right now?", and it is
+	// what the install call sites refuse on. Observation is unaffected — meshkit's
+	// operator handler reads the deployment config only in Deploy and Undeploy,
+	// never in GetStatus or GetVersion — so the handler stays attached and keeps
+	// reporting a healthy operator's status and image tag. Guarded by opErrMu.
+	operatorChartError error
 }
 
 // setOperatorError records (or clears, when err is nil) the latest operator
@@ -135,6 +145,22 @@ func (mch *MesheryControllersHelper) GetOperatorError() error {
 	mch.opErrMu.RLock()
 	defer mch.opErrMu.RUnlock()
 	return mch.lastOperatorError
+}
+
+// setOperatorChartError records (or clears, when err is nil) the failure to
+// resolve a publishable operator chart version. See operatorChartError.
+func (mch *MesheryControllersHelper) setOperatorChartError(err error) {
+	mch.opErrMu.Lock()
+	mch.operatorChartError = err
+	mch.opErrMu.Unlock()
+}
+
+// GetOperatorChartError returns why Meshery may not install the Meshery
+// Operator on this context, or nil when a chart version was resolved.
+func (mch *MesheryControllersHelper) GetOperatorChartError() error {
+	mch.opErrMu.RLock()
+	defer mch.opErrMu.RUnlock()
+	return mch.operatorChartError
 }
 
 func (mch *MesheryControllersHelper) GetControllerHandlersForEachContext() map[MesheryController]controllers.IMesheryController {
@@ -682,6 +708,7 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 	// below (and in DeployUndeployedOperators) if this attempt fails, so the
 	// diagnostics API always reflects the latest operator setup outcome.
 	mch.setOperatorError(nil)
+	mch.setOperatorChartError(nil)
 
 	cfg, err := ctx.GenerateKubeConfig()
 	if err != nil {
@@ -722,13 +749,16 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 	// chart-not-found error rather than as this connection's operator error.
 	depConfig, substitution, err := mch.pinnedOperatorDeploymentConfig()
 	if err != nil {
-		// No version is safe to install, so no operator handler is attached and
-		// operator lifecycle is withheld for this connection. Broker and MeshSync
-		// handlers still attach: an operator installed by other means keeps
-		// reporting status and feeding the MeshSync pipeline, so a chart
-		// repository that is briefly unreachable does not also take out
-		// discovery. The recorded error surfaces as the connection's
-		// operator_deploy_failed diagnostic.
+		// A chart version is what it takes to *install* the operator, not to
+		// *observe* one: meshkit's handler consults the deployment config in
+		// Deploy and Undeploy only, so GetStatus and GetVersion work without it.
+		// The handler is therefore attached with the unresolved config and
+		// installation alone is withheld, recorded on operatorChartError for the
+		// install call sites to refuse on. Withholding the handler instead cost
+		// the operator card its status and image tag - the very value the
+		// troubleshooting guide tells users to read - on a cluster whose operator
+		// was installed and healthy all along.
+		mch.setOperatorChartError(err)
 		mch.setOperatorError(err)
 		mch.log.Error(err)
 		mch.emitErrorEvent("Failed to resolve the Meshery Operator chart version", err, map[string]any{
@@ -737,9 +767,11 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 			"connectionID":                  ctx.ConnectionID,
 			"requestedOperatorChartVersion": mch.operatorDeploymentConfig().MesheryReleaseVersion,
 		}, uuid.Nil)
+		ctxHandlers[MesheryOperator] = controllers.NewMesheryOperatorHandler(client, mch.operatorDeploymentConfig())
 		mch.ctxControllerHandlers = ctxHandlers
-		// Nothing is attached to compare against, so the next reconcile must not
-		// mistake a stale value for "already at the desired version".
+		// The attached handler carries no installable version, so the next
+		// reconcile must not mistake a stale value for "already at the desired
+		// version".
 		mch.attachedOperatorChartVersion = ""
 		return mch
 	}
@@ -876,16 +908,16 @@ func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sCon
 	// every failure path so a transient Helm error is retried rather than
 	// silently becoming the resting state.
 	//
-	// Restoring is conditional on a handler actually being attached: when
-	// AddCtxControllerHandlers attaches none it has already cleared the
-	// attached version *for the same reason*, and putting the stale one back
+	// Restoring is conditional on AddCtxControllerHandlers having left an
+	// attached version behind: when it could not resolve an installable one it
+	// cleared the value *for the same reason*, and putting the stale one back
 	// would withhold operator lifecycle until the connection is rebuilt.
 	previousChartVersion := mch.attachedOperatorChartVersion
 	mch.AddCtxControllerHandlers(k8sctx)
 	operatorHandler, attached := mch.ctxControllerHandlers[MesheryOperator]
 	attached = attached && operatorHandler != nil
 	if setupErr := mch.GetOperatorError(); setupErr != nil {
-		if attached {
+		if mch.attachedOperatorChartVersion != "" {
 			mch.attachedOperatorChartVersion = previousChartVersion
 		}
 		return desired, false, ErrReconcileOperatorChartVersion(setupErr)
@@ -968,6 +1000,33 @@ func (ot *OperatorTracker) IsUndeployed(ctxID string) bool {
 	return ot.ctxIDtoDeploymentStatus[ctxID]
 }
 
+// attachedOperatorHandler returns the Meshery Operator controller handler for
+// this context, or nil when none is attached.
+//
+// A nil handler is never a no-op the caller may pass over in silence: it means
+// AddCtxControllerHandlers could not read the kubeconfig or build a Kubernetes
+// client, so nothing was done to the cluster. Callers report it via
+// reportMissingOperatorHandler rather than returning as though they had acted.
+func (mch *MesheryControllersHelper) attachedOperatorHandler() controllers.IMesheryController {
+	if mch.ctxControllerHandlers == nil {
+		return nil
+	}
+	return mch.ctxControllerHandlers[MesheryOperator]
+}
+
+// reportMissingOperatorHandler records and surfaces the absence of an operator
+// handler for an action that needed one, so a lifecycle request that did
+// nothing does not read to the user as one that succeeded.
+func (mch *MesheryControllersHelper) reportMissingOperatorHandler(action string) {
+	err := ErrOperatorHandlerNotAttached(mch.contextID)
+	mch.setOperatorError(err)
+	mch.log.Error(err)
+	mch.emitErrorEvent(action, err, map[string]any{
+		"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
+		"operatorStatus":         mch.ctxOperatorStatus,
+	}, uuid.Nil)
+}
+
 // looks at the status of Meshery Operator for each cluster and takes necessary action.
 // it will deploy the operator only when it is in NotDeployed state
 func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTracker) *MesheryControllersHelper {
@@ -977,55 +1036,64 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 	if mch.meshsyncDeploymentMode != connections.MeshsyncDeploymentModeOperator {
 		return mch
 	}
-	// go func(mch *MesheryControllersHelper) {
-
-	if mch.ctxOperatorStatus == controllers.NotDeployed {
-		if mch.ctxControllerHandlers != nil {
-			operatorHandler, ok := mch.ctxControllerHandlers[MesheryOperator]
-			if ok {
-				err := operatorHandler.Deploy(false)
-
-				if err != nil {
-					mch.setOperatorError(err)
-					mch.log.Error(err)
-					mch.emitErrorEvent("Failed to deploy Meshery Operator", err, map[string]any{
-						"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
-						"operatorStatus":         mch.ctxOperatorStatus,
-					}, uuid.Nil)
-				}
-			}
-		}
+	if mch.ctxOperatorStatus != controllers.NotDeployed {
+		return mch
 	}
 
-	// }(mch)
+	operatorHandler := mch.attachedOperatorHandler()
+	if operatorHandler == nil {
+		mch.reportMissingOperatorHandler("Failed to deploy Meshery Operator")
+		return mch
+	}
+
+	// Installing is the one operator action that needs a chart version, and the
+	// handler is attached for observation even when none could be resolved.
+	// Refuse here with the structured resolution failure rather than handing
+	// Helm a version the repository does not publish, which would surface as an
+	// opaque chart-not-found error instead. AddCtxControllerHandlers already
+	// emitted this, so it is recorded and logged rather than emitted again.
+	if chartErr := mch.GetOperatorChartError(); chartErr != nil {
+		mch.setOperatorError(chartErr)
+		mch.log.Error(chartErr)
+		return mch
+	}
+
+	if err := operatorHandler.Deploy(false); err != nil {
+		mch.setOperatorError(err)
+		mch.log.Error(err)
+		mch.emitErrorEvent("Failed to deploy Meshery Operator", err, map[string]any{
+			"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
+			"operatorStatus":         mch.ctxOperatorStatus,
+		}, uuid.Nil)
+	}
 
 	return mch
 }
 
 func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTracker) *MesheryControllersHelper {
-	// go func(mch *MesheryControllersHelper) {
-
-	oprStatus := mch.ctxOperatorStatus
-
-	if oprStatus != controllers.Undeployed {
-
-		if mch.ctxControllerHandlers != nil {
-			operatorHandler, ok := mch.ctxControllerHandlers[MesheryOperator]
-			if ok {
-				err := operatorHandler.Undeploy()
-
-				if err != nil {
-					mch.log.Error(err)
-					mch.emitErrorEvent("Failed to undeploy Meshery Operator", err, map[string]any{
-						"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
-						"operatorStatus":         mch.ctxOperatorStatus,
-					}, uuid.Nil)
-				}
-			}
-		}
+	if mch.ctxOperatorStatus == controllers.Undeployed {
+		return mch
 	}
 
-	// }(mch)
+	// Unlike deploy, this is not gated on GetOperatorChartError. Removal is the
+	// direction that must always be attempted: refusing it would leave the
+	// operator running on a cluster the user asked to have it taken off, which
+	// is a worse outcome than a Helm uninstall that fails and says so.
+	operatorHandler := mch.attachedOperatorHandler()
+	if operatorHandler == nil {
+		mch.reportMissingOperatorHandler("Failed to undeploy Meshery Operator")
+		return mch
+	}
+
+	if err := operatorHandler.Undeploy(); err != nil {
+		mch.setOperatorError(err)
+		mch.log.Error(err)
+		mch.emitErrorEvent("Failed to undeploy Meshery Operator", err, map[string]any{
+			"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
+			"operatorStatus":         mch.ctxOperatorStatus,
+		}, uuid.Nil)
+	}
+
 	return mch
 }
 

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -58,7 +58,17 @@ const (
 var MesheryControllers = []MesheryController{MesheryBroker, Meshsync, MesheryOperator}
 
 type MesheryControllersHelper struct {
-	// context that is being manged by a particular controllerHelper instance
+	// contextID is the Kubernetes context this helper serves.
+	//
+	// KNOWN BUG - nothing ever assigns it, so it is permanently "". The one
+	// reader is UpdateOperatorsStatusMap, whose ot.IsUndeployed(mch.contextID)
+	// therefore always probes the empty-string key and never matches a real
+	// context: an operator explicitly undeployed for a context is not reported
+	// as Undeployed there, and its live status is read from the handler instead.
+	// Assigning it would silently change that operator-undeploy behavior, so it
+	// is deliberately left alone here and tracked as a follow-up. Code that
+	// needs a context identifier takes one from its caller (the K8sContext is
+	// available at every call site) rather than reading this field.
 	contextID string
 	//  controller handlers for a particular context
 	// this will be used as the source of truth
@@ -136,6 +146,23 @@ type MesheryControllersHelper struct {
 func (mch *MesheryControllersHelper) setOperatorError(err error) {
 	mch.opErrMu.Lock()
 	mch.lastOperatorError = err
+	mch.opErrMu.Unlock()
+}
+
+// setOperatorErrorIfUnset records err only when no operator failure is already
+// recorded for this context.
+//
+// It exists for the one diagnostic that is strictly less informative than
+// anything it could replace: "no operator handler is attached" is the
+// *consequence* of an unreadable kubeconfig or a failed Kubernetes client, both
+// of which AddCtxControllerHandlers has already recorded by name. Letting the
+// consequence overwrite the cause meant tearing down such a connection replaced
+// the actionable diagnostic with a generic one.
+func (mch *MesheryControllersHelper) setOperatorErrorIfUnset(err error) {
+	mch.opErrMu.Lock()
+	if mch.lastOperatorError == nil {
+		mch.lastOperatorError = err
+	}
 	mch.opErrMu.Unlock()
 }
 
@@ -1003,10 +1030,9 @@ func (ot *OperatorTracker) IsUndeployed(ctxID string) bool {
 // attachedOperatorHandler returns the Meshery Operator controller handler for
 // this context, or nil when none is attached.
 //
-// A nil handler is never a no-op the caller may pass over in silence: it means
+// A nil handler is never a no-op a caller may pass over in silence: it means
 // AddCtxControllerHandlers could not read the kubeconfig or build a Kubernetes
-// client, so nothing was done to the cluster. Callers report it via
-// reportMissingOperatorHandler rather than returning as though they had acted.
+// client, so nothing was done to the cluster.
 func (mch *MesheryControllersHelper) attachedOperatorHandler() controllers.IMesheryController {
 	if mch.ctxControllerHandlers == nil {
 		return nil
@@ -1014,22 +1040,96 @@ func (mch *MesheryControllersHelper) attachedOperatorHandler() controllers.IMesh
 	return mch.ctxControllerHandlers[MesheryOperator]
 }
 
+// operatorInstallTarget returns the handler to install the Meshery Operator
+// through, or a structured error naming why installation may not proceed.
+// attached reports whether a handler was present at all, which is the one
+// condition callers report differently (see setOperatorErrorIfUnset).
+//
+// This is the single guard every install path goes through - the FSM's
+// DeployUndeployedOperators and the user-initiated SetOperatorDeployment - so
+// the two cannot drift into one refusing an unpublishable chart version while
+// the other hands it to Helm.
+//
+// Installing is the one operator action that needs a chart version. The handler
+// is attached for observation even when none could be resolved, so refusing
+// here keeps the structured resolution failure in front of the user instead of
+// the opaque chart-not-found error Helm would raise from an unpublished version.
+func (mch *MesheryControllersHelper) operatorInstallTarget(contextID string) (handler controllers.IMesheryController, attached bool, err error) {
+	operatorHandler := mch.attachedOperatorHandler()
+	if operatorHandler == nil {
+		return nil, false, ErrOperatorHandlerNotAttached(contextID)
+	}
+	if chartErr := mch.GetOperatorChartError(); chartErr != nil {
+		return nil, true, chartErr
+	}
+	return operatorHandler, true, nil
+}
+
 // reportMissingOperatorHandler records and surfaces the absence of an operator
 // handler for an action that needed one, so a lifecycle request that did
 // nothing does not read to the user as one that succeeded.
-func (mch *MesheryControllersHelper) reportMissingOperatorHandler(action string) {
-	err := ErrOperatorHandlerNotAttached(mch.contextID)
-	mch.setOperatorError(err)
+func (mch *MesheryControllersHelper) reportMissingOperatorHandler(action, contextID string) {
+	err := ErrOperatorHandlerNotAttached(contextID)
+	mch.setOperatorErrorIfUnset(err)
 	mch.log.Error(err)
 	mch.emitErrorEvent(action, err, map[string]any{
+		"k8sContextID":           contextID,
 		"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
 		"operatorStatus":         mch.ctxOperatorStatus,
 	}, uuid.Nil)
 }
 
+// operatorStatusObserved reports whether Meshery has ever actually read this
+// context's operator status, as opposed to still carrying the Unknown that
+// NewMesheryControllersHelper seeds. It distinguishes "we saw an operator and
+// can no longer act on it" from "we never reached this cluster at all".
+func (mch *MesheryControllersHelper) operatorStatusObserved() bool {
+	return mch.ctxOperatorStatus != controllers.Unknown
+}
+
+// SetOperatorDeployment applies a user-initiated Meshery Operator lifecycle
+// request for contextID: deploy=true installs or upgrades it, deploy=false
+// removes it. It is the counterpart to the FSM's DeployUndeployedOperators and
+// UndeployDeployedOperators for callers that must be told the outcome - the
+// GraphQL changeOperatorStatus mutation - and shares their guard rather than
+// restating it.
+//
+// The error is returned rather than emitted: the caller owns how a request it
+// initiated is surfaced. A failure is still recorded for the diagnostics API.
+func (mch *MesheryControllersHelper) SetOperatorDeployment(contextID string, deploy bool) error {
+	if !deploy {
+		operatorHandler := mch.attachedOperatorHandler()
+		if operatorHandler == nil {
+			err := ErrOperatorHandlerNotAttached(contextID)
+			mch.setOperatorErrorIfUnset(err)
+			return err
+		}
+		if err := operatorHandler.Undeploy(); err != nil {
+			mch.setOperatorError(err)
+			return err
+		}
+		return nil
+	}
+
+	operatorHandler, attached, err := mch.operatorInstallTarget(contextID)
+	if err != nil {
+		if attached {
+			mch.setOperatorError(err)
+		} else {
+			mch.setOperatorErrorIfUnset(err)
+		}
+		return err
+	}
+	if err := operatorHandler.Deploy(true); err != nil {
+		mch.setOperatorError(err)
+		return err
+	}
+	return nil
+}
+
 // looks at the status of Meshery Operator for each cluster and takes necessary action.
 // it will deploy the operator only when it is in NotDeployed state
-func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTracker) *MesheryControllersHelper {
+func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTracker, contextID string) *MesheryControllersHelper {
 	if ot.DisableOperator { //Return true everytime so that operators stay in undeployed state across all contexts
 		return mch
 	}
@@ -1040,21 +1140,17 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 		return mch
 	}
 
-	operatorHandler := mch.attachedOperatorHandler()
-	if operatorHandler == nil {
-		mch.reportMissingOperatorHandler("Failed to deploy Meshery Operator")
-		return mch
-	}
-
-	// Installing is the one operator action that needs a chart version, and the
-	// handler is attached for observation even when none could be resolved.
-	// Refuse here with the structured resolution failure rather than handing
-	// Helm a version the repository does not publish, which would surface as an
-	// opaque chart-not-found error instead. AddCtxControllerHandlers already
-	// emitted this, so it is recorded and logged rather than emitted again.
-	if chartErr := mch.GetOperatorChartError(); chartErr != nil {
-		mch.setOperatorError(chartErr)
-		mch.log.Error(chartErr)
+	operatorHandler, attached, err := mch.operatorInstallTarget(contextID)
+	if err != nil {
+		if !attached {
+			mch.reportMissingOperatorHandler("Failed to deploy Meshery Operator", contextID)
+			return mch
+		}
+		// The chart-resolution failure is the same one AddCtxControllerHandlers
+		// already emitted for this connection, so it is recorded and logged
+		// rather than emitted a second time on every reconcile.
+		mch.setOperatorError(err)
+		mch.log.Error(err)
 		return mch
 	}
 
@@ -1062,6 +1158,7 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 		mch.setOperatorError(err)
 		mch.log.Error(err)
 		mch.emitErrorEvent("Failed to deploy Meshery Operator", err, map[string]any{
+			"k8sContextID":           contextID,
 			"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
 			"operatorStatus":         mch.ctxOperatorStatus,
 		}, uuid.Nil)
@@ -1070,18 +1167,32 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 	return mch
 }
 
-func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTracker) *MesheryControllersHelper {
+func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTracker, contextID string) *MesheryControllersHelper {
 	if mch.ctxOperatorStatus == controllers.Undeployed {
 		return mch
 	}
 
 	// Unlike deploy, this is not gated on GetOperatorChartError. Removal is the
-	// direction that must always be attempted: refusing it would leave the
-	// operator running on a cluster the user asked to have it taken off, which
-	// is a worse outcome than a Helm uninstall that fails and says so.
+	// direction to attempt rather than refuse: refusing would leave the operator
+	// running on a cluster the user asked to have it taken off.
+	//
+	// Attempted is all it is, though. meshkit's ApplyHelmChart downloads and
+	// loads the chart archive before dispatching UNINSTALL just as it does for
+	// INSTALL, from the same repository whose index could not be read - so in the
+	// very case that motivates not refusing, Undeploy fails at chart download,
+	// the operator stays on the cluster, and the user gets a Helm error. A
+	// removal path that does not need the archive would have to come from
+	// meshkit; until then this surfaces the failure rather than hiding it.
 	operatorHandler := mch.attachedOperatorHandler()
 	if operatorHandler == nil {
-		mch.reportMissingOperatorHandler("Failed to undeploy Meshery Operator")
+		// A connection whose cluster was never reached has no operator to
+		// remove and never had one, so reporting a failed removal on its
+		// teardown would be a second alert for a non-event - and would bury the
+		// kubeconfig or Kubernetes-client diagnostic that explains it. Report
+		// only when an operator was actually observed here at some point.
+		if mch.operatorStatusObserved() {
+			mch.reportMissingOperatorHandler("Failed to undeploy Meshery Operator", contextID)
+		}
 		return mch
 	}
 
@@ -1089,6 +1200,7 @@ func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTrack
 		mch.setOperatorError(err)
 		mch.log.Error(err)
 		mch.emitErrorEvent("Failed to undeploy Meshery Operator", err, map[string]any{
+			"k8sContextID":           contextID,
 			"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
 			"operatorStatus":         mch.ctxOperatorStatus,
 		}, uuid.Nil)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 
 	"github.com/gofrs/uuid"
+	mesheryutils "github.com/meshery/meshery/server/helpers/utils"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/broker"
 	channelBroker "github.com/meshery/meshkit/broker/channel"
@@ -92,6 +93,11 @@ type MesheryControllersHelper struct {
 	// from before a redeploy is warranted. "" until handlers are attached.
 	attachedOperatorChartVersion string
 
+	// chartVersions lists the versions a Helm repository publishes for a chart.
+	// Injected rather than called directly so tests resolve against a fixed
+	// catalogue instead of the network. Never nil once constructed.
+	chartVersions func(repo, chart string) ([]string, error)
+
 	// event broadcasting dependencies
 	eventBroadcaster *Broadcast
 	provider         Provider
@@ -153,6 +159,7 @@ func NewMesheryControllersHelper(
 		// Resetting this value results in again subscribing to the Broker.
 		ctxMeshsyncDataHandler: nil,
 		dbHandler:              dbHandler,
+		chartVersions:          mesheryutils.PublishedChartVersions,
 		meshsyncDeploymentMode: connections.MeshsyncDeploymentModeOperator,
 		eventBroadcaster:       eventBroadcaster,
 		provider:               provider,
@@ -693,12 +700,53 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 		return mch
 	}
 
-	depConfig := mch.operatorDeploymentConfig()
-	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{
-		MesheryBroker:   controllers.NewMesheryBrokerHandler(client),
-		MesheryOperator: controllers.NewMesheryOperatorHandler(client, depConfig),
-		Meshsync:        controllers.NewMeshsyncHandler(client),
+	// Broker and MeshSync handlers only observe what is already in the cluster,
+	// so they need no chart version and are always attached.
+	ctxHandlers := map[MesheryController]controllers.IMesheryController{
+		MesheryBroker: controllers.NewMesheryBrokerHandler(client),
+		Meshsync:      controllers.NewMeshsyncHandler(client),
 	}
+
+	// The operator handler is different: it captures its chart version at
+	// construction and installs from it. Pin that version first - attaching a
+	// handler carrying a version the repository does not publish only defers the
+	// failure to the Helm install, where it surfaces as an opaque
+	// chart-not-found error rather than as this connection's operator error.
+	depConfig, substitution, err := mch.pinnedOperatorDeploymentConfig()
+	if err != nil {
+		// No version is safe to install, so no operator handler is attached and
+		// operator lifecycle is withheld for this connection. Broker and MeshSync
+		// handlers still attach: an operator installed by other means keeps
+		// reporting status and feeding the MeshSync pipeline, so a chart
+		// repository that is briefly unreachable does not also take out
+		// discovery. The recorded error surfaces as the connection's
+		// operator_deploy_failed diagnostic.
+		mch.setOperatorError(err)
+		mch.log.Error(err)
+		mch.emitErrorEvent("Failed to resolve the Meshery Operator chart version", err, map[string]any{
+			"k8sContextID":                  ctx.ID,
+			"k8sContextName":                ctx.Name,
+			"connectionID":                  ctx.ConnectionID,
+			"requestedOperatorChartVersion": mch.operatorDeploymentConfig().MesheryReleaseVersion,
+		}, uuid.Nil)
+		mch.ctxControllerHandlers = ctxHandlers
+		// Nothing is attached to compare against, so the next reconcile must not
+		// mistake a stale value for "already at the desired version".
+		mch.attachedOperatorChartVersion = ""
+		return mch
+	}
+	if substitution != "" {
+		mch.log.Warn(ErrOperatorChartSubstituted(substitution))
+		mch.emitWarningEvent("Meshery Operator chart version adjusted", ErrOperatorChartSubstituted(substitution), map[string]any{
+			"k8sContextID":         ctx.ID,
+			"k8sContextName":       ctx.Name,
+			"connectionID":         ctx.ConnectionID,
+			"operatorChartVersion": depConfig.MesheryReleaseVersion,
+		}, uuid.Nil)
+	}
+
+	ctxHandlers[MesheryOperator] = controllers.NewMesheryOperatorHandler(client, depConfig)
+	mch.ctxControllerHandlers = ctxHandlers
 	mch.attachedOperatorChartVersion = depConfig.MesheryReleaseVersion
 
 	// }(mch)
@@ -711,18 +759,63 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 // Helm chart version replaced by this connection's resolved `operator.version`
 // when a layer sets one.
 //
+// The chart version this returns is the one that was *asked for*; it is not yet
+// known to exist. pinnedOperatorDeploymentConfig is what turns it into a
+// version the chart repository actually publishes, and every path that reaches
+// a cluster goes through that instead.
+//
 // Leaving `operator.version` unset at every layer yields the boot-time chart
-// version verbatim, which is exactly the behavior before the field was wired
-// up. The operator handler captures this configuration at construction, so the
-// resolved controllers configuration must be stashed (SetControllersConfig)
-// before AddCtxControllerHandlers runs - see ReconcileOperatorChartVersion for
-// the path that re-attaches when the version changes on a live connection.
+// version verbatim. The operator handler captures this configuration at
+// construction, so the resolved controllers configuration must be stashed
+// (SetControllersConfig) before AddCtxControllerHandlers runs - see
+// ReconcileOperatorChartVersion for the path that re-attaches when the version
+// changes on a live connection.
 func (mch *MesheryControllersHelper) operatorDeploymentConfig() controllers.OperatorDeploymentConfig {
 	depConfig := mch.oprDepConfig
 	if version := connections.OperatorChartVersionFromControllersConfig(mch.controllersConfig); version != "" {
 		depConfig.MesheryReleaseVersion = version
 	}
 	return depConfig
+}
+
+// pinnedOperatorDeploymentConfig is operatorDeploymentConfig with the chart
+// version pinned to one the chart repository actually publishes.
+//
+// This is the only deployment config that may reach Helm. The version
+// operatorDeploymentConfig returns is either an explicit `operator.version` or
+// the Meshery Server release stamped in at boot, and neither is guaranteed to
+// name a published chart: chart publishing trails server releases, so a current
+// server routinely asks for a chart that does not exist yet, and a server old
+// enough to predate MinimumOperatorChartVersion asks for one that exists but
+// cannot run. ResolveOperatorChartVersion settles both, failing loudly when the
+// version was explicitly requested and substituting - with a reason - when it
+// was merely derived.
+//
+// The returned reason is empty unless a substitution happened; callers log it
+// and emit it so no correction is silent.
+func (mch *MesheryControllersHelper) pinnedOperatorDeploymentConfig() (depConfig controllers.OperatorDeploymentConfig, reason string, err error) {
+	depConfig = mch.operatorDeploymentConfig()
+
+	source := OperatorChartVersionDerived
+	if connections.OperatorChartVersionFromControllersConfig(mch.controllersConfig) != "" {
+		source = OperatorChartVersionRequested
+	}
+
+	lister := mch.chartVersions
+	if lister == nil {
+		lister = mesheryutils.PublishedChartVersions
+	}
+	published, err := lister(depConfig.HelmChartRepo, OperatorChartName)
+	if err != nil {
+		return depConfig, "", err
+	}
+
+	version, reason, err := ResolveOperatorChartVersion(published, depConfig.MesheryReleaseVersion, source)
+	if err != nil {
+		return depConfig, "", err
+	}
+	depConfig.MesheryReleaseVersion = version
+	return depConfig, reason, nil
 }
 
 // ReconcileOperatorChartVersion brings the operator running on this connection's
@@ -742,15 +835,30 @@ func (mch *MesheryControllersHelper) operatorDeploymentConfig() controllers.Oper
 //     this context, or
 //   - the resolved chart version already matches the attached handler's.
 func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sContext, ot *OperatorTracker) (chartVersion string, redeployed bool, err error) {
-	desired := mch.operatorDeploymentConfig().MesheryReleaseVersion
+	requested := mch.operatorDeploymentConfig().MesheryReleaseVersion
 	if mch.meshsyncDeploymentMode != connections.MeshsyncDeploymentModeOperator {
-		return desired, false, nil
+		return requested, false, nil
 	}
 	if ot == nil || ot.DisableOperator || ot.IsUndeployed(k8sctx.ID) {
-		return desired, false, nil
+		return requested, false, nil
 	}
+
+	// Compare pinned against pinned. attachedOperatorChartVersion records what
+	// the handler was built with, which is always a published version, so
+	// comparing the raw request against it would redeploy on every call
+	// whenever the request is being substituted (an unpublished server release
+	// or a below-floor one) - an endless upgrade loop against the cluster.
+	pinned, substitution, err := mch.pinnedOperatorDeploymentConfig()
+	if err != nil {
+		mch.setOperatorError(err)
+		return requested, false, ErrReconcileOperatorChartVersion(err)
+	}
+	desired := pinned.MesheryReleaseVersion
 	if desired == mch.attachedOperatorChartVersion {
 		return desired, false, nil
+	}
+	if substitution != "" {
+		mch.log.Warn(ErrOperatorChartSubstituted(substitution))
 	}
 
 	// Re-attaching records the desired version as attached, which the guard
@@ -907,17 +1015,22 @@ func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTrack
 }
 
 func NewOperatorDeploymentConfig(adapterTracker AdaptersTrackerInterface) controllers.OperatorDeploymentConfig {
-	// get meshery release version
+	// The chart version is the Meshery Server release this binary was stamped
+	// with, which is a *request*, not a promise: it is pinned to a version the
+	// chart repository actually publishes by pinnedOperatorDeploymentConfig
+	// before it ever reaches Helm.
+	//
+	// An unstamped build (a source run, or an edge image) has no release to
+	// name, so it is left empty deliberately rather than resolved against the
+	// GitHub releases API. The newest *GitHub release* is not the newest
+	// *published chart* - charts are republished at server releases and trail
+	// them - so asking GitHub yields a version that frequently does not exist
+	// in the chart repository at all, on top of spending an unauthenticated,
+	// rate-limited API call at boot. An empty version resolves to the newest
+	// published chart, which is what was actually wanted.
 	mesheryReleaseVersion := viper.GetString("BUILD")
-	if mesheryReleaseVersion == "" || mesheryReleaseVersion == "Not Set" || mesheryReleaseVersion == "edge-latest" {
-		_, latestRelease, err := CheckLatestVersion(mesheryReleaseVersion)
-		// if unable to fetch latest release tag, meshkit helm functions handle
-		// this automatically fetch the latest one
-		if err != nil {
-			mesheryReleaseVersion = ""
-		} else {
-			mesheryReleaseVersion = latestRelease
-		}
+	if !isPinnedChartVersion(mesheryReleaseVersion) {
+		mesheryReleaseVersion = ""
 	}
 
 	return controllers.OperatorDeploymentConfig{
@@ -934,11 +1047,17 @@ func NewOperatorDeploymentConfig(adapterTracker AdaptersTrackerInterface) contro
 func CheckLatestVersion(serverVersion string) (*bool, string, error) {
 	// Inform user of the latest release version
 	versions, err := utils.GetLatestReleaseTagsSorted("meshery", "meshery")
-	latestVersion := versions[len(versions)-1]
-	isOutdated := false
 	if err != nil {
 		return nil, "", ErrCreateOperatorDeploymentConfig(err)
 	}
+	// Index only after the error check: a failed fetch returns a nil slice, and
+	// indexing it panicked - taking down whichever request or boot step called
+	// in - every time GitHub was unreachable or rate-limited.
+	if len(versions) == 0 {
+		return nil, "", ErrCreateOperatorDeploymentConfig(ErrNoMesheryReleasesFound())
+	}
+	latestVersion := versions[len(versions)-1]
+	isOutdated := false
 	// Compare current running Meshery server version to the latest available Meshery release on GitHub.
 	if latestVersion != serverVersion {
 		isOutdated = true

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -49,6 +49,14 @@ const (
 	MesheryOperator
 )
 
+// MesheryControllers is every controller Meshery manages on a Kubernetes
+// connection, in enum order. It is the authoritative set: AddCtxControllerHandlers
+// attaches a handler for each of these, so a caller that must account for every
+// controller - whether or not a handler could be attached - iterates this rather
+// than the handler map, which is missing entries precisely when something went
+// wrong.
+var MesheryControllers = []MesheryController{MesheryBroker, Meshsync, MesheryOperator}
+
 type MesheryControllersHelper struct {
 	// context that is being manged by a particular controllerHelper instance
 	contextID string

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -116,6 +116,19 @@ type MesheryControllersHelper struct {
 	// catalogue instead of the network. Never nil once constructed.
 	chartVersions func(repo, chart string) ([]string, error)
 
+	// reattachControllerHandlers re-runs handler attachment ahead of an install,
+	// which is what re-resolves the chart version. It is AddCtxControllerHandlers
+	// and is injected for the same reason chartVersions is: the state it produces
+	// is otherwise unreachable from a test.
+	//
+	// Specifically, AddCtxControllerHandlers clears operatorChartError exactly
+	// where it resolves a version, so it can never return having both succeeded
+	// and left a refusal standing. That is the state operatorInstallTarget guards
+	// the install sites against, and without this seam the guard is unreachable -
+	// so nothing would notice an install site that stopped consulting it, which is
+	// how this gap survived once already. Never nil once constructed.
+	reattachControllerHandlers func(K8sContext)
+
 	// event broadcasting dependencies
 	eventBroadcaster *Broadcast
 	provider         Provider
@@ -210,7 +223,7 @@ func NewMesheryControllersHelper(
 	provider Provider,
 	systemID *core.Uuid,
 ) *MesheryControllersHelper {
-	return &MesheryControllersHelper{
+	mch := &MesheryControllersHelper{
 		ctxControllerHandlers: make(map[MesheryController]controllers.IMesheryController),
 		log:                   log,
 		oprDepConfig:          operatorDepConfig,
@@ -226,6 +239,17 @@ func NewMesheryControllersHelper(
 		provider:               provider,
 		systemID:               systemID,
 	}
+	mch.reattachControllerHandlers = func(ctx K8sContext) { mch.AddCtxControllerHandlers(ctx) }
+	return mch
+}
+
+// reattach re-runs handler attachment for ctx. See reattachControllerHandlers.
+func (mch *MesheryControllersHelper) reattach(ctx K8sContext) {
+	if mch.reattachControllerHandlers == nil {
+		mch.AddCtxControllerHandlers(ctx)
+		return
+	}
+	mch.reattachControllerHandlers(ctx)
 }
 
 func (mch *MesheryControllersHelper) SetMeshsyncDeploymentMode(value connections.MeshsyncDeploymentMode) *MesheryControllersHelper {
@@ -949,7 +973,7 @@ func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sCon
 	// cleared the value *for the same reason*, and putting the stale one back
 	// would withhold operator lifecycle until the connection is rebuilt.
 	previousChartVersion := mch.attachedOperatorChartVersion
-	mch.AddCtxControllerHandlers(k8sctx)
+	mch.reattach(k8sctx)
 	if setupErr := mch.GetOperatorError(); setupErr != nil {
 		if mch.attachedOperatorChartVersion != "" {
 			mch.attachedOperatorChartVersion = previousChartVersion
@@ -1144,7 +1168,7 @@ func (mch *MesheryControllersHelper) SetOperatorDeployment(k8sctx K8sContext, de
 	}
 
 	if mch.GetOperatorChartError() != nil {
-		mch.AddCtxControllerHandlers(k8sctx)
+		mch.reattach(k8sctx)
 	}
 
 	operatorHandler, attached, err := mch.operatorInstallTarget(k8sctx.ID)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -810,7 +810,7 @@ func (mch *MesheryControllersHelper) pinnedOperatorDeploymentConfig() (depConfig
 		return depConfig, "", err
 	}
 
-	version, reason, err := ResolveOperatorChartVersion(published, depConfig.MesheryReleaseVersion, source)
+	version, reason, err := ResolveOperatorChartVersion(depConfig.HelmChartRepo, published, depConfig.MesheryReleaseVersion, source)
 	if err != nil {
 		return depConfig, "", err
 	}
@@ -848,7 +848,7 @@ func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sCon
 	// comparing the raw request against it would redeploy on every call
 	// whenever the request is being substituted (an unpublished server release
 	// or a below-floor one) - an endless upgrade loop against the cluster.
-	pinned, substitution, err := mch.pinnedOperatorDeploymentConfig()
+	pinned, _, err := mch.pinnedOperatorDeploymentConfig()
 	if err != nil {
 		mch.setOperatorError(err)
 		return requested, false, ErrReconcileOperatorChartVersion(err)
@@ -857,9 +857,9 @@ func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sCon
 	if desired == mch.attachedOperatorChartVersion {
 		return desired, false, nil
 	}
-	if substitution != "" {
-		mch.log.Warn(ErrOperatorChartSubstituted(substitution))
-	}
+	// Any substitution is logged and emitted by AddCtxControllerHandlers below,
+	// which resolves against the same catalogue; reporting it here too would
+	// duplicate every warning.
 
 	// Re-attaching records the desired version as attached, which the guard
 	// above then treats as "already reconciled". If anything below fails, that
@@ -867,15 +867,22 @@ func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sCon
 	// would short-circuit and never try again. Restore the previous value on
 	// every failure path so a transient Helm error is retried rather than
 	// silently becoming the resting state.
+	//
+	// Restoring is conditional on a handler actually being attached: when
+	// AddCtxControllerHandlers attaches none it has already cleared the
+	// attached version *for the same reason*, and putting the stale one back
+	// would withhold operator lifecycle until the connection is rebuilt.
 	previousChartVersion := mch.attachedOperatorChartVersion
 	mch.AddCtxControllerHandlers(k8sctx)
+	operatorHandler, attached := mch.ctxControllerHandlers[MesheryOperator]
+	attached = attached && operatorHandler != nil
 	if setupErr := mch.GetOperatorError(); setupErr != nil {
-		mch.attachedOperatorChartVersion = previousChartVersion
+		if attached {
+			mch.attachedOperatorChartVersion = previousChartVersion
+		}
 		return desired, false, ErrReconcileOperatorChartVersion(setupErr)
 	}
-	operatorHandler, ok := mch.ctxControllerHandlers[MesheryOperator]
-	if !ok || operatorHandler == nil {
-		mch.attachedOperatorChartVersion = previousChartVersion
+	if !attached {
 		return desired, false, ErrOperatorHandlerNotAttached(k8sctx.ID)
 	}
 	// Deploy(false) is a no-op against an operator this handler undeployed and a

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -941,16 +941,24 @@ func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sCon
 	// would withhold operator lifecycle until the connection is rebuilt.
 	previousChartVersion := mch.attachedOperatorChartVersion
 	mch.AddCtxControllerHandlers(k8sctx)
-	operatorHandler, attached := mch.ctxControllerHandlers[MesheryOperator]
-	attached = attached && operatorHandler != nil
 	if setupErr := mch.GetOperatorError(); setupErr != nil {
 		if mch.attachedOperatorChartVersion != "" {
 			mch.attachedOperatorChartVersion = previousChartVersion
 		}
 		return desired, false, ErrReconcileOperatorChartVersion(setupErr)
 	}
-	if !attached {
-		return desired, false, ErrOperatorHandlerNotAttached(k8sctx.ID)
+	// Through the same guard as every other install, rather than reading the
+	// handler out of the map directly. Reaching Deploy here was gated only by
+	// GetOperatorError being nil after the re-attach above, which holds solely
+	// because AddCtxControllerHandlers writes both errors together - a coupling
+	// nothing enforces, and one that five other setOperatorError writers could
+	// break into an unresolved version reaching Helm.
+	operatorHandler, _, targetErr := mch.operatorInstallTarget(k8sctx.ID)
+	if targetErr != nil {
+		if mch.attachedOperatorChartVersion != "" {
+			mch.attachedOperatorChartVersion = previousChartVersion
+		}
+		return desired, false, ErrReconcileOperatorChartVersion(targetErr)
 	}
 	// Deploy(false) is a no-op against an operator this handler undeployed and a
 	// Helm upgrade against one that is installed, so an operator the user turned
@@ -1045,10 +1053,12 @@ func (mch *MesheryControllersHelper) attachedOperatorHandler() controllers.IMesh
 // attached reports whether a handler was present at all, which is the one
 // condition callers report differently (see setOperatorErrorIfUnset).
 //
-// This is the single guard every install path goes through - the FSM's
-// DeployUndeployedOperators and the user-initiated SetOperatorDeployment - so
-// the two cannot drift into one refusing an unpublishable chart version while
-// the other hands it to Helm.
+// This is the single guard every install path goes through. There are exactly
+// three, and all three call this: the FSM's DeployUndeployedOperators, the
+// user-initiated SetOperatorDeployment, and ReconcileOperatorChartVersion. They
+// are the only callers of Deploy on an operator handler in this repository, so
+// none of them can drift into handing Helm an unpublishable chart version while
+// the others refuse it.
 //
 // Installing is the one operator action that needs a chart version. The handler
 // is attached for observation even when none could be resolved, so refusing
@@ -1088,19 +1098,32 @@ func (mch *MesheryControllersHelper) operatorStatusObserved() bool {
 }
 
 // SetOperatorDeployment applies a user-initiated Meshery Operator lifecycle
-// request for contextID: deploy=true installs or upgrades it, deploy=false
-// removes it. It is the counterpart to the FSM's DeployUndeployedOperators and
+// request for k8sctx: deploy=true installs or upgrades it, deploy=false removes
+// it. It is the counterpart to the FSM's DeployUndeployedOperators and
 // UndeployDeployedOperators for callers that must be told the outcome - the
 // GraphQL changeOperatorStatus mutation - and shares their guard rather than
 // restating it.
 //
+// A latched chart-resolution failure is retried here rather than being final.
+// operatorChartError is written only when handlers are attached, so a connect
+// that landed during a chart-repository outage would otherwise refuse every
+// later install for the life of that connection, no matter how long ago the
+// repository came back - and the user is told, correctly, to confirm the
+// repository is reachable and retry. Re-attaching is what makes that
+// instruction true: clearing the latch alone would not, because the handler the
+// failure path attached still carries the raw unresolved chart version, so the
+// version and the latch have to be corrected together. AddCtxControllerHandlers
+// does exactly that, and only a resolution that actually succeeds clears the
+// latch; one that fails again replaces it with the fresh error, which the guard
+// below then refuses on instead of falling through to a Deploy.
+//
 // The error is returned rather than emitted: the caller owns how a request it
 // initiated is surfaced. A failure is still recorded for the diagnostics API.
-func (mch *MesheryControllersHelper) SetOperatorDeployment(contextID string, deploy bool) error {
+func (mch *MesheryControllersHelper) SetOperatorDeployment(k8sctx K8sContext, deploy bool) error {
 	if !deploy {
 		operatorHandler := mch.attachedOperatorHandler()
 		if operatorHandler == nil {
-			err := ErrOperatorHandlerNotAttached(contextID)
+			err := ErrOperatorHandlerNotAttached(k8sctx.ID)
 			mch.setOperatorErrorIfUnset(err)
 			return err
 		}
@@ -1111,7 +1134,11 @@ func (mch *MesheryControllersHelper) SetOperatorDeployment(contextID string, dep
 		return nil
 	}
 
-	operatorHandler, attached, err := mch.operatorInstallTarget(contextID)
+	if mch.GetOperatorChartError() != nil {
+		mch.AddCtxControllerHandlers(k8sctx)
+	}
+
+	operatorHandler, attached, err := mch.operatorInstallTarget(k8sctx.ID)
 	if err != nil {
 		if attached {
 			mch.setOperatorError(err)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -734,8 +734,16 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 	// Fresh setup attempt: clear any error from a previous attempt. It is re-set
 	// below (and in DeployUndeployedOperators) if this attempt fails, so the
 	// diagnostics API always reflects the latest operator setup outcome.
+	//
+	// operatorChartError is deliberately NOT cleared here. It is the refusal that
+	// keeps an unresolved chart version away from Helm, and the two paths below
+	// return without reaching resolution while leaving the previously attached
+	// operator handler - which still carries that unresolved version - in place.
+	// Clearing it up here therefore produced the one state the install guard
+	// cannot see: a stale handler with no refusal against it. It is cleared on
+	// the success path instead, so it lifts only when a resolution actually
+	// succeeded.
 	mch.setOperatorError(nil)
-	mch.setOperatorChartError(nil)
 
 	cfg, err := ctx.GenerateKubeConfig()
 	if err != nil {
@@ -815,6 +823,7 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 	ctxHandlers[MesheryOperator] = controllers.NewMesheryOperatorHandler(client, depConfig)
 	mch.ctxControllerHandlers = ctxHandlers
 	mch.attachedOperatorChartVersion = depConfig.MesheryReleaseVersion
+	mch.setOperatorChartError(nil)
 
 	// }(mch)
 	return mch

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -29,13 +29,19 @@ func reachableK8sContext() K8sContext {
 	}
 }
 
-// publishedCharts is the catalogue these tests resolve against: the two current
-// charts, the first one that works (MinimumOperatorChartVersion), and two that
-// predate it. It deliberately stops below the newest *server* releases, which
-// is the real-world condition that broke operator deployment - chart publishing
-// trails Meshery Server releases, so a current server routinely asks the
-// repository for a chart that does not exist yet.
-var publishedCharts = []string{"v1.0.64", "v1.0.63", "v1.0.62", "v1.0.40", "v0.7.9"}
+// publishedCharts is the catalogue every test in package models resolves
+// against: three current charts, the oldest one verified to deploy
+// (MinimumOperatorChartVersion), and two that predate it. It deliberately stops
+// below the newest *server* releases, which is the real-world condition that
+// broke operator deployment - chart publishing trails Meshery Server releases,
+// so a current server routinely asks the repository for a chart that does not
+// exist yet.
+//
+// It is one variable rather than one per test file on purpose: the helper that
+// builds a MesheryControllersHelper resolves against it too, so two catalogues
+// drifting apart would make a reconcile test assert against a chart set its own
+// helper never saw.
+var publishedCharts = []string{"v1.0.64", "v1.0.63", "v1.0.62", "v1.0.51", "v1.0.40", "v0.7.9"}
 
 // testChartRepo stands in for the repository the catalogue was read from. It is
 // deliberately not ChartRepo: resolution must report the repository it actually
@@ -81,22 +87,48 @@ func TestDerivedChartVersionSubstitutionIsNeverSilent(t *testing.T) {
 // TestDerivedChartVersionIsFlooredToTheOldestWorkingChart pins the fix for the
 // reported failure: a server old enough to predate MinimumOperatorChartVersion
 // requests a chart that *is* published but cannot run (retired kube-rbac-proxy
-// image, no webhook certificate). It must be raised to the oldest working
-// chart - not to the newest, which would be a larger change than the defect
-// requires.
+// image, no webhook certificate). It must be raised to the oldest *published*
+// chart at or above the floor - not to the newest, which would be a larger
+// change than the defect requires, and not to the floor constant itself, which
+// the repository is not obliged to publish.
 func TestDerivedChartVersionIsFlooredToTheOldestWorkingChart(t *testing.T) {
-	version, reason := mustResolve(t, publishedCharts, "v1.0.40", OperatorChartVersionDerived)
+	t.Run("the floor itself is published", func(t *testing.T) {
+		version, reason := mustResolve(t, publishedCharts, "v1.0.40", OperatorChartVersionDerived)
 
-	if version != MinimumOperatorChartVersion {
-		t.Fatalf("chart version = %q, want the floor %q", version, MinimumOperatorChartVersion)
-	}
-	if reason == "" {
-		t.Fatal("expected the floor to be explained to the user")
-	}
+		if version != MinimumOperatorChartVersion {
+			t.Fatalf("chart version = %q, want the floor %q", version, MinimumOperatorChartVersion)
+		}
+		if reason == "" {
+			t.Fatal("expected the floor to be explained to the user")
+		}
+	})
+
+	t.Run("the floor itself is not published", func(t *testing.T) {
+		// The floor is a policy boundary, not a promise that the repository
+		// carries that exact release. Handing MinimumOperatorChartVersion to
+		// Helm here would ask for an archive this repository does not publish,
+		// and jumping to the newest would upgrade further than the defect
+		// requires.
+		version, reason := mustResolve(t, []string{"v1.0.64", "v1.0.62", "v1.0.40"}, "v1.0.40", OperatorChartVersionDerived)
+
+		if version != "v1.0.62" {
+			t.Fatalf("chart version = %q, want the oldest published chart at or above the floor, v1.0.62", version)
+		}
+		if reason == "" {
+			t.Fatal("expected the floor to be explained to the user")
+		}
+	})
 }
 
+// TestDerivedChartVersionAtOrAboveTheFloorIsUsedVerbatim guards the floor from
+// being raised past a chart that works. Each version listed here was rendered
+// from its published archive and confirmed to carry no kube-rbac-proxy sidecar
+// and ENABLE_WEBHOOKS="false", so substituting any of them would tell a user
+// their working chart cannot deploy. They are spelled out as literals rather
+// than derived from MinimumOperatorChartVersion precisely so that raising the
+// constant fails here instead of silently redefining what the test asserts.
 func TestDerivedChartVersionAtOrAboveTheFloorIsUsedVerbatim(t *testing.T) {
-	for _, requested := range []string{MinimumOperatorChartVersion, "v1.0.64"} {
+	for _, requested := range []string{"v1.0.51", "v1.0.62", "v1.0.63", "v1.0.64"} {
 		version, reason := mustResolve(t, publishedCharts, requested, OperatorChartVersionDerived)
 		if version != requested {
 			t.Fatalf("chart version = %q, want %q used verbatim", version, requested)
@@ -438,7 +470,9 @@ func TestCompareChartVersionsOrdersBySemverNotLexically(t *testing.T) {
 	if compareChartVersions("v1.0.64", "v1.0.9") <= 0 {
 		t.Fatal("v1.0.64 must compare greater than v1.0.9")
 	}
-	if compareChartVersions("v1.0.63", MinimumOperatorChartVersion) != 0 {
+	// Helm treats "1.0.64" and "v1.0.64" as one release, so they must compare
+	// equal rather than by their differing spellings.
+	if compareChartVersions("v1.0.64", "1.0.64") != 0 {
 		t.Fatal("equal versions must compare equal")
 	}
 	if compareChartVersions("stable-latest", "v0.0.1") >= 0 {

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -1,0 +1,342 @@
+package models
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/meshery/meshery/server/models/connections"
+	meshkiterrors "github.com/meshery/meshkit/errors"
+	"github.com/spf13/viper"
+)
+
+// publishedCharts is the catalogue these tests resolve against: the two current
+// charts, the first one that works (MinimumOperatorChartVersion), and two that
+// predate it. It deliberately stops below the newest *server* releases, which
+// is the real-world condition that broke operator deployment - chart publishing
+// trails Meshery Server releases, so a current server routinely asks the
+// repository for a chart that does not exist yet.
+var publishedCharts = []string{"v1.0.64", "v1.0.63", "v1.0.62", "v1.0.40", "v0.7.9"}
+
+func mustResolve(t *testing.T, published []string, requested string, source OperatorChartVersionSource) (string, string) {
+	t.Helper()
+	version, reason, err := ResolveOperatorChartVersion(published, requested, source)
+	if err != nil {
+		t.Fatalf("ResolveOperatorChartVersion(%q) returned an unexpected error: %v", requested, err)
+	}
+	return version, reason
+}
+
+// TestDerivedChartVersionIsAlwaysPublished is the headline regression. Before
+// this change the chart version was the Meshery Server release verbatim, so a
+// server released after the last chart publish asked Helm for an archive that
+// does not exist and the operator never deployed. Resolution must now land on a
+// version the repository actually publishes, and must say that it did.
+func TestDerivedChartVersionIsAlwaysPublished(t *testing.T) {
+	version, _ := mustResolve(t, publishedCharts, "v1.0.66", OperatorChartVersionDerived)
+
+	if version != "v1.0.64" {
+		t.Fatalf("chart version = %q, want the newest published chart v1.0.64", version)
+	}
+	for _, v := range publishedCharts {
+		if v == version {
+			return
+		}
+	}
+	t.Fatalf("resolved chart version %q is not published", version)
+}
+
+func TestDerivedChartVersionSubstitutionIsNeverSilent(t *testing.T) {
+	_, reason := mustResolve(t, publishedCharts, "v1.0.66", OperatorChartVersionDerived)
+	if reason == "" {
+		t.Fatal("expected a user-readable reason explaining the substitution, got none")
+	}
+}
+
+// TestDerivedChartVersionIsFlooredToTheOldestWorkingChart pins the fix for the
+// reported failure: a server old enough to predate MinimumOperatorChartVersion
+// requests a chart that *is* published but cannot run (retired kube-rbac-proxy
+// image, no webhook certificate). It must be raised to the oldest working
+// chart - not to the newest, which would be a larger change than the defect
+// requires.
+func TestDerivedChartVersionIsFlooredToTheOldestWorkingChart(t *testing.T) {
+	version, reason := mustResolve(t, publishedCharts, "v1.0.40", OperatorChartVersionDerived)
+
+	if version != MinimumOperatorChartVersion {
+		t.Fatalf("chart version = %q, want the floor %q", version, MinimumOperatorChartVersion)
+	}
+	if reason == "" {
+		t.Fatal("expected the floor to be explained to the user")
+	}
+}
+
+func TestDerivedChartVersionAtOrAboveTheFloorIsUsedVerbatim(t *testing.T) {
+	for _, requested := range []string{MinimumOperatorChartVersion, "v1.0.64"} {
+		version, reason := mustResolve(t, publishedCharts, requested, OperatorChartVersionDerived)
+		if version != requested {
+			t.Fatalf("chart version = %q, want %q used verbatim", version, requested)
+		}
+		if reason != "" {
+			t.Fatalf("expected no substitution for %q, got reason %q", requested, reason)
+		}
+	}
+}
+
+// TestMovingChartVersionNeverReachesHelm covers every way a server can fail to
+// name a release: an unstamped source build, viper's "Not Set" placeholder, and
+// the moving channel tags. None of them identifies a published archive, so none
+// may be handed to Helm as a chart version.
+func TestMovingChartVersionNeverReachesHelm(t *testing.T) {
+	for _, requested := range []string{"", "   ", "Not Set", "edge-latest", "stable-latest", "latest"} {
+		t.Run(requested, func(t *testing.T) {
+			if isPinnedChartVersion(requested) {
+				t.Fatalf("%q must not be treated as a pinned chart version", requested)
+			}
+			version, reason := mustResolve(t, publishedCharts, requested, OperatorChartVersionDerived)
+			if version != "v1.0.64" {
+				t.Fatalf("chart version = %q, want the newest published chart", version)
+			}
+			if reason == "" {
+				t.Fatal("expected the fallback to be explained")
+			}
+		})
+	}
+}
+
+// TestExplicitChartVersionFailsLoudlyWhenUnusable asserts the deliberate
+// asymmetry: a version nobody chose may be corrected, but one an operator typed
+// is never quietly replaced - the deployment fails so the mistake is visible.
+func TestExplicitChartVersionFailsLoudlyWhenUnusable(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		wantCode  string
+	}{
+		{
+			name:      "a version the repository does not publish",
+			requested: "v9.9.9",
+			wantCode:  ErrOperatorChartNotPublishedCode,
+		},
+		{
+			name:      "a moving tag, which names no specific archive",
+			requested: "stable-latest",
+			wantCode:  ErrOperatorChartNotPinnedCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, reason, err := ResolveOperatorChartVersion(publishedCharts, tt.requested, OperatorChartVersionRequested)
+			if err == nil {
+				t.Fatalf("expected %q to fail, got version %q", tt.requested, version)
+			}
+			if version != "" || reason != "" {
+				t.Fatalf("a failed resolution must yield nothing to deploy, got version %q reason %q", version, reason)
+			}
+			if code := meshkiterrors.GetCode(err); code != tt.wantCode {
+				t.Fatalf("error code = %q, want %q (from %v)", code, tt.wantCode, err)
+			}
+		})
+	}
+}
+
+// TestExplicitChartVersionBelowTheFloorIsHonored keeps the escape hatch open:
+// the floor exists to rescue servers that did not choose their chart version.
+// Someone who deliberately pins an old chart is not overruled.
+func TestExplicitChartVersionBelowTheFloorIsHonored(t *testing.T) {
+	version, reason := mustResolve(t, publishedCharts, "v0.7.9", OperatorChartVersionRequested)
+	if version != "v0.7.9" {
+		t.Fatalf("chart version = %q, want the explicitly requested v0.7.9", version)
+	}
+	if reason != "" {
+		t.Fatalf("an honored explicit request is not a substitution, got reason %q", reason)
+	}
+}
+
+func TestResolutionFailsWhenNothingUsableIsPublished(t *testing.T) {
+	for _, published := range [][]string{nil, {}, {"stable-latest", "edge-latest"}} {
+		_, _, err := ResolveOperatorChartVersion(published, "v1.0.64", OperatorChartVersionDerived)
+		if err == nil {
+			t.Fatalf("expected a failure when the repository publishes %v", published)
+		}
+		if code := meshkiterrors.GetCode(err); code != ErrNoOperatorChartPublishedCode {
+			t.Fatalf("error code = %q, want %q", code, ErrNoOperatorChartPublishedCode)
+		}
+	}
+}
+
+// TestFloorFallsBackToNewestWhenNothingReachesIt guards the degenerate case
+// where the repository has not yet published anything at or above the floor:
+// the newest published chart is still better than a version known to be broken,
+// and it must not resolve to "".
+func TestFloorFallsBackToNewestWhenNothingReachesIt(t *testing.T) {
+	version, reason := mustResolve(t, []string{"v1.0.40", "v0.7.9"}, "v0.7.9", OperatorChartVersionDerived)
+	if version != "v1.0.40" {
+		t.Fatalf("chart version = %q, want the newest published chart v1.0.40", version)
+	}
+	if reason == "" {
+		t.Fatal("expected the substitution to be explained")
+	}
+}
+
+// TestPinnedDeploymentConfigSurfacesAnUnreadableIndex asserts the failure is
+// loud rather than a guess: if the repository index cannot be read there is no
+// way to know which versions exist, so no version may be deployed.
+func TestPinnedDeploymentConfigSurfacesAnUnreadableIndex(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	indexErr := errors.New("repository unreachable")
+	mch.chartVersions = func(string, string) ([]string, error) { return nil, indexErr }
+
+	_, _, err := mch.pinnedOperatorDeploymentConfig()
+	if err == nil {
+		t.Fatal("expected an unreadable chart index to fail the resolution")
+	}
+	if !errors.Is(err, indexErr) {
+		t.Fatalf("expected the index failure to be reported, got %v", err)
+	}
+}
+
+// TestUnreadableIndexStillAttachesBrokerAndMeshSync asserts the blast radius of
+// an unreachable chart repository is confined to operator lifecycle. The Broker
+// and MeshSync handlers only observe what is already in the cluster, so
+// withholding them too would turn a momentary repository blip into lost
+// discovery on a cluster whose operator is already installed and healthy.
+func TestUnreadableIndexStillAttachesBrokerAndMeshSync(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.chartVersions = func(string, string) ([]string, error) { return nil, errors.New("repository unreachable") }
+	mch.attachedOperatorChartVersion = "v1.0.64"
+
+	// A structurally complete context yields a Kubernetes client without
+	// contacting the cluster, so this reaches the chart-version resolution.
+	mch.AddCtxControllerHandlers(K8sContext{
+		ID:   "ctx-1",
+		Name: "test-cluster",
+		Cluster: map[string]interface{}{
+			"name":    "test-cluster",
+			"cluster": map[string]interface{}{"server": "https://127.0.0.1:6443"},
+		},
+		Auth: map[string]interface{}{
+			"name": "test-user",
+			"user": map[string]interface{}{"token": "test-token"},
+		},
+		Server: "https://127.0.0.1:6443",
+	})
+
+	handlers := mch.GetControllerHandlersForEachContext()
+	if _, ok := handlers[MesheryOperator]; ok {
+		t.Fatal("no chart version is safe to install, so no operator handler may be attached")
+	}
+	for controller, name := range map[MesheryController]string{MesheryBroker: "broker", Meshsync: "meshsync"} {
+		if h, ok := handlers[controller]; !ok || h == nil {
+			t.Fatalf("the %s handler needs no chart version and must still be attached", name)
+		}
+	}
+	if mch.GetOperatorError() == nil {
+		t.Fatal("the reason operator lifecycle is withheld must be recorded for diagnostics")
+	}
+	if mch.attachedOperatorChartVersion != "" {
+		t.Fatalf("attached chart version = %q, want it cleared so the next reconcile retries", mch.attachedOperatorChartVersion)
+	}
+}
+
+// TestPinnedDeploymentConfigQueriesTheOperatorChart asserts the pin is computed
+// against the operator chart in the server-wide repository, and that pinning
+// replaces the chart version and nothing else.
+func TestPinnedDeploymentConfigQueriesTheOperatorChart(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	var gotRepo, gotChart string
+	mch.chartVersions = func(repo, chart string) ([]string, error) {
+		gotRepo, gotChart = repo, chart
+		return publishedCharts, nil
+	}
+
+	depConfig, _, err := mch.pinnedOperatorDeploymentConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRepo != "https://example.invalid/charts" {
+		t.Fatalf("queried repo = %q, want the server-wide chart repository", gotRepo)
+	}
+	if gotChart != OperatorChartName {
+		t.Fatalf("queried chart = %q, want %q", gotChart, OperatorChartName)
+	}
+	if depConfig.HelmChartRepo != "https://example.invalid/charts" || depConfig.GetHelmOverrides == nil {
+		t.Fatal("pinning must replace the chart version only, leaving the server-wide fields intact")
+	}
+	if mch.oprDepConfig.MesheryReleaseVersion != bootChartVersion {
+		t.Fatalf("server-wide deployment config was mutated: %q", mch.oprDepConfig.MesheryReleaseVersion)
+	}
+}
+
+// TestReconcileComparesPinnedVersionsNotRequestedOnes pins a loop that the
+// naive comparison would create. The attached handler always records a
+// *published* version, so comparing it against the raw request would differ
+// forever whenever the request is being substituted - re-running the Helm
+// upgrade against the cluster on every reconcile.
+func TestReconcileComparesPinnedVersionsNotRequestedOnes(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
+	// A server release with no published chart: pinning lands on v1.0.64, which
+	// is exactly what the attached handler already carries.
+	mch.oprDepConfig.MesheryReleaseVersion = "v1.0.66"
+	mch.SetControllersConfig(operatorVersionConfig("", connections.MeshsyncDeploymentModeOperator))
+	mch.attachedOperatorChartVersion = "v1.0.64"
+
+	chartVersion, redeployed, err := mch.ReconcileOperatorChartVersion(
+		K8sContext{ID: "ctx-1", Name: "test-cluster"},
+		NewOperatorTracker(false),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if redeployed {
+		t.Fatal("the pinned version already matches the attached handler; redeploying is an upgrade loop")
+	}
+	if chartVersion != "v1.0.64" {
+		t.Fatalf("chart version = %q, want the pinned v1.0.64", chartVersion)
+	}
+}
+
+// TestNewOperatorDeploymentConfigNeverStampsAMovingVersion asserts the boot-time
+// config carries either a real release or nothing at all. It previously reached
+// for the newest *GitHub release*, which is not the newest *published chart* -
+// spending a rate-limited API call to produce a version that frequently does not
+// exist in the chart repository.
+func TestNewOperatorDeploymentConfigNeverStampsAMovingVersion(t *testing.T) {
+	tests := []struct {
+		build string
+		want  string
+	}{
+		{build: "", want: ""},
+		{build: "Not Set", want: ""},
+		{build: "edge-latest", want: ""},
+		{build: "stable-latest", want: ""},
+		{build: "v1.0.64", want: "v1.0.64"},
+	}
+
+	original := viper.GetString("BUILD")
+	t.Cleanup(func() { viper.Set("BUILD", original) })
+
+	for _, tt := range tests {
+		t.Run(tt.build, func(t *testing.T) {
+			viper.Set("BUILD", tt.build)
+			got := NewOperatorDeploymentConfig(nil).MesheryReleaseVersion
+			if got != tt.want {
+				t.Fatalf("MesheryReleaseVersion = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareChartVersionsOrdersBySemverNotLexically(t *testing.T) {
+	// "v1.0.9" sorts after "v1.0.64" lexically, which would pick a broken chart
+	// as "newest".
+	if compareChartVersions("v1.0.64", "v1.0.9") <= 0 {
+		t.Fatal("v1.0.64 must compare greater than v1.0.9")
+	}
+	if compareChartVersions("v1.0.63", MinimumOperatorChartVersion) != 0 {
+		t.Fatal("equal versions must compare equal")
+	}
+	if compareChartVersions("stable-latest", "v0.0.1") >= 0 {
+		t.Fatal("an unparseable version must never outrank a real one")
+	}
+}

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -14,6 +14,16 @@ import (
 // reachableK8sContext is structurally complete enough to yield a Kubernetes
 // client without contacting the cluster, so a test reaches the chart-version
 // resolution that follows client creation.
+//
+// A context this complete makes AddCtxControllerHandlers attach REAL meshkit
+// handlers, so any test that goes on to reach Deploy or Undeploy performs live
+// Helm and cluster I/O: meshkit downloads the multi-megabyte index and the chart
+// archive from the configured repository before it touches the cluster at all,
+// and 127.0.0.1:6443 is a live cluster on any machine running Docker Desktop
+// Kubernetes or k3s - where a Deploy would really install the operator into it.
+// Never let a test in this package reach an install or a removal on a handler
+// this produced. Assert the guard through operatorInstallTarget, or swap a
+// stubController into ctxControllerHandlers first.
 func reachableK8sContext() K8sContext {
 	return K8sContext{
 		ID:   "ctx-1",
@@ -472,16 +482,23 @@ func TestUserInitiatedDeployIsRefusedWhileNoChartVersionResolves(t *testing.T) {
 // Clearing the latch alone would not have been enough either: the handler
 // attached on the failure path still carries the raw unresolved chart version,
 // so re-resolving and re-attaching have to happen together.
+// It is asserted through the two steps SetOperatorDeployment composes for a
+// latched deploy - AddCtxControllerHandlers then operatorInstallTarget - rather
+// than by calling SetOperatorDeployment itself, because a successful retry ends
+// in a Deploy on a real meshkit handler, which downloads the chart archive and
+// would install the operator for real on a machine where 127.0.0.1:6443 is a
+// live cluster. That SetOperatorDeployment performs this retry at all is pinned
+// by TestUserInitiatedDeployIsRefusedWhileNoChartVersionResolves, which only
+// passes because the refusal it gets back is the re-resolution's own failure
+// rather than the stale latch.
 func TestUserInitiatedDeployRetriesResolutionAfterTheRepositoryRecovers(t *testing.T) {
 	mch := newTestControllersHelper(t)
 	mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
 	mch.attachedOperatorChartVersion = ""
 
-	// The catalogue is readable again, so this call must re-resolve rather than
-	// serve the latched refusal. The Deploy it then attempts runs against a
-	// cluster that does not exist and is expected to fail; what matters is that
-	// the refusal is gone and the handler carries a resolved version.
-	err := mch.SetOperatorDeployment(reachableK8sContext(), true)
+	// The catalogue is readable again, so re-attaching must resolve rather than
+	// leave the refusal standing.
+	mch.AddCtxControllerHandlers(reachableK8sContext())
 
 	if chartErr := mch.GetOperatorChartError(); chartErr != nil {
 		t.Fatalf("operator chart error = %v, want the latch cleared by a resolution that succeeded", chartErr)
@@ -490,8 +507,13 @@ func TestUserInitiatedDeployRetriesResolutionAfterTheRepositoryRecovers(t *testi
 		t.Fatalf("attached chart version = %q, want %q re-attached by the retry",
 			mch.attachedOperatorChartVersion, bootChartVersion)
 	}
-	if err != nil && meshkiterrors.GetCode(err) == ErrNoOperatorChartPublishedCode {
-		t.Fatalf("the retry still refused on the stale latch: %v", err)
+
+	handler, attached, err := mch.operatorInstallTarget(testContextID)
+	if err != nil {
+		t.Fatalf("the install guard still refuses after a successful re-resolution: %v", err)
+	}
+	if !attached || handler == nil {
+		t.Fatal("a resolved re-attach must yield a handler to install through")
 	}
 }
 
@@ -759,35 +781,101 @@ func TestReconcileLeavesTheAttachedVersionClearedWhenResolutionFails(t *testing.
 	}
 }
 
-// TestReconcileInstallGoesThroughTheSharedGuard is the third install path.
-// operatorInstallTarget claims to be the one guard every install goes through,
-// and the reconcile used to read the handler straight out of the map and reach
-// Deploy without ever consulting the chart error - guarded only incidentally, by
-// lastOperatorError happening to be written in the same call that writes the
-// chart error.
+// TestInstallGuardRefusesOnALatchedChartError pins the guard itself, which all
+// three install sites - the FSM deploy, the user-initiated deploy, and the
+// chart-version reconcile - now route through. A handler is attached for
+// observation even when no version could be resolved, so "a handler exists" is
+// never on its own enough to install.
+func TestInstallGuardRefusesOnALatchedChartError(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	stub := &stubController{status: controllers.NotDeployed}
+	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
+
+	latched := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
+	mch.setOperatorChartError(latched)
+
+	handler, attached, err := mch.operatorInstallTarget(testContextID)
+	if !errors.Is(err, latched) {
+		t.Fatalf("err = %v, want the latched chart failure", err)
+	}
+	if !attached {
+		t.Fatal("a handler was attached, so the refusal is about the chart version, not a missing handler")
+	}
+	if handler != nil {
+		t.Fatal("a refused install must yield nothing to install through")
+	}
+}
+
+// TestChartErrorLatchSurvivesAReattachThatNeverResolves is the sequence the
+// guard could not see. The refusal used to be cleared at the top of
+// AddCtxControllerHandlers, before the kubeconfig and Kubernetes-client steps
+// that return early - and those returns deliberately leave the previously
+// attached operator handler in place so observation survives. A connection that
+// first attached during a chart-repository outage, and whose credentials then
+// stopped working, therefore ended up with a handler still carrying the raw
+// unresolved chart version and no refusal against it, and the very next
+// DeployUndeployedOperators in the FSM chain would hand that version to Helm.
 //
-// Reaching that guard needs the two errors to disagree, which
-// AddCtxControllerHandlers never lets happen, so the divergence is injected
-// through the version lister: it succeeds - leaving lastOperatorError nil - and
-// latches a chart error on the re-attach's own resolution, which is exactly the
-// state a future writer of lastOperatorError could otherwise create.
-func TestReconcileInstallGoesThroughTheSharedGuard(t *testing.T) {
+// The refusal now lifts only where a resolution actually succeeded.
+func TestChartErrorLatchSurvivesAReattachThatNeverResolves(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
+
+	indexErr := errors.New("repository unreachable")
+	mch.chartVersions = func(string, string) ([]string, error) { return nil, indexErr }
+	mch.AddCtxControllerHandlers(reachableK8sContext())
+	if mch.GetOperatorChartError() == nil {
+		t.Fatal("an unreadable index must withhold installation")
+	}
+	if mch.ctxControllerHandlers[MesheryOperator] == nil {
+		t.Fatal("the operator handler must stay attached for observation")
+	}
+
+	// The repository is readable again, but the stored kubeconfig no longer
+	// yields a Kubernetes client, so this run returns before it ever resolves a
+	// chart version - leaving the previous handler, and its unresolved version,
+	// in place.
+	mch.chartVersions = func(string, string) ([]string, error) { return publishedCharts, nil }
+	mch.AddCtxControllerHandlers(K8sContext{ID: testContextID, Name: "unparseable"})
+
+	if mch.GetOperatorChartError() == nil {
+		t.Fatal("a run that never reached resolution cleared the refusal, leaving a stale handler unguarded")
+	}
+	if mch.GetOperatorError() == nil {
+		t.Fatal("the Kubernetes client failure must still be recorded")
+	}
+
+	// Observed through a stub so that a regression refuses into a counter rather
+	// than into meshkit's Helm client.
+	stub := &stubController{status: controllers.NotDeployed}
+	mch.ctxControllerHandlers[MesheryOperator] = stub
+	mch.ctxOperatorStatus = controllers.NotDeployed
+
+	mch.DeployUndeployedOperators(NewOperatorTracker(false), testContextID)
+
+	if stub.deploys != 0 {
+		t.Fatalf("Deploy was called %d times with an unresolved chart version still attached", stub.deploys)
+	}
+}
+
+// TestReconcileInstallRefusesOnALatchedChartError covers the reconcile's own
+// install site. Its re-attach cannot clear a latch it never resolved past, so a
+// connection whose cluster became unreachable during a chart-repository outage
+// reports the failure instead of installing.
+func TestReconcileInstallRefusesOnALatchedChartError(t *testing.T) {
 	mch := newTestControllersHelper(t)
 	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
 	mch.SetControllersConfig(operatorVersionConfig("", connections.MeshsyncDeploymentModeOperator))
 	mch.attachedOperatorChartVersion = "v1.0.51"
 
-	latched := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
-	reads := 0
-	mch.chartVersions = func(string, string) ([]string, error) {
-		reads++
-		if reads >= 2 {
-			mch.setOperatorChartError(latched)
-		}
-		return publishedCharts, nil
-	}
+	stub := &stubController{status: controllers.NotDeployed}
+	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
+	mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
 
-	_, redeployed, err := mch.ReconcileOperatorChartVersion(reachableK8sContext(), NewOperatorTracker(false))
+	_, redeployed, err := mch.ReconcileOperatorChartVersion(
+		K8sContext{ID: testContextID, Name: "unparseable"},
+		NewOperatorTracker(false),
+	)
 	if redeployed {
 		t.Fatal("installation was refused, so nothing can have been redeployed")
 	}
@@ -797,8 +885,11 @@ func TestReconcileInstallGoesThroughTheSharedGuard(t *testing.T) {
 	if code := meshkiterrors.GetCode(err); code != ErrReconcileOperatorChartVersionCode {
 		t.Fatalf("error code = %q, want %q (from %v)", code, ErrReconcileOperatorChartVersionCode, err)
 	}
-	if !strings.Contains(err.Error(), "advertises no released") {
-		t.Fatalf("the reconcile reached Helm instead of refusing on the latched chart error: %v", err)
+	if stub.deploys != 0 {
+		t.Fatalf("Deploy was called %d times while a chart error was latched", stub.deploys)
+	}
+	if mch.GetOperatorChartError() == nil {
+		t.Fatal("a reconcile that never resolved must leave the refusal standing")
 	}
 	if mch.attachedOperatorChartVersion != "v1.0.51" {
 		t.Fatalf("attached chart version = %q, want the pre-reconcile value restored so the refusal is retried",

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -2,12 +2,32 @@ package models
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/meshery/meshery/server/models/connections"
 	meshkiterrors "github.com/meshery/meshkit/errors"
 	"github.com/spf13/viper"
 )
+
+// reachableK8sContext is structurally complete enough to yield a Kubernetes
+// client without contacting the cluster, so a test reaches the chart-version
+// resolution that follows client creation.
+func reachableK8sContext() K8sContext {
+	return K8sContext{
+		ID:   "ctx-1",
+		Name: "test-cluster",
+		Cluster: map[string]interface{}{
+			"name":    "test-cluster",
+			"cluster": map[string]interface{}{"server": "https://127.0.0.1:6443"},
+		},
+		Auth: map[string]interface{}{
+			"name": "test-user",
+			"user": map[string]interface{}{"token": "test-token"},
+		},
+		Server: "https://127.0.0.1:6443",
+	}
+}
 
 // publishedCharts is the catalogue these tests resolve against: the two current
 // charts, the first one that works (MinimumOperatorChartVersion), and two that
@@ -17,9 +37,15 @@ import (
 // repository for a chart that does not exist yet.
 var publishedCharts = []string{"v1.0.64", "v1.0.63", "v1.0.62", "v1.0.40", "v0.7.9"}
 
+// testChartRepo stands in for the repository the catalogue was read from. It is
+// deliberately not ChartRepo: resolution must report the repository it actually
+// resolved against, so a mirror or an in-cluster repository is never described
+// to the user as the default one.
+const testChartRepo = "https://example.invalid/charts"
+
 func mustResolve(t *testing.T, published []string, requested string, source OperatorChartVersionSource) (string, string) {
 	t.Helper()
-	version, reason, err := ResolveOperatorChartVersion(published, requested, source)
+	version, reason, err := ResolveOperatorChartVersion(testChartRepo, published, requested, source)
 	if err != nil {
 		t.Fatalf("ResolveOperatorChartVersion(%q) returned an unexpected error: %v", requested, err)
 	}
@@ -125,7 +151,7 @@ func TestExplicitChartVersionFailsLoudlyWhenUnusable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			version, reason, err := ResolveOperatorChartVersion(publishedCharts, tt.requested, OperatorChartVersionRequested)
+			version, reason, err := ResolveOperatorChartVersion(testChartRepo, publishedCharts, tt.requested, OperatorChartVersionRequested)
 			if err == nil {
 				t.Fatalf("expected %q to fail, got version %q", tt.requested, version)
 			}
@@ -154,7 +180,7 @@ func TestExplicitChartVersionBelowTheFloorIsHonored(t *testing.T) {
 
 func TestResolutionFailsWhenNothingUsableIsPublished(t *testing.T) {
 	for _, published := range [][]string{nil, {}, {"stable-latest", "edge-latest"}} {
-		_, _, err := ResolveOperatorChartVersion(published, "v1.0.64", OperatorChartVersionDerived)
+		_, _, err := ResolveOperatorChartVersion(testChartRepo, published, "v1.0.64", OperatorChartVersionDerived)
 		if err == nil {
 			t.Fatalf("expected a failure when the repository publishes %v", published)
 		}
@@ -168,6 +194,10 @@ func TestResolutionFailsWhenNothingUsableIsPublished(t *testing.T) {
 // where the repository has not yet published anything at or above the floor:
 // the newest published chart is still better than a version known to be broken,
 // and it must not resolve to "".
+//
+// It must also not be described as working. Calling a below-floor chart "the
+// oldest working chart" sends the user looking for a fix that has already been
+// applied, when the actionable fact is that no working chart is published yet.
 func TestFloorFallsBackToNewestWhenNothingReachesIt(t *testing.T) {
 	version, reason := mustResolve(t, []string{"v1.0.40", "v0.7.9"}, "v0.7.9", OperatorChartVersionDerived)
 	if version != "v1.0.40" {
@@ -175,6 +205,54 @@ func TestFloorFallsBackToNewestWhenNothingReachesIt(t *testing.T) {
 	}
 	if reason == "" {
 		t.Fatal("expected the substitution to be explained")
+	}
+	if strings.Contains(reason, "working chart") {
+		t.Fatalf("a below-floor chart must not be described as working: %q", reason)
+	}
+	if !strings.Contains(reason, MinimumOperatorChartVersion) {
+		t.Fatalf("the reason must name the minimum that nothing published reaches: %q", reason)
+	}
+}
+
+// TestChartVersionSpellingIsSemverNotStringEquality: Helm treats "1.0.64" and
+// "v1.0.64" as the same version. Matching on raw string equality rejected an
+// explicit pin that the repository does in fact publish, and reported a
+// substitution on the derived path for a version that needed none. The version
+// handed back is always the repository's own spelling, because that is what
+// reaches Helm and what the attached-version comparison is made against.
+func TestChartVersionSpellingIsSemverNotStringEquality(t *testing.T) {
+	for _, source := range []OperatorChartVersionSource{OperatorChartVersionRequested, OperatorChartVersionDerived} {
+		version, reason := mustResolve(t, publishedCharts, "1.0.64", source)
+		if version != "v1.0.64" {
+			t.Fatalf("chart version = %q, want the repository's own spelling v1.0.64", version)
+		}
+		if reason != "" {
+			t.Fatalf("the same release in another spelling is not a substitution, got reason %q", reason)
+		}
+	}
+}
+
+// TestUnpublishedVersionsNameTheRepositoryThatWasRead: the catalogue comes from
+// the deployment config's chart repository, which need not be the default one.
+// Telling the user to check a repository Meshery did not read sends them to the
+// wrong index.
+func TestUnpublishedVersionsNameTheRepositoryThatWasRead(t *testing.T) {
+	const mirror = "https://mirror.invalid/charts"
+
+	_, _, err := ResolveOperatorChartVersion(mirror, nil, "v1.0.64", OperatorChartVersionDerived)
+	if err == nil || !strings.Contains(err.Error(), mirror) {
+		t.Fatalf("an empty catalogue must name the repository it was read from, got %v", err)
+	}
+
+	_, reason, err := ResolveOperatorChartVersion(mirror, publishedCharts, "v1.0.66", OperatorChartVersionDerived)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(reason, mirror) {
+		t.Fatalf("the substitution reason must name the repository that was read, got %q", reason)
+	}
+	if strings.Contains(reason, ChartRepo) {
+		t.Fatalf("the substitution reason must not name a repository that was not read, got %q", reason)
 	}
 }
 
@@ -205,21 +283,7 @@ func TestUnreadableIndexStillAttachesBrokerAndMeshSync(t *testing.T) {
 	mch.chartVersions = func(string, string) ([]string, error) { return nil, errors.New("repository unreachable") }
 	mch.attachedOperatorChartVersion = "v1.0.64"
 
-	// A structurally complete context yields a Kubernetes client without
-	// contacting the cluster, so this reaches the chart-version resolution.
-	mch.AddCtxControllerHandlers(K8sContext{
-		ID:   "ctx-1",
-		Name: "test-cluster",
-		Cluster: map[string]interface{}{
-			"name":    "test-cluster",
-			"cluster": map[string]interface{}{"server": "https://127.0.0.1:6443"},
-		},
-		Auth: map[string]interface{}{
-			"name": "test-user",
-			"user": map[string]interface{}{"token": "test-token"},
-		},
-		Server: "https://127.0.0.1:6443",
-	})
+	mch.AddCtxControllerHandlers(reachableK8sContext())
 
 	handlers := mch.GetControllerHandlersForEachContext()
 	if _, ok := handlers[MesheryOperator]; ok {
@@ -293,6 +357,47 @@ func TestReconcileComparesPinnedVersionsNotRequestedOnes(t *testing.T) {
 	}
 	if chartVersion != "v1.0.64" {
 		t.Fatalf("chart version = %q, want the pinned v1.0.64", chartVersion)
+	}
+}
+
+// TestReconcileLeavesTheAttachedVersionClearedWhenNoHandlerAttaches guards the
+// retry path. When re-attaching cannot resolve a chart version it attaches no
+// operator handler and clears attachedOperatorChartVersion *deliberately*, so
+// the next reconcile tries again instead of reading a stale value as "already
+// at the desired version". Restoring the pre-reconcile value over that clearing
+// stranded operator lifecycle: reverting operator.version would then match the
+// stale attached version, short-circuit, and never re-attach a handler.
+func TestReconcileLeavesTheAttachedVersionClearedWhenNoHandlerAttaches(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
+	mch.SetControllersConfig(operatorVersionConfig("v1.0.63", connections.MeshsyncDeploymentModeOperator))
+	mch.attachedOperatorChartVersion = "v1.0.64"
+
+	// The index is readable when the reconcile computes the desired version and
+	// unreadable by the time re-attaching resolves it again - a TTL expiry, or a
+	// blip, between the two reads.
+	reads := 0
+	mch.chartVersions = func(string, string) ([]string, error) {
+		reads++
+		if reads == 1 {
+			return publishedCharts, nil
+		}
+		return nil, errors.New("repository unreachable")
+	}
+
+	_, redeployed, err := mch.ReconcileOperatorChartVersion(reachableK8sContext(), NewOperatorTracker(false))
+	if redeployed {
+		t.Fatal("no operator handler attached, so nothing can have been redeployed")
+	}
+	if err == nil {
+		t.Fatal("expected the failed re-attach to be reported")
+	}
+	if _, ok := mch.GetControllerHandlersForEachContext()[MesheryOperator]; ok {
+		t.Fatal("no chart version resolved, so no operator handler may be attached")
+	}
+	if mch.attachedOperatorChartVersion != "" {
+		t.Fatalf("attached chart version = %q, want it left cleared so the next reconcile retries",
+			mch.attachedOperatorChartVersion)
 	}
 }
 

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -432,26 +432,66 @@ func TestUserInitiatedDeployIsRefusedWhileNoChartVersionResolves(t *testing.T) {
 	stub := &stubController{status: controllers.NotDeployed}
 	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
 
-	chartErr := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
-	mch.setOperatorChartError(chartErr)
+	// The repository is still unreadable, so the retry this path performs
+	// resolves again and fails again. The refusal must then carry the *fresh*
+	// failure rather than falling through to a Deploy.
+	indexErr := errors.New("repository unreachable")
+	mch.chartVersions = func(string, string) ([]string, error) { return nil, indexErr }
+	mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
 
-	err := mch.SetOperatorDeployment(testContextID, true)
-	if !errors.Is(err, chartErr) {
-		t.Fatalf("err = %v, want the structured chart resolution failure returned to the caller", err)
+	err := mch.SetOperatorDeployment(reachableK8sContext(), true)
+	if !errors.Is(err, indexErr) {
+		t.Fatalf("err = %v, want the re-resolution's own failure returned to the caller", err)
 	}
 	if stub.deploys != 0 {
 		t.Fatalf("Deploy was called %d times with no installable chart version", stub.deploys)
 	}
-	if !errors.Is(mch.GetOperatorError(), chartErr) {
+	if !errors.Is(mch.GetOperatorError(), indexErr) {
 		t.Fatalf("operator error = %v, want the chart resolution failure recorded", mch.GetOperatorError())
 	}
 
-	mch.setOperatorChartError(nil)
-	if err := mch.SetOperatorDeployment(testContextID, true); err != nil {
-		t.Fatalf("unexpected error once a chart version resolved: %v", err)
+	// With nothing latched there is no retry, and the same handler installs.
+	mch = newTestControllersHelper(t)
+	stub = &stubController{status: controllers.NotDeployed}
+	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
+	if err := mch.SetOperatorDeployment(K8sContext{ID: testContextID}, true); err != nil {
+		t.Fatalf("unexpected error with a resolvable chart version: %v", err)
 	}
 	if stub.deploys != 1 {
-		t.Fatalf("Deploy was called %d times once a chart version resolved, want 1", stub.deploys)
+		t.Fatalf("Deploy was called %d times with a resolvable chart version, want 1", stub.deploys)
+	}
+}
+
+// TestUserInitiatedDeployRetriesResolutionAfterTheRepositoryRecovers is what
+// makes ErrHelmChartIndex's remediation - "confirm the repository is reachable,
+// then retry" - a true instruction rather than a dead end.
+//
+// operatorChartError is written only where handlers are attached, so a connect
+// that landed during a repository outage used to refuse every later install for
+// the life of that connection however long ago the repository came back.
+// Clearing the latch alone would not have been enough either: the handler
+// attached on the failure path still carries the raw unresolved chart version,
+// so re-resolving and re-attaching have to happen together.
+func TestUserInitiatedDeployRetriesResolutionAfterTheRepositoryRecovers(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
+	mch.attachedOperatorChartVersion = ""
+
+	// The catalogue is readable again, so this call must re-resolve rather than
+	// serve the latched refusal. The Deploy it then attempts runs against a
+	// cluster that does not exist and is expected to fail; what matters is that
+	// the refusal is gone and the handler carries a resolved version.
+	err := mch.SetOperatorDeployment(reachableK8sContext(), true)
+
+	if chartErr := mch.GetOperatorChartError(); chartErr != nil {
+		t.Fatalf("operator chart error = %v, want the latch cleared by a resolution that succeeded", chartErr)
+	}
+	if mch.attachedOperatorChartVersion != bootChartVersion {
+		t.Fatalf("attached chart version = %q, want %q re-attached by the retry",
+			mch.attachedOperatorChartVersion, bootChartVersion)
+	}
+	if err != nil && meshkiterrors.GetCode(err) == ErrNoOperatorChartPublishedCode {
+		t.Fatalf("the retry still refused on the stale latch: %v", err)
 	}
 }
 
@@ -463,7 +503,7 @@ func TestUserInitiatedUndeployIsNeverSilent(t *testing.T) {
 	mch := newTestControllersHelper(t)
 	mch.ctxControllerHandlers = nil
 
-	err := mch.SetOperatorDeployment(testContextID, false)
+	err := mch.SetOperatorDeployment(K8sContext{ID: testContextID}, false)
 	if err == nil {
 		t.Fatal("a user-initiated undeploy with no handler must not report success")
 	}
@@ -494,7 +534,7 @@ func TestUndeployIsNotBlockedByAnUnresolvableChartVersion(t *testing.T) {
 		{
 			name: "user initiated",
 			act: func(mch *MesheryControllersHelper) {
-				if err := mch.SetOperatorDeployment(testContextID, false); err != nil {
+				if err := mch.SetOperatorDeployment(K8sContext{ID: testContextID}, false); err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 			},
@@ -715,6 +755,53 @@ func TestReconcileLeavesTheAttachedVersionClearedWhenResolutionFails(t *testing.
 	}
 	if mch.attachedOperatorChartVersion != "" {
 		t.Fatalf("attached chart version = %q, want it left cleared so the next reconcile retries",
+			mch.attachedOperatorChartVersion)
+	}
+}
+
+// TestReconcileInstallGoesThroughTheSharedGuard is the third install path.
+// operatorInstallTarget claims to be the one guard every install goes through,
+// and the reconcile used to read the handler straight out of the map and reach
+// Deploy without ever consulting the chart error - guarded only incidentally, by
+// lastOperatorError happening to be written in the same call that writes the
+// chart error.
+//
+// Reaching that guard needs the two errors to disagree, which
+// AddCtxControllerHandlers never lets happen, so the divergence is injected
+// through the version lister: it succeeds - leaving lastOperatorError nil - and
+// latches a chart error on the re-attach's own resolution, which is exactly the
+// state a future writer of lastOperatorError could otherwise create.
+func TestReconcileInstallGoesThroughTheSharedGuard(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
+	mch.SetControllersConfig(operatorVersionConfig("", connections.MeshsyncDeploymentModeOperator))
+	mch.attachedOperatorChartVersion = "v1.0.51"
+
+	latched := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
+	reads := 0
+	mch.chartVersions = func(string, string) ([]string, error) {
+		reads++
+		if reads >= 2 {
+			mch.setOperatorChartError(latched)
+		}
+		return publishedCharts, nil
+	}
+
+	_, redeployed, err := mch.ReconcileOperatorChartVersion(reachableK8sContext(), NewOperatorTracker(false))
+	if redeployed {
+		t.Fatal("installation was refused, so nothing can have been redeployed")
+	}
+	if err == nil {
+		t.Fatal("expected the refusal to be reported")
+	}
+	if code := meshkiterrors.GetCode(err); code != ErrReconcileOperatorChartVersionCode {
+		t.Fatalf("error code = %q, want %q (from %v)", code, ErrReconcileOperatorChartVersionCode, err)
+	}
+	if !strings.Contains(err.Error(), "advertises no released") {
+		t.Fatalf("the reconcile reached Helm instead of refusing on the latched chart error: %v", err)
+	}
+	if mch.attachedOperatorChartVersion != "v1.0.51" {
+		t.Fatalf("attached chart version = %q, want the pre-reconcile value restored so the refusal is retried",
 			mch.attachedOperatorChartVersion)
 	}
 }

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -367,6 +367,12 @@ func TestChartResolutionFailureIsClearedByALaterSuccess(t *testing.T) {
 	}
 }
 
+// testContextID is the Kubernetes context identifier the lifecycle call sites
+// are given. It is non-empty on purpose: ErrOperatorHandlerNotAttached renders
+// it into the cause the user reads, and an operator triaging several
+// connections needs to be told which one lost its handler.
+const testContextID = "ctx-1"
+
 // stubController is an IMesheryController that records what it was asked to do,
 // so the deploy/undeploy call sites can be tested without a cluster.
 type stubController struct {
@@ -399,7 +405,7 @@ func TestDeployIsRefusedWhileNoChartVersionResolves(t *testing.T) {
 	chartErr := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
 	mch.setOperatorChartError(chartErr)
 
-	mch.DeployUndeployedOperators(NewOperatorTracker(false))
+	mch.DeployUndeployedOperators(NewOperatorTracker(false), testContextID)
 
 	if stub.deploys != 0 {
 		t.Fatalf("Deploy was called %d times with no installable chart version", stub.deploys)
@@ -410,26 +416,103 @@ func TestDeployIsRefusedWhileNoChartVersionResolves(t *testing.T) {
 
 	// Cleared, the same handler installs.
 	mch.setOperatorChartError(nil)
-	mch.DeployUndeployedOperators(NewOperatorTracker(false))
+	mch.DeployUndeployedOperators(NewOperatorTracker(false), testContextID)
 	if stub.deploys != 1 {
 		t.Fatalf("Deploy was called %d times once a chart version resolved, want 1", stub.deploys)
 	}
 }
 
-// TestUndeployIsNotBlockedByAnUnresolvableChartVersion: removal is the
-// direction that must always be attempted. Refusing it would leave the operator
-// running on a cluster the user asked to have it taken off.
-func TestUndeployIsNotBlockedByAnUnresolvableChartVersion(t *testing.T) {
+// TestUserInitiatedDeployIsRefusedWhileNoChartVersionResolves closes the second
+// way in. The GraphQL changeOperatorStatus mutation used to reach around the
+// helper for a raw meshkit handler, so the guard the connect-time path applies
+// did not exist on the path a user actually clicks. Both now share
+// operatorInstallTarget and must refuse identically.
+func TestUserInitiatedDeployIsRefusedWhileNoChartVersionResolves(t *testing.T) {
 	mch := newTestControllersHelper(t)
-	stub := &stubController{status: controllers.Deployed}
+	stub := &stubController{status: controllers.NotDeployed}
 	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
-	mch.ctxOperatorStatus = controllers.Deployed
-	mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
 
-	mch.UndeployDeployedOperators(NewOperatorTracker(false))
+	chartErr := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
+	mch.setOperatorChartError(chartErr)
 
-	if stub.undeploys != 1 {
-		t.Fatalf("Undeploy was called %d times, want 1: an unresolvable chart version must not strand the operator", stub.undeploys)
+	err := mch.SetOperatorDeployment(testContextID, true)
+	if !errors.Is(err, chartErr) {
+		t.Fatalf("err = %v, want the structured chart resolution failure returned to the caller", err)
+	}
+	if stub.deploys != 0 {
+		t.Fatalf("Deploy was called %d times with no installable chart version", stub.deploys)
+	}
+	if !errors.Is(mch.GetOperatorError(), chartErr) {
+		t.Fatalf("operator error = %v, want the chart resolution failure recorded", mch.GetOperatorError())
+	}
+
+	mch.setOperatorChartError(nil)
+	if err := mch.SetOperatorDeployment(testContextID, true); err != nil {
+		t.Fatalf("unexpected error once a chart version resolved: %v", err)
+	}
+	if stub.deploys != 1 {
+		t.Fatalf("Deploy was called %d times once a chart version resolved, want 1", stub.deploys)
+	}
+}
+
+// TestUserInitiatedUndeployIsNeverSilent: a user who switches the operator off
+// must be told when nothing could be done, whether or not Meshery ever observed
+// an operator here. This is the case the teardown gate below deliberately does
+// not cover.
+func TestUserInitiatedUndeployIsNeverSilent(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.ctxControllerHandlers = nil
+
+	err := mch.SetOperatorDeployment(testContextID, false)
+	if err == nil {
+		t.Fatal("a user-initiated undeploy with no handler must not report success")
+	}
+	if code := meshkiterrors.GetCode(err); code != ErrOperatorHandlerNotAttachedCode {
+		t.Fatalf("error code = %q, want %q (from %v)", code, ErrOperatorHandlerNotAttachedCode, err)
+	}
+	if !strings.Contains(err.Error(), testContextID) {
+		t.Fatalf("the error must name the context it is about, got %v", err)
+	}
+}
+
+// TestUndeployIsNotBlockedByAnUnresolvableChartVersion: removal is the
+// direction to attempt rather than refuse. Refusing would leave the operator
+// running on a cluster the user asked to have it taken off - even though the
+// attempt itself may still fail in meshkit, which downloads the chart archive
+// for UNINSTALL from the very repository that could not be read.
+func TestUndeployIsNotBlockedByAnUnresolvableChartVersion(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		act  func(*MesheryControllersHelper)
+	}{
+		{
+			name: "reconcile",
+			act: func(mch *MesheryControllersHelper) {
+				mch.UndeployDeployedOperators(NewOperatorTracker(false), testContextID)
+			},
+		},
+		{
+			name: "user initiated",
+			act: func(mch *MesheryControllersHelper) {
+				if err := mch.SetOperatorDeployment(testContextID, false); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mch := newTestControllersHelper(t)
+			stub := &stubController{status: controllers.Deployed}
+			mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
+			mch.ctxOperatorStatus = controllers.Deployed
+			mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
+
+			tt.act(mch)
+
+			if stub.undeploys != 1 {
+				t.Fatalf("Undeploy was called %d times, want 1: an unresolvable chart version must not strand the operator", stub.undeploys)
+			}
+		})
 	}
 }
 
@@ -447,14 +530,14 @@ func TestMissingOperatorHandlerIsNeverASilentNoOp(t *testing.T) {
 			name:   "deploy",
 			status: controllers.NotDeployed,
 			act: func(mch *MesheryControllersHelper) {
-				mch.DeployUndeployedOperators(NewOperatorTracker(false))
+				mch.DeployUndeployedOperators(NewOperatorTracker(false), testContextID)
 			},
 		},
 		{
 			name:   "undeploy",
 			status: controllers.Deployed,
 			act: func(mch *MesheryControllersHelper) {
-				mch.UndeployDeployedOperators(NewOperatorTracker(false))
+				mch.UndeployDeployedOperators(NewOperatorTracker(false), testContextID)
 			},
 		},
 	}
@@ -479,8 +562,54 @@ func TestMissingOperatorHandlerIsNeverASilentNoOp(t *testing.T) {
 				if code := meshkiterrors.GetCode(err); code != ErrOperatorHandlerNotAttachedCode {
 					t.Fatalf("error code = %q, want %q (from %v)", code, ErrOperatorHandlerNotAttachedCode, err)
 				}
+				if !strings.Contains(err.Error(), testContextID) {
+					t.Fatalf("%s: the error must name the context it is about, got %v", tt.name, err)
+				}
 			}
 		})
+	}
+}
+
+// TestTeardownOfANeverConnectedConnectionIsQuiet: disconnect and delete run
+// UndeployDeployedOperators unconditionally, and a connection whose cluster was
+// never reachable has no handler *and never had an operator*. Alerting that its
+// removal failed would be a second alert for a non-event, on top of the
+// Kubernetes-client failure the connect attempt already reported.
+//
+// The discriminator is whether the operator status was ever genuinely observed,
+// which is exactly what distinguishes "we saw one and can no longer act on it"
+// from "we never reached this cluster".
+func TestTeardownOfANeverConnectedConnectionIsQuiet(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.ctxControllerHandlers = nil
+	if mch.ctxOperatorStatus != controllers.Unknown {
+		t.Fatalf("seeded operator status = %v, want the unobserved Unknown this test is about", mch.ctxOperatorStatus)
+	}
+
+	mch.UndeployDeployedOperators(NewOperatorTracker(false), testContextID)
+
+	if err := mch.GetOperatorError(); err != nil {
+		t.Fatalf("tearing down a never-connected connection reported %v; it has no operator to fail to remove", err)
+	}
+}
+
+// TestMissingHandlerNeverClobbersTheSpecificDiagnostic: "no operator handler is
+// attached" is the *consequence* of the kubeconfig or Kubernetes-client failure
+// that AddCtxControllerHandlers already recorded by name. Letting the
+// consequence overwrite the cause meant tearing a connection down degraded the
+// very diagnostic this work exists to provide.
+func TestMissingHandlerNeverClobbersTheSpecificDiagnostic(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	clientErr := errors.New("failed to create Kubernetes client: no such host")
+	mch.setOperatorError(clientErr)
+	mch.ctxControllerHandlers = nil
+	// Observed, so the teardown gate above does not apply and the report runs.
+	mch.ctxOperatorStatus = controllers.Deployed
+
+	mch.UndeployDeployedOperators(NewOperatorTracker(false), testContextID)
+
+	if !errors.Is(mch.GetOperatorError(), clientErr) {
+		t.Fatalf("operator error = %v, want the actionable client failure to survive the teardown", mch.GetOperatorError())
 	}
 }
 

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -132,8 +132,9 @@ func TestDerivedChartVersionSubstitutionIsNeverSilent(t *testing.T) {
 
 // TestDerivedChartVersionIsFlooredToTheOldestWorkingChart pins the fix for the
 // reported failure: a server old enough to predate MinimumOperatorChartVersion
-// requests a chart that *is* published but cannot run (retired kube-rbac-proxy
-// image, no webhook certificate). It must be raised to the oldest *published*
+// requests a chart that *is* published but cannot run (a kube-rbac-proxy
+// sidecar that affected clusters cannot pull, no webhook certificate). It must
+// be raised to the oldest *published*
 // chart at or above the floor - not to the newest, which would be a larger
 // change than the defect requires, and not to the floor constant itself, which
 // the repository is not obliged to publish.

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/meshery/meshery/server/models/connections"
 	meshkiterrors "github.com/meshery/meshkit/errors"
+	"github.com/meshery/meshkit/models/controllers"
 	"github.com/spf13/viper"
 )
 
@@ -305,32 +306,181 @@ func TestPinnedDeploymentConfigSurfacesAnUnreadableIndex(t *testing.T) {
 	}
 }
 
-// TestUnreadableIndexStillAttachesBrokerAndMeshSync asserts the blast radius of
-// an unreachable chart repository is confined to operator lifecycle. The Broker
-// and MeshSync handlers only observe what is already in the cluster, so
-// withholding them too would turn a momentary repository blip into lost
-// discovery on a cluster whose operator is already installed and healthy.
-func TestUnreadableIndexStillAttachesBrokerAndMeshSync(t *testing.T) {
+// TestUnreadableIndexWithholdsInstallationNotObservation draws the line the
+// chart version actually sits on. meshkit's operator handler reads its
+// deployment config in Deploy and Undeploy only - GetStatus and GetVersion
+// never touch it - so a version is what it takes to *install* the operator, not
+// to *watch* one. Withholding the handler when the repository could not be read
+// therefore cost a healthy, already-installed operator its status and its image
+// tag, which is the exact value the troubleshooting guide tells users to read.
+//
+// All three handlers attach; only installation is withheld, and why is recorded
+// for the diagnostics API.
+func TestUnreadableIndexWithholdsInstallationNotObservation(t *testing.T) {
 	mch := newTestControllersHelper(t)
-	mch.chartVersions = func(string, string) ([]string, error) { return nil, errors.New("repository unreachable") }
+	indexErr := errors.New("repository unreachable")
+	mch.chartVersions = func(string, string) ([]string, error) { return nil, indexErr }
 	mch.attachedOperatorChartVersion = "v1.0.64"
 
 	mch.AddCtxControllerHandlers(reachableK8sContext())
 
 	handlers := mch.GetControllerHandlersForEachContext()
-	if _, ok := handlers[MesheryOperator]; ok {
-		t.Fatal("no chart version is safe to install, so no operator handler may be attached")
-	}
-	for controller, name := range map[MesheryController]string{MesheryBroker: "broker", Meshsync: "meshsync"} {
+	for controller, name := range map[MesheryController]string{
+		MesheryBroker:   "broker",
+		Meshsync:        "meshsync",
+		MesheryOperator: "operator",
+	} {
 		if h, ok := handlers[controller]; !ok || h == nil {
-			t.Fatalf("the %s handler needs no chart version and must still be attached", name)
+			t.Fatalf("the %s handler observes the cluster and must be attached", name)
 		}
 	}
+	if chartErr := mch.GetOperatorChartError(); !errors.Is(chartErr, indexErr) {
+		t.Fatalf("operator chart error = %v, want the index failure that withholds installation", chartErr)
+	}
 	if mch.GetOperatorError() == nil {
-		t.Fatal("the reason operator lifecycle is withheld must be recorded for diagnostics")
+		t.Fatal("the reason installation is withheld must be recorded for diagnostics")
 	}
 	if mch.attachedOperatorChartVersion != "" {
 		t.Fatalf("attached chart version = %q, want it cleared so the next reconcile retries", mch.attachedOperatorChartVersion)
+	}
+}
+
+// TestChartResolutionFailureIsClearedByALaterSuccess: the refusal is a live
+// condition, not a latch. A repository that comes back must not leave
+// installation withheld until the server restarts.
+func TestChartResolutionFailureIsClearedByALaterSuccess(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.chartVersions = func(string, string) ([]string, error) { return nil, errors.New("repository unreachable") }
+	mch.AddCtxControllerHandlers(reachableK8sContext())
+	if mch.GetOperatorChartError() == nil {
+		t.Fatal("expected the unreadable index to withhold installation")
+	}
+
+	mch.chartVersions = func(string, string) ([]string, error) { return publishedCharts, nil }
+	mch.AddCtxControllerHandlers(reachableK8sContext())
+
+	if err := mch.GetOperatorChartError(); err != nil {
+		t.Fatalf("operator chart error = %v, want it cleared once a version resolved", err)
+	}
+	if mch.attachedOperatorChartVersion != bootChartVersion {
+		t.Fatalf("attached chart version = %q, want %q", mch.attachedOperatorChartVersion, bootChartVersion)
+	}
+}
+
+// stubController is an IMesheryController that records what it was asked to do,
+// so the deploy/undeploy call sites can be tested without a cluster.
+type stubController struct {
+	status    controllers.MesheryControllerStatus
+	deploys   int
+	undeploys int
+	deployErr error
+}
+
+func (s *stubController) GetName() string                                { return "stub" }
+func (s *stubController) GetStatus() controllers.MesheryControllerStatus { return s.status }
+func (s *stubController) Deploy(bool) error                              { s.deploys++; return s.deployErr }
+func (s *stubController) Undeploy() error                                { s.undeploys++; return nil }
+func (s *stubController) GetPublicEndpoint() (string, error)             { return "", nil }
+func (s *stubController) GetVersion() (string, error)                    { return "1.0.5", nil }
+func (s *stubController) GetEndpointForPort(string) (string, error)      { return "", nil }
+
+// TestDeployIsRefusedWhileNoChartVersionResolves is the other half of attaching
+// the handler unconditionally: the handler exists for observation, so the
+// refusal has to live at the point of installation. Handing Helm a version the
+// repository does not publish would surface as an opaque chart-not-found error
+// instead of this connection's recorded resolution failure.
+func TestDeployIsRefusedWhileNoChartVersionResolves(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
+	stub := &stubController{status: controllers.NotDeployed}
+	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
+	mch.ctxOperatorStatus = controllers.NotDeployed
+
+	chartErr := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
+	mch.setOperatorChartError(chartErr)
+
+	mch.DeployUndeployedOperators(NewOperatorTracker(false))
+
+	if stub.deploys != 0 {
+		t.Fatalf("Deploy was called %d times with no installable chart version", stub.deploys)
+	}
+	if !errors.Is(mch.GetOperatorError(), chartErr) {
+		t.Fatalf("operator error = %v, want the chart resolution failure", mch.GetOperatorError())
+	}
+
+	// Cleared, the same handler installs.
+	mch.setOperatorChartError(nil)
+	mch.DeployUndeployedOperators(NewOperatorTracker(false))
+	if stub.deploys != 1 {
+		t.Fatalf("Deploy was called %d times once a chart version resolved, want 1", stub.deploys)
+	}
+}
+
+// TestUndeployIsNotBlockedByAnUnresolvableChartVersion: removal is the
+// direction that must always be attempted. Refusing it would leave the operator
+// running on a cluster the user asked to have it taken off.
+func TestUndeployIsNotBlockedByAnUnresolvableChartVersion(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	stub := &stubController{status: controllers.Deployed}
+	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
+	mch.ctxOperatorStatus = controllers.Deployed
+	mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
+
+	mch.UndeployDeployedOperators(NewOperatorTracker(false))
+
+	if stub.undeploys != 1 {
+		t.Fatalf("Undeploy was called %d times, want 1: an unresolvable chart version must not strand the operator", stub.undeploys)
+	}
+}
+
+// TestMissingOperatorHandlerIsNeverASilentNoOp pins the condition that used to
+// be unreachable and is now routine: with no operator handler attached, deploy
+// and undeploy did nothing and said nothing, so a user who switched the
+// operator off saw success while it kept running on the cluster.
+func TestMissingOperatorHandlerIsNeverASilentNoOp(t *testing.T) {
+	tests := []struct {
+		name   string
+		status controllers.MesheryControllerStatus
+		act    func(*MesheryControllersHelper)
+	}{
+		{
+			name:   "deploy",
+			status: controllers.NotDeployed,
+			act: func(mch *MesheryControllersHelper) {
+				mch.DeployUndeployedOperators(NewOperatorTracker(false))
+			},
+		},
+		{
+			name:   "undeploy",
+			status: controllers.Deployed,
+			act: func(mch *MesheryControllersHelper) {
+				mch.UndeployDeployedOperators(NewOperatorTracker(false))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, handlers := range []map[MesheryController]controllers.IMesheryController{
+				nil,
+				{MesheryBroker: &stubController{}},
+			} {
+				mch := newTestControllersHelper(t)
+				mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
+				mch.ctxControllerHandlers = handlers
+				mch.ctxOperatorStatus = tt.status
+
+				tt.act(mch)
+
+				err := mch.GetOperatorError()
+				if err == nil {
+					t.Fatalf("%s with no operator handler reported nothing; it must not read as success", tt.name)
+				}
+				if code := meshkiterrors.GetCode(err); code != ErrOperatorHandlerNotAttachedCode {
+					t.Fatalf("error code = %q, want %q (from %v)", code, ErrOperatorHandlerNotAttachedCode, err)
+				}
+			}
+		})
 	}
 }
 
@@ -392,14 +542,18 @@ func TestReconcileComparesPinnedVersionsNotRequestedOnes(t *testing.T) {
 	}
 }
 
-// TestReconcileLeavesTheAttachedVersionClearedWhenNoHandlerAttaches guards the
-// retry path. When re-attaching cannot resolve a chart version it attaches no
-// operator handler and clears attachedOperatorChartVersion *deliberately*, so
-// the next reconcile tries again instead of reading a stale value as "already
-// at the desired version". Restoring the pre-reconcile value over that clearing
-// stranded operator lifecycle: reverting operator.version would then match the
-// stale attached version, short-circuit, and never re-attach a handler.
-func TestReconcileLeavesTheAttachedVersionClearedWhenNoHandlerAttaches(t *testing.T) {
+// TestReconcileLeavesTheAttachedVersionClearedWhenResolutionFails guards the
+// retry path. When re-attaching cannot resolve a chart version it clears
+// attachedOperatorChartVersion *deliberately*, so the next reconcile tries
+// again instead of reading a stale value as "already at the desired version".
+// Restoring the pre-reconcile value over that clearing stranded operator
+// lifecycle: reverting operator.version would then match the stale attached
+// version, short-circuit, and never resolve again.
+//
+// The handler itself stays attached - it is what keeps reporting the operator's
+// status and image tag - so the restore must key on the cleared version, not on
+// whether a handler is present.
+func TestReconcileLeavesTheAttachedVersionClearedWhenResolutionFails(t *testing.T) {
 	mch := newTestControllersHelper(t)
 	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
 	mch.SetControllersConfig(operatorVersionConfig("v1.0.63", connections.MeshsyncDeploymentModeOperator))
@@ -419,18 +573,114 @@ func TestReconcileLeavesTheAttachedVersionClearedWhenNoHandlerAttaches(t *testin
 
 	_, redeployed, err := mch.ReconcileOperatorChartVersion(reachableK8sContext(), NewOperatorTracker(false))
 	if redeployed {
-		t.Fatal("no operator handler attached, so nothing can have been redeployed")
+		t.Fatal("no chart version resolved, so nothing can have been redeployed")
 	}
 	if err == nil {
 		t.Fatal("expected the failed re-attach to be reported")
 	}
-	if _, ok := mch.GetControllerHandlersForEachContext()[MesheryOperator]; ok {
-		t.Fatal("no chart version resolved, so no operator handler may be attached")
+	if h := mch.GetControllerHandlersForEachContext()[MesheryOperator]; h == nil {
+		t.Fatal("the operator handler observes the cluster and must stay attached")
+	}
+	if mch.GetOperatorChartError() == nil {
+		t.Fatal("installation must stay withheld until a chart version resolves")
 	}
 	if mch.attachedOperatorChartVersion != "" {
 		t.Fatalf("attached chart version = %q, want it left cleared so the next reconcile retries",
 			mch.attachedOperatorChartVersion)
 	}
+}
+
+// TestPrereleaseChartsAreNeverSelectedAutomatically covers the whole automatic
+// path. meshery.io has carried prerelease operator charts (v0.6.0-rc.6,
+// v0.6.0-rc.5l, v0.5.0-rc-5g), and by semver a release candidate outranks every
+// stable chart below it - so an rc published ahead of its release would
+// otherwise be what every server whose own chart is not yet published installs
+// onto a production cluster.
+func TestPrereleaseChartsAreNeverSelectedAutomatically(t *testing.T) {
+	t.Run("the newest-published fallback skips a prerelease", func(t *testing.T) {
+		published := []string{"v1.0.66-rc.1", "v1.0.65", "v1.0.51"}
+		version, reason := mustResolve(t, published, "v1.0.70", OperatorChartVersionDerived)
+		if version != "v1.0.65" {
+			t.Fatalf("chart version = %q, want the newest *stable* chart v1.0.65", version)
+		}
+		if reason == "" {
+			t.Fatal("expected the fallback to be explained")
+		}
+	})
+
+	t.Run("an unpinned server release skips a prerelease", func(t *testing.T) {
+		published := []string{"v1.0.66-rc.1", "v1.0.65", "v1.0.51"}
+		version, _ := mustResolve(t, published, "", OperatorChartVersionDerived)
+		if version != "v1.0.65" {
+			t.Fatalf("chart version = %q, want the newest *stable* chart v1.0.65", version)
+		}
+	})
+
+	t.Run("the floor raise skips a prerelease sitting at the boundary", func(t *testing.T) {
+		// v1.0.52-rc.1 is the oldest published chart at or above the floor, and
+		// selecting it would land a release candidate on a cluster whose only
+		// fault was running an old server.
+		published := []string{"v1.0.53", "v1.0.52-rc.1", "v1.0.40"}
+		version, reason := mustResolve(t, published, "v1.0.40", OperatorChartVersionDerived)
+		if version != "v1.0.53" {
+			t.Fatalf("chart version = %q, want the oldest *stable* chart at or above the floor, v1.0.53", version)
+		}
+		if reason == "" {
+			t.Fatal("expected the floor raise to be explained")
+		}
+	})
+
+	t.Run("a repository publishing only prereleases fails rather than selecting one", func(t *testing.T) {
+		_, _, err := ResolveOperatorChartVersion(testChartRepo, []string{"v1.0.66-rc.1", "v1.0.65-rc.2"}, "v1.0.70", OperatorChartVersionDerived)
+		if err == nil {
+			t.Fatal("expected resolution to fail rather than select a release candidate nobody asked for")
+		}
+		if code := meshkiterrors.GetCode(err); code != ErrNoOperatorChartPublishedCode {
+			t.Fatalf("error code = %q, want %q (from %v)", code, ErrNoOperatorChartPublishedCode, err)
+		}
+	})
+}
+
+// TestPrereleaseChartsRemainReachableWhenNamed is the other side of the rule:
+// exclusion applies to what Meshery *chooses*, never to what it is *told*. A
+// prerelease pinned by name is honored exactly, and a prerelease server release
+// that matches a published prerelease chart is not a choice either - it names
+// one release, and it is the one the server was built alongside.
+func TestPrereleaseChartsRemainReachableWhenNamed(t *testing.T) {
+	published := []string{"v1.0.66-rc.1", "v1.0.65", "v1.0.51"}
+
+	t.Run("an explicit prerelease pin is honored", func(t *testing.T) {
+		version, reason := mustResolve(t, published, "v1.0.66-rc.1", OperatorChartVersionRequested)
+		if version != "v1.0.66-rc.1" {
+			t.Fatalf("chart version = %q, want the explicitly requested v1.0.66-rc.1", version)
+		}
+		if reason != "" {
+			t.Fatalf("an honored explicit request is not a substitution, got reason %q", reason)
+		}
+	})
+
+	t.Run("a prerelease server release matching a published chart is used verbatim", func(t *testing.T) {
+		version, reason := mustResolve(t, published, "v1.0.66-rc.1", OperatorChartVersionDerived)
+		if version != "v1.0.66-rc.1" {
+			t.Fatalf("chart version = %q, want the matching published chart v1.0.66-rc.1", version)
+		}
+		if reason != "" {
+			t.Fatalf("naming a published release exactly is not a substitution, got reason %q", reason)
+		}
+	})
+
+	t.Run("an unusable explicit pin is pointed at a stable version", func(t *testing.T) {
+		_, _, err := ResolveOperatorChartVersion(testChartRepo, published, "v9.9.9", OperatorChartVersionRequested)
+		if err == nil {
+			t.Fatal("expected an unpublished explicit pin to fail")
+		}
+		if !strings.Contains(err.Error(), "v1.0.65") {
+			t.Fatalf("the remedy must name a stable chart, got %v", err)
+		}
+		if strings.Contains(err.Error(), "v1.0.66-rc.1") {
+			t.Fatalf("the remedy must not recommend a release candidate, got %v", err)
+		}
+	})
 }
 
 // TestNewOperatorDeploymentConfigNeverStampsAMovingVersion asserts the boot-time

--- a/server/models/operator_chart_pinning_test.go
+++ b/server/models/operator_chart_pinning_test.go
@@ -40,6 +40,41 @@ func reachableK8sContext() K8sContext {
 	}
 }
 
+// unresolvableK8sContext is the counterpart to reachableK8sContext. It carries
+// no cluster and no auth, so mesherykube.New rejects it and
+// AddCtxControllerHandlers returns before it attaches a handler or resolves a
+// chart version - which is what keeps a test using it away from meshkit's Helm
+// client entirely.
+//
+// That it fails, rather than quietly falling back to whatever kubeconfig the
+// machine happens to have, rests on a meshkit detail: ProcessConfig runs
+// clientcmd.Validate, which rejects the generated document, and DetectKubeConfig
+// returns that error immediately instead of continuing to rest.InClusterConfig,
+// $KUBECONFIG or ~/.kube/config. Should that ever change, mesherykube.New would
+// hand back a live client aimed at the developer's current kubectl context and a
+// test relying on this seam could install the operator into it for real. Every
+// such test therefore calls requireUnresolvableK8sContext first rather than
+// assuming the seam still holds.
+func unresolvableK8sContext() K8sContext {
+	return K8sContext{ID: testContextID, Name: "unresolvable-cluster"}
+}
+
+// requireUnresolvableK8sContext fails the test unless unresolvableK8sContext
+// still cannot yield a Kubernetes client. Call it before any code path that
+// would otherwise install through a real handler, so a meshkit change that
+// relaxes the validation above surfaces here instead of as a live helm install.
+func requireUnresolvableK8sContext(t *testing.T) {
+	t.Helper()
+	probe := newTestControllersHelper(t)
+	probe.AddCtxControllerHandlers(unresolvableK8sContext())
+	if probe.GetOperatorError() == nil {
+		t.Fatal("unresolvableK8sContext now yields a Kubernetes client: meshkit's kubeconfig validation changed, and tests built on this seam can reach a real Helm install")
+	}
+	if probe.attachedOperatorHandler() != nil {
+		t.Fatal("unresolvableK8sContext attached an operator handler: the seam these tests rely on no longer holds")
+	}
+}
+
 // publishedCharts is the catalogue every test in package models resolves
 // against: three current charts, the oldest one verified to deploy
 // (MinimumOperatorChartVersion), and two that predate it. It deliberately stops
@@ -835,8 +870,9 @@ func TestChartErrorLatchSurvivesAReattachThatNeverResolves(t *testing.T) {
 	// yields a Kubernetes client, so this run returns before it ever resolves a
 	// chart version - leaving the previous handler, and its unresolved version,
 	// in place.
+	requireUnresolvableK8sContext(t)
 	mch.chartVersions = func(string, string) ([]string, error) { return publishedCharts, nil }
-	mch.AddCtxControllerHandlers(K8sContext{ID: testContextID, Name: "unparseable"})
+	mch.AddCtxControllerHandlers(unresolvableK8sContext())
 
 	if mch.GetOperatorChartError() == nil {
 		t.Fatal("a run that never reached resolution cleared the refusal, leaving a stale handler unguarded")
@@ -858,11 +894,19 @@ func TestChartErrorLatchSurvivesAReattachThatNeverResolves(t *testing.T) {
 	}
 }
 
-// TestReconcileInstallRefusesOnALatchedChartError covers the reconcile's own
-// install site. Its re-attach cannot clear a latch it never resolved past, so a
-// connection whose cluster became unreachable during a chart-repository outage
-// reports the failure instead of installing.
-func TestReconcileInstallRefusesOnALatchedChartError(t *testing.T) {
+// TestReconcileLeavesTheLatchStandingWhenReattachFails pins the reconcile
+// counterpart of the latch fix, and only that: its re-attach fails at the
+// Kubernetes client, so the reconcile returns at the operator-error branch
+// before the install site is reached. What it proves is that a re-attach which
+// never resolved a chart version neither installs nor lifts the refusal, and
+// that the pre-reconcile chart version is restored so the next attempt retries.
+//
+// It deliberately does NOT cover the reconcile's wiring to the shared install
+// guard - nothing here reaches that branch. TestReconcileInstallGoesThroughTheSharedGuard
+// is what covers it.
+func TestReconcileLeavesTheLatchStandingWhenReattachFails(t *testing.T) {
+	requireUnresolvableK8sContext(t)
+
 	mch := newTestControllersHelper(t)
 	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
 	mch.SetControllersConfig(operatorVersionConfig("", connections.MeshsyncDeploymentModeOperator))
@@ -872,10 +916,71 @@ func TestReconcileInstallRefusesOnALatchedChartError(t *testing.T) {
 	mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
 	mch.setOperatorChartError(ErrNoOperatorChartPublished(OperatorChartName, testChartRepo))
 
+	_, redeployed, err := mch.ReconcileOperatorChartVersion(unresolvableK8sContext(), NewOperatorTracker(false))
+	if redeployed {
+		t.Fatal("the re-attach failed, so nothing can have been redeployed")
+	}
+	if err == nil {
+		t.Fatal("expected the failed re-attach to be reported")
+	}
+	if code := meshkiterrors.GetCode(err); code != ErrReconcileOperatorChartVersionCode {
+		t.Fatalf("error code = %q, want %q (from %v)", code, ErrReconcileOperatorChartVersionCode, err)
+	}
+	if stub.deploys != 0 {
+		t.Fatalf("Deploy was called %d times after a re-attach that never resolved a chart version", stub.deploys)
+	}
+	if mch.GetOperatorChartError() == nil {
+		t.Fatal("a reconcile that never resolved must leave the refusal standing")
+	}
+	if mch.attachedOperatorChartVersion != "v1.0.51" {
+		t.Fatalf("attached chart version = %q, want the pre-reconcile value restored so the refusal is retried",
+			mch.attachedOperatorChartVersion)
+	}
+}
+
+// TestReconcileInstallGoesThroughTheSharedGuard covers the reconcile's install
+// site itself: that it asks operatorInstallTarget for the handler rather than
+// reading the handler map, so a standing chart refusal stops it.
+//
+// The state that distinguishes the two - a re-attach that succeeded and yet left
+// a refusal standing - is one AddCtxControllerHandlers cannot produce, because it
+// clears the refusal exactly where it resolves. That is why the re-attach is
+// injected here: without the seam this branch is unreachable, nothing would
+// notice an install site that stopped consulting the guard, and that is precisely
+// how the gap survived the first time.
+//
+// The injected re-attach installs a stub, so removing the guard call or
+// replacing it with a direct map read makes stub.deploys 1 and err nil - this
+// test fails by construction, and still never reaches meshkit's Helm client.
+func TestReconcileInstallGoesThroughTheSharedGuard(t *testing.T) {
+	mch := newTestControllersHelper(t)
+	mch.SetMeshsyncDeploymentMode(connections.MeshsyncDeploymentModeOperator)
+	mch.SetControllersConfig(operatorVersionConfig("", connections.MeshsyncDeploymentModeOperator))
+	mch.attachedOperatorChartVersion = "v1.0.51"
+
+	latched := ErrNoOperatorChartPublished(OperatorChartName, testChartRepo)
+	stub := &stubController{status: controllers.NotDeployed}
+	reattached := 0
+	mch.reattachControllerHandlers = func(K8sContext) {
+		reattached++
+		mch.setOperatorError(nil)
+		mch.setOperatorChartError(latched)
+		mch.ctxControllerHandlers = map[MesheryController]controllers.IMesheryController{MesheryOperator: stub}
+		mch.attachedOperatorChartVersion = bootChartVersion
+	}
+
+	// The context is inert: the injected re-attach never builds a client from it.
 	_, redeployed, err := mch.ReconcileOperatorChartVersion(
-		K8sContext{ID: testContextID, Name: "unparseable"},
+		K8sContext{ID: testContextID},
 		NewOperatorTracker(false),
 	)
+
+	if reattached != 1 {
+		t.Fatalf("the re-attach ran %d times, want 1: this test is not exercising the path it claims to", reattached)
+	}
+	if stub.deploys != 0 {
+		t.Fatalf("Deploy was called %d times with a chart refusal standing: the install site is not going through operatorInstallTarget", stub.deploys)
+	}
 	if redeployed {
 		t.Fatal("installation was refused, so nothing can have been redeployed")
 	}
@@ -885,11 +990,8 @@ func TestReconcileInstallRefusesOnALatchedChartError(t *testing.T) {
 	if code := meshkiterrors.GetCode(err); code != ErrReconcileOperatorChartVersionCode {
 		t.Fatalf("error code = %q, want %q (from %v)", code, ErrReconcileOperatorChartVersionCode, err)
 	}
-	if stub.deploys != 0 {
-		t.Fatalf("Deploy was called %d times while a chart error was latched", stub.deploys)
-	}
-	if mch.GetOperatorChartError() == nil {
-		t.Fatal("a reconcile that never resolved must leave the refusal standing")
+	if !strings.Contains(err.Error(), "advertises no released") {
+		t.Fatalf("the refusal must carry the latched chart failure, got %v", err)
 	}
 	if mch.attachedOperatorChartVersion != "v1.0.51" {
 		t.Fatalf("attached chart version = %q, want the pre-reconcile value restored so the refusal is retried",

--- a/server/models/operator_chart_version.go
+++ b/server/models/operator_chart_version.go
@@ -27,14 +27,21 @@ const (
 	//   - v1.0.51 renders with no `kube-rbac-proxy` container and pins
 	//     ENABLE_WEBHOOKS="false" on the manager. So does every chart above it.
 	//   - Every published chart checked below it - v1.0.40, and the contiguous
-	//     run v1.0.41 through v1.0.50 (v1.0.47 was never published) - ships a
-	//     `gcr.io/kubebuilder/kube-rbac-proxy` sidecar and sets no
-	//     ENABLE_WEBHOOKS. That registry has been retired, so the sidecar lands
-	//     in ImagePullBackOff; and an unset ENABLE_WEBHOOKS means *enabled* in
+	//     run v1.0.41 through v1.0.50 (v1.0.47 was never published) - renders a
+	//     `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0` sidecar and sets
+	//     no ENABLE_WEBHOOKS. (Much older charts, v0.8.180 among them, name that
+	//     same sidecar under gcr.io instead; both spellings appear in user
+	//     reports.) Affected clusters report the sidecar stuck in
+	//     ImagePullBackOff so the Pod never becomes Ready. Why the pull fails is
+	//     deliberately not claimed here: the gcr.io copy of v0.16.0 is gone (404,
+	//     empty tag list) but the registry.k8s.io copy still resolves, so that
+	//     half is an environment fact, not a chart fact. The chart facts are
+	//     enough on their own - an unset ENABLE_WEBHOOKS means *enabled* in
 	//     current operator images, so the manager crash-loops on
 	//     `open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or
-	//     directory`. Both defects are permanent, being baked into an immutable
-	//     published archive.
+	//     directory` regardless of the sidecar - and both the sidecar reference
+	//     and the missing ENABLE_WEBHOOKS are permanent, being baked into an
+	//     immutable published archive.
 	//
 	// Charts older than v1.0.40 were not rendered, so nothing here claims a
 	// cause for them - only that they are below the oldest chart verified to

--- a/server/models/operator_chart_version.go
+++ b/server/models/operator_chart_version.go
@@ -1,0 +1,189 @@
+package models
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+const (
+	// OperatorChartName is the chart published in ChartRepo that carries the
+	// Meshery Operator, plus the Broker and MeshSync custom resources it
+	// reconciles as subcharts.
+	OperatorChartName = "meshery-operator"
+
+	// MinimumOperatorChartVersion is the oldest published meshery-operator
+	// chart that still deploys successfully onto a current cluster.
+	//
+	// Every chart below it is broken in two independent ways, and both are
+	// permanent because they are baked into the published archive:
+	//
+	//  1. It ships a `gcr.io/kubebuilder/kube-rbac-proxy` sidecar. That
+	//     registry has been retired, so the sidecar lands in ImagePullBackOff
+	//     and the operator Pod never becomes Ready.
+	//  2. It sets no ENABLE_WEBHOOKS on the manager and mounts no serving
+	//     certificate. An unset ENABLE_WEBHOOKS means *enabled* in current
+	//     operator images, so the manager crash-loops on
+	//     `open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or
+	//     directory`.
+	//
+	// v1.0.63 is the first chart that drops the sidecar and pins
+	// ENABLE_WEBHOOKS=false with the webhook opt-in default-off.
+	//
+	// The floor matters because the chart version a server asks for is derived
+	// from the *server's own release* (see NewOperatorDeploymentConfig): a
+	// server released before that chart was published would otherwise keep
+	// installing an unusable operator, on every cluster it is ever pointed at,
+	// for the rest of its life. The floor therefore applies only to that
+	// derived default - an `operator.version` someone set deliberately is still
+	// honored, so pinning an older chart on purpose remains possible.
+	MinimumOperatorChartVersion = "v1.0.63"
+)
+
+// OperatorChartVersionSource records who asked for a chart version, which is
+// what decides the behavior when that version turns out not to be published.
+type OperatorChartVersionSource int
+
+const (
+	// OperatorChartVersionDerived means nobody chose this version: it is the
+	// Meshery Server release stamped in at boot, standing in for "the chart
+	// that goes with this server". Chart publishing is decoupled from server
+	// releases and trails them, so this value is a *guess*, and correcting it
+	// to a published version beats failing the deployment over it.
+	OperatorChartVersionDerived OperatorChartVersionSource = iota
+
+	// OperatorChartVersionRequested means a layer of the controllers
+	// configuration set `operator.version` explicitly. An explicit request is
+	// never silently substituted: an unpublished pin fails loudly so the user
+	// learns the pin is wrong instead of quietly running something else.
+	OperatorChartVersionRequested
+)
+
+// isPinnedChartVersion reports whether v names one immutable chart release.
+//
+// Moving channel tags (stable-latest, edge-latest, latest), the "Not Set"
+// placeholder viper hands back for an unstamped build, and the empty string all
+// fail this test. None of them identifies a specific published archive, so none
+// may ever reach Helm as a chart version - that is how a cluster ends up
+// running an operator nobody can name.
+func isPinnedChartVersion(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	_, err := semver.NewVersion(v)
+	return err == nil
+}
+
+// compareChartVersions orders two chart versions by semver. Unparseable
+// versions sort below every parseable one, so they can never be picked as
+// "newest".
+func compareChartVersions(a, b string) int {
+	av, aerr := semver.NewVersion(strings.TrimSpace(a))
+	bv, berr := semver.NewVersion(strings.TrimSpace(b))
+	switch {
+	case aerr != nil && berr != nil:
+		return strings.Compare(a, b)
+	case aerr != nil:
+		return -1
+	case berr != nil:
+		return 1
+	default:
+		return av.Compare(bv)
+	}
+}
+
+// ResolveOperatorChartVersion pins requested to a Meshery Operator chart
+// version that actually exists in published, which is the set of versions the
+// chart repository advertises (any order; unparseable entries are ignored).
+//
+// It returns the version to deploy and, when that differs from what was asked
+// for, a one-sentence reason to log and surface to the user. A substitution is
+// never silent: reason is empty if and only if the returned version is exactly
+// the requested one.
+//
+// The rules, in order:
+//
+//   - Nothing published at all: fail. No version could work.
+//   - An explicit request must be pinned and published, or it fails.
+//     Substituting for it would deploy something the user did not ask for.
+//   - A derived (server-release) request that is published and at or above
+//     MinimumOperatorChartVersion is used verbatim. This is the pre-existing
+//     behavior and the common case on a current server.
+//   - A derived request below the floor is raised to the oldest published
+//     chart at or above it: the smallest change that yields a working
+//     operator on an old server.
+//   - A derived request that is unpinned or unpublished falls back to the
+//     newest published chart, because chart publishing trails server releases
+//     and the newest chart is the closest thing to "the chart for this
+//     server".
+func ResolveOperatorChartVersion(published []string, requested string, source OperatorChartVersionSource) (version, reason string, err error) {
+	requested = strings.TrimSpace(requested)
+
+	pinned := make([]string, 0, len(published))
+	for _, v := range published {
+		if isPinnedChartVersion(v) {
+			pinned = append(pinned, strings.TrimSpace(v))
+		}
+	}
+	if len(pinned) == 0 {
+		return "", "", ErrNoOperatorChartPublished(OperatorChartName, ChartRepo)
+	}
+	sort.SliceStable(pinned, func(i, j int) bool { return compareChartVersions(pinned[i], pinned[j]) > 0 })
+	newest := pinned[0]
+
+	isPublished := func(v string) bool {
+		for _, p := range pinned {
+			if p == v {
+				return true
+			}
+		}
+		return false
+	}
+
+	if source == OperatorChartVersionRequested {
+		if !isPinnedChartVersion(requested) {
+			return "", "", ErrOperatorChartNotPinned(requested, newest)
+		}
+		if !isPublished(requested) {
+			return "", "", ErrOperatorChartNotPublished(requested, newest)
+		}
+		return requested, "", nil
+	}
+
+	if !isPinnedChartVersion(requested) {
+		return newest, "This Meshery Server carries no pinned release version, so Meshery Operator was deployed from the newest published chart, " + newest + ".", nil
+	}
+
+	if !isPublished(requested) {
+		return newest, "Meshery Operator chart " + requested + " is not published in " + ChartRepo +
+			" (chart publishing trails Meshery Server releases), so the newest published chart, " + newest + ", was deployed instead.", nil
+	}
+
+	if compareChartVersions(requested, MinimumOperatorChartVersion) < 0 {
+		floored := oldestPublishedAtLeast(pinned, MinimumOperatorChartVersion)
+		if floored == "" {
+			floored = newest
+		}
+		return floored, "Meshery Operator chart " + requested + " cannot deploy successfully - its kube-rbac-proxy sidecar image no longer exists and its manager has no webhook certificate - so the oldest working chart, " +
+			floored + ", was deployed instead. Set operator.version on the connection to override.", nil
+	}
+
+	return requested, "", nil
+}
+
+// oldestPublishedAtLeast returns the smallest version in pinned that is at or
+// above floor, or "" when every published version is older than floor.
+func oldestPublishedAtLeast(pinned []string, floor string) string {
+	best := ""
+	for _, v := range pinned {
+		if compareChartVersions(v, floor) < 0 {
+			continue
+		}
+		if best == "" || compareChartVersions(v, best) < 0 {
+			best = v
+		}
+	}
+	return best
+}

--- a/server/models/operator_chart_version.go
+++ b/server/models/operator_chart_version.go
@@ -14,22 +14,33 @@ const (
 	OperatorChartName = "meshery-operator"
 
 	// MinimumOperatorChartVersion is the oldest published meshery-operator
-	// chart that still deploys successfully onto a current cluster.
+	// chart verified to deploy successfully onto a current cluster.
 	//
-	// Every chart below it is broken in two independent ways, and both are
-	// permanent because they are baked into the published archive:
+	// The floor means exactly one thing: below it, the chart cannot deploy at
+	// all. It is not a "newest is better" preference - raising a server past a
+	// chart that works is what a server upgrade is for, not what this floor is
+	// for - so it must sit at the oldest version that actually renders clean.
 	//
-	//  1. It ships a `gcr.io/kubebuilder/kube-rbac-proxy` sidecar. That
-	//     registry has been retired, so the sidecar lands in ImagePullBackOff
-	//     and the operator Pod never becomes Ready.
-	//  2. It sets no ENABLE_WEBHOOKS on the manager and mounts no serving
-	//     certificate. An unset ENABLE_WEBHOOKS means *enabled* in current
-	//     operator images, so the manager crash-loops on
+	// What was verified, by rendering the published archives with `helm
+	// template`:
+	//
+	//   - v1.0.51 renders with no `kube-rbac-proxy` container and pins
+	//     ENABLE_WEBHOOKS="false" on the manager. So does every chart above it.
+	//   - Every published chart checked below it - v1.0.40, and the contiguous
+	//     run v1.0.41 through v1.0.50 (v1.0.47 was never published) - ships a
+	//     `gcr.io/kubebuilder/kube-rbac-proxy` sidecar and sets no
+	//     ENABLE_WEBHOOKS. That registry has been retired, so the sidecar lands
+	//     in ImagePullBackOff; and an unset ENABLE_WEBHOOKS means *enabled* in
+	//     current operator images, so the manager crash-loops on
 	//     `open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or
-	//     directory`.
+	//     directory`. Both defects are permanent, being baked into an immutable
+	//     published archive.
 	//
-	// v1.0.63 is the first chart that drops the sidecar and pins
-	// ENABLE_WEBHOOKS=false with the webhook opt-in default-off.
+	// Charts older than v1.0.40 were not rendered, so nothing here claims a
+	// cause for them - only that they are below the oldest chart verified to
+	// work. v1.0.51 carries operator image 1.0.1 rather than the current 1.0.4;
+	// that image is functional, and pinning the floor higher to reach a newer
+	// operator image would substitute charts that provably deploy.
 	//
 	// The floor matters because the chart version a server asks for is derived
 	// from the *server's own release* (see NewOperatorDeploymentConfig): a
@@ -38,7 +49,7 @@ const (
 	// for the rest of its life. The floor therefore applies only to that
 	// derived default - an `operator.version` someone set deliberately is still
 	// honored, so pinning an older chart on purpose remains possible.
-	MinimumOperatorChartVersion = "v1.0.63"
+	MinimumOperatorChartVersion = "v1.0.51"
 )
 
 // OperatorChartVersionSource records who asked for a chart version, which is
@@ -180,17 +191,20 @@ func ResolveOperatorChartVersion(repo string, published []string, requested stri
 	if compareChartVersions(match, MinimumOperatorChartVersion) < 0 {
 		floored := oldestPublishedAtLeast(pinned, MinimumOperatorChartVersion)
 		if floored == "" {
-			// Nothing published reaches the floor, so newest carries the same
-			// defects as the requested chart. Saying it is "the oldest working
-			// chart" would send the user looking for a fix that has already
-			// been applied; the actionable fact is that no working chart is
-			// published yet.
-			return newest, "Meshery Operator chart " + requested + " cannot deploy successfully - its kube-rbac-proxy sidecar image no longer exists and its manager has no webhook certificate - and " +
-				repo + " publishes no chart at or above " + MinimumOperatorChartVersion + " yet, so the newest published chart, " + newest +
-				", was deployed instead. It carries the same defects; Meshery Operator will not become ready until a chart at or above " + MinimumOperatorChartVersion + " is published.", nil
+			// Nothing published reaches the floor, so newest is no more likely
+			// to deploy than the requested chart. Saying it is "the oldest
+			// working chart" would send the user looking for a fix that has
+			// already been applied; the actionable fact is that no chart
+			// verified to deploy is published yet.
+			return newest, "Meshery Operator chart " + requested + " is older than " + MinimumOperatorChartVersion +
+				", the oldest chart verified to deploy successfully, and " + repo + " publishes no chart at or above " +
+				MinimumOperatorChartVersion + " yet, so the newest published chart, " + newest +
+				", was deployed instead. It is older too; Meshery Operator may not become ready until a chart at or above " +
+				MinimumOperatorChartVersion + " is published.", nil
 		}
-		return floored, "Meshery Operator chart " + requested + " cannot deploy successfully - its kube-rbac-proxy sidecar image no longer exists and its manager has no webhook certificate - so the oldest working chart, " +
-			floored + ", was deployed instead. Set operator.version on the connection to override.", nil
+		return floored, "Meshery Operator chart " + requested + " is older than " + MinimumOperatorChartVersion +
+			", the oldest chart verified to deploy successfully, so " + floored +
+			" was deployed instead. Set operator.version on the connection to override.", nil
 	}
 
 	return match, "", nil

--- a/server/models/operator_chart_version.go
+++ b/server/models/operator_chart_version.go
@@ -96,12 +96,18 @@ func compareChartVersions(a, b string) int {
 
 // ResolveOperatorChartVersion pins requested to a Meshery Operator chart
 // version that actually exists in published, which is the set of versions the
-// chart repository advertises (any order; unparseable entries are ignored).
+// chart repository at repo advertises (any order; unparseable entries are
+// ignored). repo is used only to name the repository that was actually read in
+// the error and reason text, so a mirror or an in-cluster repository is
+// reported as itself rather than as the default.
 //
-// It returns the version to deploy and, when that differs from what was asked
-// for, a one-sentence reason to log and surface to the user. A substitution is
-// never silent: reason is empty if and only if the returned version is exactly
-// the requested one.
+// It returns the version to deploy and, when that names a different release
+// than the one asked for, a one-sentence reason to log and surface to the user.
+// A substitution is never silent: reason is empty if and only if the returned
+// version is the requested one. The returned version is always the
+// repository's own spelling of that release, which is what Helm is handed - a
+// request for "1.0.64" against a repository publishing "v1.0.64" is the same
+// release, not a substitution, and resolves without a reason.
 //
 // The rules, in order:
 //
@@ -118,7 +124,7 @@ func compareChartVersions(a, b string) int {
 //     newest published chart, because chart publishing trails server releases
 //     and the newest chart is the closest thing to "the chart for this
 //     server".
-func ResolveOperatorChartVersion(published []string, requested string, source OperatorChartVersionSource) (version, reason string, err error) {
+func ResolveOperatorChartVersion(repo string, published []string, requested string, source OperatorChartVersionSource) (version, reason string, err error) {
 	requested = strings.TrimSpace(requested)
 
 	pinned := make([]string, 0, len(published))
@@ -128,49 +134,66 @@ func ResolveOperatorChartVersion(published []string, requested string, source Op
 		}
 	}
 	if len(pinned) == 0 {
-		return "", "", ErrNoOperatorChartPublished(OperatorChartName, ChartRepo)
+		return "", "", ErrNoOperatorChartPublished(OperatorChartName, repo)
 	}
 	sort.SliceStable(pinned, func(i, j int) bool { return compareChartVersions(pinned[i], pinned[j]) > 0 })
 	newest := pinned[0]
 
-	isPublished := func(v string) bool {
+	// publishedSpelling returns the repository's own spelling of the release v
+	// names, or "" when the repository publishes no such release. Membership is
+	// decided by semver, not by string equality, because Helm treats "1.0.64"
+	// and "v1.0.64" as the same version and rejecting one spelling would refuse
+	// a chart that exists.
+	publishedSpelling := func(v string) string {
+		if !isPinnedChartVersion(v) {
+			return ""
+		}
 		for _, p := range pinned {
-			if p == v {
-				return true
+			if compareChartVersions(p, v) == 0 {
+				return p
 			}
 		}
-		return false
+		return ""
 	}
 
 	if source == OperatorChartVersionRequested {
 		if !isPinnedChartVersion(requested) {
 			return "", "", ErrOperatorChartNotPinned(requested, newest)
 		}
-		if !isPublished(requested) {
+		match := publishedSpelling(requested)
+		if match == "" {
 			return "", "", ErrOperatorChartNotPublished(requested, newest)
 		}
-		return requested, "", nil
+		return match, "", nil
 	}
 
 	if !isPinnedChartVersion(requested) {
 		return newest, "This Meshery Server carries no pinned release version, so Meshery Operator was deployed from the newest published chart, " + newest + ".", nil
 	}
 
-	if !isPublished(requested) {
-		return newest, "Meshery Operator chart " + requested + " is not published in " + ChartRepo +
+	match := publishedSpelling(requested)
+	if match == "" {
+		return newest, "Meshery Operator chart " + requested + " is not published in " + repo +
 			" (chart publishing trails Meshery Server releases), so the newest published chart, " + newest + ", was deployed instead.", nil
 	}
 
-	if compareChartVersions(requested, MinimumOperatorChartVersion) < 0 {
+	if compareChartVersions(match, MinimumOperatorChartVersion) < 0 {
 		floored := oldestPublishedAtLeast(pinned, MinimumOperatorChartVersion)
 		if floored == "" {
-			floored = newest
+			// Nothing published reaches the floor, so newest carries the same
+			// defects as the requested chart. Saying it is "the oldest working
+			// chart" would send the user looking for a fix that has already
+			// been applied; the actionable fact is that no working chart is
+			// published yet.
+			return newest, "Meshery Operator chart " + requested + " cannot deploy successfully - its kube-rbac-proxy sidecar image no longer exists and its manager has no webhook certificate - and " +
+				repo + " publishes no chart at or above " + MinimumOperatorChartVersion + " yet, so the newest published chart, " + newest +
+				", was deployed instead. It carries the same defects; Meshery Operator will not become ready until a chart at or above " + MinimumOperatorChartVersion + " is published.", nil
 		}
 		return floored, "Meshery Operator chart " + requested + " cannot deploy successfully - its kube-rbac-proxy sidecar image no longer exists and its manager has no webhook certificate - so the oldest working chart, " +
 			floored + ", was deployed instead. Set operator.version on the connection to override.", nil
 	}
 
-	return requested, "", nil
+	return match, "", nil
 }
 
 // oldestPublishedAtLeast returns the smallest version in pinned that is at or

--- a/server/models/operator_chart_version.go
+++ b/server/models/operator_chart_version.go
@@ -87,6 +87,21 @@ func isPinnedChartVersion(v string) bool {
 	return err == nil
 }
 
+// isPrereleaseChartVersion reports whether v carries a semver prerelease
+// segment (v1.0.66-rc.1, v0.6.0-rc.6). Such charts are published to this
+// repository ahead of the release they precede, so by semver they outrank every
+// stable chart below them - which is why they are excluded from every selection
+// Meshery makes on the user's behalf. An unparseable version is not a
+// prerelease; it is not a version at all, and isPinnedChartVersion has already
+// rejected it before this is reached.
+func isPrereleaseChartVersion(v string) bool {
+	sv, err := semver.NewVersion(strings.TrimSpace(v))
+	if err != nil {
+		return false
+	}
+	return sv.Prerelease() != ""
+}
+
 // compareChartVersions orders two chart versions by semver. Unparseable
 // versions sort below every parseable one, so they can never be picked as
 // "newest".
@@ -120,6 +135,15 @@ func compareChartVersions(a, b string) int {
 // request for "1.0.64" against a repository publishing "v1.0.64" is the same
 // release, not a substitution, and resolves without a reason.
 //
+// Prereleases (v1.0.66-rc.1) are published to this repository, and by semver
+// they outrank every stable chart below them. They are therefore excluded from
+// every version Meshery *chooses* - the newest-published fallback and the
+// floor raise - so a release candidate published ahead of its release is never
+// what lands on a production cluster by default. They remain fully reachable:
+// an explicit `operator.version` naming one is honored exactly, as is a derived
+// version that already matches a published prerelease, because a prerelease
+// server asking for its own prerelease chart chose nothing.
+//
 // The rules, in order:
 //
 //   - Nothing published at all: fail. No version could work.
@@ -129,12 +153,14 @@ func compareChartVersions(a, b string) int {
 //     MinimumOperatorChartVersion is used verbatim. This is the pre-existing
 //     behavior and the common case on a current server.
 //   - A derived request below the floor is raised to the oldest published
-//     chart at or above it: the smallest change that yields a working
+//     stable chart at or above it: the smallest change that yields a working
 //     operator on an old server.
 //   - A derived request that is unpinned or unpublished falls back to the
-//     newest published chart, because chart publishing trails server releases
-//     and the newest chart is the closest thing to "the chart for this
-//     server".
+//     newest published stable chart, because chart publishing trails server
+//     releases and the newest chart is the closest thing to "the chart for
+//     this server".
+//   - Any of the last two with no stable chart published at all: fail, rather
+//     than select a prerelease nobody asked for.
 func ResolveOperatorChartVersion(repo string, published []string, requested string, source OperatorChartVersionSource) (version, reason string, err error) {
 	requested = strings.TrimSpace(requested)
 
@@ -148,13 +174,30 @@ func ResolveOperatorChartVersion(repo string, published []string, requested stri
 		return "", "", ErrNoOperatorChartPublished(OperatorChartName, repo)
 	}
 	sort.SliceStable(pinned, func(i, j int) bool { return compareChartVersions(pinned[i], pinned[j]) > 0 })
-	newest := pinned[0]
+
+	// stable is the set every automatic selection draws from, in the same
+	// newest-first order.
+	stable := make([]string, 0, len(pinned))
+	for _, v := range pinned {
+		if !isPrereleaseChartVersion(v) {
+			stable = append(stable, v)
+		}
+	}
+
+	// newestSelectable is the version an error tells the user to reach for
+	// instead. It names a stable chart whenever one is published, because
+	// recommending a release candidate is not advice worth giving.
+	newestSelectable := pinned[0]
+	if len(stable) > 0 {
+		newestSelectable = stable[0]
+	}
 
 	// publishedSpelling returns the repository's own spelling of the release v
 	// names, or "" when the repository publishes no such release. Membership is
 	// decided by semver, not by string equality, because Helm treats "1.0.64"
 	// and "v1.0.64" as the same version and rejecting one spelling would refuse
-	// a chart that exists.
+	// a chart that exists. It searches every published chart, prereleases
+	// included: naming a release exactly is not choosing one.
 	publishedSpelling := func(v string) string {
 		if !isPinnedChartVersion(v) {
 			return ""
@@ -169,52 +212,58 @@ func ResolveOperatorChartVersion(repo string, published []string, requested stri
 
 	if source == OperatorChartVersionRequested {
 		if !isPinnedChartVersion(requested) {
-			return "", "", ErrOperatorChartNotPinned(requested, newest)
+			return "", "", ErrOperatorChartNotPinned(requested, newestSelectable)
 		}
 		match := publishedSpelling(requested)
 		if match == "" {
-			return "", "", ErrOperatorChartNotPublished(requested, newest)
+			return "", "", ErrOperatorChartNotPublished(requested, newestSelectable)
 		}
 		return match, "", nil
 	}
 
-	if !isPinnedChartVersion(requested) {
-		return newest, "This Meshery Server carries no pinned release version, so Meshery Operator was deployed from the newest published chart, " + newest + ".", nil
+	match := publishedSpelling(requested)
+	if match != "" && compareChartVersions(match, MinimumOperatorChartVersion) >= 0 {
+		return match, "", nil
 	}
 
-	match := publishedSpelling(requested)
+	// Everything below picks a chart the request did not name, so it picks from
+	// stable releases only. With none published there is nothing to pick.
+	if len(stable) == 0 {
+		return "", "", ErrNoOperatorChartPublished(OperatorChartName, repo)
+	}
+	newest := stable[0]
+
 	if match == "" {
+		if !isPinnedChartVersion(requested) {
+			return newest, "This Meshery Server carries no pinned release version, so Meshery Operator was deployed from the newest published chart, " + newest + ".", nil
+		}
 		return newest, "Meshery Operator chart " + requested + " is not published in " + repo +
 			" (chart publishing trails Meshery Server releases), so the newest published chart, " + newest + ", was deployed instead.", nil
 	}
 
-	if compareChartVersions(match, MinimumOperatorChartVersion) < 0 {
-		floored := oldestPublishedAtLeast(pinned, MinimumOperatorChartVersion)
-		if floored == "" {
-			// Nothing published reaches the floor, so newest is no more likely
-			// to deploy than the requested chart. Saying it is "the oldest
-			// working chart" would send the user looking for a fix that has
-			// already been applied; the actionable fact is that no chart
-			// verified to deploy is published yet.
-			return newest, "Meshery Operator chart " + requested + " is older than " + MinimumOperatorChartVersion +
-				", the oldest chart verified to deploy successfully, and " + repo + " publishes no chart at or above " +
-				MinimumOperatorChartVersion + " yet, so the newest published chart, " + newest +
-				", was deployed instead. It is older too; Meshery Operator may not become ready until a chart at or above " +
-				MinimumOperatorChartVersion + " is published.", nil
-		}
-		return floored, "Meshery Operator chart " + requested + " is older than " + MinimumOperatorChartVersion +
-			", the oldest chart verified to deploy successfully, so " + floored +
-			" was deployed instead. Set operator.version on the connection to override.", nil
+	floored := oldestPublishedAtLeast(stable, MinimumOperatorChartVersion)
+	if floored == "" {
+		// Nothing published reaches the floor, so newest is no more likely to
+		// deploy than the requested chart. Saying it is "the oldest working
+		// chart" would send the user looking for a fix that has already been
+		// applied; the actionable fact is that no chart verified to deploy is
+		// published yet.
+		return newest, "Meshery Operator chart " + requested + " is older than " + MinimumOperatorChartVersion +
+			", the oldest chart verified to deploy successfully, and " + repo + " publishes no chart at or above " +
+			MinimumOperatorChartVersion + " yet, so the newest published chart, " + newest +
+			", was deployed instead. It is older too; Meshery Operator may not become ready until a chart at or above " +
+			MinimumOperatorChartVersion + " is published.", nil
 	}
-
-	return match, "", nil
+	return floored, "Meshery Operator chart " + requested + " is older than " + MinimumOperatorChartVersion +
+		", the oldest chart verified to deploy successfully, so " + floored +
+		" was deployed instead. Set operator.version on the connection to override.", nil
 }
 
-// oldestPublishedAtLeast returns the smallest version in pinned that is at or
-// above floor, or "" when every published version is older than floor.
-func oldestPublishedAtLeast(pinned []string, floor string) string {
+// oldestPublishedAtLeast returns the smallest version in versions that is at or
+// above floor, or "" when every version is older than floor.
+func oldestPublishedAtLeast(versions []string, floor string) string {
 	best := ""
-	for _, v := range pinned {
+	for _, v := range versions {
 		if compareChartVersions(v, floor) < 0 {
 			continue
 		}

--- a/server/models/operator_chart_version_test.go
+++ b/server/models/operator_chart_version_test.go
@@ -12,14 +12,10 @@ import (
 
 // bootChartVersion stands in for the Meshery Server release stamped into the
 // deployment config at boot. It is a published, at-or-above-floor version so
-// that pinning it against testChartCatalogue is the identity: these tests are
+// that pinning it against publishedCharts is the identity: these tests are
 // about how `operator.version` layers, not about chart-version pinning, which
 // operator_chart_pinning_test.go covers.
 const bootChartVersion = "v1.0.64"
-
-// testChartCatalogue is what the chart repository publishes as far as these
-// tests are concerned: two current charts, one at the floor, and two below it.
-var testChartCatalogue = []string{"v1.0.64", "v1.0.63", "v1.0.62", "v1.0.40", "v0.7.9"}
 
 func operatorVersionConfig(version string, mode connections.MeshsyncDeploymentMode) *controllersconfig.MesheryControllersConfig {
 	cfg := &controllersconfig.MesheryControllersConfig{
@@ -56,7 +52,7 @@ func newTestControllersHelper(t *testing.T) *MesheryControllersHelper {
 	)
 	// Resolve against a fixed catalogue: chart-version pinning must never make
 	// a unit test depend on the network or on what is published today.
-	mch.chartVersions = func(string, string) ([]string, error) { return testChartCatalogue, nil }
+	mch.chartVersions = func(string, string) ([]string, error) { return publishedCharts, nil }
 	return mch
 }
 

--- a/server/models/operator_chart_version_test.go
+++ b/server/models/operator_chart_version_test.go
@@ -10,7 +10,16 @@ import (
 	controllersconfig "github.com/meshery/schemas/models/v1alpha1/controllers_config"
 )
 
-const bootChartVersion = "v0.8.0"
+// bootChartVersion stands in for the Meshery Server release stamped into the
+// deployment config at boot. It is a published, at-or-above-floor version so
+// that pinning it against testChartCatalogue is the identity: these tests are
+// about how `operator.version` layers, not about chart-version pinning, which
+// operator_chart_pinning_test.go covers.
+const bootChartVersion = "v1.0.64"
+
+// testChartCatalogue is what the chart repository publishes as far as these
+// tests are concerned: two current charts, one at the floor, and two below it.
+var testChartCatalogue = []string{"v1.0.64", "v1.0.63", "v1.0.62", "v1.0.40", "v0.7.9"}
 
 func operatorVersionConfig(version string, mode connections.MeshsyncDeploymentMode) *controllersconfig.MesheryControllersConfig {
 	cfg := &controllersconfig.MesheryControllersConfig{
@@ -33,7 +42,7 @@ func newTestControllersHelper(t *testing.T) *MesheryControllersHelper {
 	if err != nil {
 		t.Fatalf("failed to build test logger: %v", err)
 	}
-	return NewMesheryControllersHelper(
+	mch := NewMesheryControllersHelper(
 		log,
 		controllers.OperatorDeploymentConfig{
 			MesheryReleaseVersion: bootChartVersion,
@@ -45,6 +54,10 @@ func newTestControllersHelper(t *testing.T) *MesheryControllersHelper {
 		nil,
 		nil,
 	)
+	// Resolve against a fixed catalogue: chart-version pinning must never make
+	// a unit test depend on the network or on what is published today.
+	mch.chartVersions = func(string, string) ([]string, error) { return testChartCatalogue, nil }
+	return mch
 }
 
 // TestB2OperatorVersionSelectsTheOperatorChartVersion covers defect B2: the

--- a/server/models/providers.go
+++ b/server/models/providers.go
@@ -339,8 +339,14 @@ const (
 	KubeClustersKey   ContextKey = "kubeclusters"
 	AllKubeClusterKey ContextKey = "allkubeclusters"
 
-	MesheryControllerHandlersKey ContextKey = "mesherycontrollerhandlerskey"
-	MeshSyncDataHandlersKey      ContextKey = "meshsyncdatahandlerskey"
+	// MesheryControllerHandlersKey is retired. Nothing ever populated it, so the
+	// one reader - the changeOperatorStatus resolver - always read a nil map and
+	// called Deploy/Undeploy on a nil controller interface. Operator lifecycle
+	// now goes through the connection's MesheryControllersHelper, which is what
+	// holds the resolved Helm chart version; a context key that looks like a
+	// handler source but is never filled is how that was missed. Do not
+	// reintroduce it.
+	MeshSyncDataHandlersKey ContextKey = "meshsyncdatahandlerskey"
 
 	RegistryManagerKey ContextKey = "registrymanagerkey"
 


### PR DESCRIPTION
## Symptom

A helm-installed Meshery, then "Add kubeconfig", and the server-driven operator deploy fails two ways at once:

```
kubectl -n meshery get pods
# meshery-operator-...  1/2  ImagePullBackOff   (kube-rbac-proxy)
#                            CrashLoopBackOff   (manager)

kubectl -n meshery logs deploy/meshery-operator -c manager
# open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory
```

## Root cause

The Helm chart version Meshery Server installs the operator at is **the Meshery Server release verbatim** (`NewOperatorDeploymentConfig` → `OperatorDeploymentConfig.MesheryReleaseVersion`, passed straight through MeshKit as the chart `Version`), and nothing ever checked that such a chart exists. Chart publishing is decoupled from server releases, so that value fails two ways:

- **It trails.** Charts are republished at server releases and lag them, so a current server routinely asks Helm for an archive that 404s and the operator never deploys. Unstamped/edge builds were worse: they resolved the newest *GitHub release*, likewise often unpublished as a chart, at the cost of a rate-limited unauthenticated API call at boot.
- **It sticks.** Charts below the working floor are published but do not run, and because the requested version tracks the server's own release, an old server installs one of those on **every cluster it is ever pointed at, forever**.

Rendering the published archives confirms the chain end to end: the chart a current helm-installed server asks for renders the `kube-rbac-proxy` sidecar and no `ENABLE_WEBHOOKS`, which is exactly the reported ImagePullBackOff plus missing `tls.crt`; the chart resolution now selects renders a single manager container with `ENABLE_WEBHOOKS=false` and a pinned operator image.

## Fix

Resolve the chart version against what the repository actually publishes, before it can reach Helm.

- `helpers/utils.PublishedChartVersions` reads `index.yaml` into MeshKit's existing `HelmIndex` type — TTL-cached, timeout-bounded, single-flight, panic-safe, serving a stale catalogue rather than blocking a cluster-connect request, and never caching failures as successes.
- `models.ResolveOperatorChartVersion` pins the request, distinguishing two sources:
  - **Derived** (the boot-time server release — nobody chose it) *may* be corrected: unpinned or unpublished falls back to the newest published chart; anything below `MinimumOperatorChartVersion` is raised to the oldest published chart at or above it. Every correction returns a reason that is logged and emitted as a warning event, so no substitution is silent.
  - **Requested** (an explicit `operator.version`) is **never** substituted. A moving tag or an unpublished version fails loudly through the existing operator-error surface, visible as the connection's `operator_deploy_failed` diagnostic. The floor does not apply, so deliberately pinning an older chart still works.
  - Both automatic corrections draw only from **stable** releases. The repository publishes prerelease charts, and by semver an rc outranks every stable chart below it, so an rc published ahead of its release would otherwise land on production clusters.
- All operator install paths — the connect path, the reconcile path, and the `changeOperatorStatus` GraphQL mutation — go through one shared guard, so no path can hand Helm an unresolved version.
- An unreadable index withholds **installation only**. `GetStatus`/`GetVersion` need no chart version, so the operator handler still attaches and keeps reporting — otherwise a restricted-egress cluster with a healthy operator would hide the very image tag the new troubleshooting doc tells users to check. A latched chart error re-resolves on a user-initiated deploy, so a transient repository blip self-heals rather than disabling deploy until someone guesses to reconnect.

## Chart

Both `meshery-operator` subcharts advertised `appVersion: stable-latest` inside immutable published archives; they now name a real published operator release. `install/scripts/check-operator-chart-appversions.sh` enforces agreement in CI so this cannot silently drift again.

Two honest limits on that check, both documented in the script:

- The published parent's `appVersion` is rewritten to the *Meshery Server* tag at package time by helm-chart-releaser, so parent/subchart agreement holds **in this repository only**, never in the shipped archive. The check's real value is pinning subcharts to a real release instead of a moving tag.
- The vendored `install/kubernetes/helm/meshery/charts/meshery-operator-*.tgz` still contains `stable-latest` subcharts. It is built *from this repo* at chart-publish time, so it cannot carry the pin until this merges and a new chart is published and re-vendored — a hard failure there would block its own prerequisite. That portion therefore **warns loudly and exits 0**, with a one-line promotion to hard-fail documented for whoever re-vendors next.

## Adjacent fixes

Flagged per maintainer convention — real defects found in the touched paths, fixed here rather than stepped over:

- `models.CheckLatestVersion` indexed the release slice **before** checking the error, panicking on every unreachable or rate-limited GitHub call.
- Controller status rows vanished entirely when no handler was attached (unreadable kubeconfig, failed Kubernetes client), so the UI dropped the cards rather than showing an unknown state. All three controllers now always report a row.
- `server/internal/graphql/model` `Initialize`/`installUsingHelm` was a second, dead (no callers) copy of the same unpinned resolution. Removed rather than left to be revived.
- A missing operator handler read as a *successful* undeploy — silent no-op on a user-initiated action.
- The parent operator chart README advertised `1.0.0` against a `1.0.5` chart, plus a guard so the documented `make helm-operator-docs` target cannot silently delete its hand-written content.

## Documentation

- Troubleshooting entry for the exact two-symptom signature, documenting **both** registry forms of the sidecar image, with the `helm repo update` + upgrade remedy and the commands to confirm the deployed operator version.
- What `UNKOWN` means on a controller card (no observation made — not a health state).
- Contributor doc covering the resolution rules, the floor's meaning and the evidence required to change it.

## Known follow-ups

- **meshery/meshery-operator#878** — `hack/sync-downstream.sh` stamps an incomplete file set (not the subcharts, not the README), which is the upstream root cause. The new CI check will deliberately go red at the next operator release until that lands.
- **helm-docs regenerability** — the operator READMEs are helm-docs output that can no longer be regenerated (curated prose, no `# --` comments, no `README.md.gotmpl`). Deferred to its own PR; generated-doc infrastructure deserves separate review.
- **`mch.contextID` is never assigned**, so `UpdateOperatorsStatusMap`'s `ot.IsUndeployed(mch.contextID)` always probes the empty key and never matches a real context. Populating it would silently change operator-undeploy behaviour, so it is recorded at the declaration and left for a focused change rather than riding along here.
- **MeshKit uninstall** downloads the chart archive for `UNINSTALL` as well as `INSTALL`, so with an unreadable index a removal attempt surfaces a Helm error rather than removing. A removal path not needing the archive would have to come from MeshKit.

## Testing

Unit coverage for the resolver (floor, unpublished fallback, moving tags, explicit-pin refusal, prerelease exclusion, pinned-vs-pinned reconcile), the index cache (TTL reuse, failures not cached, panic safety, single-flight), the status rows, and the appVersion check. New tests fail against the old resolution behaviour — verified by restoring it.

Validated end to end against the live Meshery chart repository across server/connection configurations: every version handed to Helm resolves to an archive that exists, explicit unpublished and moving pins refuse loudly, and a deliberate below-floor explicit pin is honored.

No test reaches MeshKit's Helm client. One earlier revision did, which on a machine where `127.0.0.1:6443` is a live cluster would have performed a real `helm install` into it; the seam that made that possible is now named and asserted so the hazard cannot silently return.

<!-- no-mistakes-run: 01KZDP7AGWJYCFFAX787FP7WB1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meshery Operator deployments now resolve against published, compatible Helm chart versions.
  * Explicit chart versions are validated with clear diagnostics when unavailable or unsupported.
  * Deployment and undeployment actions target the selected Kubernetes connection.
  * Controller status views include all controllers, including unknown statuses.
  * Operator, Broker, and MeshSync chart versions are aligned to the published release.

* **Bug Fixes**
  * Improved chart repository failure handling, retries, and lifecycle diagnostics.
  * Prevented installation when no usable chart version is confirmed.

* **Documentation**
  * Expanded chart versioning, upgrade, troubleshooting, and connectivity guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->