### PR TITLE
mesheryctl: bypass interactive pagination when stdout is redirected (#21334)

### DIFF
--- a/mesheryctl/internal/cli/root/connections/list.go
+++ b/mesheryctl/internal/cli/root/connections/list.go
@@ -81,6 +81,11 @@ mesheryctl connection list --count
 			DisplayCountOnly: connectionListFlagsProvided.count,
 		}
 
+		// Bypass interactive pagination if terminal is non-interactive (stdout redirected)
+		if !utils.IsInteractiveTerminal() {
+			data.PageSize = 0
+		}
+
 		return display.ListAsyncPagination(data, processConnectionData)
 	},
 }


### PR DESCRIPTION
### Description
Fixes #21334

Bypasses interactive pagination in `mesheryctl connection list` when stdout is attached to a non-interactive terminal (`utils.IsInteractiveTerminal()`), preventing CLI commands from hanging in CI/scripting environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection listing when output is redirected or run in non-interactive environments.
  * Interactive pagination is now bypassed for non-interactive terminal output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->