### PR TITLE
[Models] Relate API Gateway v2 Stage to its Deployment

### DIFF
--- a/models/aws-apigatewayv2-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-deployment.json
+++ b/models/aws-apigatewayv2-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-deployment.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.0"
+    },
+    "name": "aws-apigatewayv2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Stage",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "deploymentRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21274

## Summary

A Stage names the deployment it serves through `spec.deploymentRef`, but the model had no reference relationship for that field, so connecting the two on the canvas neither evaluated nor patched anything. ACK declares the reference explicitly — `Stage.DeploymentId` references the `Deployment` resource — so `deploymentRef` is the field to match on rather than the raw `deploymentID`.

Orientation follows `aws-eks-controller`: the Deployment supplies its display name and the Stage receives it. The reference definitions already in this model are inverted and would instead patch the provider's display name; they are left untouched here.

## Verification

`mesheryctl model build aws-apigatewayv2-controller/v1.4.0 --path ./models` succeeds with the new definition present in the resulting layer. Evaluated against a server built from this branch, which registers it as `edge/non-binding/reference: Deployment -> Stage`; demo below.

https://github.com/user-attachments/assets/8ae9fcd8-225b-4315-a5dc-8ba6b96c44c2



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

---
Drafted-by: Claude Code (Opus 5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for linking API Gateway deployments with their corresponding stages.
  - Deployment information is now automatically reflected in stage references and display names.
  - The relationship is enabled by default for the AWS API Gateway controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->