### PR TITLE
[Server] Preference sync never activates if a remote provider is unreachable at boot, and /api/system/sync then hangs forever

### DIFF
--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -112,6 +112,13 @@ type RemoteProvider struct {
 	// provider and token cookie expiry bound
 	CookieDuration time.Duration
 
+	// syncMu guards the preference-sync worker's lifecycle: the two channels
+	// below and the flag recording whether the worker is running. Activation
+	// is no longer a boot-time-only event (capabilities can load at any time,
+	// see SyncPreferences), so the request path and the capability-load path
+	// can race to start it.
+	syncMu       sync.Mutex
+	syncActive   bool
 	syncStopChan chan struct{}
 	syncChan     chan *userSession
 
@@ -194,9 +201,16 @@ func (l *RemoteProvider) VerifyAvailability(ctx context.Context) (ProviderProper
 
 func (l *RemoteProvider) SetProviderProperties(providerProperties ProviderProperties) {
 	l.propertiesMu.Lock()
-	defer l.propertiesMu.Unlock()
 	l.ProviderProperties = providerProperties
 	l.ProviderURL = providerProperties.ProviderURL
+	l.propertiesMu.Unlock()
+
+	// This is the single funnel through which a capability set reaches the
+	// provider, and preference sync cannot start until one has. Activating
+	// here is what lets a remote that was unreachable at boot recover: the
+	// lock is already released, and SyncPreferences is idempotent, so an
+	// already-running worker is left alone.
+	l.SyncPreferences()
 }
 
 func (l *RemoteProvider) loadCapabilitiesFromLocalFile(filePath string) (ProviderProperties, error) {
@@ -417,24 +431,89 @@ func (l *RemoteProvider) GetProviderProperties() ProviderProperties {
 	return l.ProviderProperties
 }
 
-// SyncPreferences - used to sync preferences with the remote provider
+// supportsSyncPrefs reports whether the currently cached capability set
+// advertises preference sync. Capabilities are replaced wholesale by
+// SetProviderProperties from the tracker's probe goroutines, so the read is
+// taken under propertiesMu rather than off the embedded struct directly.
+func (l *RemoteProvider) supportsSyncPrefs() bool {
+	l.propertiesMu.RLock()
+	defer l.propertiesMu.RUnlock()
+	return l.Capabilities.IsSupported(SyncPrefs)
+}
+
+// SyncPreferences starts the worker that pushes preference writes to the
+// remote provider. It is idempotent and safe to call from any goroutine.
+//
+// Activation is capability-gated, and capabilities are not known at boot: the
+// concurrent-availability refactor made Initialize cheap and moved the
+// /capabilities fetch into an asynchronous probe. So this is called both from
+// main.go once the boot probe settles and from SetProviderProperties every
+// time a capability set lands, whichever happens first. Before that, a remote
+// that was unreachable at boot left the worker permanently unstarted and
+// RecordPreferences sent on a nil channel, hanging the request forever.
 func (l *RemoteProvider) SyncPreferences() {
-	if !l.Capabilities.IsSupported(SyncPrefs) {
+	if !l.supportsSyncPrefs() {
 		return
 	}
 
-	l.syncStopChan = make(chan struct{})
-	l.syncChan = make(chan *userSession, 100)
-	go func() {
-		for {
-			select {
-			case uSess := <-l.syncChan:
-				l.executePrefSync(uSess.token, uSess.session)
-			case <-l.syncStopChan:
-				return
-			}
+	l.syncMu.Lock()
+	defer l.syncMu.Unlock()
+
+	if l.syncActive {
+		return
+	}
+
+	// The worker is handed the channels as arguments rather than reading the
+	// fields, so it never touches state that a later Stop/restart mutates.
+	syncChan := make(chan *userSession, 100)
+	stopChan := make(chan struct{})
+	l.syncChan = syncChan
+	l.syncStopChan = stopChan
+	l.syncActive = true
+
+	go l.runPrefSync(syncChan, stopChan)
+}
+
+// runPrefSync drains queued preference writes until stopChan is closed.
+func (l *RemoteProvider) runPrefSync(syncChan <-chan *userSession, stopChan <-chan struct{}) {
+	for {
+		select {
+		case uSess := <-syncChan:
+			l.executePrefSync(uSess.token, uSess.session)
+		case <-stopChan:
+			return
 		}
-	}()
+	}
+}
+
+// enqueuePrefSync hands a preference write to the sync worker.
+//
+// It never blocks. A send on a nil channel blocks forever and a send into a
+// full buffer blocks until the worker drains it; either one would park the
+// goroutine serving the request, so both are turned into a return instead.
+//
+// The two outcomes are deliberately different. No worker means the write
+// cannot be synced at all, which the caller reports. A full buffer means the
+// worker is merely behind: the preference is already persisted locally by
+// then, and failing the user's request over a saturated best-effort queue
+// would be worse than logging it, so that case is logged and accepted.
+func (l *RemoteProvider) enqueuePrefSync(token string, sess *Preference) error {
+	l.syncMu.Lock()
+	syncChan := l.syncChan
+	active := l.syncActive
+	l.syncMu.Unlock()
+
+	if !active || syncChan == nil {
+		return ErrOperationNotAvailable
+	}
+
+	select {
+	case syncChan <- &userSession{token: token, session: sess}:
+		return nil
+	default:
+		l.Log.Warnf("preference sync queue for provider %q is full; dropping this update. The preference is saved locally but the remote provider will not see it until the next write.", l.Name())
+		return nil
+	}
 }
 
 // GetProviderCapabilities returns all of the provider properties
@@ -468,23 +547,29 @@ func (l *RemoteProvider) GetProviderCapabilities(w http.ResponseWriter, req *htt
 	}
 }
 
-// StopSyncPreferences - used to stop sync preferences
+// StopSyncPreferences stops the preference-sync worker.
 //
-// Safe to call even when SyncPreferences was never activated: with the
-// concurrent-availability refactor, capabilities may load after the boot
-// loop has already returned, so the post-probe SyncPreferences activation
-// runs asynchronously. The nil-channel guard prevents a shutdown defer
-// from blocking forever sending to an uninitialized syncStopChan in
-// the race where SyncPrefs became supported but SyncPreferences never
-// ran (e.g. shutdown raced with VerifyAll).
+// Safe to call when the worker was never started, and safe to call twice:
+// main.go defers it for every remote regardless of whether activation ever
+// happened. Stopping closes the channel rather than sending on it so a second
+// call cannot block on a worker that has already returned.
+//
+// The capability gate is deliberately absent. Capabilities are refreshed by
+// the tracker's probe, so a remote that goes offline before shutdown would
+// otherwise report SyncPrefs as unsupported and leak the running worker.
+// Whether the worker exists is tracked directly instead.
 func (l *RemoteProvider) StopSyncPreferences() {
-	if !l.Capabilities.IsSupported(SyncPrefs) {
+	l.syncMu.Lock()
+	defer l.syncMu.Unlock()
+
+	if !l.syncActive {
 		return
 	}
-	if l.syncStopChan == nil {
-		return
-	}
-	l.syncStopChan <- struct{}{}
+
+	close(l.syncStopChan)
+	l.syncActive = false
+	l.syncStopChan = nil
+	l.syncChan = nil
 }
 
 func (l *RemoteProvider) executePrefSync(tokenString string, sess *Preference) {
@@ -4089,7 +4174,7 @@ func (l *RemoteProvider) DeleteSchedule(req *http.Request, scheduleID string) ([
 
 // RecordPreferences - records the user preference
 func (l *RemoteProvider) RecordPreferences(req *http.Request, userID string, data *Preference) error {
-	if !l.Capabilities.IsSupported(SyncPrefs) {
+	if !l.supportsSyncPrefs() {
 		l.Log.Error(ErrOperationNotAvailable)
 		return ErrInvalidCapability("SyncPrefs", l.ProviderName)
 	}
@@ -4097,11 +4182,7 @@ func (l *RemoteProvider) RecordPreferences(req *http.Request, userID string, dat
 		return err
 	}
 	tokenVal, _ := l.GetToken(req)
-	l.syncChan <- &userSession{
-		token:   tokenVal,
-		session: data,
-	}
-	return nil
+	return l.enqueuePrefSync(tokenVal, data)
 }
 
 // TokenHandler - specific to remote auth
@@ -4134,7 +4215,16 @@ func (l *RemoteProvider) TokenHandler(w http.ResponseWriter, r *http.Request, _ 
 		return
 	}
 
-	l.ProviderProperties = providerProperties
+	// Route through SetProviderProperties rather than assigning the embedded
+	// struct: the write has to be taken under propertiesMu to stay off
+	// GetProviderProperties' readers, and login is the path that first loads
+	// capabilities for a deployment with a preselected PROVIDER, where the
+	// chooser's /api/providers/stream refresh never runs. ProviderURL is
+	// re-stamped first because a remote may return its own providerUrl in
+	// /capabilities, and the configured URL is what the rest of the server
+	// routes against (same reason GetProviderCapabilities re-stamps it).
+	providerProperties.ProviderURL = l.RemoteProviderURL
+	l.SetProviderProperties(providerProperties)
 
 	// Download the package for the user only if they have extension capability
 	if len(l.GetProviderProperties().Extensions.Navigator) > 0 {

--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -511,7 +511,7 @@ func (l *RemoteProvider) enqueuePrefSync(token string, sess *Preference) error {
 	case syncChan <- &userSession{token: token, session: sess}:
 		return nil
 	default:
-		l.Log.Warnf("preference sync queue for provider %q is full; dropping this update. The preference is saved locally but the remote provider will not see it until the next write.", l.Name())
+		l.Log.Warnf("preference sync queue for provider %q is full; dropping this update. The preference is saved locally but the remote provider will not see it until the next write.", l.GetProviderProperties().ProviderName)
 		return nil
 	}
 }
@@ -4174,9 +4174,14 @@ func (l *RemoteProvider) DeleteSchedule(req *http.Request, scheduleID string) ([
 
 // RecordPreferences - records the user preference
 func (l *RemoteProvider) RecordPreferences(req *http.Request, userID string, data *Preference) error {
-	if !l.supportsSyncPrefs() {
-		l.Log.Error(ErrOperationNotAvailable)
-		return ErrInvalidCapability("SyncPrefs", l.ProviderName)
+	// One snapshot for both the capability check and the provider name, so the
+	// error cannot name a provider whose capabilities were read from a
+	// different revision of the struct.
+	props := l.GetProviderProperties()
+	if !props.Capabilities.IsSupported(SyncPrefs) {
+		err := ErrInvalidCapability("SyncPrefs", props.ProviderName)
+		l.Log.Error(err)
+		return err
 	}
 	if err := l.WriteToPersister(userID, data); err != nil {
 		return err

--- a/server/models/remote_provider_sync_prefs_test.go
+++ b/server/models/remote_provider_sync_prefs_test.go
@@ -1,0 +1,246 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncPrefsTestProvider returns a RemoteProvider whose preference-sync PUTs land
+// on a local test server, plus a channel that reports each one that arrives.
+// Capabilities start empty, which is the state Initialize leaves behind: the
+// /capabilities fetch happens later, in VerifyAvailability.
+func syncPrefsTestProvider(t *testing.T) (*RemoteProvider, <-chan struct{}) {
+	t.Helper()
+
+	synced := make(chan struct{}, 32)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		select {
+		case synced <- struct{}{}:
+		default:
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	l := &RemoteProvider{
+		RemoteProviderURL: srv.URL,
+		Log:               newTestLogger(t),
+	}
+	l.Initialize()
+	t.Cleanup(l.StopSyncPreferences)
+
+	return l, synced
+}
+
+// syncPrefsCapabilities is the capability set a reachable remote reports, as
+// VerifyAvailability would hand it to SetProviderProperties.
+func syncPrefsCapabilities(providerURL string) ProviderProperties {
+	return ProviderProperties{
+		ProviderType: RemoteProviderType,
+		ProviderName: "Meshery",
+		ProviderURL:  providerURL,
+		Capabilities: Capabilities{{Feature: SyncPrefs, Endpoint: "/api/user/preferences"}},
+	}
+}
+
+// syncWorkerRunning reads the worker flag under its own lock so these
+// assertions stay clean under -race.
+func syncWorkerRunning(l *RemoteProvider) bool {
+	l.syncMu.Lock()
+	defer l.syncMu.Unlock()
+	return l.syncActive
+}
+
+func syncQueue(l *RemoteProvider) chan *userSession {
+	l.syncMu.Lock()
+	defer l.syncMu.Unlock()
+	return l.syncChan
+}
+
+// enqueueWithin runs the enqueue the request path performs and fails the test
+// if it does not return within d. Blocking here is the defect being guarded
+// against: it parks the goroutine serving the user's request permanently.
+func enqueueWithin(t *testing.T, l *RemoteProvider, d time.Duration) error {
+	t.Helper()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.enqueuePrefSync("test-token", NewDefaultPreference())
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(d):
+		t.Fatalf("enqueuePrefSync blocked for %s; the goroutine serving the request would be wedged", d)
+		return nil
+	}
+}
+
+// TestSyncPreferencesActivatesWhenCapabilitiesLoadAfterBoot is the regression
+// test for #21260.
+//
+// A remote that is unreachable when the boot probe runs has no capabilities, so
+// the boot-time SyncPreferences call cannot start the worker. It used to be the
+// only call site, which left the queue nil for the rest of the process and hung
+// every preference write on a nil-channel send. Capabilities arriving later must
+// start the worker instead.
+func TestSyncPreferencesActivatesWhenCapabilitiesLoadAfterBoot(t *testing.T) {
+	l, synced := syncPrefsTestProvider(t)
+
+	// Boot: the probe failed, so main.go's activation finds no capabilities.
+	l.SyncPreferences()
+	if syncWorkerRunning(l) {
+		t.Fatal("worker started without SyncPrefs in the capability set")
+	}
+
+	// A write in this window must fail fast rather than hang.
+	if err := enqueueWithin(t, l, 2*time.Second); err == nil {
+		t.Error("expected an error while no worker is running, got nil")
+	}
+
+	// The remote comes back and a capability set lands. This is exactly what
+	// VerifyAvailability does after a successful /capabilities fetch, whether
+	// it runs from the boot probe or from an /api/providers/stream refresh.
+	l.SetProviderProperties(syncPrefsCapabilities(l.RemoteProviderURL))
+
+	if !syncWorkerRunning(l) {
+		t.Fatal("capabilities loaded but the sync worker was not started")
+	}
+
+	if err := enqueueWithin(t, l, 2*time.Second); err != nil {
+		t.Fatalf("enqueue failed after activation: %v", err)
+	}
+
+	select {
+	case <-synced:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the preference never reached the remote provider")
+	}
+}
+
+// TestSyncPreferencesIsIdempotent covers activation now happening from two
+// places: main.go after the boot probe, and every SetProviderProperties. A
+// second activation must not replace the queue, which would abandon whatever is
+// still buffered in it and leave two workers competing for the same writes.
+func TestSyncPreferencesIsIdempotent(t *testing.T) {
+	l, _ := syncPrefsTestProvider(t)
+	l.SetProviderProperties(syncPrefsCapabilities(l.RemoteProviderURL))
+
+	first := syncQueue(l)
+	if first == nil {
+		t.Fatal("expected a queue after activation")
+	}
+
+	for i := 0; i < 5; i++ {
+		l.SyncPreferences()
+	}
+
+	if syncQueue(l) != first {
+		t.Error("SyncPreferences replaced the queue; a duplicate worker is running")
+	}
+}
+
+// TestEnqueuePrefSyncDoesNotBlockOnFullQueue pins the second way the send could
+// park a request goroutine. The preference is already persisted locally by this
+// point, so a saturated best-effort queue is logged and accepted rather than
+// failing the user's request.
+//
+// The state is built directly because a queue that is genuinely full while a
+// worker drains it cannot be produced deterministically.
+func TestEnqueuePrefSyncDoesNotBlockOnFullQueue(t *testing.T) {
+	l := &RemoteProvider{Log: newTestLogger(t)}
+
+	l.syncMu.Lock()
+	l.syncChan = make(chan *userSession, 1)
+	l.syncChan <- &userSession{session: NewDefaultPreference()}
+	l.syncActive = true
+	l.syncMu.Unlock()
+
+	if err := enqueueWithin(t, l, 2*time.Second); err != nil {
+		t.Errorf("a full queue should be accepted and logged, got %v", err)
+	}
+}
+
+// TestStopSyncPreferencesIsSafeWhenNeverStarted covers main.go, which defers
+// StopSyncPreferences for every remote whether or not activation happened.
+func TestStopSyncPreferencesIsSafeWhenNeverStarted(t *testing.T) {
+	l, _ := syncPrefsTestProvider(t)
+
+	stopWithin(t, l, 2*time.Second)
+}
+
+// TestStopSyncPreferencesIsIdempotent guards the shutdown path against a second
+// call. Signalling the worker used to be a send on an unbuffered channel, which
+// blocks once the worker has returned.
+func TestStopSyncPreferencesIsIdempotent(t *testing.T) {
+	l, _ := syncPrefsTestProvider(t)
+	l.SetProviderProperties(syncPrefsCapabilities(l.RemoteProviderURL))
+
+	stopWithin(t, l, 2*time.Second)
+	if syncWorkerRunning(l) {
+		t.Error("worker still marked running after Stop")
+	}
+	stopWithin(t, l, 2*time.Second)
+}
+
+func stopWithin(t *testing.T, l *RemoteProvider, d time.Duration) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		l.StopSyncPreferences()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("StopSyncPreferences blocked for %s", d)
+	}
+}
+
+// TestSyncPrefsLifecycleConcurrent exercises the three entry points together.
+// Activation is reachable from every probe goroutine and from main.go, enqueue
+// from every request goroutine, and Stop from the shutdown defer. Run with
+// -race.
+func TestSyncPrefsLifecycleConcurrent(t *testing.T) {
+	l, _ := syncPrefsTestProvider(t)
+	l.SetProviderProperties(syncPrefsCapabilities(l.RemoteProviderURL))
+
+	const workers = 8
+	const iterations = 40
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				switch (id + j) % 4 {
+				case 0:
+					l.SyncPreferences()
+				case 1, 2:
+					_ = l.enqueuePrefSync("test-token", NewDefaultPreference())
+				case 3:
+					l.StopSyncPreferences()
+				}
+			}
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("preference-sync lifecycle deadlocked under concurrent access")
+	}
+}


### PR DESCRIPTION


**Notes for Reviewers**

- This PR fixes #21260 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of remote provider preference synchronization during startup, capability updates, and shutdown.
  * Prevented preference updates from blocking indefinitely when synchronization is unavailable or busy.
  * Ensured provider URL and capability settings remain consistent during login.
  * Improved handling of concurrent synchronization activity and repeated lifecycle operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->