### PR TITLE
[mesheryctl] Report the auth error instead of crashing on adapter validate

### DIFF
--- a/mesheryctl/internal/cli/root/adapter/adapter.go
+++ b/mesheryctl/internal/cli/root/adapter/adapter.go
@@ -272,15 +272,16 @@ func waitForValidateResponse(mctlCfg *config.MesheryCtlConfig, query string) (st
 	method := "GET"
 	client := &http.Client{}
 	req, err := utils.NewRequest(method, path, nil)
-	req.Header.Add("Accept", "text/event-stream")
 	if err != nil {
-		return "", ErrCreatingDeployResponseRequest(err)
+		return "", ErrCreatingValidateResponseRequest(err)
 	}
+	req.Header.Add("Accept", "text/event-stream")
 
 	res, err := client.Do(req)
 	if err != nil {
 		return "", ErrCreatingValidateRequest(err)
 	}
+	defer func() { _ = res.Body.Close() }()
 
 	event, err := utils.ConvertRespToSSE(res)
 	if err != nil {

--- a/mesheryctl/internal/cli/root/adapter/adapter_test.go
+++ b/mesheryctl/internal/cli/root/adapter/adapter_test.go
@@ -1,0 +1,31 @@
+package adapter
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshkit/errors"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitForValidateResponseWithMissingToken(t *testing.T) {
+	utils.SetupContextEnv(t)
+	utils.SetupMeshkitLoggerTesting(t, false)
+
+	mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalToken := utils.TokenFlag
+	t.Cleanup(func() { utils.TokenFlag = originalToken })
+	utils.TokenFlag = filepath.Join(t.TempDir(), "absent-token.json")
+
+	_, err = waitForValidateResponse(mctlCfg, "Smi conformance test")
+
+	assert.Error(t, err)
+	assert.Equal(t, ErrCreatingValidateResponseRequestCode, errors.GetCode(err))
+}


### PR DESCRIPTION
## Summary

`mesheryctl system adapter validate` opens an SSE stream to follow conformance results. When the user is not logged in, building the request fails while reading the auth token. The code then dereferenced the failed request while setting the `Accept` header, causing a nil-pointer panic instead of returning the CLI error.

The request error is now checked before accessing the request. The command returns `mesheryctl-1030`, which is the existing error code for validation failures and provides the appropriate remediation for a missing token. The previous `mesheryctl-1024` code was a deployment error with unrelated guidance.

The response body is also now closed, matching the existing `waitForDeployResponse` behavior and ensuring the reader goroutine can exit cleanly.

## Tests

Added `TestWaitForValidateResponseWithMissingToken`, which reproduces the panic against `master` and verifies the expected `mesheryctl-1030` error code.

---

Drafted-by: Claude Code (Opus 5) (human review before posting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation response handling when request creation fails.
  * Ensured response resources are properly closed after validation requests.
  * Corrected error reporting for missing authentication token files.
  * Removed an incorrect deployment-related error mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->