### PR TITLE
[mesheryctl] Guard type assertions in GetID and GetName

### DIFF
--- a/mesheryctl/pkg/utils/helpers.go
+++ b/mesheryctl/pkg/utils/helpers.go
@@ -691,7 +691,15 @@ func GetID(mesheryServerUrl, configuration string) ([]string, error) {
 		return idList, ErrNotFound(errors.New("no results found"))
 	}
 	for _, config := range dat[configType].([]interface{}) {
-		idList = append(idList, config.(map[string]interface{})["id"].(string))
+		configMap, ok := config.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, ok := configMap["id"].(string)
+		if !ok {
+			continue
+		}
+		idList = append(idList, id)
 	}
 	return idList, nil
 }
@@ -727,7 +735,19 @@ func GetName(mesheryServerUrl, configuration string) (map[string]string, error) 
 		return nameIdMap, ErrNotFound(errors.New("no results found"))
 	}
 	for _, config := range dat[configType].([]interface{}) {
-		nameIdMap[config.(map[string]interface{})["name"].(string)] = config.(map[string]interface{})["id"].(string)
+		configMap, ok := config.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, ok := configMap["name"].(string)
+		if !ok {
+			continue
+		}
+		id, ok := configMap["id"].(string)
+		if !ok {
+			continue
+		}
+		nameIdMap[name] = id
 	}
 	return nameIdMap, nil
 }

--- a/mesheryctl/pkg/utils/helpers_test.go
+++ b/mesheryctl/pkg/utils/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/constants"
 	"github.com/pkg/errors"
@@ -760,5 +761,67 @@ func TestSubcommandNames(t *testing.T) {
 				t.Errorf("SubcommandNames() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+// TestGetIDSkipsMalformedEntries pins GetID against a server response where an
+// item's id is missing or not a string. dat[configType] is decoded straight off
+// the wire as []interface{}, and nothing constrains the shape of an individual
+// entry beyond that - a partial record, or a schema drift between mesheryctl and
+// the server it talks to, should not crash a lookup that `design view`, `design
+// delete`, `design export`, `design undeploy`, `filter view` and `filter delete`
+// all depend on (via ValidId) to resolve a name or ID prefix typed on the command
+// line into a full ID.
+func TestGetIDSkipsMalformedEntries(t *testing.T) {
+	StartMockery(t)
+	defer StopMockery(t)
+
+	TokenFlag = GetToken(t)
+	defer func() { TokenFlag = "Not Set" }()
+
+	httpmock.RegisterResponder("GET", MesheryEndpoint+"/api/filter?page_size=10000",
+		httpmock.NewStringResponder(200, `{"filters":[
+			{"id":"11111111-1111-4111-8111-111111111111","name":"good"},
+			{"id":null,"name":"missing-id"},
+			{"name":"no-id-field"}
+		]}`))
+
+	ids, err := GetID(MesheryEndpoint, "filter")
+	if err != nil {
+		t.Fatalf("GetID returned an error: %v", err)
+	}
+
+	want := []string{"11111111-1111-4111-8111-111111111111"}
+	if !reflect.DeepEqual(ids, want) {
+		t.Errorf("GetID() = %v, want %v (entries without a string id should be skipped, not crash the lookup)", ids, want)
+	}
+}
+
+// TestGetNameSkipsMalformedEntries is GetName's side of the same contract: an
+// entry whose name or id isn't a string is left out of the map instead of
+// taking down the whole lookup (used by ValidName, behind `filter delete` when
+// the argument doesn't parse as an ID).
+func TestGetNameSkipsMalformedEntries(t *testing.T) {
+	StartMockery(t)
+	defer StopMockery(t)
+
+	TokenFlag = GetToken(t)
+	defer func() { TokenFlag = "Not Set" }()
+
+	httpmock.RegisterResponder("GET", MesheryEndpoint+"/api/filter?page_size=10000",
+		httpmock.NewStringResponder(200, `{"filters":[
+			{"id":"11111111-1111-4111-8111-111111111111","name":"good"},
+			{"id":"22222222-2222-4222-8222-222222222222","name":42},
+			{"id":33,"name":"numeric-id"}
+		]}`))
+
+	got, err := GetName(MesheryEndpoint, "filter")
+	if err != nil {
+		t.Fatalf("GetName returned an error: %v", err)
+	}
+
+	want := map[string]string{"good": "11111111-1111-4111-8111-111111111111"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetName() = %v, want %v (entries without a string name/id should be skipped, not crash the lookup)", got, want)
 	}
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21318

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

---

`GetID` and `GetName` (`mesheryctl/pkg/utils/helpers.go`) decode a meshery server list response as `[]interface{}` and assert each entry straight to `map[string]interface{}["id"].(string)` (`GetName` also asserts `["name"].(string)`), with no comma-ok guard:

```go
for _, config := range dat[configType].([]interface{}) {
    idList = append(idList, config.(map[string]interface{})["id"].(string))
}
```

An entry missing that field, or whose value isn't a string, panics instead of returning an error.

These two functions back `ValidId` and `ValidName`, which `design view`, `design delete`, `design export`, `design undeploy`, `filter view` and `filter delete` all call to resolve a name or ID prefix typed on the command line into a full ID. `design/view.go` already wraps `ValidId`'s error in `ErrInvalidNameOrID` for a clean CLI message, but that path never runs, because the panic happens one level down inside `GetID`, before `ValidId` gets a chance to return it.

**What changed**

Switched both loops to the comma-ok form. An entry that isn't a `map[string]interface{}`, or whose `id`/`name` field isn't a string, is now skipped instead of panicking. No behavior change for a well-formed response. Same defensive pattern already used for decoded API data elsewhere in mesheryctl (`displaySuccessfulComponents` in `model/import.go`).

**Test plan**

Added `TestGetIDSkipsMalformedEntries` and `TestGetNameSkipsMalformedEntries` in `mesheryctl/pkg/utils/helpers_test.go`, each mocking a server response where one list entry is well-formed and the others are missing `id`, have a `null` id, or have a non-string `id`/`name`.

Before the fix: both panic --

    interface conversion: interface {} is nil, not string
    interface conversion: interface {} is float64, not string

After the fix: both pass, and only the well-formed entry comes back.

    cd mesheryctl && go test ./pkg/utils/... -run "TestGetIDSkipsMalformedEntries|TestGetNameSkipsMalformedEntries" -v

Also ran the full `pkg/utils` suite (`go test ./pkg/utils/...`) and `go build ./...` clean.

release note: fix a panic in `mesheryctl design view`, `design delete`, `design export`, `design undeploy`, `filter view` and `filter delete` when the server's list response contains an entry with a missing or non-string id/name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed response data.
  * Entries missing valid text identifiers or names are now skipped safely instead of causing errors or crashes.
  * Valid records continue to be processed normally.

* **Tests**
  * Added coverage for missing, invalid, and valid identifier and name values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->