### PR TITLE
fix: handle formatter error before use in design view

### DIFF
--- a/mesheryctl/internal/cli/root/design/view.go
+++ b/mesheryctl/internal/cli/root/design/view.go
@@ -113,7 +113,7 @@ mesheryctl design view [design-name | ID]
 		if err != nil {
 			return err
 		}
-		outputFormatter.WithOutput(cmd.OutOrStdout())
+		outputFormatter = outputFormatter.WithOutput(cmd.OutOrStdout())
 
 		return outputFormatter.Display()
 	},

--- a/mesheryctl/internal/cli/root/design/view.go
+++ b/mesheryctl/internal/cli/root/design/view.go
@@ -110,10 +110,10 @@ mesheryctl design view [design-name | ID]
 
 		outputFormatFactory := display.OutputFormatterFactory[interface{}]{}
 		outputFormatter, err := outputFormatFactory.New(designViewFlagsProvided.OutputFormat, designData)
-		outputFormatter.WithOutput(cmd.OutOrStdout())
 		if err != nil {
 			return err
 		}
+		outputFormatter.WithOutput(cmd.OutOrStdout())
 
 		return outputFormatter.Display()
 	},

--- a/mesheryctl/internal/cli/root/design/view_test.go
+++ b/mesheryctl/internal/cli/root/design/view_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/display"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 )
 
@@ -91,6 +92,28 @@ func TestDesignView(t *testing.T) {
 			ExpectError:    true,
 			IsOutputGolden: false,
 			ExpectedError:  ErrDesignNotFound("nonexistent-design"),
+		},
+		{
+			Name:             "given invalid output format when design view then error is returned",
+			Args:             []string{"view", "desgin", "--output-format", "invalid"},
+			ExpectedResponse: "",
+			URLs: []utils.MockURL{
+				{
+					Method:       "GET",
+					URL:          testContext.BaseURL + "/api/pattern?populate=pattern_file&page_size=10000",
+					Response:     "view.design.api.response.golden",
+					ResponseCode: 200,
+				},
+				{
+					Method:       "GET",
+					URL:          testContext.BaseURL + "/api/pattern?populate=pattern_file&search=desgin",
+					Response:     "view.design.api.response.golden",
+					ResponseCode: 200,
+				},
+			},
+			ExpectError:    true,
+			IsOutputGolden: false,
+			ExpectedError:  display.ErrUnsupportedFormat("invalid"),
 		},
 	}
 


### PR DESCRIPTION
**Notes for Reviewers**

- Fixes #21188
- Moves the output formatter error check before `WithOutput()` in `design view`.
- Prevents the formatter from being used when formatter creation returns an error.
- Relevant `design` package tests pass successfully.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for design view output formatting.
  * Invalid output format values now return a clear unsupported-format error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->