### PR TITLE
fix: tolerate every persisted credential secret shape on read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,24 @@ the schemas construct and pin the column explicitly with `gorm:"column:..."` -
 see `server/models/pattern_resource.go`. Guard it with a test that compares the
 emitted JSON keys against the schemas type rather than restating them by hand.
 
+### A credential's persisted `secret` has four shapes, and readers must tolerate all of them
+
+Canonical (what `meshery/schemas`
+`constructs/v1beta1/credential/forms/*.json` declares, and what Layer5 Cloud is
+moving to) is a top-level `name` plus a `secret` object that **is** the payload.
+Stored data also holds the Kubernetes `{auth, cluster}` shape, the legacy
+double-nested `{credentialName, secret:{...}}` shape Meshery's credential form
+still writes, and a legacy `{secret: "<token>"}` string. Legacy rows are never
+rewritten, so tolerance - not migration - is what keeps them working.
+
+`server/models/credential_secret.go` and its mirror `ui/utils/credentialSecret.ts`
+own that decision for both languages; every read site delegates to them rather
+than indexing the map. Reaching into `secret["secret"]` directly is how a
+canonical credential's API key silently became an empty `Authorization` header.
+The two files must stay in step - the shape catalogue and the resolution rules
+are documented once in
+`docs/content/en/project/contributing/models/connections.md`.
+
 ## Build & Development Commands
 
 - Use the `gh-axi` CLI tool to interact with GitHub. Prefer `gh-axi` over `gh`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,8 +174,9 @@ rewritten, so tolerance - not migration - is what keeps them working.
 own that decision for both languages; every read site delegates to them rather
 than indexing the map. Reaching into `secret["secret"]` directly is how a
 canonical credential's API key silently became an empty `Authorization` header.
-The two files must stay in step - the shape catalogue and the resolution rules
-are documented once in
+The two files must keep the same *resolution rules* - their return types
+deliberately differ on the legacy string shape. The shape catalogue and the
+rules are documented once in
 `docs/content/en/project/contributing/models/connections.md`.
 
 ## Build & Development Commands

--- a/docs/content/en/project/contributing/models/connections.md
+++ b/docs/content/en/project/contributing/models/connections.md
@@ -119,7 +119,7 @@ Because these schemas live on the definition, the wizard needs no per-kind UI co
 
 The canonical form, declared in [`meshery/schemas`](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta1/credential/forms), is a top-level `name` plus a `secret` object holding the kind-specific fields. **The persisted `secret` object *is* the payload.**
 
-Three other shapes exist in stored data and Meshery reads all of them. Two of the three are still written today: Meshery writes the Kubernetes shape when it imports a kubeconfig, and its credential form writes the double-nested wrapper.
+Four shapes exist in stored data in total - the canonical one plus three others - and Meshery reads all of them. Two of the three non-canonical shapes are still written today: Meshery writes the Kubernetes shape when it imports a kubeconfig, and its credential form writes the double-nested wrapper.
 
 | Shape | Stored `secret` | Where the payload is |
 | --- | --- | --- |
@@ -133,7 +133,9 @@ Legacy rows are never rewritten - tolerance is what keeps them working. Two mirr
 - **Go** - `models.CredentialPayload` (the object carrying the credential's fields) and `models.CredentialAuthSecret` (the string auth material) in `server/models/credential_secret.go`.
 - **TypeScript** - `resolveCredentialPayload` and `resolveCredentialAuthSecret` in `ui/utils/credentialSecret.ts`.
 
-Ambiguity resolves toward the canonical shape: an object is only unwrapped when it consists of nothing but the legacy wrapper keys (`credentialName`, `name`, `secret`), so a canonical payload that happens to carry its own `secret` field is left alone. If you add a credential kind whose canonical form holds string auth material under a new property, add that property to `canonicalAuthSecretKeys` / `CANONICAL_AUTH_SECRET_KEYS` in both files - they must stay in step.
+Ambiguity resolves toward the canonical shape: an object is only unwrapped when it consists of nothing but the legacy wrapper keys (`credentialName`, `name`, `secret`), so a canonical payload that happens to carry its own `secret` field is left alone. The one shape this cannot distinguish is a payload whose *only* fields are `name` and `secret` - no canonical form has that shape, so keep a new credential kind's payload away from it.
+
+What must stay in step between the two files is the **resolution rules**, not the return types: the helpers deliberately differ on the legacy string shape, where the TypeScript `resolveCredentialPayload` returns the bare string and the Go `CredentialPayload` returns nil because it is typed to a map (Go callers use `CredentialAuthSecret`). The auth-key list is currently grafana only; a credential kind whose canonical form holds string auth material under a new property must be added to `canonicalAuthSecretKeys` **and** `CANONICAL_AUTH_SECRET_KEYS`.
 
 The helpers resolve the wrapper, not the field names inside it. A Kubernetes credential created through the credential form describes its cluster with `clusterName`/`clusterServerURL` rather than the kubeconfig-style `cluster` block `K8sContextFromConnection` reads, so it yields an auth block but no cluster; which side moves is tracked in [meshery/meshery#21336](https://github.com/meshery/meshery/issues/21336).
 

--- a/docs/content/en/project/contributing/models/connections.md
+++ b/docs/content/en/project/contributing/models/connections.md
@@ -119,7 +119,7 @@ Because these schemas live on the definition, the wizard needs no per-kind UI co
 
 The canonical form, declared in [`meshery/schemas`](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta1/credential/forms), is a top-level `name` plus a `secret` object holding the kind-specific fields. **The persisted `secret` object *is* the payload.**
 
-Three other shapes exist in stored data, written before that form settled, and Meshery reads all of them:
+Three other shapes exist in stored data and Meshery reads all of them. Two of the three are still written today: Meshery writes the Kubernetes shape when it imports a kubeconfig, and its credential form writes the double-nested wrapper.
 
 | Shape | Stored `secret` | Where the payload is |
 | --- | --- | --- |
@@ -134,6 +134,8 @@ Legacy rows are never rewritten - tolerance is what keeps them working. Two mirr
 - **TypeScript** - `resolveCredentialPayload` and `resolveCredentialAuthSecret` in `ui/utils/credentialSecret.ts`.
 
 Ambiguity resolves toward the canonical shape: an object is only unwrapped when it consists of nothing but the legacy wrapper keys (`credentialName`, `name`, `secret`), so a canonical payload that happens to carry its own `secret` field is left alone. If you add a credential kind whose canonical form holds string auth material under a new property, add that property to `canonicalAuthSecretKeys` / `CANONICAL_AUTH_SECRET_KEYS` in both files - they must stay in step.
+
+The helpers resolve the wrapper, not the field names inside it. A Kubernetes credential created through the credential form describes its cluster with `clusterName`/`clusterServerURL` rather than the kubeconfig-style `cluster` block `K8sContextFromConnection` reads, so it yields an auth block but no cluster; which side moves is tracked in [meshery/meshery#21336](https://github.com/meshery/meshery/issues/21336).
 
 {{% alert color="warning" title="The registration payload's `secret` is a string" %}}
 The server rehydrates `credentialSecret.secret` into `PromCred`/`GrafanaCred`, whose `secret` field is a plain string. Handing it an object fails the `register` (verify) step outright, which is why the wizard sends `resolveCredentialAuthSecret(...)` rather than the payload object.

--- a/docs/content/en/project/contributing/models/connections.md
+++ b/docs/content/en/project/contributing/models/connections.md
@@ -115,6 +115,30 @@ Both are [JSON Schemas](https://json-schema.org/). The Connection Wizard renders
 
 Because these schemas live on the definition, the wizard needs no per-kind UI code to render them. Adding a property to the schema adds a field to the form.
 
+#### How a credential's `secret` is persisted - and read
+
+The canonical form, declared in [`meshery/schemas`](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta1/credential/forms), is a top-level `name` plus a `secret` object holding the kind-specific fields. **The persisted `secret` object *is* the payload.**
+
+Three other shapes exist in stored data, written before that form settled, and Meshery reads all of them:
+
+| Shape | Stored `secret` | Where the payload is |
+| --- | --- | --- |
+| Canonical | `{"grafanaURL": "...", "grafanaAPIKey": "..."}` | the object itself |
+| Kubernetes | `{"auth": {...}, "cluster": {...}}` | the object itself |
+| Legacy double-nested | `{"credentialName": "x", "secret": {...}}` | one level down |
+| Legacy string | `{"secret": "<token>"}` | a bare string |
+
+Legacy rows are never rewritten - tolerance is what keeps them working. Two mirrored helpers own the whole decision, and every read site goes through them rather than reaching into the map:
+
+- **Go** - `models.CredentialPayload` (the object carrying the credential's fields) and `models.CredentialAuthSecret` (the string auth material) in `server/models/credential_secret.go`.
+- **TypeScript** - `resolveCredentialPayload` and `resolveCredentialAuthSecret` in `ui/utils/credentialSecret.ts`.
+
+Ambiguity resolves toward the canonical shape: an object is only unwrapped when it consists of nothing but the legacy wrapper keys (`credentialName`, `name`, `secret`), so a canonical payload that happens to carry its own `secret` field is left alone. If you add a credential kind whose canonical form holds string auth material under a new property, add that property to `canonicalAuthSecretKeys` / `CANONICAL_AUTH_SECRET_KEYS` in both files - they must stay in step.
+
+{{% alert color="warning" title="The registration payload's `secret` is a string" %}}
+The server rehydrates `credentialSecret.secret` into `PromCred`/`GrafanaCred`, whose `secret` field is a plain string. Handing it an object fails the `register` (verify) step outright, which is why the wizard sends `resolveCredentialAuthSecret(...)` rather than the payload object.
+{{% /alert %}}
+
 ### Visual identity: `styles`
 
 `styles` carries inline SVG markup for the kind's icon: `svgColor` (for light backgrounds), `svgWhite` (for dark backgrounds), and optionally `svgComplete`. Follow the same icon conventions as [Components]({{< ref "project/contributing/models/components" >}}).

--- a/server/handlers/telemetry_credential_secret_test.go
+++ b/server/handlers/telemetry_credential_secret_test.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/schemas/models/core"
+)
+
+// Meshery has to read every credential `secret` shape that exists in production,
+// because Layer5 Cloud is moving to the canonical shape meshery/schemas declares
+// while the legacy rows stay exactly as they were written. These tests pin the
+// telemetry read path - the one that turns a stored credential into the
+// Authorization header sent to Grafana/Prometheus - against all of them.
+//
+// The shape catalogue and the resolution rules live in
+// server/models/credential_secret.go.
+
+// newTelemetryCredentialFixture wires a handler over an in-memory database with
+// a single connection of the given kind pointing at fakeURL and backed by a
+// credential holding secret.
+func newTelemetryCredentialFixture(
+	t *testing.T,
+	kind, fakeURL string,
+	secret map[string]interface{},
+) (*Handler, models.Provider, uuid.UUID) {
+	t.Helper()
+
+	db, err := database.New(database.Options{Engine: database.SQLITE, Filename: ":memory:"})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := db.AutoMigrate(connections.Connection{}, models.Credential{}); err != nil {
+		t.Fatalf("migrate tables: %v", err)
+	}
+
+	provider := &models.DefaultLocalProvider{
+		ConnectionPersister: &models.ConnectionPersister{DB: &db},
+		GenericPersister:    &db,
+	}
+
+	credential, err := provider.SaveUserCredential("", &models.Credential{
+		Name:   "telemetry-cred",
+		Type:   kind,
+		Secret: secret,
+	})
+	if err != nil {
+		t.Fatalf("save credential: %v", err)
+	}
+
+	connectionID := uuid.Must(uuid.NewV4())
+	credentialID := credential.ID
+	connection := &connections.Connection{
+		ID:             connectionID,
+		Name:           kind + "-connection",
+		Kind:           kind,
+		ConnectionType: "telemetry",
+		SubType:        "metrics",
+		Status:         connections.CONNECTED,
+		CredentialID:   &credentialID,
+		Metadata:       core.Map{"url": fakeURL},
+	}
+	if _, err := provider.ConnectionPersister.SaveConnection(connection); err != nil {
+		t.Fatalf("save connection: %v", err)
+	}
+
+	systemID := uuid.Must(uuid.NewV4())
+	h := &Handler{
+		config:   &models.HandlerConfig{EventBroadcaster: &models.Broadcast{}},
+		log:      newTestLogger(t),
+		SystemID: &systemID,
+	}
+	return h, provider, connectionID
+}
+
+// newAuthCapturingServer stands in for a Grafana/Prometheus instance and records
+// the Authorization header of the last request it served.
+func newAuthCapturingServer(t *testing.T) (*httptest.Server, *string) {
+	t.Helper()
+
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"11.0.0","database":"ok","status":"success"}`))
+	}))
+	t.Cleanup(server.Close)
+	return server, &got
+}
+
+// TestGrafanaClientForConnectionCredentialShapes proves the Grafana telemetry
+// read path resolves the API key out of every persisted credential shape. Before
+// the tolerant read it reached straight into `secret["secret"]`, so the canonical
+// shape (`secret` object IS the payload) and the double-nested shape Meshery UI
+// writes both produced an unauthenticated client.
+func TestGrafanaClientForConnectionCredentialShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		secret  map[string]interface{}
+		wantHdr string
+	}{
+		{
+			name:    "canonical shape",
+			secret:  map[string]interface{}{"grafanaURL": "https://grafana.example", "grafanaAPIKey": "canonical-key"},
+			wantHdr: "Bearer canonical-key",
+		},
+		{
+			name: "legacy double-nested shape",
+			secret: map[string]interface{}{
+				"credentialName": "grafana-cred",
+				"secret":         map[string]interface{}{"grafanaURL": "https://grafana.example", "grafanaAPIKey": "nested-key"},
+			},
+			wantHdr: "Bearer nested-key",
+		},
+		{
+			name:    "legacy string shape",
+			secret:  map[string]interface{}{"secret": "legacy-key"},
+			wantHdr: "Bearer legacy-key",
+		},
+		{
+			name:    "anonymous credential",
+			secret:  map[string]interface{}{"grafanaURL": "https://grafana.example"},
+			wantHdr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, gotHdr := newAuthCapturingServer(t)
+			h, provider, connectionID := newTelemetryCredentialFixture(t, "grafana", server.URL, tt.secret)
+
+			client, _, _, err := h.grafanaClientForConnection("", connectionID, provider)
+			if err != nil {
+				t.Fatalf("grafanaClientForConnection: %v", err)
+			}
+			if _, err := client.Health(context.Background()); err != nil {
+				t.Fatalf("health: %v", err)
+			}
+			if *gotHdr != tt.wantHdr {
+				t.Fatalf("Authorization = %q, want %q", *gotHdr, tt.wantHdr)
+			}
+		})
+	}
+}
+
+// TestPrometheusClientForConnectionCredentialShapes is the Prometheus half of
+// TestGrafanaClientForConnectionCredentialShapes. The canonical Prometheus
+// credential form carries no auth field, so a canonical credential is correctly
+// anonymous; the legacy shapes must keep authenticating.
+func TestPrometheusClientForConnectionCredentialShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		secret  map[string]interface{}
+		wantHdr string
+	}{
+		{
+			name:    "legacy string shape",
+			secret:  map[string]interface{}{"secret": "legacy-key"},
+			wantHdr: "Bearer legacy-key",
+		},
+		{
+			name:    "legacy string shape with basic auth",
+			secret:  map[string]interface{}{"credentialName": "prom-cred", "secret": "user:pass"},
+			wantHdr: "Basic dXNlcjpwYXNz",
+		},
+		{
+			name:    "canonical shape is anonymous",
+			secret:  map[string]interface{}{"prometheusURL": "https://prom.example"},
+			wantHdr: "",
+		},
+		{
+			name: "legacy double-nested shape is anonymous",
+			secret: map[string]interface{}{
+				"credentialName": "prom-cred",
+				"secret":         map[string]interface{}{"prometheusURL": "https://prom.example"},
+			},
+			wantHdr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, gotHdr := newAuthCapturingServer(t)
+			h, provider, connectionID := newTelemetryCredentialFixture(t, "prometheus", server.URL, tt.secret)
+
+			client, _, _, err := h.prometheusTelemetryClientForConnection("", connectionID, provider)
+			if err != nil {
+				t.Fatalf("prometheusTelemetryClientForConnection: %v", err)
+			}
+			if _, err := client.Health(context.Background()); err != nil {
+				t.Fatalf("health: %v", err)
+			}
+			if *gotHdr != tt.wantHdr {
+				t.Fatalf("Authorization = %q, want %q", *gotHdr, tt.wantHdr)
+			}
+		})
+	}
+}

--- a/server/handlers/telemetry_grafana_handler.go
+++ b/server/handlers/telemetry_grafana_handler.go
@@ -44,7 +44,7 @@ func (h *Handler) grafanaClientForConnection(token string, connectionID uuid.UUI
 			return nil, connection, sc, cerr
 		}
 		if cred != nil {
-			secret, _ = cred.Secret["secret"].(string)
+			secret = models.CredentialAuthSecret(cred.Secret)
 		}
 	}
 	return grafana.New(baseURL, secret, h.log), connection, http.StatusOK, nil

--- a/server/handlers/telemetry_prometheus_handler.go
+++ b/server/handlers/telemetry_prometheus_handler.go
@@ -48,7 +48,7 @@ func (h *Handler) prometheusTelemetryClientForConnection(token string, connectio
 			return nil, connection, sc, cerr
 		}
 		if cred != nil {
-			secret, _ = cred.Secret["secret"].(string)
+			secret = models.CredentialAuthSecret(cred.Secret)
 		}
 	}
 	return prometheus.New(baseURL, secret, h.log), connection, http.StatusOK, nil

--- a/server/models/credential_secret.go
+++ b/server/models/credential_secret.go
@@ -16,12 +16,26 @@ package models
 // writes. Readers must not care which they are handed, so they go through
 // CredentialPayload / CredentialAuthSecret rather than reaching into the map.
 //
-// ui/utils/credentialSecret.ts is the TypeScript mirror of this file; the two
-// must stay in step.
+// ui/utils/credentialSecret.ts is the TypeScript mirror of this file. What must
+// stay in step is the *resolution rules* - which shapes are recognized, which
+// keys make up the wrapper, and that ambiguity resolves toward canonical - not
+// the return types. The two deliberately differ on the legacy string shape:
+// CredentialPayload returns nil because it is typed to a map, and Go callers
+// reach for CredentialAuthSecret instead, while the TypeScript
+// resolveCredentialPayload returns the bare string. Port behaviour across, not
+// signatures.
 
 // legacyWrapperKeys are the only keys the legacy double-nested wrapper carries.
 // An outer map made up of nothing but these, with an object or string under
 // `secret`, is a wrapper rather than a payload.
+//
+// "name" is here because the registration path persists the wrapper as
+// {name, secret} (server/machines/actions.go), not just as
+// {credentialName, secret}. The cost is that a canonical payload whose only
+// fields were "name" and "secret" would be unwrapped as a wrapper. No canonical
+// form has that shape - prometheus, grafana and kubernetes carry neither field -
+// so if you add a credential kind, keep its payload from being exactly
+// {name, secret}.
 var legacyWrapperKeys = map[string]struct{}{
 	"credentialName": {},
 	"name":           {},
@@ -29,9 +43,12 @@ var legacyWrapperKeys = map[string]struct{}{
 }
 
 // canonicalAuthSecretKeys names the canonical credential fields that hold string
-// auth material, per meshery/schemas .../credential/forms/*.json. Prometheus and
-// Kubernetes have none: a canonical Prometheus credential is anonymous, and a
-// Kubernetes credential's auth is a structured object read via CredentialPayload.
+// auth material, per meshery/schemas .../credential/forms/*.json. Currently
+// grafana only. Prometheus and Kubernetes have none: a canonical Prometheus
+// credential is anonymous, and a Kubernetes credential's auth is a structured
+// object read via CredentialPayload. Adding a kind whose canonical form carries
+// string auth under a new property means adding it here *and* to
+// CANONICAL_AUTH_SECRET_KEYS in the TypeScript mirror.
 var canonicalAuthSecretKeys = []string{"grafanaAPIKey"}
 
 // isLegacyWrapper reports whether secret is the legacy double-nested wrapper

--- a/server/models/credential_secret.go
+++ b/server/models/credential_secret.go
@@ -1,0 +1,109 @@
+package models
+
+// credential_secret.go is the single place Meshery decides what a persisted
+// credential's `secret` map actually contains. Four shapes exist in production
+// and every one of them has to keep reading:
+//
+//	canonical      {"prometheusURL": "..."}                     the secret map IS the payload
+//	kubernetes     {"auth": {...}, "cluster": {...}}            the secret map IS the payload
+//	legacy nested  {"credentialName": "x", "secret": {...}}     the payload is one level down
+//	legacy string  {"secret": "<token>"}                        the payload is a bare string
+//
+// The canonical shape is the one meshery/schemas declares
+// (schemas/constructs/v1beta1/credential/forms/*.json: top-level `name` plus a
+// `secret` object holding the kind-specific fields), and the one Layer5 Cloud is
+// moving to. The legacy nested shape is what Meshery UI's credential form still
+// writes. Readers must not care which they are handed, so they go through
+// CredentialPayload / CredentialAuthSecret rather than reaching into the map.
+//
+// ui/utils/credentialSecret.ts is the TypeScript mirror of this file; the two
+// must stay in step.
+
+// legacyWrapperKeys are the only keys the legacy double-nested wrapper carries.
+// An outer map made up of nothing but these, with an object or string under
+// `secret`, is a wrapper rather than a payload.
+var legacyWrapperKeys = map[string]struct{}{
+	"credentialName": {},
+	"name":           {},
+	"secret":         {},
+}
+
+// canonicalAuthSecretKeys names the canonical credential fields that hold string
+// auth material, per meshery/schemas .../credential/forms/*.json. Prometheus and
+// Kubernetes have none: a canonical Prometheus credential is anonymous, and a
+// Kubernetes credential's auth is a structured object read via CredentialPayload.
+var canonicalAuthSecretKeys = []string{"grafanaAPIKey"}
+
+// isLegacyWrapper reports whether secret is the legacy double-nested wrapper
+// rather than a payload that merely happens to carry a `secret` field. Ambiguity
+// resolves toward canonical: only a map consisting solely of wrapper keys, and
+// carrying a `secret` entry, is unwrapped.
+func isLegacyWrapper(secret map[string]interface{}) bool {
+	if _, ok := secret["secret"]; !ok {
+		return false
+	}
+	for key := range secret {
+		if _, ok := legacyWrapperKeys[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// CredentialPayload resolves a persisted credential secret map to the object
+// carrying the credential's fields, unwrapping the legacy double-nested shape
+// and returning the canonical and Kubernetes shapes untouched.
+//
+// It returns nil when the credential stores a bare string rather than an object
+// (the legacy string shape) - use CredentialAuthSecret for that.
+func CredentialPayload(secret map[string]interface{}) map[string]interface{} {
+	if secret == nil {
+		return nil
+	}
+	if isLegacyWrapper(secret) {
+		nested, _ := secret["secret"].(map[string]interface{})
+		return nested
+	}
+	return secret
+}
+
+// CredentialAuthSecret resolves the string auth material a credential carries -
+// an API key, a service-account token, or "username:password" for basic auth -
+// tolerating every persisted shape. It returns "" for credentials that carry no
+// string auth material, which is the correct result for an anonymous Prometheus
+// or a Kubernetes credential and is what the telemetry clients read as "no auth".
+func CredentialAuthSecret(secret map[string]interface{}) string {
+	if secret == nil {
+		return ""
+	}
+
+	if isLegacyWrapper(secret) {
+		// Legacy string shape: {"secret": "<token>"}.
+		if nested, ok := secret["secret"].(string); ok {
+			return nested
+		}
+		nested, _ := secret["secret"].(map[string]interface{})
+		return authSecretFromPayload(nested)
+	}
+
+	return authSecretFromPayload(secret)
+}
+
+// authSecretFromPayload reads the string auth material out of an already
+// unwrapped payload, preferring the canonical field names over the legacy
+// string-valued `secret` field.
+func authSecretFromPayload(payload map[string]interface{}) string {
+	if payload == nil {
+		return ""
+	}
+	for _, key := range canonicalAuthSecretKeys {
+		if value, ok := payload[key].(string); ok && value != "" {
+			return value
+		}
+	}
+	// A payload that is not a pure wrapper can still carry a string `secret`
+	// field (e.g. {"apiKey": "...", "secret": "<token>"}); keep reading it so
+	// tolerance is never narrower than the pre-existing behaviour.
+	value, _ := payload["secret"].(string)
+	return value
+}

--- a/server/models/credential_secret_test.go
+++ b/server/models/credential_secret_test.go
@@ -1,0 +1,175 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The shapes below are the ones read-only production inspection found on
+// layer5io/meshery-cloud issue #5918: ~36.9k Kubernetes credentials shaped
+// {auth, cluster}, ~154 shaped {secret: "<string>"}, and 8 double-nested
+// {credentialName, secret: {...}} rows written by Meshery UI's credential form.
+// The canonical shape is what meshery/schemas declares and what Cloud is moving
+// to. All four have to keep resolving.
+
+func TestCredentialPayload(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret map[string]interface{}
+		want   map[string]interface{}
+	}{
+		{
+			name:   "canonical prometheus payload is the secret map itself",
+			secret: map[string]interface{}{"prometheusURL": "https://prom.example"},
+			want:   map[string]interface{}{"prometheusURL": "https://prom.example"},
+		},
+		{
+			name: "canonical kubernetes payload is the secret map itself",
+			secret: map[string]interface{}{
+				"clusterName":      "cluster-a",
+				"clusterServerURL": "https://k8s.example",
+				"auth":             map[string]interface{}{"clusterToken": "tok"},
+			},
+			want: map[string]interface{}{
+				"clusterName":      "cluster-a",
+				"clusterServerURL": "https://k8s.example",
+				"auth":             map[string]interface{}{"clusterToken": "tok"},
+			},
+		},
+		{
+			name: "stored kubernetes shape is the secret map itself",
+			secret: map[string]interface{}{
+				"auth":    map[string]interface{}{"clusterToken": "tok"},
+				"cluster": map[string]interface{}{"server": "https://k8s.example"},
+			},
+			want: map[string]interface{}{
+				"auth":    map[string]interface{}{"clusterToken": "tok"},
+				"cluster": map[string]interface{}{"server": "https://k8s.example"},
+			},
+		},
+		{
+			name: "legacy double-nested payload is unwrapped",
+			secret: map[string]interface{}{
+				"credentialName": "kube-cred",
+				"secret": map[string]interface{}{
+					"auth":    map[string]interface{}{"clusterToken": "tok"},
+					"cluster": map[string]interface{}{"server": "https://k8s.example"},
+				},
+			},
+			want: map[string]interface{}{
+				"auth":    map[string]interface{}{"clusterToken": "tok"},
+				"cluster": map[string]interface{}{"server": "https://k8s.example"},
+			},
+		},
+		{
+			name: "legacy double-nested payload keyed by name is unwrapped",
+			secret: map[string]interface{}{
+				"name":   "kube-cred",
+				"secret": map[string]interface{}{"auth": map[string]interface{}{"clusterToken": "tok"}},
+			},
+			want: map[string]interface{}{"auth": map[string]interface{}{"clusterToken": "tok"}},
+		},
+		{
+			name:   "legacy string shape carries no object payload",
+			secret: map[string]interface{}{"secret": "super-secret"},
+			want:   nil,
+		},
+		{
+			name: "a payload carrying its own secret field is not unwrapped",
+			secret: map[string]interface{}{
+				"grafanaURL": "https://grafana.example",
+				"secret":     map[string]interface{}{"nested": "value"},
+			},
+			want: map[string]interface{}{
+				"grafanaURL": "https://grafana.example",
+				"secret":     map[string]interface{}{"nested": "value"},
+			},
+		},
+		{
+			name:   "nil secret",
+			secret: nil,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CredentialPayload(tt.secret)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("CredentialPayload() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCredentialAuthSecret(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret map[string]interface{}
+		want   string
+	}{
+		{
+			name:   "legacy string shape",
+			secret: map[string]interface{}{"secret": "super-secret"},
+			want:   "super-secret",
+		},
+		{
+			name:   "legacy string shape alongside a credential name",
+			secret: map[string]interface{}{"credentialName": "prom-token", "secret": "super-secret"},
+			want:   "super-secret",
+		},
+		{
+			name: "canonical grafana payload",
+			secret: map[string]interface{}{
+				"grafanaURL":    "https://grafana.example",
+				"grafanaAPIKey": "canonical-key",
+			},
+			want: "canonical-key",
+		},
+		{
+			name: "legacy double-nested grafana payload",
+			secret: map[string]interface{}{
+				"credentialName": "grafana-cred",
+				"secret": map[string]interface{}{
+					"grafanaURL":    "https://grafana.example",
+					"grafanaAPIKey": "nested-key",
+				},
+			},
+			want: "nested-key",
+		},
+		{
+			name:   "canonical prometheus payload is anonymous",
+			secret: map[string]interface{}{"prometheusURL": "https://prom.example"},
+			want:   "",
+		},
+		{
+			name: "kubernetes payload carries no string auth material",
+			secret: map[string]interface{}{
+				"auth":    map[string]interface{}{"clusterToken": "tok"},
+				"cluster": map[string]interface{}{"server": "https://k8s.example"},
+			},
+			want: "",
+		},
+		{
+			name: "canonical field wins over a sibling legacy secret string",
+			secret: map[string]interface{}{
+				"grafanaAPIKey": "canonical-key",
+				"secret":        "legacy-key",
+			},
+			want: "canonical-key",
+		},
+		{
+			name:   "nil secret",
+			secret: nil,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CredentialAuthSecret(tt.secret); got != tt.want {
+				t.Fatalf("CredentialAuthSecret() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/models/k8s_context.go
+++ b/server/models/k8s_context.go
@@ -77,8 +77,12 @@ func K8sContextFromConnection(provider Provider, token string, connection *conne
 	}
 
 	ctx.ConnectionID = connection.ID.String()
-	ctx.Auth, _ = credential.Secret["auth"].(map[string]interface{})
-	ctx.Cluster, _ = credential.Secret["cluster"].(map[string]interface{})
+	// Kubernetes credentials are persisted with the secret map as the payload
+	// ({auth, cluster}), but the credential form writes a double-nested wrapper
+	// around that same payload. CredentialPayload resolves both.
+	credentialPayload := CredentialPayload(credential.Secret)
+	ctx.Auth, _ = credentialPayload["auth"].(map[string]interface{})
+	ctx.Cluster, _ = credentialPayload["cluster"].(map[string]interface{})
 	ctx.CreatedAt = &connection.CreatedAt
 	ctx.UpdatedAt = &connection.UpdatedAt
 

--- a/server/models/k8s_context.go
+++ b/server/models/k8s_context.go
@@ -78,8 +78,11 @@ func K8sContextFromConnection(provider Provider, token string, connection *conne
 
 	ctx.ConnectionID = connection.ID.String()
 	// Kubernetes credentials are persisted with the secret map as the payload
-	// ({auth, cluster}), but the credential form writes a double-nested wrapper
-	// around that same payload. CredentialPayload resolves both.
+	// ({auth, cluster}), while the credential form writes a double-nested wrapper
+	// one level up. CredentialPayload unwraps both to the payload. The form's
+	// payload then names the cluster with clusterName/clusterServerURL rather
+	// than a `cluster` block, so it yields auth but no cluster - see
+	// https://github.com/meshery/meshery/issues/21336.
 	credentialPayload := CredentialPayload(credential.Secret)
 	ctx.Auth, _ = credentialPayload["auth"].(map[string]interface{})
 	ctx.Cluster, _ = credentialPayload["cluster"].(map[string]interface{})

--- a/server/models/k8s_context_credential_secret_test.go
+++ b/server/models/k8s_context_credential_secret_test.go
@@ -11,28 +11,57 @@ import (
 )
 
 // K8sContextFromConnection reads the cluster and auth blocks straight out of the
-// stored credential. The ~36.9k Kubernetes credentials in production hold them at
-// the top of the secret map, while the credential form writes the same payload
-// one level down under a `secret` key - both have to resolve. The shape
+// stored credential, whichever shape that credential was persisted in. The ~36.9k
+// Kubernetes credentials in production hold both blocks at the top of the secret
+// map; the credential form instead writes a double-nested wrapper whose inner
+// payload names the cluster with clusterName/clusterServerURL. The shape
 // catalogue lives in credential_secret.go.
 func TestK8sContextFromConnectionCredentialShapes(t *testing.T) {
-	auth := map[string]interface{}{"clusterToken": "tok", "clusterUserName": "u1"}
-	cluster := map[string]interface{}{"server": "https://k8s.example", "name": "cluster-a"}
+	storedAuth := map[string]interface{}{"clusterToken": "tok", "clusterUserName": "u1"}
+	storedCluster := map[string]interface{}{"server": "https://k8s.example", "name": "cluster-a"}
+
+	// Exactly the auth block ui/components/schemas/credentials/kubernetes.tsx
+	// renders and MesheryCredentialComponent persists.
+	formAuth := map[string]interface{}{
+		"clusterUserName":                 "u1",
+		"clusterToken":                    "tok",
+		"clusterClientCertificateData":    "cert",
+		"clusterClientKeyData":            "key",
+		"clusterCertificateAuthorityData": "ca",
+	}
 
 	tests := []struct {
-		name   string
-		secret map[string]interface{}
+		name        string
+		secret      map[string]interface{}
+		wantAuth    map[string]interface{}
+		wantCluster map[string]interface{}
 	}{
 		{
-			name:   "stored kubernetes shape",
-			secret: map[string]interface{}{"auth": auth, "cluster": cluster},
+			name:        "stored kubernetes shape",
+			secret:      map[string]interface{}{"auth": storedAuth, "cluster": storedCluster},
+			wantAuth:    storedAuth,
+			wantCluster: storedCluster,
 		},
 		{
-			name: "legacy double-nested shape",
+			name: "credential form double-nested shape",
 			secret: map[string]interface{}{
 				"credentialName": "kube-cred",
-				"secret":         map[string]interface{}{"auth": auth, "cluster": cluster},
+				"secret": map[string]interface{}{
+					"clusterName":      "cluster-a",
+					"clusterServerURL": "https://k8s.example",
+					"auth":             formAuth,
+				},
 			},
+			wantAuth: formAuth,
+			// Cluster is nil here, and that is the tolerant read working rather
+			// than failing: the wrapper is unwrapped correctly and the auth block
+			// arrives intact, but this payload describes the cluster with
+			// clusterName/clusterServerURL instead of the kubeconfig-style
+			// `cluster` block K8sContext reads. Pinned deliberately - deciding
+			// which side moves is tracked in
+			// https://github.com/meshery/meshery/issues/21336. Update this
+			// expectation only alongside that decision.
+			wantCluster: nil,
 		},
 	}
 
@@ -68,13 +97,13 @@ func TestK8sContextFromConnectionCredentialShapes(t *testing.T) {
 				t.Fatalf("K8sContextFromConnection: %v", err)
 			}
 
-			// ctx.Auth/ctx.Cluster are core.Map, so compare the contents rather
+			// ctx.Auth/ctx.Cluster are sql.Map, so compare the contents rather
 			// than the named map type the assignment converts to.
-			if !reflect.DeepEqual(map[string]interface{}(ctx.Auth), auth) {
-				t.Errorf("Auth = %#v, want %#v", ctx.Auth, auth)
+			if !reflect.DeepEqual(map[string]interface{}(ctx.Auth), tt.wantAuth) {
+				t.Errorf("Auth = %#v, want %#v", ctx.Auth, tt.wantAuth)
 			}
-			if !reflect.DeepEqual(map[string]interface{}(ctx.Cluster), cluster) {
-				t.Errorf("Cluster = %#v, want %#v", ctx.Cluster, cluster)
+			if !reflect.DeepEqual(map[string]interface{}(ctx.Cluster), tt.wantCluster) {
+				t.Errorf("Cluster = %#v, want %#v", ctx.Cluster, tt.wantCluster)
 			}
 		})
 	}

--- a/server/models/k8s_context_credential_secret_test.go
+++ b/server/models/k8s_context_credential_secret_test.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/schemas/models/core"
+)
+
+// K8sContextFromConnection reads the cluster and auth blocks straight out of the
+// stored credential. The ~36.9k Kubernetes credentials in production hold them at
+// the top of the secret map, while the credential form writes the same payload
+// one level down under a `secret` key - both have to resolve. The shape
+// catalogue lives in credential_secret.go.
+func TestK8sContextFromConnectionCredentialShapes(t *testing.T) {
+	auth := map[string]interface{}{"clusterToken": "tok", "clusterUserName": "u1"}
+	cluster := map[string]interface{}{"server": "https://k8s.example", "name": "cluster-a"}
+
+	tests := []struct {
+		name   string
+		secret map[string]interface{}
+	}{
+		{
+			name:   "stored kubernetes shape",
+			secret: map[string]interface{}{"auth": auth, "cluster": cluster},
+		},
+		{
+			name: "legacy double-nested shape",
+			secret: map[string]interface{}{
+				"credentialName": "kube-cred",
+				"secret":         map[string]interface{}{"auth": auth, "cluster": cluster},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := database.New(database.Options{Engine: database.SQLITE, Filename: ":memory:"})
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			if err := db.AutoMigrate(Credential{}); err != nil {
+				t.Fatalf("migrate tables: %v", err)
+			}
+			provider := &DefaultLocalProvider{GenericPersister: &db}
+
+			credential, err := provider.SaveUserCredential("", &Credential{
+				Name:   "kube-cred",
+				Type:   "kubernetes",
+				Secret: tt.secret,
+			})
+			if err != nil {
+				t.Fatalf("save credential: %v", err)
+			}
+
+			credentialID := credential.ID
+			ctx, err := K8sContextFromConnection(provider, "", &connections.Connection{
+				ID:           uuid.Must(uuid.NewV4()),
+				Name:         "cluster-a",
+				Kind:         "kubernetes",
+				CredentialID: &credentialID,
+				Metadata:     core.Map{"name": "cluster-a"},
+			})
+			if err != nil {
+				t.Fatalf("K8sContextFromConnection: %v", err)
+			}
+
+			// ctx.Auth/ctx.Cluster are core.Map, so compare the contents rather
+			// than the named map type the assignment converts to.
+			if !reflect.DeepEqual(map[string]interface{}(ctx.Auth), auth) {
+				t.Errorf("Auth = %#v, want %#v", ctx.Auth, auth)
+			}
+			if !reflect.DeepEqual(map[string]interface{}(ctx.Cluster), cluster) {
+				t.Errorf("Cluster = %#v, want %#v", ctx.Cluster, cluster)
+			}
+		})
+	}
+}

--- a/ui/components/connections/ConnectionWizard.helpers.test.ts
+++ b/ui/components/connections/ConnectionWizard.helpers.test.ts
@@ -54,6 +54,81 @@ describe('ConnectionWizard.helpers', () => {
     });
   });
 
+  // Persisted credential `secret` shapes, all of which exist in production and
+  // all of which have to keep resolving to the string auth material PromCred /
+  // GrafanaCred rehydrate from `credentialSecret.secret`. See
+  // ui/utils/credentialSecret.ts for the shape catalogue.
+  it('resolves the canonical secret shape where the secret object is the payload', () => {
+    expect(
+      buildCredentialSecret(
+        {
+          id: 'cred-canonical',
+          name: 'grafana-canonical',
+          secret: { grafanaURL: 'https://grafana.example', grafanaAPIKey: 'canonical-key' },
+        },
+        null,
+      ),
+    ).toEqual({
+      id: 'cred-canonical',
+      name: 'grafana-canonical',
+      secret: 'canonical-key',
+    });
+  });
+
+  it('resolves the legacy double-nested secret shape', () => {
+    expect(
+      buildCredentialSecret(
+        {
+          id: 'cred-nested',
+          name: 'grafana-nested',
+          secret: {
+            credentialName: 'grafana-nested',
+            secret: { grafanaURL: 'https://grafana.example', grafanaAPIKey: 'nested-key' },
+          },
+        },
+        null,
+      ),
+    ).toEqual({
+      id: 'cred-nested',
+      name: 'grafana-nested',
+      secret: 'nested-key',
+    });
+  });
+
+  it('resolves an anonymous canonical credential to no auth material', () => {
+    expect(
+      buildCredentialSecret(
+        {
+          id: 'cred-prom',
+          name: 'prom-canonical',
+          secret: { prometheusURL: 'https://prom.example' },
+        },
+        null,
+      ),
+    ).toEqual({
+      id: 'cred-prom',
+      name: 'prom-canonical',
+      secret: undefined,
+    });
+  });
+
+  it('leaves the kubernetes secret shape without string auth material', () => {
+    expect(
+      buildCredentialSecret(
+        {
+          id: 'cred-k8s',
+          name: 'kube-cred',
+          secret: { auth: { clusterToken: 'tok' }, cluster: { server: 'https://k8s.example' } },
+        },
+        null,
+      ),
+    ).toEqual({
+      id: 'cred-k8s',
+      name: 'kube-cred',
+      secret: undefined,
+    });
+  });
+
   it('normalizes the new-credential form payload when no credential is selected', () => {
     expect(
       buildCredentialSecret(null, {

--- a/ui/components/connections/ConnectionWizard.helpers.tsx
+++ b/ui/components/connections/ConnectionWizard.helpers.tsx
@@ -1,4 +1,5 @@
 import { CoreConnectionKinds } from '@/utils/Enum';
+import { resolveCredentialAuthSecret } from '@/utils/credentialSecret';
 import { EVENT_TYPES } from 'lib/event-types';
 
 /*
@@ -264,11 +265,13 @@ export const normalizeCredentialPayload = (formData?: GenericRecord | null): Gen
 /**
  * Builds the `credentialSecret` payload the registration state machine expects.
  *
- * For an existing credential we must forward the stored secret (nested under
- * `secret.secret`) alongside the id and name, otherwise the backend `register`
- * (verify) step rehydrates an empty `PromCred`/`GrafanaCred` and verification
- * fails for any auth-protected endpoint. For a new credential we pass the
- * normalized form payload, which the backend persists verbatim.
+ * For an existing credential we must forward the stored auth material alongside
+ * the id and name, otherwise the backend `register` (verify) step rehydrates an
+ * empty `PromCred`/`GrafanaCred` and verification fails for any auth-protected
+ * endpoint. Which persisted shape holds that material is not this function's
+ * business - `resolveCredentialAuthSecret` tolerates all of them. For a new
+ * credential we pass the normalized form payload, which the backend persists
+ * verbatim.
  */
 export const buildCredentialSecret = (
   selectedCredential?: CredentialRecord | null,
@@ -278,7 +281,7 @@ export const buildCredentialSecret = (
     return {
       id: selectedCredential.id,
       name: selectedCredential.name,
-      secret: selectedCredential.secret?.secret,
+      secret: resolveCredentialAuthSecret(selectedCredential.secret),
     };
   }
 

--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -24,6 +24,7 @@ import { JsonParse, randomPatternNameGenerator } from '../../../../utils/utils';
 import Notification from './Notification';
 import { useProcessConnectionRegistrationMutation } from '@/rtk-query/connection';
 import { useGetCredentialsQuery } from '@/rtk-query/credentials';
+import { resolveCredentialAuthSecret } from '@/utils/credentialSecret';
 
 const CONNECTION_TYPES = ['Prometheus Connection', 'Grafana Connection'];
 
@@ -237,7 +238,9 @@ export const CredentialDetails = ({ sharedData, handleNext, handleRegistrationCo
     return {
       id: selectedCredential?.id,
       name: selectedCredential?.name,
-      secret: selectedCredential?.secret?.secret,
+      // Which persisted shape holds the auth material is not this component's
+      // business - see ui/utils/credentialSecret.ts for the shape catalogue.
+      secret: resolveCredentialAuthSecret(selectedCredential?.secret),
     };
   };
 

--- a/ui/utils/__tests__/credentialSecret.test.ts
+++ b/ui/utils/__tests__/credentialSecret.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCredentialAuthSecret, resolveCredentialPayload } from '../credentialSecret';
+
+// The shapes below are the ones read-only production inspection found on
+// layer5io/meshery-cloud issue #5918: ~36.9k Kubernetes credentials shaped
+// {auth, cluster}, ~154 shaped {secret: '<string>'}, and 8 double-nested
+// {credentialName, secret: {...}} rows written by Meshery UI's credential form.
+// The canonical shape is what meshery/schemas declares and what Cloud is moving
+// to. All four have to keep resolving.
+
+describe('resolveCredentialPayload', () => {
+  it('returns the canonical secret object as the payload', () => {
+    const secret = { prometheusURL: 'https://prom.example' };
+    expect(resolveCredentialPayload(secret)).toEqual(secret);
+  });
+
+  it('returns the kubernetes secret object as the payload', () => {
+    const secret = {
+      auth: { clusterToken: 'tok' },
+      cluster: { server: 'https://k8s.example' },
+    };
+    expect(resolveCredentialPayload(secret)).toEqual(secret);
+  });
+
+  it('unwraps the legacy double-nested payload', () => {
+    expect(
+      resolveCredentialPayload({
+        credentialName: 'kube-cred',
+        secret: { auth: { clusterToken: 'tok' } },
+      }),
+    ).toEqual({ auth: { clusterToken: 'tok' } });
+  });
+
+  it('unwraps a legacy double-nested payload keyed by name', () => {
+    expect(
+      resolveCredentialPayload({ name: 'kube-cred', secret: { clusterName: 'cluster-a' } }),
+    ).toEqual({ clusterName: 'cluster-a' });
+  });
+
+  it('unwraps the legacy string-valued secret', () => {
+    expect(resolveCredentialPayload({ secret: 'super-secret' })).toBe('super-secret');
+  });
+
+  it('leaves a canonical payload that carries its own secret field alone', () => {
+    const secret = { grafanaURL: 'https://grafana.example', secret: { nested: 'value' } };
+    expect(resolveCredentialPayload(secret)).toEqual(secret);
+  });
+
+  it('passes through values that are not objects', () => {
+    expect(resolveCredentialPayload(undefined)).toBeUndefined();
+    expect(resolveCredentialPayload(null)).toBeNull();
+    expect(resolveCredentialPayload('raw')).toBe('raw');
+  });
+});
+
+describe('resolveCredentialAuthSecret', () => {
+  it('reads the legacy string-valued secret', () => {
+    expect(resolveCredentialAuthSecret({ secret: 'super-secret' })).toBe('super-secret');
+    expect(
+      resolveCredentialAuthSecret({ credentialName: 'prom-token', secret: 'super-secret' }),
+    ).toBe('super-secret');
+  });
+
+  it('reads the canonical grafana API key', () => {
+    expect(
+      resolveCredentialAuthSecret({
+        grafanaURL: 'https://grafana.example',
+        grafanaAPIKey: 'canonical-key',
+      }),
+    ).toBe('canonical-key');
+  });
+
+  it('reads the grafana API key out of the legacy double-nested shape', () => {
+    expect(
+      resolveCredentialAuthSecret({
+        credentialName: 'grafana-cred',
+        secret: { grafanaURL: 'https://grafana.example', grafanaAPIKey: 'nested-key' },
+      }),
+    ).toBe('nested-key');
+  });
+
+  it('prefers the canonical field over a sibling legacy secret string', () => {
+    expect(
+      resolveCredentialAuthSecret({ grafanaAPIKey: 'canonical-key', secret: 'legacy-key' }),
+    ).toBe('canonical-key');
+  });
+
+  it('reports no auth material for an anonymous canonical credential', () => {
+    expect(resolveCredentialAuthSecret({ prometheusURL: 'https://prom.example' })).toBeUndefined();
+    expect(
+      resolveCredentialAuthSecret({
+        credentialName: 'prom-cred',
+        secret: { prometheusURL: 'https://prom.example' },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('reports no auth material for a kubernetes credential', () => {
+    expect(
+      resolveCredentialAuthSecret({
+        auth: { clusterToken: 'tok' },
+        cluster: { server: 'https://k8s.example' },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('reports no auth material for absent or non-object secrets', () => {
+    expect(resolveCredentialAuthSecret(undefined)).toBeUndefined();
+    expect(resolveCredentialAuthSecret(null)).toBeUndefined();
+    expect(resolveCredentialAuthSecret({})).toBeUndefined();
+  });
+});

--- a/ui/utils/__tests__/credentialSecret.test.ts
+++ b/ui/utils/__tests__/credentialSecret.test.ts
@@ -46,6 +46,18 @@ describe('resolveCredentialPayload', () => {
     expect(resolveCredentialPayload(secret)).toEqual(secret);
   });
 
+  it('ignores an inherited secret property when classifying the wrapper', () => {
+    // Every own key is a wrapper key, so the own-key check alone cannot decide
+    // this: only the `secret` probe can. With `'secret' in obj` the object would
+    // be treated as a wrapper and unwrapped to the *prototype's* value, even
+    // though it owns no `secret` at all.
+    const payload = Object.create({ secret: { grafanaAPIKey: 'inherited' } });
+    payload.name = 'grafana-cred';
+
+    expect(resolveCredentialPayload(payload)).toBe(payload);
+    expect(resolveCredentialAuthSecret(payload)).toBeUndefined();
+  });
+
   it('passes through values that are not objects', () => {
     expect(resolveCredentialPayload(undefined)).toBeUndefined();
     expect(resolveCredentialPayload(null)).toBeNull();

--- a/ui/utils/credentialSecret.ts
+++ b/ui/utils/credentialSecret.ts
@@ -17,8 +17,14 @@
  * writes. Readers must not care which they are handed, so they go through these
  * helpers rather than reaching into the map.
  *
- * server/models/credential_secret.go is the Go mirror of this module; the two
- * must stay in step.
+ * server/models/credential_secret.go is the Go mirror of this module. What must
+ * stay in step is the *resolution rules* - which shapes are recognized, which
+ * keys make up the wrapper, and that ambiguity resolves toward canonical - not
+ * the return types. The two deliberately differ on the legacy string shape:
+ * `resolveCredentialPayload` returns the bare string, while Go's
+ * `CredentialPayload` returns nil because it is typed to a map and Go callers
+ * reach for `CredentialAuthSecret` instead. Port behaviour across, not
+ * signatures.
  */
 
 /** Loosely-typed persisted credential secret map. */
@@ -28,14 +34,24 @@ export type CredentialSecret = Record<string, unknown>;
  * The only keys the legacy double-nested wrapper carries. An outer object made
  * up of nothing but these, with a `secret` entry, is a wrapper rather than a
  * payload.
+ *
+ * `name` is here because the registration path persists the wrapper as
+ * `{name, secret}` (server/machines/actions.go), not just as `{credentialName,
+ * secret}`. The cost is that a canonical payload whose only fields were `name`
+ * and `secret` would be unwrapped as a wrapper. No canonical form has that
+ * shape - prometheus, grafana and kubernetes carry neither field - so if you
+ * add a credential kind, keep its payload from being exactly `{name, secret}`.
  */
 const LEGACY_WRAPPER_KEYS = new Set(['credentialName', 'name', 'secret']);
 
 /**
  * Canonical credential fields that hold string auth material, per
- * meshery/schemas .../credential/forms/*.json. Prometheus and Kubernetes have
- * none: a canonical Prometheus credential is anonymous, and a Kubernetes
- * credential's auth is a structured object read via resolveCredentialPayload.
+ * meshery/schemas .../credential/forms/*.json. Currently grafana only.
+ * Prometheus and Kubernetes have none: a canonical Prometheus credential is
+ * anonymous, and a Kubernetes credential's auth is a structured object read via
+ * resolveCredentialPayload. Adding a kind whose canonical form carries string
+ * auth under a new property means adding it here *and* to
+ * `canonicalAuthSecretKeys` in the Go mirror.
  */
 const CANONICAL_AUTH_SECRET_KEYS = ['grafanaAPIKey'];
 
@@ -47,9 +63,15 @@ const isPlainObject = (value: unknown): value is CredentialSecret =>
  * that merely happens to carry a `secret` field. Ambiguity resolves toward
  * canonical: only an object consisting solely of wrapper keys, and carrying a
  * `secret` entry, is unwrapped.
+ *
+ * The `secret` probe is an own-property check to match `Object.keys` below (and
+ * the Go mirror, where a map lookup has no prototype chain to fall through):
+ * `'secret' in secret` would also answer true for an inherited `secret`, which
+ * would unwrap an object whose own keys never included it.
  */
 const isLegacyWrapper = (secret: CredentialSecret): boolean =>
-  'secret' in secret && Object.keys(secret).every((key) => LEGACY_WRAPPER_KEYS.has(key));
+  Object.prototype.hasOwnProperty.call(secret, 'secret') &&
+  Object.keys(secret).every((key) => LEGACY_WRAPPER_KEYS.has(key));
 
 /**
  * Resolves a persisted credential secret to the value carrying the credential's

--- a/ui/utils/credentialSecret.ts
+++ b/ui/utils/credentialSecret.ts
@@ -1,0 +1,100 @@
+/**
+ * credentialSecret.ts is the single place Meshery UI decides what a persisted
+ * credential's `secret` map actually contains. Four shapes exist in production
+ * and every one of them has to keep reading:
+ *
+ * | shape         | stored `secret`                             | payload lives      |
+ * | ------------- | ------------------------------------------- | ------------------ |
+ * | canonical     | `{ prometheusURL: '...' }`                  | the map itself     |
+ * | kubernetes    | `{ auth: {...}, cluster: {...} }`           | the map itself     |
+ * | legacy nested | `{ credentialName: 'x', secret: {...} }`    | one level down     |
+ * | legacy string | `{ secret: '<token>' }`                     | a bare string      |
+ *
+ * The canonical shape is the one meshery/schemas declares
+ * (schemas/constructs/v1beta1/credential/forms/*.json: top-level `name` plus a
+ * `secret` object holding the kind-specific fields), and the one Layer5 Cloud is
+ * moving to. The legacy nested shape is what Meshery UI's credential form still
+ * writes. Readers must not care which they are handed, so they go through these
+ * helpers rather than reaching into the map.
+ *
+ * server/models/credential_secret.go is the Go mirror of this module; the two
+ * must stay in step.
+ */
+
+/** Loosely-typed persisted credential secret map. */
+export type CredentialSecret = Record<string, unknown>;
+
+/**
+ * The only keys the legacy double-nested wrapper carries. An outer object made
+ * up of nothing but these, with a `secret` entry, is a wrapper rather than a
+ * payload.
+ */
+const LEGACY_WRAPPER_KEYS = new Set(['credentialName', 'name', 'secret']);
+
+/**
+ * Canonical credential fields that hold string auth material, per
+ * meshery/schemas .../credential/forms/*.json. Prometheus and Kubernetes have
+ * none: a canonical Prometheus credential is anonymous, and a Kubernetes
+ * credential's auth is a structured object read via resolveCredentialPayload.
+ */
+const CANONICAL_AUTH_SECRET_KEYS = ['grafanaAPIKey'];
+
+const isPlainObject = (value: unknown): value is CredentialSecret =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Whether `secret` is the legacy double-nested wrapper rather than a payload
+ * that merely happens to carry a `secret` field. Ambiguity resolves toward
+ * canonical: only an object consisting solely of wrapper keys, and carrying a
+ * `secret` entry, is unwrapped.
+ */
+const isLegacyWrapper = (secret: CredentialSecret): boolean =>
+  'secret' in secret && Object.keys(secret).every((key) => LEGACY_WRAPPER_KEYS.has(key));
+
+/**
+ * Resolves a persisted credential secret to the value carrying the credential's
+ * fields: the object itself for the canonical and Kubernetes shapes, the nested
+ * object for the legacy double-nested shape, and the bare string for the legacy
+ * string shape.
+ */
+export const resolveCredentialPayload = (secret?: unknown): unknown => {
+  if (!isPlainObject(secret)) {
+    return secret;
+  }
+  return isLegacyWrapper(secret) ? secret.secret : secret;
+};
+
+/**
+ * Resolves the string auth material a credential carries - an API key, a
+ * service-account token, or `username:password` for basic auth - tolerating
+ * every persisted shape.
+ *
+ * This is what the connection registration payload's `credentialSecret.secret`
+ * must be: the server rehydrates it into `PromCred`/`GrafanaCred`, whose
+ * `secret` field is a plain string, so handing it an object fails the register
+ * step outright. `undefined` is the correct answer for credentials with no auth
+ * material (an anonymous Prometheus, a Kubernetes credential) and is read
+ * server-side as "no auth".
+ */
+export const resolveCredentialAuthSecret = (secret?: unknown): string | undefined => {
+  const payload = resolveCredentialPayload(secret);
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+  if (!isPlainObject(payload)) {
+    return undefined;
+  }
+
+  for (const key of CANONICAL_AUTH_SECRET_KEYS) {
+    const value = payload[key];
+    if (typeof value === 'string' && value) {
+      return value;
+    }
+  }
+
+  // A payload that is not a pure wrapper can still carry a string `secret`
+  // field (e.g. `{ apiKey: '...', secret: '<token>' }`); keep reading it so
+  // tolerance is never narrower than the pre-existing behaviour.
+  return typeof payload.secret === 'string' ? payload.secret : undefined;
+};


### PR DESCRIPTION
> **Note on authorship.** This PR was opened under the wrong GitHub account
> (`@yi-nuo426`) because of a defect in our local tooling, which picked up
> another workspace's identity when it created the pull request. The work is
> mine: every commit on this branch is authored by and signed off by
> Mohd Hamza Shaikh <mohd.hamza@tata-consulting.co.uk>. Two commits were
> initially pushed under that same wrong identity and without a sign-off; they
> have been rewritten to the correct author with a real `Signed-off-by`, rather
> than papered over with a DCO remediation commit that would have certified the
> wrong person. Flagging it here so the mismatch between the PR author and the
> commit authors is on the record rather than silently wrong. The tooling defect
> is being tracked separately.

## Intent

Make Meshery tolerate BOTH credential secret shapes, so that Layer5 Cloud can move to the canonical schema without breaking existing records or the connection wizard. This is the FIRST half of a coordinated two-repo change and MUST land BEFORE the Cloud side; tracked against layer5io/meshery-cloud issue #5918, where a meshery-cloud change is BLOCKED waiting on this merge.

WHY THIS EXISTS (a reviewer seeing only the diff will read this as a defensive change with no trigger - it has one). The captain ruled that schemas are the source of truth and all projects shall be schema-driven. The canonical credential form schema in meshery/schemas (schemas/constructs/v1beta1/credential/forms/prometheus.json) declares a top-level 'name' plus 'secret: { prometheusURL }' - meaning the persisted 'secret' object IS the payload. meshery-cloud is moving its credential form to that canonical shape. Before this change Meshery could not read it. This tolerant read is what keeps every existing row readable across that transition.

ESTABLISHED FROM READ-ONLY PRODUCTION INSPECTION - four shapes exist in stored data and all must keep working:
- 36,916 rows: Kubernetes credentials shaped {auth, cluster}
- 154 rows: Prometheus/Grafana shaped {secret: '<string>'}, read as cred.Secret['secret'].(string)
- 8 rows: the double-nested {credentialName, secret:{...}} shape
- canonical: the secret object IS the payload (what Cloud is moving to)

EXPLICIT CONSTRAINTS THE USER SET, which the diff will otherwise look surprising against:
- NO STORED DATA IS MIGRATED OR REWRITTEN. Legacy rows stay exactly as they are; tolerance is what keeps them working. Deliberately no migration, no backfill, no data rewrite anywhere in this change.
- MESHERY'S WRITE SIDE IS DELIBERATELY UNCHANGED IN THIS TASK. Meshery still writes the legacy double-nested shape from MesheryCredentialComponent.tsx (secret: formData, where formData is {credentialName, secret:{...}}). The user instructed not to change what Meshery writes unless leaving it is what breaks tolerance - it is not, so it was left alone on purpose. Do not flag the unchanged write side, the local credential form schemas under ui/components/schemas/credentials/*.tsx, or the credentialName-vs-name divergence as an oversight; changing them is explicitly out of scope for this task and was reported to the user instead.
- Prefer canonical when both shapes could apply.
- Do it in as few places as possible - a single shared helper the read sites use, rather than scattered conditionals.

WHAT WAS BUILT. Two mirrored helpers now own the entire decision, and every read site delegates to them instead of indexing the secret map:
- Go: server/models/credential_secret.go - CredentialPayload (the object carrying the credential's fields) and CredentialAuthSecret (the string auth material).
- TypeScript: ui/utils/credentialSecret.ts - resolveCredentialPayload and resolveCredentialAuthSecret.
Ambiguity resolves toward canonical: an object is unwrapped only when it consists of nothing but the legacy wrapper keys (credentialName, name, secret), so a canonical payload that happens to carry its own 'secret' field is left alone. The registration payload's credentialSecret.secret must be a STRING because the server rehydrates it into PromCred/GrafanaCred whose secret field is a plain string - handing it an object fails the register/verify step outright - which is why the wizard sends resolveCredentialAuthSecret(...) rather than the payload object.

READ SITES FOUND AND FIXED - the brief named two, the audit found FIVE:
- server/handlers/telemetry_grafana_handler.go
- server/handlers/telemetry_prometheus_handler.go
- server/models/k8s_context.go (K8sContextFromConnection)
- ui/components/connections/ConnectionWizard.helpers.tsx (buildCredentialSecret)
- ui/components/connections/meshSync/Stepper/StepperContent.tsx (the same expression as the wizard helper)

REPRODUCED FIRST, as the user required. Before the fix: a canonical Grafana credential produced an empty Authorization header (API key silently dropped); the double-nested shape also produced an empty Authorization header on the telemetry path and forwarded an object the server's PromCred unmarshal rejects on the registration path; a double-nested Kubernetes credential produced a nil auth/cluster block in K8sContextFromConnection. Each regression test was run RED before its fix, including temporarily reverting k8s_context.go to confirm.

REGRESSION COVERAGE, colocated per this repo's conventions: the telemetry read path tested end-to-end against a fake Grafana/Prometheus asserting the actual Authorization header per shape; K8sContextFromConnection per shape; and unit tables for both helpers covering all four shapes plus the ambiguous and nil cases.

TWO LARGER ISSUES FOUND AND DELIBERATELY NOT FIXED HERE (reported to the user instead, per the instruction to fix same-read sites and report anything larger): (1) ui/components/schemas/credentials/*.tsx are local forks of the schemas credential forms declaring credentialName where schemas declares name - that fork is why the double-nested shape gets written, but fixing it is a write-side change excluded from this task. (2) The canonical Kubernetes form declares secret.{clusterName, clusterServerURL, auth} while k8s_context.go reads secret.{auth, cluster} and all 36,916 production rows are the latter - a field-mapping mismatch that tolerance cannot paper over and that needs a decision about which side moves.

DOCUMENTATION: the shape catalogue and resolution rules are documented once in docs/content/en/project/contributing/models/connections.md, with a pointer entry added to AGENTS.md.

DELIVERY: merge authority is granted for this PR. meshery/meshery allows merge-commit only (no squash, no rebase) - verified via the API.

## What Changed

- Added two mirrored helpers that own the entire "what is in this credential's `secret`?" decision: `server/models/credential_secret.go` (`CredentialPayload`, `CredentialAuthSecret`) and `ui/utils/credentialSecret.ts` (`resolveCredentialPayload`, `resolveCredentialAuthSecret`). Between them they resolve all four shapes present in stored data - the canonical shape `meshery/schemas` declares (the `secret` object *is* the payload), the Kubernetes `{auth, cluster}` shape, the legacy double-nested `{credentialName, secret:{...}}` wrapper Meshery's credential form still writes, and the legacy `{secret: "<token>"}` string. Ambiguity resolves toward canonical: an object is unwrapped only when it consists of nothing but the wrapper keys (`credentialName`, `name`, `secret`), so a canonical payload carrying its own `secret` field is left alone. No stored data is migrated or rewritten, and Meshery's write side is unchanged.
- Routed all five read sites through the helpers instead of indexing the secret map: `telemetry_grafana_handler.go` and `telemetry_prometheus_handler.go` (which previously read `cred.Secret["secret"].(string)` and produced an empty `Authorization` header for canonical and double-nested credentials), `K8sContextFromConnection` in `server/models/k8s_context.go` (which returned nil auth/cluster for a double-nested Kubernetes credential), and the two UI sites that build the registration payload - `buildCredentialSecret` in `ConnectionWizard.helpers.tsx` and `CredentialDetails` in `meshSync/Stepper/StepperContent.tsx`, both of which must send a string because the server rehydrates it into `PromCred`/`GrafanaCred`.
- Added regression coverage and documentation: the telemetry read path tested end-to-end against a fake Grafana/Prometheus asserting the actual `Authorization` header per shape, `K8sContextFromConnection` per shape, and unit tables for both helpers covering the four shapes plus ambiguous and nil cases. The shape catalogue and resolution rules are documented in `docs/content/en/project/contributing/models/connections.md`, with a pointer entry in `AGENTS.md`; the docs also record the Kubernetes form's `clusterName`/`clusterServerURL` vs `cluster` field-mapping gap that tolerance cannot paper over (meshery/meshery#21336).

## Risk Assessment

✅ Low: Additive read-side tolerance with no write-side, schema, or migration changes; the independent read-site audit confirms all five sites converted with no direct secret["secret"] index remaining, every persisted shape traces correctly against its real writer, the tests are genuine regressions that fail against the pre-fix code, and the one known gap (form-written Kubernetes cluster block) is explicitly pinned with a tracking issue rather than papered over.

## Testing

Ran the targeted Go and UI suites for this change plus red-before-green and cross-layer evidence runs: `go test ./server/handlers/` (Grafana/Prometheus telemetry credential shapes, asserting the real Authorization header against a fake instance), `go test ./server/models/` (CredentialPayload/CredentialAuthSecret tables and K8sContextFromConnection per shape), and `npx vitest run` over the credentialSecret and ConnectionWizard.helpers suites (39 tests) after a clean `npm ci`. I reverted the three Go read sites to base a7366b3 to confirm each regression test fails first (empty Authorization header for canonical and double-nested Grafana credentials; nil Kubernetes auth block), then restored them. For product-level evidence I drove the real grafana RegisterAction - the code path behind the wizard's Verify Connection - with the payload the wizard builds, showing the pre-fix payload failing registration (401 and a GrafanaCred.secret unmarshal error) and the post-fix payload registering with Bearer canonical-key, and printed the wizard's credentialSecret payload per production shape from the real helper. No screenshot was captured because the change alters the outbound registration payload and Authorization header rather than any rendered surface, copy, or layout; the two UI read sites are non-rendering payload builders, so the CLI/HTTP transcripts are the surface an end user actually experiences (connection verifies instead of failing). Temporary evidence harnesses were deleted; the worktree is clean apart from gitignored ui/node_modules left installed for later phases. Everything passes.

<details>
<summary>Evidence: End-to-end: Grafana connection registration (Verify Connection path) per wizard payload, before vs after</summary>

<code>BEFORE fix - wizard forwards selectedCredential.secret?.secret&#10;credentialSecret.secret = &lt;nil&gt;&#10;Authorization seen by Grafana = &#34;&#34;&#10;-&gt; registration FAILED: grafana: GET /api/health returned 401: {&#34;message&#34;:&#34;Unauthorized&#34;}&#10;&#10;BEFORE fix - legacy double-nested credential forwards an object&#10;credentialSecret.secret = map[string]interface {}{&#34;grafanaAPIKey&#34;:&#34;canonical-key&#34;}&#10;Authorization seen by Grafana = &#34;&#34;&#10;-&gt; registration FAILED: json: cannot unmarshal object into Go struct field GrafanaCred.secret of type string&#10;&#10;AFTER fix - wizard forwards resolveCredentialAuthSecret(...)&#10;credentialSecret.secret = &#34;canonical-key&#34;&#10;Authorization seen by Grafana = &#34;Bearer canonical-key&#34;&#10;-&gt; connection REGISTERED</code>

```text
=== RUN   TestEvidenceRegisterGrafanaConnectionCredentialShapes
    credential_shape_evidence_test.go:101: 
          BEFORE fix - wizard forwards selectedCredential.secret?.secret
            credentialSecret.secret = <nil>
            Authorization seen by Grafana = ""
            -> registration FAILED: grafana: GET /api/health returned 401: {"message":"Unauthorized"} | Short Description: Unable to connect to grafana | Probable Cause: Grafana endpoint might not be reachable from Meshery.Grafana endpoint is incorrect | Suggested Remediation: Check if your Grafana Endpoint is correct.Connect to Grafana from the settings page in the UI
    credential_shape_evidence_test.go:101: 
          BEFORE fix - legacy double-nested credential forwards an object
            credentialSecret.secret = map[string]interface {}{"grafanaAPIKey":"canonical-key"}
            Authorization seen by Grafana = ""
            -> registration FAILED: json: cannot unmarshal object into Go struct field GrafanaCred.secret of type string | Short Description: Unmarshal type error at key: %s. Error: %s.object | Probable Cause: Invalid object format | Suggested Remediation: Make sure to input a valid JSON object
    credential_shape_evidence_test.go:101: 
          AFTER fix - wizard forwards resolveCredentialAuthSecret(...)
            credentialSecret.secret = "canonical-key"
            Authorization seen by Grafana = "Bearer canonical-key"
            -> connection REGISTERED
--- PASS: TestEvidenceRegisterGrafanaConnectionCredentialShapes (0.00s)
PASS
ok  	github.com/meshery/meshery/server/machines/grafana	(cached)
```
</details>
<details>
<summary>Evidence: Reproduction: regression tests against the pre-fix read sites (base a7366b3)</summary>

<code>--- FAIL: TestGrafanaClientForConnectionCredentialShapes/canonical_shape&#10;Authorization = &#34;&#34;, want &#34;Bearer canonical-key&#34;&#10;--- FAIL: TestGrafanaClientForConnectionCredentialShapes/legacy_double-nested_shape&#10;Authorization = &#34;&#34;, want &#34;Bearer nested-key&#34;&#10;--- FAIL: TestK8sContextFromConnectionCredentialShapes/credential_form_double-nested_shape&#10;Auth = sql.Map(nil), want map[...]{&#34;clusterToken&#34;:&#34;tok&#34;, &#34;clusterUserName&#34;:&#34;u1&#34;, ...}</code>

```text
=== BEFORE THE FIX: read sites reverted to base a7366b3, regression tests re-run ===

--- server/handlers: Authorization header sent to the fake Grafana/Prometheus ---
--- FAIL: TestGrafanaClientForConnectionCredentialShapes (0.02s)
    --- FAIL: TestGrafanaClientForConnectionCredentialShapes/canonical_shape (0.01s)
        telemetry_credential_secret_test.go:146: Authorization = "", want "Bearer canonical-key"
    --- FAIL: TestGrafanaClientForConnectionCredentialShapes/legacy_double-nested_shape (0.00s)
        telemetry_credential_secret_test.go:146: Authorization = "", want "Bearer nested-key"
FAIL
FAIL	github.com/meshery/meshery/server/handlers	1.634s
FAIL

--- server/models: K8sContextFromConnection auth/cluster blocks ---
--- FAIL: TestK8sContextFromConnectionCredentialShapes (0.00s)
    --- FAIL: TestK8sContextFromConnectionCredentialShapes/credential_form_double-nested_shape (0.00s)
        k8s_context_credential_secret_test.go:103: Auth = sql.Map(nil), want map[string]interface {}{"clusterCertificateAuthorityData":"ca", "clusterClientCertificateData":"cert", "clusterClientKeyData":"key", "clusterToken":"tok", "clusterUserName":"u1"}
FAIL
FAIL	github.com/meshery/meshery/server/models	1.341s
FAIL
```
</details>
<details>
<summary>Evidence: Server telemetry + K8s context: all shapes pass with the tolerant read</summary>

```text
=== AFTER THE FIX: tolerant read via models.CredentialAuthSecret / models.CredentialPayload ===

--- server/handlers: Authorization header sent to the fake Grafana/Prometheus, per stored shape ---
=== RUN   TestGrafanaClientForConnectionCredentialShapes
=== RUN   TestGrafanaClientForConnectionCredentialShapes/canonical_shape
=== RUN   TestGrafanaClientForConnectionCredentialShapes/legacy_double-nested_shape
=== RUN   TestGrafanaClientForConnectionCredentialShapes/legacy_string_shape
=== RUN   TestGrafanaClientForConnectionCredentialShapes/anonymous_credential
--- PASS: TestGrafanaClientForConnectionCredentialShapes (0.01s)
    --- PASS: TestGrafanaClientForConnectionCredentialShapes/canonical_shape (0.00s)
    --- PASS: TestGrafanaClientForConnectionCredentialShapes/legacy_double-nested_shape (0.00s)
    --- PASS: TestGrafanaClientForConnectionCredentialShapes/legacy_string_shape (0.00s)
    --- PASS: TestGrafanaClientForConnectionCredentialShapes/anonymous_credential (0.00s)
=== RUN   TestPrometheusClientForConnectionCredentialShapes
=== RUN   TestPrometheusClientForConnectionCredentialShapes/legacy_string_shape
=== RUN   TestPrometheusClientForConnectionCredentialShapes/legacy_string_shape_with_basic_auth
=== RUN   TestPrometheusClientForConnectionCredentialShapes/canonical_shape_is_anonymous
=== RUN   TestPrometheusClientForConnectionCredentialShapes/legacy_double-nested_shape_is_anonymous
--- PASS: TestPrometheusClientForConnectionCredentialShapes (0.01s)
    --- PASS: TestPrometheusClientForConnectionCredentialShapes/legacy_string_shape (0.00s)
    --- PASS: TestPrometheusClientForConnectionCredentialShapes/legacy_string_shape_with_basic_auth (0.00s)
    --- PASS: TestPrometheusClientForConnectionCredentialShapes/canonical_shape_is_anonymous (0.00s)
    --- PASS: TestPrometheusClientForConnectionCredentialShapes/legacy_double-nested_shape_is_anonymous (0.00s)
PASS
ok  	github.com/meshery/meshery/server/handlers	1.600s

--- server/models: helpers + K8sContextFromConnection ---
--- PASS: TestCredentialPayload (0.00s)
    --- PASS: TestCredentialPayload/canonical_prometheus_payload_is_the_secret_map_itself (0.00s)
    --- PASS: TestCredentialPayload/canonical_kubernetes_payload_is_the_secret_map_itself (0.00s)
    --- PASS: TestCredentialPayload/stored_kubernetes_shape_is_the_secret_map_itself (0.00s)
    --- PASS: TestCredentialPayload/legacy_double-nested_payload_is_unwrapped (0.00s)
    --- PASS: TestCredentialPayload/legacy_double-nested_payload_keyed_by_name_is_unwrapped (0.00s)
    --- PASS: TestCredentialPayload/legacy_string_shape_carries_no_object_payload (0.00s)
    --- PASS: TestCredentialPayload/a_payload_carrying_its_own_secret_field_is_not_unwrapped (0.00s)
    --- PASS: TestCredentialPayload/nil_secret (0.00s)
--- PASS: TestCredentialAuthSecret (0.00s)
    --- PASS: TestCredentialAuthSecret/legacy_string_shape (0.00s)
    --- PASS: TestCredentialAuthSecret/legacy_string_shape_alongside_a_credential_name (0.00s)
    --- PASS: TestCredentialAuthSecret/canonical_grafana_payload (0.00s)
    --- PASS: TestCredentialAuthSecret/legacy_double-nested_grafana_payload (0.00s)
    --- PASS: TestCredentialAuthSecret/canonical_prometheus_payload_is_anonymous (0.00s)
    --- PASS: TestCredentialAuthSecret/kubernetes_payload_carries_no_string_auth_material (0.00s)
    --- PASS: TestCredentialAuthSecret/canonical_field_wins_over_a_sibling_legacy_secret_string (0.00s)
    --- PASS: TestCredentialAuthSecret/nil_secret (0.00s)
--- PASS: TestK8sContextFromConnectionCredentialShapes (0.00s)
    --- PASS: TestK8sContextFromConnectionCredentialShapes/stored_kubernetes_shape (0.00s)
    --- PASS: TestK8sContextFromConnectionCredentialShapes/credential_form_double-nested_shape (0.00s)
PASS
ok  	github.com/meshery/meshery/server/models	1.242s
```
</details>
<details>
<summary>Evidence: Wizard registration payload per persisted credential shape (real buildCredentialSecret)</summary>

<code>stored secret : {&#34;grafanaURL&#34;:&#34;https://grafana.example&#34;,&#34;grafanaAPIKey&#34;:&#34;canonical-key&#34;}&#10;shape : canonical (what Layer5 Cloud is moving to)&#10;before fix : credentialSecret.secret = undefined &lt;- no auth material&#10;after fix : credentialSecret.secret = &#34;canonical-key&#34;&#10;&#10;stored secret : {&#34;credentialName&#34;:&#34;grafana-nested&#34;,&#34;secret&#34;:{...,&#34;grafanaAPIKey&#34;:&#34;nested-key&#34;}}&#10;shape : legacy double-nested (8 rows; what Meshery UI still writes)&#10;before fix : credentialSecret.secret = {...} &lt;- OBJECT: GrafanaCred/PromCred unmarshal fails&#10;after fix : credentialSecret.secret = &#34;nested-key&#34;&#10;&#10;stored secret : {&#34;secret&#34;:&#34;legacy-key&#34;} shape: legacy string (154 rows)&#10;before fix : &#34;legacy-key&#34; after fix: &#34;legacy-key&#34;&#10;&#10;stored secret : {&#34;auth&#34;:{...},&#34;cluster&#34;:{...}} shape: kubernetes (36,916 rows)&#10;before fix : undefined after fix: undefined &lt;- no string auth material, as intended</code>

```text

 RUN  v4.1.9 /Users/l/.no-mistakes/worktrees/8e90410cb9af/01KZS0BMRTJKC6KT89PP9T6QP1/ui

stored secret : {"grafanaURL":"https://grafana.example","grafanaAPIKey":"canonical-key"}
shape         : canonical (what Layer5 Cloud is moving to)
  before fix  : credentialSecret.secret = undefined  <- no auth material
  after  fix  : credentialSecret.secret = "canonical-key"

stored secret : {"credentialName":"grafana-nested","secret":{"grafanaURL":"https://grafana.example","grafanaAPIKey":"nested-key"}}
shape         : legacy double-nested (8 rows; what Meshery UI still writes)
  before fix  : credentialSecret.secret = {"grafanaURL":"https://grafana.example","grafanaAPIKey":"nested-key"}  <- OBJECT: GrafanaCred/PromCred unmarshal fails
  after  fix  : credentialSecret.secret = "nested-key"

stored secret : {"secret":"legacy-key"}
shape         : legacy string (154 rows)
  before fix  : credentialSecret.secret = "legacy-key"
  after  fix  : credentialSecret.secret = "legacy-key"

stored secret : {"auth":{"clusterToken":"tok"},"cluster":{"server":"https://k8s.example"}}
shape         : kubernetes {auth, cluster} (36,916 rows)
  before fix  : credentialSecret.secret = undefined  <- no auth material
  after  fix  : credentialSecret.secret = undefined  <- no auth material

 ✓ components/connections/credentialShapeEvidence.test.ts > wizard registration payload per persisted credential shape > prints credentialSecret.secret before and after the tolerant read 3ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  13:54:01
   Duration  1.09s (transform 59ms, setup 83ms, import 123ms, tests 4ms, environment 709ms)
```
</details>
<details>
<summary>Evidence: UI vitest run (credentialSecret + ConnectionWizard.helpers)</summary>

<code>Test Files 2 passed (2)&#10;Tests 39 passed (39)</code>

```text

 RUN  v4.1.9 /Users/l/.no-mistakes/worktrees/8e90410cb9af/01KZS0BMRTJKC6KT89PP9T6QP1/ui


 Test Files  2 passed (2)
      Tests  39 passed (39)
   Start at  13:50:09
   Duration  4.65s (transform 205ms, setup 1.19s, import 317ms, tests 27ms, environment 6.88s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"26400c3209ccde5dad72b7371c81f4f540b5c54e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `server/models/k8s_context_credential_secret_test.go:34` - The &#34;legacy double-nested shape&#34; fixture is {credentialName, secret:{auth, cluster}}, which no writer in this repo produces, so the passing test overstates real-world Kubernetes coverage. The ~36.9k production rows are written top-level as {auth, cluster} (server/models/remote_provider.go:1123, server/models/default_local_provider.go:541) and are never double-nested. The only double-nesting writer is the credential form, whose ui/components/schemas/credentials/kubernetes.tsx schema produces {credentialName, secret:{clusterName, clusterServerURL, auth}} - and for THAT shape CredentialPayload unwraps correctly but k8s_context.go:85 still reads a &#39;cluster&#39; key that is absent, leaving ctx.Cluster nil (and ctx.Auth in the form&#39;s flat shape, not the kubeconfig user block K8sContext expects). That is precisely the field-mapping mismatch the intent deliberately defers, so this is a coverage-claim issue, not a request to fix the mapping here: either add the real form-written shape as an explicitly-xfail/documented case, or note in the test comment that the fixture exercises the unwrap only and the real k8s double-nested row remains blocked on the deferred decision.
- ℹ️ `ui/components/connections/meshSync/Stepper/StepperContent.tsx:318` - Pre-existing operator-precedence bug in the same component this change touches: `(formState !== null &amp;&amp; formState[&#39;secret&#39;]) !== undefined` groups the `&amp;&amp;` before the `!==`, so when formState is null it evaluates `false !== undefined` -&gt; true and setDisableVerify(false) always runs. The Verify Connection button is therefore never disabled, even with no credential selected and no form input. Intended condition is `selectedCredential !== null || (formState !== null &amp;&amp; formState[&#39;secret&#39;] !== undefined)`. Not introduced by this change; user-visible, so worth an explicit decision rather than a silent fix.
- ℹ️ `ui/utils/credentialSecret.ts:60` - The two &#39;mirrored&#39; helpers diverge on the legacy string shape: Go&#39;s CredentialPayload (server/models/credential_secret.go:73) returns nil for {&#34;secret&#34;: &#34;&lt;token&gt;&#34;}, while resolveCredentialPayload returns the bare string. Each file documents its own behavior, and both are currently safe (Go&#39;s nil map indexes to zero values; TS&#39;s only consumer is resolveCredentialAuthSecret, which type-checks for string first), but AGENTS.md and the docs both state the two files &#39;must stay in step&#39;, so a future maintainer porting a read site across languages could reasonably assume identical return contracts. Noting the intentional asymmetry; no change needed.

🔧 Fix: [Server] Pin real form-written Kubernetes credential shape in test
1 info still open:
- ℹ️ `docs/content/en/project/contributing/models/connections.md:122` - The new doc section says &#34;Three other shapes exist in stored data, written before that form settled&#34; and then presents a four-row table whose first row is Canonical - the shape the preceding paragraph just introduced as the current one, not an &#34;other&#34; legacy shape. A reader counting rows against the sentence concludes either that Canonical is one of the pre-existing legacy shapes or that a fourth legacy shape is missing from the table. Fix by reframing the lead-in to cover all four (e.g. &#34;Four shapes exist in stored data - the canonical one plus three written before that form settled - and Meshery reads all of them:&#34;), keeping the table as-is. The Go and TS source comments already catalogue all four correctly, so only this prose is inconsistent.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`env -u GOROOT go test ./server/handlers/ -run &#39;TestGrafanaClientForConnectionCredentialShapes|TestPrometheusClientForConnectionCredentialShapes&#39; -v` - real Authorization header per stored credential shape against a fake Grafana/Prometheus</code>
- `env -u GOROOT go test ./server/models/ -run 'TestCredentialPayload|TestCredentialAuthSecret|TestK8sContextFromConnectionCredentialShapes' -v`
- <code>Red-before-green: `git diff a7366b3..e93a804 -- server/handlers/telemetry_grafana_handler.go server/handlers/telemetry_prometheus_handler.go server/models/k8s_context.go | git apply -R`, re-ran both Go suites (canonical + double-nested Grafana -&gt; empty Authorization; Kubernetes form shape -&gt; nil auth), then `git checkout --` to restore</code>
- <code>`npm ci` in `ui/`, then `npx vitest run utils/__tests__/credentialSecret.test.ts components/connections/ConnectionWizard.helpers.test.ts` (2 files, 39 tests)</code>
- <code>Temporary evidence harness in `ui/components/connections/` executing the real `buildCredentialSecret` to print the wizard&#39;s `credentialSecret` payload for all four production shapes, before vs after (removed after capture)</code>
- <code>Temporary evidence harness in `server/machines/grafana/` driving the real `RegisterAction.Execute` (the Verify Connection path) against a fake Grafana that 401s without the key, with the wizard payload pre- and post-fix (removed after capture)</code>
- <code>Final re-run of both Go suites on the default build cache with the standard command - both `ok`</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:163` - Judgment call, left as-is: the new AGENTS.md entry restates the four-shape catalogue that docs/content/en/project/contributing/models/connections.md owns, rather than being a bare pointer to it. Kept because an agent editing a credential read site needs the &#39;do not index the secret map&#39; invariant without loading the docs page, it matches the compression of the sibling AGENTS.md entries, and it already names the owner document. The cost is that the two must be kept in step if the catalogue changes; if that drifts once, reduce the AGENTS.md entry to the invariant plus the pointer.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential handling across Grafana, Prometheus, and Kubernetes connections.
  * Existing credentials in older or alternate formats now authenticate correctly.
  * Anonymous connections and credentials using different authentication fields are handled safely.
  * Connection setup and synchronization preserve supported credential data without errors.

* **Documentation**
  * Added guidance on supported credential formats and retrieval behavior.

* **Tests**
  * Expanded coverage for credential compatibility, authentication, and Kubernetes connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
