### PR TITLE
[Models] Add Anthropic ConnectionDefinition + ad hoc connectivity check for AI Adapter

### DIFF
--- a/models/meshery-core/0.7.2/v1.0.0/connections/AnthropicConnection.json
+++ b/models/meshery-core/0.7.2/v1.0.0/connections/AnthropicConnection.json
@@ -1,0 +1,87 @@
+{
+    "schemaVersion": "connections.meshery.io/v1beta3",
+    "name": "Anthropic Claude",
+    "description": "Connect Meshery to Anthropic's Claude API to generate Kubernetes Designs from natural language prompts. Your API key is stored as a Credential and is never included in generated Designs, logs, or events.",
+    "kind": "anthropic",
+    "type": "model-provider",
+    "subType": "inference",
+    "status": "registered",
+    "transitionMap": {
+        "registered": [
+            {
+                "nextState": "connected",
+                "description": "Validates the stored API key against Anthropic's API and marks this provider ready for Design generation."
+            },
+            {
+                "nextState": "ignored",
+                "description": "Keeps the connection registered but excludes it from the provider list shown during Design generation."
+            }
+        ],
+        "connected": [
+            {
+                "nextState": "disconnected",
+                "description": "Stops using this provider for Design generation. The connection and credential are kept, so it can be reconnected without re-entering the API key."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes this connection and its associated credential from Meshery."
+            }
+        ],
+        "disconnected": [
+            {
+                "nextState": "connected",
+                "description": "Re-validates the stored API key and resumes using this provider for Design generation."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes this connection and its associated credential from Meshery."
+            }
+        ]
+    },
+    "connectionSchema": {
+        "type": "object",
+        "title": "Anthropic Claude Connection",
+        "required": [
+            "baseUrl"
+        ],
+        "properties": {
+            "baseUrl": {
+                "type": "string",
+                "format": "uri",
+                "title": "API Base URL",
+                "default": "https://api.anthropic.com/v1",
+                "description": "Base URL for Anthropic's API. Change only if routing through a proxy."
+            },
+            "defaultModel": {
+                "type": "string",
+                "title": "Default Model",
+                "default": "claude-sonnet-4-6",
+                "description": "Model used for Design generation requests unless overridden per-request."
+            },
+            "name": {
+                "type": "string",
+                "title": "Connection Name",
+                "description": "Optional friendly name for this connection."
+            }
+        }
+    },
+    "credentialSchema": {
+        "type": "object",
+        "title": "Anthropic API Key",
+        "required": [
+            "apiKey"
+        ],
+        "properties": {
+            "apiKey": {
+                "type": "string",
+                "format": "password",
+                "title": "API Key",
+                "description": "Your Anthropic API key. Stored as a Credential, never written to Connection metadata, generated Designs, logs, or events."
+            }
+        }
+    },
+    "styles": {
+        "svgColor": "<!-- placeholder: use Anthropic's official logo SVG here -->",
+        "svgWhite": "<!-- placeholder: use Anthropic's official logo SVG (white variant) here -->"
+    }
+}

--- a/server/handlers/anthropic_connectivity_test.go
+++ b/server/handlers/anthropic_connectivity_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+// This file is an ad hoc connectivity check for the Anthropic model-provider
+// Connection/Credential, per the first steps outlined on meshery/meshery#20994:
+// https://github.com/meshery/meshery/issues/20994#issuecomment-5114456107
+//
+// It intentionally does NOT attempt to be the production provider health/readiness
+// check described in the AI Adapter project's expected outcomes - that belongs to
+// a later, dedicated PR with proper status/error/event semantics and
+// operationId correlation. This is only meant to prove, end to end, that a real
+// Anthropic API key can be exercised through the connection/credential shape
+// established in #19877/#19888.
+//
+// It is skipped by default (no network access, no CI dependency). To run it
+// locally with a real key:
+//
+//	$env:ANTHROPIC_API_KEY = "sk-ant-..."
+//	go test ./server/handlers/ -run TestAnthropicConnectionLiveConnectivity -v
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+const anthropicAPIBaseURL = "https://api.anthropic.com/v1"
+const anthropicAPIVersion = "2023-06-01"
+
+// TestAnthropicConnectionLiveConnectivity makes a minimal, real request to
+// Anthropic's API using a locally supplied API key, to confirm that a stored
+// Credential's apiKey value is sufficient to authenticate. It does not assert
+// on model output or response body - only that authentication succeeds - since
+// its only job is to prove the credential round-trips correctly, not to
+// exercise generation.
+func TestAnthropicConnectionLiveConnectivity(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set; skipping live connectivity check")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, anthropicAPIBaseURL+"/models", nil)
+	if err != nil {
+		t.Fatalf("building connectivity check request: %v", err)
+	}
+	// Never log apiKey; only its presence/absence and the resulting status code.
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("anthropic connectivity check failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("anthropic connectivity check returned status %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}


### PR DESCRIPTION
## What this does

1. Adds a `ConnectionDefinition` + `credentialSchema` for Anthropic Claude as a model-provider connection (`kind: anthropic`, `type: model-provider`, `subType: inference`), under `models/meshery-core`, following the existing `GitHubConnection.json` pattern and the field conventions
2. Adds an ad hoc connectivity test (`server/handlers/anthropic_connectivity_test.go`) that exercises a real Anthropic API key end-to-end, skipped by default (`t.Skip()`) unless `ANTHROPIC_API_KEY` is set locally — no CI/network dependency.

## What this deliberately does NOT do

This is scoped to exactly the 4 starter steps, not the full AI Adapter deliverables:
- No UI wizard changes
- No production health/readiness check (status/error/event semantics, operationId correlation) — that belongs to a dedicated follow-up
- No generation pipeline (prompt → Design)
- Only one provider (Anthropic), not all 8

## Why these choices

- No `discovered` state in `transitionMap`: unlike GitHub (which can discover a repo), nothing auto-detects an Anthropic API key sitting somewhere. Connections start at `registered` once a user submits the wizard form.
- `apiKey` is `required` in `credentialSchema`, which correctly makes this kind non-seedable via the existing `isSeedable()`/`requiresCredential()` logic in `seed_connections.go` — a human must create this connection.
- Reused `meshery-core` rather than a new model, per Lee's suggestion to not over-engineer this yet.

## Open question

I didn't add a `discovered` transition since there's no discovery mechanism for API keys — is that the right call, or is something else planned here?

## How to test

```bash
go build ./server/handlers/...
$env:ANTHROPIC_API_KEY = "sk-ant-..."
go test ./server/handlers/ -run TestAnthropicConnectionLiveConnectivity -v
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to Anthropic Claude models.
  * Added configuration for the Anthropic API endpoint, default model, connection name, and securely managed API key.

* **Tests**
  * Added an optional live connectivity check for Anthropic API access.
  * Connectivity checks run only when an API key is configured and safely handle authentication failures and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->