### PR TITLE
test(mesheryctl): add unit tests for SSE client utility

### DIFF
--- a/mesheryctl/pkg/utils/sse-client_test.go
+++ b/mesheryctl/pkg/utils/sse-client_test.go
@@ -1,0 +1,118 @@
+package utils
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestConvertRespToSSE(t *testing.T) {
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(
+			"id: 123\n" +
+				"event: update\n" +
+				"data: {\"details\":\"testing\",\"operation_id\":\"op-1\",\"summary\":\"complete\"}\n" +
+				"\n",
+		)),
+	}
+
+	events, err := ConvertRespToSSE(resp)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	event, ok := <-events
+
+	if !ok {
+		t.Fatal("expected event channel to return an event")
+	}
+
+	if event.ID != "123\n" {
+		t.Errorf("expected ID 123, got %q", event.ID)
+	}
+
+	if event.Name != "update" {
+		t.Errorf("expected event name update, got %q", event.Name)
+	}
+
+	if event.Data.Details != "testing" {
+		t.Errorf(
+			"expected details testing, got %q",
+			event.Data.Details,
+		)
+	}
+
+	if event.Data.OperationID != "op-1" {
+		t.Errorf(
+			"expected operation id op-1, got %q",
+			event.Data.OperationID,
+		)
+	}
+
+	if event.Data.Summary != "complete" {
+		t.Errorf(
+			"expected summary complete, got %q",
+			event.Data.Summary,
+		)
+	}
+}
+
+func TestConvertRespToSSEInvalidJSON(t *testing.T) {
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(
+			"event: update\n" +
+				"data: invalid-json\n" +
+				"\n",
+		)),
+	}
+
+	events, err := ConvertRespToSSE(resp)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, ok := <-events
+
+	if ok {
+		t.Error("expected channel to close without emitting invalid event")
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		prefix string
+		want   bool
+	}{
+		{
+			name:   "matching prefix",
+			input:  []byte("data: hello"),
+			prefix: "data:",
+			want:   true,
+		},
+		{
+			name:   "non matching prefix",
+			input:  []byte("event: hello"),
+			prefix: "data:",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasPrefix(tt.input, tt.prefix)
+
+			if got != tt.want {
+				t.Errorf(
+					"hasPrefix() = %v, want %v",
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes ##21223
The PR adds unit tests for mesheryctl/pkg/utils/sse-client.go.

The tests cover:

- Successful conversion of an HTTP response into a Server-Sent Event.
- Parsing of event ID, event name, and JSON event data.
- Handling of invalid JSON event data.
- hasPrefix behavior for matching and non-matching prefixes.

Notes for Reviewers

The implementation adds test coverage without modifying the existing SSE client implementation.

Testing:
go test ./mesheryctl/pkg/utils

Before adding the tests:

No dedicated unit tests existed for sse-client.go.

After adding the tests:

=== RUN   TestConvertRespToSSE
--- PASS: TestConvertRespToSSE (0.00s)

=== RUN   TestConvertRespToSSEInvalidJSON
--- PASS: TestConvertRespToSSEInvalidJSON (0.00s)

=== RUN   TestHasPrefix
--- PASS: TestHasPrefix (0.00s)

PASS:
ok      github.com/meshery/meshery/mesheryctl/pkg/utils

The complete package test suite also passes successfully with:

go test ./mesheryctl/pkg/utils

Signed commits

All tests pass successfully.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for parsing valid server-sent events.
  * Added checks for handling invalid JSON responses.
  * Added table-driven tests for prefix matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->