### PR TITLE
[Server] Check the error GetToken returns on connection and credential updates

### DIFF
--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -4713,9 +4713,9 @@ func (l *RemoteProvider) UpdateConnection(req *http.Request, connection *connect
 	bf := bytes.NewBuffer(_creds)
 	remoteProviderURL, _ := url.Parse(fmt.Sprintf("%s%s/%s", l.RemoteProviderURL, ep, connection.Kind))
 	cReq, _ := http.NewRequest(http.MethodPut, remoteProviderURL.String(), bf)
-	tokenString, _ := l.GetToken(req)
+	tokenString, err := l.GetToken(req)
 	if err != nil {
-		l.Log.Error(ErrGetToken(err))
+		l.Log.Error(err)
 		return nil, err
 	}
 
@@ -5199,9 +5199,9 @@ func (l *RemoteProvider) UpdateUserCredential(req *http.Request, credential *Cre
 	bf := bytes.NewBuffer(_creds)
 	remoteProviderURL, _ := url.Parse(l.RemoteProviderURL + ep)
 	cReq, _ := http.NewRequest(http.MethodPut, remoteProviderURL.String(), bf)
-	tokenString, _ := l.GetToken(req)
+	tokenString, err := l.GetToken(req)
 	if err != nil {
-		l.Log.Error(ErrGetToken(err))
+		l.Log.Error(err)
 		return nil, err
 	}
 

--- a/server/models/remote_provider_update_token_test.go
+++ b/server/models/remote_provider_update_token_test.go
@@ -1,0 +1,99 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/meshery/meshery/server/models/connections"
+	"github.com/meshery/meshkit/errors"
+)
+
+// newRequestWithoutToken builds a request with no provider session cookie.
+// GetToken reads the token off that cookie, so its absence is what fails.
+func newRequestWithoutToken(t *testing.T, target string) *http.Request {
+	t.Helper()
+
+	return httptest.NewRequest(http.MethodPut, target, nil)
+}
+
+// countingProvider stands up a remote provider that records whether it was
+// reached at all.
+func countingProvider(t *testing.T, hits *int32) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// TestRemoteProviderUpdateConnectionRequiresToken and its credential twin below
+// pin one invariant on the two update paths: a request carrying no session
+// cookie must not reach the remote provider at all.
+//
+// Both paths used to discard GetToken's error and guard on a stale one, so an
+// empty token was PUT to the provider anyway - and against a provider answering
+// 200, the caller got a zero-valued object back with no error at all. That is
+// why the assertion is the hit counter and not just the returned error.
+func TestRemoteProviderUpdateConnectionRequiresToken(t *testing.T) {
+	var hits int32
+	server := countingProvider(t, &hits)
+
+	provider := newTestRemoteProvider(t, server.URL)
+	provider.Capabilities = Capabilities{
+		{Feature: PersistConnection, Endpoint: "/api/integrations/connections"},
+	}
+
+	conn, err := provider.UpdateConnection(
+		newRequestWithoutToken(t, "/api/integrations/connections"),
+		&connections.Connection{Kind: "kubernetes"},
+	)
+	if err == nil {
+		t.Fatalf("expected an error when the request carries no token, got connection %+v", conn)
+	}
+	if conn != nil {
+		t.Errorf("expected no connection alongside the error, got %+v", conn)
+	}
+	if code := errors.GetCode(err); code != ErrGetTokenCode {
+		t.Errorf("error code = %q, want %q (err: %v)", code, ErrGetTokenCode, err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Errorf("remote provider was called %d time(s) with an empty token; a missing token must short-circuit the request", got)
+	}
+}
+
+// TestRemoteProviderUpdateUserCredentialRequiresToken covers the same swallowed
+// GetToken error on the credential path, where the body being PUT is a
+// credential and an unauthenticated write is one the provider must never make.
+func TestRemoteProviderUpdateUserCredentialRequiresToken(t *testing.T) {
+	var hits int32
+	server := countingProvider(t, &hits)
+
+	provider := newTestRemoteProvider(t, server.URL)
+	provider.Capabilities = Capabilities{
+		{Feature: PersistCredentials, Endpoint: "/api/integrations/credentials"},
+	}
+
+	cred, err := provider.UpdateUserCredential(
+		newRequestWithoutToken(t, "/api/integrations/credentials"),
+		&Credential{},
+	)
+	if err == nil {
+		t.Fatalf("expected an error when the request carries no token, got credential %+v", cred)
+	}
+	if cred != nil {
+		t.Errorf("expected no credential alongside the error, got %+v", cred)
+	}
+	if code := errors.GetCode(err); code != ErrGetTokenCode {
+		t.Errorf("error code = %q, want %q (err: %v)", code, ErrGetTokenCode, err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Errorf("remote provider was called %d time(s) with an empty token; a missing token must short-circuit the request", got)
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

`UpdateConnection` and `UpdateUserCredential` discard the token error and then guard on a stale one:

```go
_creds, err := json.Marshal(connection)
if err != nil { return nil, err }   // non-nil marshal error already returned here

tokenString, _ := l.GetToken(req)   // token error discarded
if err != nil {                     // so this tests a necessarily-nil err
    l.Log.Error(ErrGetToken(err))   // ...and this shows the check was meant for GetToken
    return nil, err
}
```

The guard can never fire, so a request with no session cookie travels on with an empty token and is `PUT` to the remote provider anyway. A missing token then surfaces as whatever the provider makes of an unauthenticated write — and against a provider answering `200`, as no error at all.

**Changes**

- `server/models/remote_provider.go`: `_` → `err` at both sites. The bare `err` return is kept because `GetToken` already wraps in `ErrGetToken`, matching the correct call sites at 5433/5889.
- Regression test asserting the remote provider is **never reached** when the token is absent.

Two other sites discard the token error and are deliberately left alone: `UpdateToken` returns the empty string by design, and `RecordPreferences` has no dead guard to establish intent — and sits in the region #21262 is editing.

**Verification**

Both tests fail without the fix, and the failure is the bug:

```
--- FAIL: TestRemoteProviderUpdateConnectionRequiresToken
    expected an error when the request carries no token, got connection
    &{ID:00000000-0000-0000-0000-000000000000 Name: ... Kind: ...}
```

No error — a blank object returned as a successful update. With the fix, both pass and the package is green (`go test ./server/models/` → `ok 20.728s`)
**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote connection and credential updates now stop safely when a provider session token is unavailable.
  * Prevents update requests from being sent when token retrieval fails and reports the error appropriately.
  * Applies consistently to both remote connections and user credentials.

* **Tests**
  * Added coverage confirming tokenless updates return the expected error and do not contact the remote provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->