### PR TITLE
fix(ui): use SettingsIcon for Settings step in connection configure wizard

### DIFF
--- a/ui/components/connections/ConnectionConfigureModal.tsx
+++ b/ui/components/connections/ConnectionConfigureModal.tsx
@@ -92,9 +92,9 @@ const ConnectionConfigureModal = ({
     }
   }, [isOpen]);
 
-  const steps = wizard.stepLabels.map((label, index) => ({
-    label,
-    icon: index === wizard.stepLabels.length - 1 ? CheckIcon : DescriptionIcon,
+  const steps = wizard.steps.map((step, index) => ({
+    label: step.label,
+    icon: step.icon || (index === wizard.steps.length - 1 ? CheckIcon : DescriptionIcon),
     component: <></>,
   }));
 


### PR DESCRIPTION
## Description

Fixes the **Settings** step icon in the Connection Configuration Wizard. The Settings step's own definition (`kubernetesSettingsStep`) already declared `icon: SettingsIcon` — it just wasn't being read, since the modal built its steps from `wizard.stepLabels` (plain strings) instead of `wizard.steps` (the full step objects).

This brings `ConnectionConfigureModal.tsx` in line with the pattern already shipped in the sibling create-flow modal, `ConnectionWizardModal.tsx`: each step's own `icon` field is used first, falling back to `CheckIcon` for the last step and `DescriptionIcon` otherwise. No new convention introduced — just making the configure wizard consistent with what the create wizard already does.

## Screenshots

**Before:**


**After:**


## Testing

- `yarn lint` passes clean on the changed file
- Verified `wizard.steps` is a real, typed field returned by `useConnectionWizard` (not just loosely-typed)
- Confirmed the Settings step's `icon: SettingsIcon` was already declared at the source and simply unused

Fixes #21248