### PR TITLE
feat(model): add AWS API Gateway v2 Api relationship definitions

### DIFF
--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "schemaVersion": "relationships.meshery.io/v1beta1",
   "selectors": [
     {
       "allow": {

--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
@@ -41,7 +41,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -73,7 +73,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -109,7 +109,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -141,7 +141,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -177,7 +177,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -209,7 +209,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -245,7 +245,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -277,7 +277,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -313,7 +313,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -345,7 +345,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -381,7 +381,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },
@@ -413,7 +413,7 @@
               },
               "name": "aws-apigatewayv2-controller",
               "registrant": {
-                "kind": ""
+                "kind": "github"
               },
               "version": ""
             },

--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
@@ -46,7 +46,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -54,8 +55,7 @@
                   "from",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -78,12 +78,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]
@@ -114,7 +114,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -122,8 +123,7 @@
                   "from",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -146,12 +146,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]
@@ -182,7 +182,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -190,8 +191,7 @@
                   "from",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -214,12 +214,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]
@@ -250,7 +250,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -258,8 +259,7 @@
                   "from",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -282,12 +282,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]
@@ -318,7 +318,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -326,8 +327,7 @@
                   "from",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -350,12 +350,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]
@@ -386,7 +386,8 @@
               "version": ""
             },
             "patch": {
-              "mutatorRef": [
+              "patchStrategy": "replace",
+              "mutatedRef": [
                 [
                   "configuration",
                   "spec",
@@ -394,8 +395,7 @@
                   "from",
                   "name"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ],
@@ -418,12 +418,12 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "patchStrategy": "replace",
+              "mutatorRef": [
                 [
                   "displayName"
                 ]
-              ],
-              "patchStrategy": "replace"
+              ]
             }
           }
         ]

--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
@@ -23,7 +23,7 @@
     },
     "version": ""
   },
-  "schemaVersion": "relationships.meshery.io/v1beta1",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "selectors": [
     {
       "allow": {

--- a/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
+++ b/models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json
@@ -1,0 +1,441 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "API Gateway v2",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.3.3"
+    },
+    "name": "aws-apigatewayv2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Deployment",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "APIMapping",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Authorizer",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Route",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Integration",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Stage",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "apiRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "API",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-apigatewayv2-controller",
+              "registrant": {
+                "kind": ""
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
### Description
This pull request adds non-binding reference relationships for the `aws-apigatewayv2-controller` model (v1.3.3) under the latest version folder. It links 6 different API Gateway v2 resources back to their parent `API` component using the `apiRef` configuration field.

### Relationships Added:
- `Deployment` ➔ `API` (via `apiRef.from.name` field)
- `APIMapping` ➔ `API` (via `apiRef.from.name` field)
- `Authorizer` ➔ `API` (via `apiRef.from.name` field)
- `Route` ➔ `API` (via `apiRef.from.name` field)
- `Integration` ➔ `API` (via `apiRef.from.name` field)
- `Stage` ➔ `API` (via `apiRef.from.name` field)

These relationships are defined in the new file:
`models/aws-apigatewayv2-controller/v1.3.3/v1.0.0/relationships/edge-non-binding-reference-api.json`


### Video

https://github.com/user-attachments/assets/3477d063-bcfa-4f9e-aa6f-2824f6cb7923


### Design
https://playground.meshery.io/extension/meshmap?mode=design&design=d7c1a77d-bf38-441c-a613-8d49a2f802c5
### Issues Resolved
Fixes #21270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for non-binding relationships among AWS API Gateway v2 resources, including APIs, deployments, routes, integrations, authorizers, API mappings, and stages.
  * Resource references and display names can now be propagated across related API Gateway resources for clearer inventory and navigation.
* **Documentation**
  * Added guidance for authoring and reviewing model relationships.
* **Validation**
  * Added local validation for GitOps EKS designs, including layout, hierarchy, configuration, and deployability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->