### PR TITLE
UI: Improve responsiveness of workspace modal and switcher

### DIFF
--- a/ui/components/workspaces/SpacesSwitcher/BottomSheetInlineSelect.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/BottomSheetInlineSelect.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import { Box, CheckCircleIcon, Collapse, ExpandMoreIcon, useTheme } from '@sistent/sistent';
+
+export type BottomSheetInlineSelectOption = {
+  id: string;
+  label: string;
+};
+
+type BottomSheetInlineSelectProps = {
+  value: string;
+  options: BottomSheetInlineSelectOption[];
+  onSelect: (id: string) => void;
+  placeholder?: string;
+  leadingIcon?: React.ReactNode;
+  renderOption?: (option: BottomSheetInlineSelectOption, selected: boolean) => React.ReactNode;
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  'data-cy'?: string;
+};
+
+/**
+ * Inline dropdown for BottomSheet — tap the field to expand options below it.
+ * Unlike MUI Select, the menu is not portaled and stays inside the sheet.
+ */
+export function BottomSheetInlineSelect({
+  value,
+  options,
+  onSelect,
+  placeholder = 'Select…',
+  leadingIcon,
+  renderOption,
+  expanded: expandedProp,
+  onExpandedChange,
+  'data-cy': dataCy,
+}: BottomSheetInlineSelectProps) {
+  const theme = useTheme();
+  const [expandedInternal, setExpandedInternal] = useState(false);
+  const expanded = expandedProp ?? expandedInternal;
+  const selected = options.find((option) => option.id === value);
+
+  const setExpanded = (next: boolean) => {
+    if (expandedProp === undefined) {
+      setExpandedInternal(next);
+    }
+    onExpandedChange?.(next);
+  };
+
+  const selectedBackground = theme.palette.action.selected;
+
+  return (
+    <Box sx={{ width: '100%' }} data-cy={dataCy}>
+      <Box
+        component="button"
+        type="button"
+        aria-expanded={expanded}
+        aria-haspopup="listbox"
+        onClick={() => setExpanded(!expanded)}
+        sx={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+          px: 2,
+          py: 1.5,
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: 1,
+          backgroundColor: expanded ? selectedBackground : theme.palette.background.card,
+          color: theme.palette.text.default,
+          cursor: 'pointer',
+          font: 'inherit',
+          fontWeight: 500,
+          fontSize: '0.9375rem',
+          textAlign: 'left',
+          transition: 'background-color 0.15s ease',
+        }}
+      >
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+          }}
+        >
+          {leadingIcon ? (
+            <Box sx={{ display: 'flex', flexShrink: 0, alignItems: 'center' }}>{leadingIcon}</Box>
+          ) : null}
+          <Box
+            component="span"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {selected?.label ?? placeholder}
+          </Box>
+        </Box>
+        <ExpandMoreIcon
+          width={20}
+          height={20}
+          fill={theme.palette.icon.default}
+          style={{
+            flexShrink: 0,
+            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 0.2s ease',
+          }}
+        />
+      </Box>
+
+      <Collapse in={expanded} unmountOnExit>
+        <Box
+          role="listbox"
+          sx={{
+            mt: 0.5,
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 1,
+            overflow: 'hidden',
+            backgroundColor: theme.palette.background.card,
+            maxHeight: 'min(32vh, 220px)',
+            overflowY: 'auto',
+          }}
+        >
+          {options.map((option, index) => {
+            const isSelected = option.id === value;
+            const isLast = index === options.length - 1;
+
+            return (
+              <Box
+                key={option.id}
+                component="button"
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => {
+                  onSelect(option.id);
+                  setExpanded(false);
+                }}
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1.5,
+                  px: 2,
+                  py: 1.25,
+                  border: 'none',
+                  borderBottom: isLast ? 'none' : `1px solid ${theme.palette.divider}`,
+                  backgroundColor: isSelected ? selectedBackground : 'transparent',
+                  color: theme.palette.text.default,
+                  cursor: 'pointer',
+                  font: 'inherit',
+                  fontSize: '0.9375rem',
+                  textAlign: 'left',
+                  '&:hover': {
+                    backgroundColor: isSelected ? selectedBackground : theme.palette.action.hover,
+                  },
+                }}
+              >
+                <Box
+                  sx={{
+                    flex: 1,
+                    minWidth: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    overflow: 'hidden',
+                  }}
+                >
+                  {renderOption ? (
+                    renderOption(option, isSelected)
+                  ) : (
+                    <Box
+                      component="span"
+                      sx={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {option.label}
+                    </Box>
+                  )}
+                </Box>
+                {isSelected ? (
+                  <CheckCircleIcon
+                    sx={{
+                      flexShrink: 0,
+                      fontSize: '1.125rem',
+                      color: theme.palette.background.brand.default,
+                    }}
+                  />
+                ) : null}
+              </Box>
+            );
+          })}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/ui/components/workspaces/SpacesSwitcher/DesignViewListItem.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/DesignViewListItem.tsx
@@ -131,7 +131,9 @@ const DesignViewListItem = ({
             }}
           >
             <StyledAvatarContainer>
-              <StyledListIcon>{useGetIconBasedOnMode({ mode: type })}</StyledListIcon>
+              <StyledListIcon withCheckbox={isMultiSelectMode}>
+                {useGetIconBasedOnMode({ mode: type })}
+              </StyledListIcon>
               <StyledListItemText
                 showWorkspaceName={showWorkspaceName}
                 primary={selectedItem.name || ''}

--- a/ui/components/workspaces/SpacesSwitcher/MobileViewSwitcher.test.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MobileViewSwitcher.test.tsx
@@ -3,16 +3,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/assets/icons/DashboardSwitcherIcon', () => ({
-  default: () => <svg data-testid="dashboard-icon" />,
-}));
-
 vi.mock('@/assets/icons/OrgOutlinedIcon', () => ({
   default: () => <svg data-testid="org-icon" />,
 }));
 
 vi.mock('css/icons.styles', () => ({
-  iconLarge: {},
+  iconSmall: { height: 20, width: 20 },
+  iconMedium: { height: 24, width: 24 },
+  iconLarge: { height: 32, width: 32 },
   iconXLarge: {},
 }));
 
@@ -23,27 +21,42 @@ vi.mock('@sistent/sistent', () => {
     return Styled;
   };
   return {
-    Box: ({ children }: any) => <div>{children}</div>,
-    Button: ({ children, onClick, ...rest }: any) => (
+    Box: ({ children, className }: any) => <div className={className}>{children}</div>,
+    BottomSheet: ({ children, open, title }: any) =>
+      open ? (
+        <div data-testid="bottom-sheet" role="dialog">
+          {title ? <h2>{title}</h2> : null}
+          {children}
+        </div>
+      ) : null,
+    Button: ({ children, onClick, variant, fullWidth, permissionKey, sx, ...rest }: any) => (
       <button onClick={onClick} {...rest}>
         {children}
       </button>
     ),
-    ClickAwayListener: ({ children }: any) => <div>{children}</div>,
+    Typography: ({ children }: any) => <span>{children}</span>,
     Grid2: ({ children }: any) => <div>{children}</div>,
-    Slide: ({ children, in: open }: any) =>
-      open ? <div data-testid="slide">{children}</div> : null,
     styled,
-    useMediaQuery: () => false,
     useTheme: () => ({
-      palette: { icon: { default: 'icon-default' } },
+      palette: {
+        common: { white: '#ffffff' },
+        icon: { default: 'icon-default' },
+        text: { secondary: 'text-secondary', default: 'text-default' },
+        background: { brand: { default: 'brand-default' } },
+        divider: 'divider-color',
+      },
+      spacing: (value: number) => `${value * 8}px`,
     }),
     WorkspaceIcon: () => <svg data-testid="ws-icon" />,
   };
 });
 
-vi.mock('../../layout/Header/Header.styles', () => ({
-  CMenuContainer: ({ children }: any) => <div data-testid="menu-container">{children}</div>,
+vi.mock('@/utils/context/WorkspaceModalContextProvider', () => ({
+  WorkspaceModalContext: React.createContext({
+    openModal: vi.fn(),
+    setCreateNewWorkspaceModalOpen: vi.fn(),
+    setSelectedWorkspace: vi.fn(),
+  }),
 }));
 
 vi.mock('./SpaceSwitcher', () => ({
@@ -61,30 +74,31 @@ describe('MobileOrgWksSwither', () => {
   const router = { push: vi.fn() };
   const organization = { id: 'org-1', name: 'Acme' };
 
-  it('renders the dashboard switcher button', () => {
+  it('renders the org and workspace switcher buttons', () => {
     render(<MobileOrgWksSwither organization={organization} router={router as any} />);
-    expect(screen.getByTestId('dashboard-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('org-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('ws-icon')).toBeInTheDocument();
   });
 
-  it('opens the slide-in menu when the trigger is clicked', async () => {
+  it('opens the bottom sheet when the trigger is clicked', async () => {
     const user = userEvent.setup();
     render(<MobileOrgWksSwither organization={organization} router={router as any} />);
 
-    expect(screen.queryByTestId('slide')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bottom-sheet')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /contexts/i }));
-    expect(screen.getByTestId('slide')).toBeInTheDocument();
-    // The slide-in contains OrgMenu and WorkspaceSwitcher with open=true
+    expect(screen.getByTestId('bottom-sheet')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /organization & workspace/i })).toBeInTheDocument();
     expect(screen.getByTestId('org-menu')).toBeInTheDocument();
     expect(screen.getByTestId('workspace-switcher')).toBeInTheDocument();
   });
 
-  it('renders OrgMenu and WorkspaceSwitcher inside the menu container once opened', async () => {
+  it('renders OrgMenu and WorkspaceSwitcher inside the bottom sheet once opened', async () => {
     const user = userEvent.setup();
     render(<MobileOrgWksSwither organization={organization} router={router as any} />);
     const trigger = screen.getByRole('button', { name: /contexts/i });
 
     await user.click(trigger);
-    expect(screen.getByTestId('menu-container')).toBeInTheDocument();
+    expect(screen.getByTestId('bottom-sheet')).toBeInTheDocument();
     expect(screen.getByTestId('org-menu')).toBeInTheDocument();
     expect(screen.getByTestId('workspace-switcher')).toBeInTheDocument();
   });

--- a/ui/components/workspaces/SpacesSwitcher/MobileViewSwitcher.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MobileViewSwitcher.tsx
@@ -1,146 +1,192 @@
-import DashboardSwitcherIcon from '@/assets/icons/DashboardSwitcherIcon';
-import {
-  Box,
-  Button,
-  ClickAwayListener,
-  Grid2,
-  Slide,
-  styled,
-  useMediaQuery,
-  useTheme,
-  WorkspaceIcon,
-} from '@sistent/sistent';
-import React, { useState } from 'react';
-import { CMenuContainer } from '../../layout/Header/Header.styles';
-import WorkspaceSwitcher from './WorkspaceSwitcher';
 import OrgOutlinedIcon from '@/assets/icons/OrgOutlinedIcon';
-import { iconLarge, iconXLarge } from 'css/icons.styles';
+import { WorkspaceModalContext } from '@/utils/context/WorkspaceModalContextProvider';
+import { Keys } from '@meshery/schemas/permissions';
+import { BottomSheet, Box, Button, Typography, useTheme, WorkspaceIcon } from '@sistent/sistent';
+import { iconMedium, iconSmall } from 'css/icons.styles';
+import React, { useContext, useState } from 'react';
+import WorkspaceSwitcher from './WorkspaceSwitcher';
 import { OrgMenu } from './SpaceSwitcher';
 
-const MobileOrgWksSwither_ = ({ organization, router }) => {
-  return (
-    <Box sx={{ margin: '0.25rem 0' }}>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'flex-start',
-          alignItems: 'center',
-        }}
-      >
-        <SwitcherMenu organization={organization} router={router} />
-      </div>
-    </Box>
-  );
-};
+const MobileOrgWksSwither_ = ({ organization, router }) => (
+  <SwitcherMenu organization={organization} router={router} />
+);
 
 export const MobileOrgWksSwither = MobileOrgWksSwither_;
 
-const StyledGrid = styled(Grid2)({
-  width: '100%',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-});
-
-function SwitcherMenu({ organization, router }) {
+function SectionLabel({ children, icon }: { children: React.ReactNode; icon: React.ReactNode }) {
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery('(max-width:400px)');
-  const [anchorEl, setAnchorEl] = useState(false);
-  const [showFullContextMenu, setShowFullContextMenu] = useState(false);
 
-  const styleSlider = {
-    position: 'absolute',
-    zIndex: '-1',
-    top: '-8%',
-    width: isSmallScreen ? '100%' : '270px',
-    transition: 'top 0.4s ease, transform 0.4s ease',
-    transform: showFullContextMenu ? `translateY(105%)` : 'translateY(-8%)',
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        mb: 1,
+      }}
+    >
+      <Box sx={{ display: 'flex', flexShrink: 0, alignItems: 'center' }}>{icon}</Box>
+      <Typography
+        variant="subtitle2"
+        component="p"
+        sx={{
+          m: 0,
+          color: theme.palette.text.secondary,
+          fontWeight: 500,
+          fontSize: '0.8125rem',
+        }}
+      >
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+type ExpandedField = 'org' | 'workspace' | null;
+
+function SwitcherMenu({ organization: _organization, router: _router }) {
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+  const [expandedField, setExpandedField] = useState<ExpandedField>(null);
+  const {
+    openModal: openWorkspaceModal,
+    setCreateNewWorkspaceModalOpen,
+    setSelectedWorkspace,
+  } = useContext(WorkspaceModalContext);
+
+  const handleClose = () => {
+    setOpen(false);
+    setExpandedField(null);
   };
 
-  let open = Boolean(anchorEl);
-  if (showFullContextMenu) {
-    open = showFullContextMenu;
-  }
+  const openWorkspaceExplorer = () => {
+    handleClose();
+    openWorkspaceModal(true);
+  };
+
+  const openCreateWorkspace = () => {
+    handleClose();
+    setSelectedWorkspace({
+      id: 'All Workspaces',
+      name: 'All Workspaces',
+    });
+    setCreateNewWorkspaceModalOpen(true);
+    openWorkspaceModal(true);
+  };
 
   return (
     <>
-      <div>
-        <Button
-          aria-label="contexts"
-          className="switcher-icon-button"
-          onClick={(e) => {
-            e.preventDefault();
-            setShowFullContextMenu((prev) => !prev);
-          }}
-          onMouseOver={(e) => {
-            e.preventDefault();
-            setAnchorEl(true);
-          }}
-          onMouseLeave={(e) => {
-            e.preventDefault();
-            setAnchorEl(false);
-          }}
-          aria-owns={open ? 'menu-list-grow' : undefined}
-          aria-haspopup="true"
-          style={{
-            minWidth: '2.5rem',
-            marginLeft: '0.5rem',
+      <Button
+        aria-label="contexts"
+        className="switcher-icon-button"
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((prev) => !prev);
+        }}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        sx={{
+          minWidth: 'auto',
+          flexShrink: 0,
+          ml: 0.25,
+          px: 0.5,
+          py: 0.25,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
           }}
         >
-          <DashboardSwitcherIcon height={28} width={28} />
-        </Button>
+          <OrgOutlinedIcon {...iconSmall} fill={theme.palette.common.white} />
+          <WorkspaceIcon
+            {...iconSmall}
+            fill={theme.palette.common.white}
+            secondaryFill={theme.palette.common.white}
+          />
+        </Box>
+      </Button>
 
-        <Slide
-          direction="down"
-          style={styleSlider}
-          timeout={400}
-          in={open}
-          mountOnEnter
-          unmountOnExit
+      <BottomSheet
+        open={open}
+        onClose={handleClose}
+        title="Organization & Workspace"
+        maxHeight="85vh"
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: '100%',
+            gap: 2.5,
+          }}
         >
-          <div>
-            <ClickAwayListener
-              onClickAway={(e) => {
-                if (
-                  !(e.target.tagName.toLowerCase() === 'body') &&
-                  !e.target.classList.contains('switcher-icon-button') &&
-                  !(e.target.tagName.toLowerCase() === 'path') &&
-                  !(e.target.tagName.toLowerCase() === 'svg') &&
-                  !(e.target.tagName.toLowerCase() === 'circle')
-                ) {
-                  setAnchorEl(false);
-                  setShowFullContextMenu(false);
-                }
-              }}
+          <Box>
+            <SectionLabel
+              icon={<OrgOutlinedIcon {...iconMedium} fill={theme.palette.icon.default} />}
             >
-              <CMenuContainer>
-                <Grid2 container spacing={2} alignItems="center" flexDirection={'column'}>
-                  <StyledGrid container>
-                    <OrgOutlinedIcon {...iconXLarge} fill={theme.palette.icon.default} />
-                    <OrgMenu open={true} fromMobileView={true} organization={organization} />
-                  </StyledGrid>
+              Organization
+            </SectionLabel>
+            <OrgMenu
+              open={true}
+              fromMobileView={true}
+              expanded={expandedField === 'org'}
+              onExpandedChange={(isExpanded) => setExpandedField(isExpanded ? 'org' : null)}
+            />
+          </Box>
 
-                  <StyledGrid container>
-                    <WorkspaceIcon
-                      {...iconLarge}
-                      style={{ marginLeft: '0.2rem' }}
-                      secondaryFill={theme.palette.icon.default}
-                      fill={theme.palette.icon.default}
-                    />
-                    <WorkspaceSwitcher
-                      open={true}
-                      fromMobileView={true}
-                      organization={organization}
-                      router={router}
-                    />
-                  </StyledGrid>
-                </Grid2>
-              </CMenuContainer>
-            </ClickAwayListener>
-          </div>
-        </Slide>
-      </div>
+          <Box>
+            <SectionLabel
+              icon={
+                <WorkspaceIcon
+                  {...iconMedium}
+                  fill={theme.palette.icon.default}
+                  secondaryFill={theme.palette.icon.default}
+                />
+              }
+            >
+              Workspace
+            </SectionLabel>
+            <WorkspaceSwitcher
+              open={true}
+              fromMobileView={true}
+              expanded={expandedField === 'workspace'}
+              onExpandedChange={(isExpanded) => setExpandedField(isExpanded ? 'workspace' : null)}
+              onMobileSelect={handleClose}
+            />
+          </Box>
+
+          <Box
+            sx={{
+              mt: 'auto',
+              pt: 2,
+              borderTop: `1px solid ${theme.palette.divider}`,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1.5,
+            }}
+          >
+            <Button
+              variant="contained"
+              fullWidth
+              onClick={openWorkspaceExplorer}
+              permissionKey={Keys.WorkspaceManagementViewWorkspace}
+            >
+              Explore Workspaces
+            </Button>
+            <Button
+              variant="outlined"
+              fullWidth
+              onClick={openCreateWorkspace}
+              permissionKey={Keys.WorkspaceManagementCreateWorkspace}
+            >
+              Create Workspace
+            </Button>
+          </Box>
+        </Box>
+      </BottomSheet>
     </>
   );
 }

--- a/ui/components/workspaces/SpacesSwitcher/MyDesignsContent.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/MyDesignsContent.tsx
@@ -124,12 +124,12 @@ const MyDesignsContent = () => {
         </Grid2>
 
         {/* Sort By Select */}
-        <Grid2 size={{ xs: 4, md: 2 }}>
+        <Grid2 size={{ xs: 12, sm: 6, md: 2 }}>
           <SortBySelect sortBy={filters.sortBy} handleSortByChange={handleSortByChange} />
         </Grid2>
 
         {/* Visibility Select */}
-        <Grid2 size={{ xs: 4, md: 2 }}>
+        <Grid2 size={{ xs: 12, sm: 6, md: 2 }}>
           <VisibilitySelect
             visibility={filters.visibility}
             handleVisibilityChange={handleVisibilityChange}
@@ -138,7 +138,7 @@ const MyDesignsContent = () => {
         </Grid2>
 
         {/* Import Button */}
-        <Grid2 size={{ xs: 4, md: 1 }}>
+        <Grid2 size={{ xs: 12, sm: 6, md: 1 }}>
           <ImportButton refetch={refetch} permissionKey={Keys.CatalogManagementImportDesign} />
         </Grid2>
       </Grid2>

--- a/ui/components/workspaces/SpacesSwitcher/SpaceSwitcher.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/SpaceSwitcher.tsx
@@ -2,6 +2,7 @@ import { useGetOrgsQuery } from '@/rtk-query/organization';
 import React, { useState, useContext } from 'react';
 import {
   Button,
+  Box,
   FormControl,
   FormControlLabel,
   FormGroup,
@@ -34,6 +35,7 @@ import {
 import { MobileOrgWksSwither } from './MobileViewSwitcher';
 import WorkspaceFormModal from '../WorkspaceFormModal';
 import { WorkspaceModalContext } from '@/utils/context/WorkspaceModalContextProvider';
+import { BottomSheetInlineSelect } from './BottomSheetInlineSelect';
 
 export const SlideInMenu = styled('div')(() => ({
   width: 0,
@@ -115,15 +117,20 @@ export const StyledTextField = styled(TextField)(({ theme }) => ({
 export const StyledHeader = styled(Typography)(({ theme }) => ({
   paddingLeft: theme.spacing(1),
   fontSize: '1.65rem',
+  color: theme.palette.common.white,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+
+  [theme.breakpoints.down('md')]: {
+    fontSize: '1.125rem',
+    flex: '1 1 auto',
+  },
 
   [theme.breakpoints.down('sm')]: {
-    fontSize: '1.25rem',
-    maxWidth: '7rem',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+    fontSize: '1rem',
   },
-  color: theme.palette.common.white,
 }));
 export const StyledBetaHeader = styled('sup')(({ theme }) => ({
   color: theme.palette.background.constant.white,
@@ -134,13 +141,15 @@ export const StyledBetaHeader = styled('sup')(({ theme }) => ({
 const StyledSwitcher = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
-  justifyContent: 'center',
   alignItems: 'center',
+  minWidth: 0,
+  flex: 1,
+  overflow: 'hidden',
   fontSize: '1.5rem',
   userSelect: 'none',
   transition: 'width 2s ease-in',
   color: theme.palette.common.white,
-  gap: '0.5rem 0rem',
+  gap: theme.spacing(0.5),
 }));
 
 export function OrgMenu(props) {
@@ -167,10 +176,9 @@ export function OrgMenu(props) {
   if (!selectedOrganization) return null;
 
   const organization = selectedOrganization;
-  const { open, fromMobileView } = props;
+  const { open, fromMobileView, expanded, onExpandedChange } = props;
 
-  const handleOrgSelect = async (e) => {
-    const id = e.target.value;
+  const handleOrgSelectById = async (id: string) => {
     const selected = uniqueOrgs.find((org) => org.id === id);
     try {
       await updateSelectedOrg(id).unwrap();
@@ -188,12 +196,61 @@ export function OrgMenu(props) {
     }
   };
 
+  const handleOrgSelect = async (e) => {
+    await handleOrgSelectById(e.target.value);
+  };
+
+  if (fromMobileView) {
+    const orgIcon = (
+      <OrgOutlinedIcon
+        width="24"
+        height="24"
+        className="OrgClass"
+        fill={theme.palette.icon.default}
+      />
+    );
+
+    return (
+      <NoSsr>
+        {isOrgsSuccess && orgs && open && (
+          <BottomSheetInlineSelect
+            data-cy="mesh-adapter-url"
+            value={organization?.id ?? ''}
+            options={uniqueOrgs.map((org) => ({
+              id: org.id,
+              label: org.name || 'Private Org',
+            }))}
+            onSelect={handleOrgSelectById}
+            expanded={expanded}
+            onExpandedChange={onExpandedChange}
+            renderOption={(option) => (
+              <>
+                {orgIcon}
+                <Box
+                  component="span"
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {option.label}
+                </Box>
+              </>
+            )}
+          />
+        )}
+      </NoSsr>
+    );
+  }
+
   return (
     <NoSsr>
       {isOrgsSuccess && orgs && open && (
         <Grid2
           sx={{
-            width: isSmallScreen ? '80%' : open ? 'auto' : 0,
+            width: isSmallScreen ? '100%' : open ? 'auto' : 0,
+            minWidth: 0,
             overflow: open ? '' : 'hidden',
             transition: 'all 1s',
           }}
@@ -220,9 +277,7 @@ export function OrgMenu(props) {
                             fill: theme.palette.background.constant.white,
                             paddingBlock: '9px 8px',
                             paddingInline: '18px 34px',
-                            color: fromMobileView
-                              ? theme.palette.text.default
-                              : theme.palette.background.constant.white,
+                            color: theme.palette.background.constant.white,
                           },
                         }}
                         renderValue={() => {
@@ -316,7 +371,7 @@ function OrganizationAndWorkSpaceSwitcher() {
                 </Button>
               </div>
             </CustomTooltip>
-            <OrgMenu open={orgOpen} organization={organization} />/
+            <OrgMenu open={orgOpen} />/
             <CustomTooltip title={'Workspaces'}>
               <div>
                 <Button
@@ -333,7 +388,7 @@ function OrganizationAndWorkSpaceSwitcher() {
                 </Button>
               </div>
             </CustomTooltip>
-            <WorkspaceSwitcher open={workspaceOpen} organization={organization} router={router} />/
+            <WorkspaceSwitcher open={workspaceOpen} />
           </>
         )}
         <div id="meshery-dynamic-header" style={{ marginLeft: DynamicComponent ? '0' : '' }} />

--- a/ui/components/workspaces/SpacesSwitcher/WorkspaceSwitcher.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/WorkspaceSwitcher.tsx
@@ -24,6 +24,7 @@ import {
   useGetSelectedWorkspace,
   useUpdateSelectedWorkspaceMutation,
 } from '@/rtk-query/user';
+import { BottomSheetInlineSelect } from './BottomSheetInlineSelect';
 
 export const HoverMenuItem = styled(MenuItem)(({ theme }) => ({
   display: 'flex',
@@ -49,7 +50,7 @@ const WorkspaceIconWrapper = styled('div')(({ theme }) => ({
   },
 }));
 
-function WorkspaceSwitcher({ open, fromMobileView }) {
+function WorkspaceSwitcher({ open, fromMobileView, expanded, onExpandedChange, onMobileSelect }) {
   const { selectedOrganization } = useGetSelectedOrganization();
   const {
     selectedWorkspace: selectedWorkspacePref,
@@ -79,18 +80,17 @@ function WorkspaceSwitcher({ open, fromMobileView }) {
     }
   }, [open]);
 
-  // useEffect(() => {
-  //   if (selectedWorkspace?.id) {
-  //     setSelectedWorkspace(selectedWorkspace);
-  //   }
-  // }, [selectedWorkspace, setSelectedWorkspace]);
-
   const handleChangeWorkspace = (e) => {
     setMenuOpen(false);
     const newId = e.target.value;
     setSelectedWorkspace(allWorkspaces.find((w) => w.id === newId));
     updateSelectedWorkspace(selectedOrganization.id, newId);
-    openWorkspaceModal(true);
+    onMobileSelect?.();
+    // Mobile UX: selecting a workspace should just switch context and close the sheet.
+    // Desktop UX: selecting should open the workspace explorer modal.
+    if (!fromMobileView) {
+      openWorkspaceModal(true);
+    }
   };
 
   if (workspaceError) {
@@ -101,12 +101,56 @@ function WorkspaceSwitcher({ open, fromMobileView }) {
     return <CircularProgress height="1.5rem" width="1.5rem" />;
   }
 
+  if (fromMobileView) {
+    const workspaceIcon = (
+      <WorkspaceIcon
+        {...iconMedium}
+        fill={theme.palette.icon.default}
+        secondaryFill={theme.palette.icon.default}
+      />
+    );
+
+    return (
+      <NoSsr>
+        {!isLoadingWorkspaces && allWorkspaces?.length > 0 && open && (
+          <BottomSheetInlineSelect
+            data-cy="mesh-adapter-url"
+            value={selectedWorkspace?.id || ''}
+            options={allWorkspaces.map((works) => ({
+              id: works.id,
+              label: works.name,
+            }))}
+            onSelect={(id) => handleChangeWorkspace({ target: { value: id } })}
+            expanded={expanded}
+            onExpandedChange={onExpandedChange}
+            renderOption={(option) => (
+              <>
+                {workspaceIcon}
+                <Box
+                  component="span"
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {option.label}
+                </Box>
+              </>
+            )}
+          />
+        )}
+      </NoSsr>
+    );
+  }
+
   return (
     <NoSsr>
       {!isLoadingWorkspaces && allWorkspaces?.length > 0 && (
         <Grid2
           sx={{
-            width: isSmallScreen ? '80%' : open ? 'auto' : 0,
+            width: isSmallScreen ? '100%' : open ? 'auto' : 0,
+            minWidth: 0,
             overflow: open ? '' : 'hidden',
             transition: 'all 1s',
           }}
@@ -143,17 +187,9 @@ function WorkspaceSwitcher({ open, fromMobileView }) {
                             paddingInline: '18px 34px',
                           },
                         }}
-                        renderValue={() => {
-                          return (
-                            <span
-                              style={{
-                                color: fromMobileView ? theme.palette.text.default : undefined,
-                              }}
-                            >
-                              {selectedWorkspace?.name || 'Private Workspace'}
-                            </span>
-                          );
-                        }}
+                        renderValue={() => (
+                          <span>{selectedWorkspace?.name || 'Private Workspace'}</span>
+                        )}
                         MenuProps={{
                           anchorOrigin: {
                             vertical: 'bottom',
@@ -184,7 +220,15 @@ function WorkspaceSwitcher({ open, fromMobileView }) {
                           </HoverMenuItem>
                         ))}
                         <Divider />
-                        <Box sx={{ gap: 2, px: 2, display: 'flex' }}>
+                        <Box
+                          sx={{
+                            gap: 2,
+                            px: 2,
+                            display: 'flex',
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                          }}
+                        >
                           <Button
                             variant="contained"
                             onClick={(e) => {

--- a/ui/components/workspaces/SpacesSwitcher/components.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/components.tsx
@@ -221,7 +221,10 @@ export const TableListHeader = ({
         width: '100%',
         paddingInline: '1rem',
         alignItems: 'center',
-        flexWrap: 'nowrap',
+        flexWrap: 'wrap',
+        [theme.breakpoints.up('md')]: {
+          flexWrap: 'nowrap',
+        },
       }}
     >
       {isMultiSelectMode && (

--- a/ui/components/workspaces/SpacesSwitcher/components.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/components.tsx
@@ -123,14 +123,30 @@ export const UserSearchAutoComplete = ({ handleAuthorChange }) => {
         <TextField
           {...params}
           label="Author"
+          InputLabelProps={{
+            ...params.InputLabelProps,
+            shrink: true,
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root.MuiAutocomplete-inputRoot': {
+              minHeight: '56px',
+              alignItems: 'center',
+              paddingBlock: 0,
+              paddingInline: 0,
+            },
+            '& .MuiOutlinedInput-root.MuiAutocomplete-inputRoot .MuiAutocomplete-input': {
+              padding: '0.85rem 14px',
+            },
+          }}
           slotProps={{
+            ...params.slotProps,
             input: {
-              ...(params?.slotProps?.input || {}),
+              ...params.slotProps?.input,
               endAdornment: (
-                <>
+                <React.Fragment>
                   {loading ? <CircularProgress color="inherit" size={20} /> : null}
-                  {params?.slotProps?.input?.endAdornment}
-                </>
+                  {params.slotProps?.input?.endAdornment}
+                </React.Fragment>
               ),
             },
           }}

--- a/ui/components/workspaces/SpacesSwitcher/styles.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/styles.tsx
@@ -182,7 +182,7 @@ export const StyledListItemText = styled(ListItemText, {
 
 export const StyledListIcon = styled(ListItemIcon, {
   shouldForwardProp: (prop) => prop !== 'withCheckbox',
-})(({ theme, withCheckbox }) => ({
+})<{ withCheckbox?: boolean }>(({ theme, withCheckbox }) => ({
   minWidth: '0px',
   paddingRight: '1rem',
   paddingLeft: withCheckbox ? theme.spacing(1) : undefined,

--- a/ui/components/workspaces/SpacesSwitcher/styles.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/styles.tsx
@@ -180,10 +180,13 @@ export const StyledListItemText = styled(ListItemText, {
   },
 }));
 
-export const StyledListIcon = styled(ListItemIcon)({
+export const StyledListIcon = styled(ListItemIcon, {
+  shouldForwardProp: (prop) => prop !== 'withCheckbox',
+})(({ theme, withCheckbox }) => ({
   minWidth: '0px',
   paddingRight: '1rem',
-});
+  paddingLeft: withCheckbox ? theme.spacing(1) : undefined,
+}));
 
 export const StyledUpdatedText = styled('p')({
   margin: '0',

--- a/ui/components/workspaces/SpacesSwitcher/styles.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/styles.tsx
@@ -36,7 +36,7 @@ export const StyledDrawer = styled(MuiDrawer, { shouldForwardProp: (prop) => pro
       zIndex: theme.zIndex.drawer,
     },
     [theme.breakpoints.down('md')]: {
-      zIndex: theme.zIndex.modal,
+      zIndex: theme.zIndex.drawer,
     },
     ...(open && {
       width: DRAWER_WIDTH,

--- a/ui/components/workspaces/SpacesSwitcher/styles.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/styles.tsx
@@ -35,6 +35,9 @@ export const StyledDrawer = styled(MuiDrawer, { shouldForwardProp: (prop) => pro
       height: '100%',
       zIndex: theme.zIndex.drawer,
     },
+    [theme.breakpoints.down('md')]: {
+      zIndex: theme.zIndex.modal,
+    },
     ...(open && {
       width: DRAWER_WIDTH,
       transition: theme.transitions.create('width', {
@@ -83,12 +86,20 @@ export const StyledDrawer = styled(MuiDrawer, { shouldForwardProp: (prop) => pro
 export const StyledMainContent = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
+  flex: 1,
+  minWidth: 0,
+  minHeight: 0,
   width: '100%',
   height: '100%',
   padding: '1rem 2rem',
   overflowY: 'auto',
+  overflowX: 'auto',
   [theme.breakpoints.down('xl')]: {
-    paddingLeft: '5rem',
+    paddingLeft: `calc(${theme.spacing(8)} + 1px + ${theme.spacing(1)})`,
+  },
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(1),
+    paddingLeft: `calc(${theme.spacing(7)} + 1px + ${theme.spacing(0.5)})`,
   },
 }));
 

--- a/ui/components/workspaces/WorkspaceFormModal.tsx
+++ b/ui/components/workspaces/WorkspaceFormModal.tsx
@@ -6,16 +6,54 @@
  * navigation surface itself lives in `WorkspaceFormModalNav.tsx`.
  */
 import React, { useState, FC } from 'react';
-import { Box, WorkspaceIcon, useMediaQuery } from '@sistent/sistent';
+import { Box, ModalBody, WorkspaceIcon, useMediaQuery } from '@sistent/sistent';
 import { styled, useTheme } from '@/theme';
 import { Modal } from '@/components/shared/Modal';
 import { iconMedium } from 'css/icons.styles';
 import { Navigation, HeaderInfo } from './WorkspaceFormModalNav';
 
 const BodyShell = styled(Box)({
-  height: '100%',
+  flex: 1,
+  minHeight: 0,
   padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
 });
+
+// Match RegistryModal: fixed viewport footprint on desktop, full-screen sheet on mobile.
+const StyledWorkspaceModal = styled(Modal)(({ theme }) => ({
+  zIndex: 1500,
+  '& .MuiDialog-paperFullScreen': {
+    margin: 0,
+  },
+  '& .MuiDialog-paperFullWidth': {
+    width: '90%',
+    height: '80%',
+    maxHeight: '80vh',
+  },
+  '& .MuiDialog-paper': {
+    display: 'flex',
+    flexDirection: 'column',
+    maxWidth: '100%',
+    [theme.breakpoints.down('md')]: {
+      margin: 0,
+      width: '100%',
+      maxWidth: '100%',
+      height: '100%',
+      maxHeight: '100%',
+      borderRadius: 0,
+    },
+  },
+}));
+
+const StyledModalBody = styled(ModalBody)(() => ({
+  flex: 1,
+  minHeight: 0,
+  padding: 0,
+  overflow: 'hidden',
+  display: 'flex',
+  flexDirection: 'column',
+}));
 
 export interface WorkspaceFormModalProps {
   workspaceModal: boolean;
@@ -34,16 +72,19 @@ const WorkspaceFormModal: FC<WorkspaceFormModalProps> = ({
   });
 
   return (
-    <Modal
+    <StyledWorkspaceModal
       isOpen={workspaceModal}
       onClose={closeWorkspaceModal}
       headerIcon={headerInfo.icon}
       title={headerInfo.title}
-      isFullScreenModeAllowed={!isSmallScreen}
       size="xl"
+      isFullScreenModeAllowed={!isSmallScreen}
+      disableBodyWrap
     >
-      <BodyShell>{workspaceModal && <Navigation setHeaderInfo={setHeaderInfo} />}</BodyShell>
-    </Modal>
+      <StyledModalBody>
+        <BodyShell>{workspaceModal && <Navigation setHeaderInfo={setHeaderInfo} />}</BodyShell>
+      </StyledModalBody>
+    </StyledWorkspaceModal>
   );
 };
 

--- a/ui/components/workspaces/WorkspaceFormModal.tsx
+++ b/ui/components/workspaces/WorkspaceFormModal.tsx
@@ -22,7 +22,7 @@ const BodyShell = styled(Box)({
 
 // Match RegistryModal: fixed viewport footprint on desktop, full-screen sheet on mobile.
 const StyledWorkspaceModal = styled(Modal)(({ theme }) => ({
-  zIndex: 1500,
+  zIndex: theme.zIndex.modal,
   '& .MuiDialog-paperFullScreen': {
     margin: 0,
   },

--- a/ui/components/workspaces/WorkspaceFormModalNav.tsx
+++ b/ui/components/workspaces/WorkspaceFormModalNav.tsx
@@ -43,6 +43,8 @@ const Layout = styled(Box)({
   display: 'flex',
   position: 'relative',
   height: '100%',
+  minHeight: 0,
+  overflow: 'hidden',
 });
 
 export type HeaderInfo = {


### PR DESCRIPTION
**Notes for Reviewers**
Fixes the workspace explorer modal so it keeps a fixed size on desktop and uses a full-screen, responsive layout on mobile.

### Changes
Modal uses a consistent 90% × 80% footprint on desktop and full viewport on mobile
Sidebar and content scroll correctly inside the modal without resizing it
Mobile filter rows and table headers wrap instead of overflowing

Before:


https://github.com/user-attachments/assets/9c19bea5-a811-455d-a26e-8f8a58266845



After:



https://github.com/user-attachments/assets/15a51422-b8cb-4288-9621-085cbd403ae5




- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added mobile bottom-sheet navigation for switching organizations and workspaces.
  * Added inline selection controls with expandable lists and selected-state indicators.

* **Style**
  * Improved responsive layouts for workspace controls, modals, drawers, and content across screen sizes.
  * Enhanced wrapping, sizing, spacing, overflow handling, and multi-select alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->