### PR TITLE
[Models] Add ReplicationGroup relationships in aws-elasticache-controller

### DIFF
--- a/models/aws-elasticache-controller/v1.6.0/v1.0.0/relationships/edge-non-binding-reference-replicationgroup.json
+++ b/models/aws-elasticache-controller/v1.6.0/v1.0.0/relationships/edge-non-binding-reference-replicationgroup.json
@@ -32,7 +32,7 @@
             "id": null,
             "kind": "ReplicationGroup",
             "match": {},
-            "match_strategy_matrix": null,
+            "matchStrategyMatrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
@@ -60,7 +60,7 @@
             "id": null,
             "kind": "CacheCluster",
             "match": {},
-            "match_strategy_matrix": null,
+            "matchStrategyMatrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
@@ -100,7 +100,7 @@
             "id": null,
             "kind": "ReplicationGroup",
             "match": {},
-            "match_strategy_matrix": null,
+            "matchStrategyMatrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
@@ -128,7 +128,7 @@
             "id": null,
             "kind": "Snapshot",
             "match": {},
-            "match_strategy_matrix": null,
+            "matchStrategyMatrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",

--- a/models/aws-elasticache-controller/v1.6.0/v1.0.0/relationships/edge-non-binding-reference-replicationgroup.json
+++ b/models/aws-elasticache-controller/v1.6.0/v1.0.0/relationships/edge-non-binding-reference-replicationgroup.json
@@ -1,0 +1,169 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.6.0"
+    },
+    "name": "aws-elasticache-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "CacheCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "replicationGroupRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Snapshot",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "replicationGroupRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21306

Adds `edge-non-binding-reference-replicationgroup.json` under
`models/aws-elasticache-controller/v1.6.0/v1.0.0/relationships/`, defining
two selectors that link components back to their parent `ReplicationGroup`:

- `ReplicationGroup` -> `CacheCluster` via `configuration.spec.replicationGroupRef.from.name`
- `ReplicationGroup` -> `Snapshot` via `configuration.spec.replicationGroupRef.from.name`

Both use the ACK spec reference field (`replicationGroupRef`) rather than the
plain `replicationGroupID` string field, per ACK best practice.

Verified with `mesheryctl model build aws-elasticache-controller --path ./models`.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-binding references from ElastiCache replication groups to related cache clusters and snapshots.
  * Replication-group name references are now automatically populated for improved resource relationships.
  * These relationships provide clearer connections between replication groups and their associated resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->