### PR TITLE
fix Breadcrumb error

### DIFF
--- a/docs/assets/scss/_layout.scss
+++ b/docs/assets/scss/_layout.scss
@@ -114,7 +114,7 @@ ol {
 
 
 .main-container {
-  padding: 3.5rem 4.4rem;
+  padding: calc(var(--navbar-height) + 1rem) 4.4rem 3.5rem;
   overflow-x: auto;
   width: 100%;
   min-height: calc(100vh - var(--footer-height));


### PR DESCRIPTION
**Notes for Reviewers**
 
- This PR fixes #21143
### Root cause
 
The breadcrumb is rendered on every viewport by `layouts/_default/baseof.html` it is not hidden by a `display: none`. On desktop it is painted underneath the fixed navbar. I've checked it by dragging the page with cursor
 
The sibling containers already self-compensate for the fixed navbar and render correctly: `.left-container` uses `margin-top: calc(var(--navbar-height))` and `.content-table` uses `top: calc(var(--navbar-height) + 5rem)`. Only `.main-container` lost its compensation.
 
### Fix
 

 -padding: 3.5rem 4.4rem;
+padding: calc(var(--navbar-height) + 1rem) 4.4rem 3.5rem;

 

### Before / After
 Before:
 
<img width="1506" height="902" alt="Screenshot 2026-08-10 004405" src="https://github.com/user-attachments/assets/ba193987-3548-4235-a13e-ddefa8928f36" />

After:

<img width="1450" height="915" alt="Screenshot 2026-08-10 004150" src="https://github.com/user-attachments/assets/414c3daa-2517-43d2-b7aa-91e566006ed2" />

 
---
 
**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the main content spacing to account for the navigation bar height, preventing content from appearing too close to or behind the navbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->