### PR TITLE
[Models] Add Ollama connection, credential schema, and RegisterAction

### DIFF
--- a/models/meshery-core/0.7.2/v1.0.0/connections/OllamaConnection.json
+++ b/models/meshery-core/0.7.2/v1.0.0/connections/OllamaConnection.json
@@ -1,0 +1,95 @@
+{
+    "schemaVersion": "connections.meshery.io/v1beta3",
+    "name": "Ollama",
+    "description": "Connect Meshery to a self-hosted Ollama instance to generate Kubernetes Designs from natural language prompts using locally-run models. No cloud API key is required by default; Ollama instances that sit behind an authenticating proxy can optionally supply a bearer token as a Credential.",
+    "kind": "ollama",
+    "type": "model-provider",
+    "subType": "inference",
+    "status": "registered",
+    "transitionMap": {
+        "registered": [
+            {
+                "nextState": "connected",
+                "description": "Confirms the configured Ollama instance is reachable and has at least one model available, and marks this provider ready for Design generation."
+            },
+            {
+                "nextState": "ignored",
+                "description": "Keeps the connection registered but excludes it from the provider list shown during Design generation."
+            }
+        ],
+        "connected": [
+            {
+                "nextState": "disconnected",
+                "description": "Stops using this provider for Design generation. The connection (and credential, if one was supplied) is kept, so it can be reconnected without re-entering configuration."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes this connection and any associated credential from Meshery."
+            }
+        ],
+        "disconnected": [
+            {
+                "nextState": "connected",
+                "description": "Re-checks reachability of the configured Ollama instance and resumes using this provider for Design generation."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes this connection and any associated credential from Meshery."
+            }
+        ],
+        "ignored": [
+            {
+                "nextState": "connected",
+                "description": "Re-checks reachability of the configured Ollama instance and resumes using this provider for Design generation."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes this connection and any associated credential from Meshery."
+            }
+        ]
+    },
+    "connectionSchema": {
+        "type": "object",
+        "title": "Ollama Connection",
+        "required": [
+            "baseUrl"
+        ],
+        "properties": {
+            "baseUrl": {
+                "type": "string",
+                "format": "uri",
+                "title": "Ollama Base URL",
+                "default": "http://localhost:11434",
+                "description": "Base URL of the Ollama instance Meshery should talk to. Can point at a local, in-cluster, or LAN address. See PR description for the SSRF-trap blocklist applied to this field server-side."
+            },
+            "defaultModel": {
+                "type": "string",
+                "title": "Default Model",
+                "default": "llama3.1",
+                "description": "Model tag used for Design generation requests unless overridden per-request. Must already be pulled on the target Ollama instance."
+            },
+            "name": {
+                "type": "string",
+                "title": "Connection Name",
+                "description": "Optional friendly name for this connection."
+            }
+        }
+    },
+    "credentialSchema": {
+        "type": "object",
+        "title": "Ollama Access Token (optional)",
+        "required": [],
+        "properties": {
+            "apiKey": {
+                "type": "string",
+                "format": "password",
+                "title": "Bearer Token",
+                "description": "Optional. Only needed if this Ollama instance sits behind an authenticating reverse proxy. Left blank for a typical local/LAN Ollama install. Never written to Connection metadata, generated Designs, logs, or events."
+            }
+        }
+    },
+    "styles": {
+        "svgColor": "<!-- TODO: use Ollama's official logo SVG here -->",
+        "svgWhite": "<!-- TODO: use Ollama's official logo SVG (white variant) here -->"
+    }
+}

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1475
+  "next_error_code": 1476
 }

--- a/server/machines/helpers/helpers.go
+++ b/server/machines/helpers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/meshery/meshery/server/machines"
 	"github.com/meshery/meshery/server/machines/grafana"
 	"github.com/meshery/meshery/server/machines/kubernetes"
+	"github.com/meshery/meshery/server/machines/ollama"
 	"github.com/meshery/meshery/server/machines/prometheus"
 	"github.com/meshery/meshery/server/models"
 	"github.com/meshery/meshery/server/models/connections"
@@ -82,6 +83,8 @@ func registerActionForKind(mtype string) machines.Action {
 	switch mtype {
 	case "grafana":
 		return &grafana.RegisterAction{}
+	case "ollama":
+		return &ollama.RegisterAction{}
 	case "prometheus":
 		return &prometheus.RegisterAction{}
 	}

--- a/server/machines/ollama/register.go
+++ b/server/machines/ollama/register.go
@@ -1,0 +1,194 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
+	"github.com/meshery/meshery/server/machines"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/meshkit/models/events"
+	"github.com/meshery/meshkit/utils"
+	"github.com/meshery/schemas/models/core"
+)
+
+const (
+	defaultOllamaTimeout = 10 * time.Second
+	ollamaTagsPath       = "/api/tags"
+)
+
+// ollamaConn mirrors the non-secret fields in OllamaConnection.json's connectionSchema.
+type ollamaConn struct {
+	BaseURL      string `json:"baseUrl"`
+	DefaultModel string `json:"defaultModel"`
+}
+
+// ollamaCred mirrors credentialSchema. APIKey is optional - most local Ollama
+// installs have no auth in front of them.
+type ollamaCred struct {
+	APIKey string `json:"apiKey"`
+}
+
+type RegisterAction struct{}
+
+func (ra *RegisterAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
+	return machines.NoOp, nil, nil
+}
+
+func (ra *RegisterAction) Execute(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
+	logLevel := viper.GetInt("LOG_LEVEL")
+	if viper.GetBool("DEBUG") {
+		logLevel = int(logrus.DebugLevel)
+	}
+	log, err := logger.New("meshery", logger.Options{
+		Format:   logger.SyslogLogFormat,
+		LogLevel: logLevel,
+	})
+	if err != nil {
+		// Matches server/machines/prometheus/register.go's existing convention.
+		// Inherited from the merged pattern, not introduced here - a repo-wide
+		// fix (returning the error instead of os.Exit) is a separate concern
+		// from this connection kind.
+		logrus.Error(err)
+		os.Exit(1)
+	}
+
+	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
+	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)
+	userUUID := user.ID
+
+	eventBuilder := events.NewEvent().
+		ActedUpon(userUUID).
+		WithCategory("connection").
+		WithAction("update").
+		FromSystem(*sysID).
+		FromOwner(userUUID).
+		WithDescription("Failed to interact with the connection.").
+		WithSeverity(events.Error)
+
+	connPayload, err := utils.Cast[connections.ConnectionPayload](data)
+	if err != nil {
+		eventBuilder.WithMetadata(map[string]interface{}{"error": err})
+		return machines.NoOp, eventBuilder.Build(), err
+	}
+
+	metadata, err := utils.Cast[map[string]interface{}](connPayload.MetaData)
+	if err != nil {
+		eventBuilder.WithMetadata(map[string]interface{}{"error": err})
+		return machines.NoOp, eventBuilder.Build(), err
+	}
+
+	conn, err := utils.MarshalAndUnmarshal[map[string]interface{}, ollamaConn](metadata)
+	if err != nil {
+		eventBuilder.WithMetadata(map[string]interface{}{"error": err})
+		return machines.NoOp, eventBuilder.Build(), err
+	}
+
+	cred, err := utils.MarshalAndUnmarshal[map[string]interface{}, ollamaCred](connPayload.CredentialSecret)
+	if err != nil && !connPayload.SkipCredentialVerification {
+		eventBuilder.WithMetadata(map[string]interface{}{"error": err})
+		return machines.NoOp, eventBuilder.Build(), err
+	}
+
+	if err := validateOllamaBaseURL(conn.BaseURL); err != nil {
+		wrapped := models.ErrOllamaConnectivity(err)
+		return machines.NoOp, eventBuilder.WithMetadata(map[string]interface{}{"error": wrapped}).Build(), wrapped
+	}
+
+	if !connPayload.SkipCredentialVerification {
+		if err := checkOllamaReachable(ctx, conn.BaseURL, cred.APIKey); err != nil {
+			wrapped := models.ErrOllamaConnectivity(err)
+			return machines.NoOp, eventBuilder.WithMetadata(map[string]interface{}{"error": wrapped}).Build(), wrapped
+		}
+	}
+
+	log.Info("ollama connectivity check passed for " + conn.BaseURL)
+	return machines.Exit, nil, nil
+}
+
+func (ra *RegisterAction) ExecuteOnExit(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
+	return machines.NoOp, nil, nil
+}
+
+// checkOllamaReachable hits Ollama's list-models endpoint as the connectivity
+// check - lightweight, and doesn't require a model to already be pulled.
+func checkOllamaReachable(ctx context.Context, baseURL, apiKey string) error {
+	reqCtx, cancel := context.WithTimeout(ctx, defaultOllamaTimeout)
+	defer cancel()
+
+	tagsURL := strings.TrimRight(baseURL, "/") + ollamaTagsPath
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, tagsURL, nil)
+	if err != nil {
+		return fmt.Errorf("building connectivity request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("reaching %s: %w", baseURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ollama returned status %d from %s", resp.StatusCode, tagsURL)
+	}
+
+	var tagsResp struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tagsResp); err != nil {
+		return fmt.Errorf("decoding /api/tags response: %w", err)
+	}
+	return nil
+}
+
+// validateOllamaBaseURL blocks the well-known cloud-metadata SSRF traps while
+// deliberately still permitting localhost/private/in-cluster addresses, since
+// pointing at a self-hosted instance on the local network is the whole point
+// of this connection kind. Different mitigation than a host-allowlist
+// approach (see PR description for why an allowlist doesn't fit Ollama).
+func validateOllamaBaseURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("baseUrl is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("not a valid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https, got %q", u.Scheme)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("missing host")
+	}
+
+	blockedHosts := map[string]bool{
+		"169.254.169.254":          true, // AWS/GCP/Azure IMDS
+		"metadata.google.internal": true,
+	}
+	if blockedHosts[strings.ToLower(host)] {
+		return fmt.Errorf("baseUrl host %q is not permitted", host)
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("baseUrl host %q is a link-local address and is not permitted", host)
+	}
+
+	return nil
+}

--- a/server/machines/ollama/register.go
+++ b/server/machines/ollama/register.go
@@ -140,7 +140,9 @@ func checkOllamaReachable(ctx context.Context, baseURL, apiKey string) error {
 	if err != nil {
 		return fmt.Errorf("reaching %s: %w", baseURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("ollama returned status %d from %s", resp.StatusCode, tagsURL)

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -167,7 +167,7 @@ const (
 	ErrOperatorChartNotPublishedCode      = "meshery-server-1470"
 	ErrOperatorChartSubstitutedCode       = "meshery-server-1471"
 	ErrNoMesheryReleasesFoundCode         = "meshery-server-1472"
-	ErrOllamaConnectivityCode             = "meshery-server-1473"
+	ErrOllamaConnectivityCode             = "meshery-server-1475"
 )
 
 var (

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -167,6 +167,7 @@ const (
 	ErrOperatorChartNotPublishedCode      = "meshery-server-1470"
 	ErrOperatorChartSubstitutedCode       = "meshery-server-1471"
 	ErrNoMesheryReleasesFoundCode         = "meshery-server-1472"
+	ErrOllamaConnectivityCode             = "meshery-server-1473"
 )
 
 var (
@@ -611,6 +612,10 @@ func ErrGrafanaScan(err error) error {
 
 func ErrPrometheusScan(err error) error {
 	return errors.New(ErrPrometheusScanCode, errors.Alert, []string{"Unable to connect to prometheus"}, []string{err.Error()}, []string{"Prometheus endpoint might not be reachable from Meshery", "Prometheus endpoint is incorrect"}, []string{"Check if your Prometheus endpoint are correct", "Connect to Prometheus from the settings page in the UI"})
+}
+
+func ErrOllamaConnectivity(err error) error {
+	return errors.New(ErrOllamaConnectivityCode, errors.Alert, []string{"Unable to connect to Ollama"}, []string{err.Error()}, []string{"Ollama endpoint might not be reachable from Meshery", "Ollama endpoint (baseUrl) is incorrect", "Ollama instance requires an access token that wasn't supplied"}, []string{"Check that your Ollama endpoint is correct and reachable from the Meshery server", "Verify the Ollama instance is running and has at least one model available", "If this Ollama instance sits behind an authenticating proxy, supply an access token when connecting"})
 }
 
 func ErrDBCreate(err error) error {


### PR DESCRIPTION
Part of #20994 (Meshery: BYOM — Adapter for AI and LLMs).

## What this does

Adds Ollama as a model-provider `Connection`/`Credential` kind, so a self-hosted Ollama instance can be plugged into the existing generic Connection/Credential system (the same one used for Kubernetes clusters, GitHub, Grafana, etc.) instead of requiring a startup env var.

This covers leecalcote's four starting steps on #20994:
1. `ConnectionDefinition` for a provider → `OllamaConnection.json`
2. `CredentialDefinition` adjoined to it → `credentialSchema` in the same file
3. Model to house it in → reused `meshery-core`, per the "for the time being" suggestion
4. Ad hoc connectivity test → went one step further and wired a real `RegisterAction` into the FSM dispatch table, rather than a standalone disposable test

## Files changed

- **`models/meshery-core/0.7.2/v1.0.0/connections/OllamaConnection.json`** — connection/credential schemas, full `transitionMap` (including `ignored`, which #21240's review flagged as missing on the equivalent Anthropic definition)
- **`server/machines/ollama/register.go`** — `RegisterAction` implementing `ExecuteOnEntry`/`Execute`/`ExecuteOnExit`, mirroring `server/machines/prometheus/register.go`'s real interface. Connectivity check hits `GET {baseUrl}/api/tags` (Ollama's list-models endpoint — lightweight, doesn't require a model to already be pulled), with an optional bearer token for proxied deployments.
- **`server/machines/helpers/helpers.go`** — added `"ollama"` case to `registerActionForKind`, alongside `grafana`/`prometheus`
- **`server/models/error.go`** — new `ErrOllamaConnectivity` / `ErrOllamaConnectivityCode = "meshery-server-1473"`, following the exact `errors.New(...)` shape used by `ErrPrometheusScan`


## Two open design questions

1. **Seedability.** `credentialSchema.required` is empty, since a typical local Ollama install has no auth in front of it. Per `seed_connections.go`, `isSeedable()` only skips auto-seeding when `requiresCredential(def)` is true — so as written, Ollama is the first model-provider kind eligible for auto-seeding (e.g. defaulting to `http://localhost:11434` on server start). That could be genuinely useful for a "provider-swap, hosted ↔ local, no code changes" workflow, but auto-seeding a network call on every server boot is a real behavior change I'd rather get an explicit yes/no on than ship as a side effect of an empty `required` array.

2. **`baseUrl` validation.** #21240's Anthropic `baseUrl` was flagged for SSRF risk and fixed with a host allowlist (`api.anthropic.com` only). That approach doesn't transfer here — pointing at an arbitrary local/LAN/in-cluster address *is* the feature for Ollama, so there's no fixed host to allowlist. Instead, `validateOllamaBaseURL` blocks the known cloud-metadata SSRF targets (`169.254.169.254`, `metadata.google.internal`, link-local addresses generally) while still permitting private ranges. Flagging explicitly so this isn't read as "the same issue #21240 has, left unfixed."

## Verification

- `go build ./...` — clean
- `go vet ./server/machines/... ./server/models/...` — clean
- `go test ./server/machines/...` — passes (including the new `ollama` package build, no test files yet)
- `go test ./server/models/...` — pre-existing local failures unrelated to this change: `CGO_ENABLED=0` in this environment means `go-sqlite3` can't open its in-memory test databases. Confirmed via `git stash` against unmodified `master` — same failures occur with none of this PR's changes applied.

## Deliberately not done here

- Real Ollama logo SVG — left as a placeholder (`styles.svgColor`/`svgWhite`)
- Tests for `register.go` / the new error code — want the design questions above resolved first, since the seedability answer affects what "correct" behavior even is to test against
- `mesheryctl` support for the new connection kind — out of scope for this first PR

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
