### PR TITLE
Fix/filter list count flag

### DIFF
--- a/mesheryctl/internal/cli/root/filter/filter.go
+++ b/mesheryctl/internal/cli/root/filter/filter.go
@@ -15,9 +15,18 @@
 package filter
 
 import (
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
+	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+type filterFlags struct {
+	Count bool `json:"count" validate:"boolean"`
+}
+
+var filterFlagsProvided filterFlags
 
 var availableSubcommands []*cobra.Command
 
@@ -31,7 +40,22 @@ Find more information at: https://docs.meshery.io/reference/mesheryctl#command-r
 // Base command for WASM filters:
 mesheryctl filter [subcommands]
 `,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return mesheryctlflags.ValidateCmdFlags(cmd, &filterFlagsProvided)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if filterFlagsProvided.Count {
+			mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
+			if err != nil {
+				return err
+			}
+			response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), "", pageSize, 0)
+			if err != nil {
+				return ErrFetchFilter(err)
+			}
+			utils.DisplayCount("filter", int64(response.TotalCount))
+			return nil
+		}
 		if len(args) == 0 {
 			return cmd.Help()
 		}
@@ -44,6 +68,7 @@ mesheryctl filter [subcommands]
 
 func init() {
 	FilterCmd.PersistentFlags().StringVarP(&utils.TokenFlag, "token", "t", "", "Path to token file default from current context")
+	FilterCmd.Flags().BoolVarP(&filterFlagsProvided.Count, "count", "", false, "(optional) Get the number of filters in total")
 	availableSubcommands = []*cobra.Command{viewCmd, deleteCmd, listCmd, importCmd}
 
 	FilterCmd.AddCommand(availableSubcommands...)

--- a/mesheryctl/internal/cli/root/filter/filter.go
+++ b/mesheryctl/internal/cli/root/filter/filter.go
@@ -47,10 +47,12 @@ mesheryctl filter [subcommands]
 		if filterFlagsProvided.Count {
 			mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 			if err != nil {
+				utils.Log.Error(err)
 				return err
 			}
 			response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), "", filterListFlagsProvided.PageSize, 0)
 			if err != nil {
+				utils.Log.Error(err)
 				return ErrFetchFilter(err)
 			}
 			utils.DisplayCount("filter", int64(response.TotalCount))

--- a/mesheryctl/internal/cli/root/filter/filter.go
+++ b/mesheryctl/internal/cli/root/filter/filter.go
@@ -49,7 +49,7 @@ mesheryctl filter [subcommands]
 			if err != nil {
 				return err
 			}
-			response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), "", pageSize, 0)
+			response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), "", filterListFlagsProvided.PageSize, 0)
 			if err != nil {
 				return ErrFetchFilter(err)
 			}

--- a/mesheryctl/internal/cli/root/filter/filter_test.go
+++ b/mesheryctl/internal/cli/root/filter/filter_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 )
 
@@ -31,6 +32,29 @@ func TestFilterCmd(t *testing.T) {
 		},
 	}
 
+	mesheryctlflags.InitValidators(FilterCmd)
 	// Run tests using the pre-existing helper
 	utils.InvokeMesheryctlTestCommand(t, update, FilterCmd, tests, currDir, "filter")
+}
+
+func TestFilterCmdCount(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("Not able to get current working directory")
+	}
+	currDir := filepath.Dir(filename)
+
+	tests := []utils.MesheryListCommandTest{
+		{
+			Name:             "Fetch Filter Count on root command",
+			Args:             []string{"--count"},
+			ExpectedResponse: "list.filter.count.output.golden",
+			Fixture:          "filter.list.api.response.golden",
+			URL:              "/api/filter",
+			ExpectError:      false,
+		},
+	}
+
+	mesheryctlflags.InitValidators(FilterCmd)
+	utils.InvokeMesheryctlTestListCommand(t, update, FilterCmd, tests, currDir, "filter")
 }

--- a/mesheryctl/internal/cli/root/filter/fixtures/filter.list.api.response.golden
+++ b/mesheryctl/internal/cli/root/filter/fixtures/filter.list.api.response.golden
@@ -1,7 +1,7 @@
 {
   "page": 0,
   "pageSize": 10000,
-  "totalCount": 2,
+  "totalCount": 5,
   "filters": [
     {
       "id": "c0c6035a-b1b9-412d-aab2-4ed1f1d51f84",

--- a/mesheryctl/internal/cli/root/filter/fixtures/filter.list.empty.api.response.golden
+++ b/mesheryctl/internal/cli/root/filter/fixtures/filter.list.empty.api.response.golden
@@ -1,0 +1,6 @@
+{
+  "page": 0,
+  "pageSize": 25,
+  "totalCount": 0,
+  "filters": []
+}

--- a/mesheryctl/internal/cli/root/filter/list.go
+++ b/mesheryctl/internal/cli/root/filter/list.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
+
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
@@ -30,10 +32,15 @@ import (
 	"github.com/spf13/viper"
 )
 
+type filterListFlags struct {
+	Count   bool `json:"count" validate:"boolean"`
+	Page    int  `json:"page" validate:"omitempty,gte=1"`
+	Verbose bool `json:"verbose" validate:"boolean"`
+}
+
 var (
-	pageSize   = 25
-	pageNumber int
-	verbose    bool
+	pageSize                = 25
+	filterListFlagsProvided filterListFlags
 )
 
 var listCmd = &cobra.Command{
@@ -50,6 +57,9 @@ mesheryctl filter list Test (maximum 25 filters)
 // Search for filter with space
 mesheryctl filter list 'Test Filter' (maximum 25 filters)
 	`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return mesheryctlflags.ValidateCmdFlags(cmd, &filterListFlagsProvided)
+	},
 	Args: cobra.MinimumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
@@ -61,9 +71,14 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 			searchString = strings.ReplaceAll(args[0], " ", "%20")
 		}
 
-		response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), searchString, pageSize, pageNumber-1)
+		response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), searchString, pageSize, filterListFlagsProvided.Page-1)
 		if err != nil {
 			return ErrFetchFilter(err)
+		}
+
+		if filterListFlagsProvided.Count {
+			utils.DisplayCount("filter", int64(response.TotalCount))
+			return nil
 		}
 
 		if len(args) > 0 && len(response.Filters) == 0 {
@@ -83,7 +98,7 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 		var header []string
 		var footer []string
 
-		if verbose {
+		if filterListFlagsProvided.Verbose {
 			if utils.IsLocalProvider(provider) {
 				for _, v := range response.Filters {
 					FilterID := v.ID.String()
@@ -139,12 +154,6 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 			footer = []string{"Total", fmt.Sprintf("%d", response.TotalCount), "", "", ""}
 		}
 
-		countFlag := cmd.Flag("count")
-		if countFlag != nil && countFlag.Value.String() == "true" {
-			utils.DisplayCount("filter", int64(response.TotalCount))
-			return nil
-		}
-
 		if cmd.Flags().Changed("page") {
 			utils.PrintToTable(header, data, footer)
 			return nil
@@ -197,7 +206,7 @@ func fetchFilters(baseURL, searchString string, pageSize, pageNumber int) (*mode
 }
 
 func init() {
-	listCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Display full length user and filter file identifiers")
-	listCmd.Flags().IntVarP(&pageNumber, "page", "p", 1, "(optional) List next set of filters with --page (default = 1)")
-	listCmd.Flags().BoolP("count", "c", false, "(optional) Display count only")
+	listCmd.Flags().BoolVarP(&filterListFlagsProvided.Count, "count", "c", false, "(optional) Display count only")
+	listCmd.Flags().IntVarP(&filterListFlagsProvided.Page, "page", "p", 1, "(optional) List next set of filters with --page (default = 1)")
+	listCmd.Flags().BoolVarP(&filterListFlagsProvided.Verbose, "verbose", "v", false, "Display full length user and filter file identifiers")
 }

--- a/mesheryctl/internal/cli/root/filter/list.go
+++ b/mesheryctl/internal/cli/root/filter/list.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/meshery/meshery/server/models"
@@ -35,8 +34,6 @@ var (
 	pageSize   = 25
 	pageNumber int
 	verbose    bool
-	// Color for the whiteboard printer
-	whiteBoardPrinter = color.New(color.FgHiBlack, color.BgWhite, color.Bold)
 )
 
 var listCmd = &cobra.Command{
@@ -144,7 +141,7 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 
 		countFlag := cmd.Flag("count")
 		if countFlag != nil && countFlag.Value.String() == "true" {
-			_, _ = whiteBoardPrinter.Println("Total number of filter: ", len(data))
+			utils.DisplayCount("filter", int64(response.TotalCount))
 			return nil
 		}
 
@@ -202,4 +199,5 @@ func fetchFilters(baseURL, searchString string, pageSize, pageNumber int) (*mode
 func init() {
 	listCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Display full length user and filter file identifiers")
 	listCmd.Flags().IntVarP(&pageNumber, "page", "p", 1, "(optional) List next set of filters with --page (default = 1)")
+	listCmd.Flags().BoolP("count", "c", false, "(optional) Display count only")
 }

--- a/mesheryctl/internal/cli/root/filter/list.go
+++ b/mesheryctl/internal/cli/root/filter/list.go
@@ -33,15 +33,13 @@ import (
 )
 
 type filterListFlags struct {
-	Count   bool `json:"count" validate:"boolean"`
-	Page    int  `json:"page" validate:"omitempty,gte=1"`
-	Verbose bool `json:"verbose" validate:"boolean"`
+	Count    bool `json:"count" validate:"boolean"`
+	Page     int  `json:"page" validate:"omitempty,gte=1"`
+	PageSize int  `json:"pagesize" validate:"omitempty,gte=1"`
+	Verbose  bool `json:"verbose" validate:"boolean"`
 }
 
-var (
-	pageSize                = 25
-	filterListFlagsProvided filterListFlags
-)
+var filterListFlagsProvided filterListFlags
 
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -71,7 +69,7 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 			searchString = strings.ReplaceAll(args[0], " ", "%20")
 		}
 
-		response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), searchString, pageSize, filterListFlagsProvided.Page-1)
+		response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), searchString, filterListFlagsProvided.PageSize, filterListFlagsProvided.Page-1)
 		if err != nil {
 			return ErrFetchFilter(err)
 		}
@@ -158,7 +156,7 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 			utils.PrintToTable(header, data, footer)
 			return nil
 		}
-		err = utils.HandlePagination(pageSize, "filter files", data, header, footer)
+		err = utils.HandlePagination(filterListFlagsProvided.PageSize, "filter files", data, header, footer)
 		if err != nil {
 			return utils.ErrHandlePagination(err)
 		}
@@ -208,5 +206,6 @@ func fetchFilters(baseURL, searchString string, pageSize, pageNumber int) (*mode
 func init() {
 	listCmd.Flags().BoolVarP(&filterListFlagsProvided.Count, "count", "c", false, "(optional) Display count only")
 	listCmd.Flags().IntVarP(&filterListFlagsProvided.Page, "page", "p", 1, "(optional) List next set of filters with --page (default = 1)")
+	listCmd.Flags().IntVarP(&filterListFlagsProvided.PageSize, "pagesize", "s", 25, "(optional) List next set of filters with --pagesize (default = 25)")
 	listCmd.Flags().BoolVarP(&filterListFlagsProvided.Verbose, "verbose", "v", false, "Display full length user and filter file identifiers")
 }

--- a/mesheryctl/internal/cli/root/filter/list.go
+++ b/mesheryctl/internal/cli/root/filter/list.go
@@ -34,8 +34,8 @@ import (
 
 type filterListFlags struct {
 	Count    bool `json:"count" validate:"boolean"`
-	Page     int  `json:"page" validate:"omitempty,gte=1"`
-	PageSize int  `json:"pagesize" validate:"omitempty,gte=1"`
+	Page     int  `json:"page" validate:"gte=1"`
+	PageSize int  `json:"pageSize" validate:"gte=1"`
 	Verbose  bool `json:"verbose" validate:"boolean"`
 }
 
@@ -71,6 +71,7 @@ mesheryctl filter list 'Test Filter' (maximum 25 filters)
 
 		response, err := fetchFilters(mctlCfg.GetBaseMesheryURL(), searchString, filterListFlagsProvided.PageSize, filterListFlagsProvided.Page-1)
 		if err != nil {
+			utils.Log.Error(err)
 			return ErrFetchFilter(err)
 		}
 

--- a/mesheryctl/internal/cli/root/filter/list_test.go
+++ b/mesheryctl/internal/cli/root/filter/list_test.go
@@ -29,6 +29,16 @@ func TestListCmd(t *testing.T) {
 			HttpMethod:       "GET",
 			HttpStatusCode:   200,
 		},
+		{
+			Name:             "Fetch Filter List with pagesize",
+			Args:             []string{"list", "--page", "1", "--pagesize", "10"},
+			ExpectedResponse: "list.filter.output.golden",
+			Fixture:          "list.filter.api.response.golden",
+			URL:              "/api/filter",
+			ExpectError:      false,
+			HttpMethod:       "GET",
+			HttpStatusCode:   200,
+		},
 	}
 	mesheryctlflags.InitValidators(FilterCmd)
 	// Run tests

--- a/mesheryctl/internal/cli/root/filter/list_test.go
+++ b/mesheryctl/internal/cli/root/filter/list_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -34,10 +35,26 @@ func TestListCmd(t *testing.T) {
 			Args:             []string{"list", "--page", "1", "--pagesize", "10"},
 			ExpectedResponse: "list.filter.output.golden",
 			Fixture:          "list.filter.api.response.golden",
-			URL:              "/api/filter",
+			URL:              "/api/filter?pagesize=10&page=0",
 			ExpectError:      false,
 			HttpMethod:       "GET",
 			HttpStatusCode:   200,
+		},
+		{
+			Name:             "List filters with invalid page number",
+			Args:             []string{"list", "--page", "0"},
+			ExpectedResponse: "",
+			ExpectError:      true,
+			IsOutputGolden:   false,
+			ExpectedError:    utils.ErrFlagsInvalid(fmt.Errorf("Invalid value for --page '0'")),
+		},
+		{
+			Name:             "List filters with invalid page size",
+			Args:             []string{"list", "--pagesize", "0"},
+			ExpectedResponse: "",
+			ExpectError:      true,
+			IsOutputGolden:   false,
+			ExpectedError:    utils.ErrFlagsInvalid(fmt.Errorf("Invalid value for --pageSize '0'")),
 		},
 	}
 	mesheryctlflags.InitValidators(FilterCmd)

--- a/mesheryctl/internal/cli/root/filter/list_test.go
+++ b/mesheryctl/internal/cli/root/filter/list_test.go
@@ -32,3 +32,24 @@ func TestListCmd(t *testing.T) {
 	// Run tests
 	utils.InvokeMesheryctlTestCommand(t, update, FilterCmd, tests, currDir, "filter")
 }
+
+func TestListCmdCount(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("Not able to get current working directory")
+	}
+	currDir := filepath.Dir(filename)
+
+	tests := []utils.MesheryListCommandTest{
+		{
+			Name:             "Fetch Filter Count",
+			Args:             []string{"list", "--count"},
+			ExpectedResponse: "list.filter.count.output.golden",
+			Fixture:          "filter.list.api.response.golden",
+			URL:              "/api/filter",
+			ExpectError:      false,
+		},
+	}
+
+	utils.InvokeMesheryctlTestListCommand(t, update, FilterCmd, tests, currDir, "filter")
+}

--- a/mesheryctl/internal/cli/root/filter/list_test.go
+++ b/mesheryctl/internal/cli/root/filter/list_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"testing"
 
+	mesheryctlflags "github.com/meshery/meshery/mesheryctl/internal/cli/pkg/flags"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 )
 
@@ -29,6 +30,7 @@ func TestListCmd(t *testing.T) {
 			HttpStatusCode:   200,
 		},
 	}
+	mesheryctlflags.InitValidators(FilterCmd)
 	// Run tests
 	utils.InvokeMesheryctlTestCommand(t, update, FilterCmd, tests, currDir, "filter")
 }
@@ -49,7 +51,16 @@ func TestListCmdCount(t *testing.T) {
 			URL:              "/api/filter",
 			ExpectError:      false,
 		},
+		{
+			Name:             "Fetch Filter Count with no matching filters",
+			Args:             []string{"list", "nonexistent", "--count"},
+			ExpectedResponse: "list.filter.count.empty.output.golden",
+			Fixture:          "filter.list.empty.api.response.golden",
+			URL:              "/api/filter",
+			ExpectError:      false,
+		},
 	}
 
+	mesheryctlflags.InitValidators(FilterCmd)
 	utils.InvokeMesheryctlTestListCommand(t, update, FilterCmd, tests, currDir, "filter")
 }

--- a/mesheryctl/internal/cli/root/filter/testdata/filter.help.output.golden
+++ b/mesheryctl/internal/cli/root/filter/testdata/filter.help.output.golden
@@ -20,6 +20,7 @@ Available Commands:
   view        View filter(s)
 
 Flags:
+      --count          (optional) Get the number of filters in total
   -h, --help           help for filter
   -t, --token string   Path to token file default from current context
 

--- a/mesheryctl/internal/cli/root/filter/testdata/list.filter.count.empty.output.golden
+++ b/mesheryctl/internal/cli/root/filter/testdata/list.filter.count.empty.output.golden
@@ -1,0 +1,1 @@
+No filters found

--- a/mesheryctl/internal/cli/root/filter/testdata/list.filter.count.output.golden
+++ b/mesheryctl/internal/cli/root/filter/testdata/list.filter.count.output.golden
@@ -1,1 +1,1 @@
-Total number of filters: 2
+Total number of filters: 5

--- a/mesheryctl/internal/cli/root/filter/testdata/list.filter.count.output.golden
+++ b/mesheryctl/internal/cli/root/filter/testdata/list.filter.count.output.golden
@@ -1,0 +1,1 @@
+Total number of filters: 2


### PR DESCRIPTION
## Notes for Reviewers

- This PR fixes [**[mesheryctl] Add --count flag to filter list #21242**](https://github.com/meshery/meshery/issues/21242)
- Adds `--count` to `mesheryctl filter` and `mesheryctl filter list`.
- `mesheryctl filter list` also supports the `-c` shorthand.
- Uses `utils.DisplayCount` with the API's `TotalCount` so the count represents the total number of filters rather than the current page.
- Adds regression coverage for count output, including the empty-result case.
- Refactors filter command flag handling to follow the existing mesheryctl flag validation approach.

[**Signed commits**](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--count` option to display the total number of filters.
  * Added validated pagination options for controlling filter-list results.
  * Filter listings now clearly report when no filters are found.
  * Updated filter command help to document the new count option.

* **Bug Fixes**
  * Improved handling and reporting of filter-fetch errors.
  * Added validation for invalid page and page-size values.
  * Improved accuracy of reported filter totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->