### PR TITLE
feat(policy): evaluate explicit via intermediary binding relationships

### DIFF
--- a/models/meshery-core/0.7.2/v1.0.0/policies/identify_binding_policy.rego
+++ b/models/meshery-core/0.7.2/v1.0.0/policies/identify_binding_policy.rego
@@ -37,8 +37,13 @@ identify_relationship(
 	from := extract_components(design_file.components, from_selectors)
 	to := extract_components(design_file.components, to_selectors)
 
-	# should consider model and versions (regex/operator/normal string)
+	via_selectors := object.get(selector_set.allow, "via", [])
 	binding_comps := {type |
+		count(via_selectors) > 0
+		some via_selector in via_selectors
+		type = via_selector.kind
+	} union {type |
+		count(via_selectors) == 0
 		some match_selector in selector_set.allow.from[_].match
 
 		match_selector[0].kind != "self"

--- a/models/meshery-core/0.7.2/v1.0.0/policies/identify_binding_policy.rego
+++ b/models/meshery-core/0.7.2/v1.0.0/policies/identify_binding_policy.rego
@@ -38,17 +38,20 @@ identify_relationship(
 	to := extract_components(design_file.components, to_selectors)
 
 	via_selectors := object.get(selector_set.allow, "via", [])
-	binding_comps := {type |
-		count(via_selectors) > 0
-		some via_selector in via_selectors
-		type = via_selector.kind
-	} union {type |
-		count(via_selectors) == 0
-		some match_selector in selector_set.allow.from[_].match
+	binding_comps := union({
+		{type |
+			count(via_selectors) > 0
+			some via_selector in via_selectors
+			type = via_selector.kind
+		},
+		{type |
+			count(via_selectors) == 0
+			some match_selector in selector_set.allow.from[_].match
 
-		match_selector[0].kind != "self"
-		type = match_selector[0].kind
-	}
+			match_selector[0].kind != "self"
+			type = match_selector[0].kind
+		}
+	})
 	deny_selectors := object.get(selector_set, "deny", [])
 
 	# This is a set of set,


### PR DESCRIPTION
### Description
This PR updates the relationship policy evaluator to support explicit intermediary components (the `via` selector field introduced in meshery/schemas) inside binding relationships.

### Changes
* **Rego Policy Engine:**
  * Updated [identify_binding_policy.rego](file:///Users/junioroyewunmi/Desktop/meshery/meshery/meshery/models/meshery-core/0.7.2/v1.0.0/policies/identify_binding_policy.rego) to identify binding components using the new `allow.via` field when defined.
  * Added a seamless fallback union block to query the legacy implicit `match` selectors if the `via` block is not present (ensuring full backward-compatibility with older models).

### Associated Issue
This resolves the backend policy phase of [meshery/meshery#10736](https://github.com/meshery/meshery/issues/10736).

https://github.com/user-attachments/assets/fb80ba7b-ce27-4d4c-8a49-09c840cc8e36





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relationship identification when optional connection selectors are provided.
  * Preserved existing behavior when connection selectors are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->