### PR TITLE
fix(ui): fix operator precedence in MeshSync connection stepper (#21337)

### DIFF
--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -312,7 +312,7 @@ export const CredentialDetails = ({ sharedData, handleNext, handleRegistrationCo
   };
 
   useEffect(() => {
-    if (selectedCredential !== null || (formState !== null && (formState['secret'] !== undefined))) {
+    if (selectedCredential !== null || (formState !== null && formState['secret'] !== undefined)) {
       setDisableVerify(false);
     } else {
       setDisableVerify(true);

--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -312,7 +312,8 @@ export const CredentialDetails = ({ sharedData, handleNext, handleRegistrationCo
   };
 
   useEffect(() => {
-    if (selectedCredential !== null || (formState !== null && formState['secret'] !== undefined)) {
+    const hasSecret = typeof formState?.secret === 'string' && formState.secret.trim().length > 0;
+    if (selectedCredential !== null || hasSecret) {
       setDisableVerify(false);
     } else {
       setDisableVerify(true);

--- a/ui/components/connections/meshSync/Stepper/StepperContent.tsx
+++ b/ui/components/connections/meshSync/Stepper/StepperContent.tsx
@@ -312,7 +312,7 @@ export const CredentialDetails = ({ sharedData, handleNext, handleRegistrationCo
   };
 
   useEffect(() => {
-    if (selectedCredential !== null || (formState !== null && formState['secret']) !== undefined) {
+    if (selectedCredential !== null || (formState !== null && (formState['secret'] !== undefined))) {
       setDisableVerify(false);
     } else {
       setDisableVerify(true);


### PR DESCRIPTION
### Summary
Fixes an operator precedence bug in `StepperContent.tsx` where an improperly parenthesized condition caused `false !== undefined` to evaluate to `true`. This prevented the "Verify Connection" button from being disabled in the MeshSync registration stepper when credentials/secrets were empty.

- Fix parenthesis grouping in disableVerify logic to check formState['secret'] !== undefined
- Ensure Verify Connection button remains disabled when no credential or secret is provided

Fixes #21337

**Notes for Reviewers**

- This PR fixes #21337 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New credential verification is now enabled only when the secret field contains non-empty, trimmed text.
  * Verification for existing credentials continues to be available when an existing credential is selected.
  * Prevents verification from being triggered when a new credential’s secret is blank or contains only whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->