### PR TITLE
[Models] Add LogGroup to Key reference relationship for aws-cloudwatc…

### DIFF
--- a/models/aws-cloudwatchlogs-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-key.json
+++ b/models/aws-cloudwatchlogs-controller/v1.4.0/v1.0.0/relationships/edge-non-binding-reference-key.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.4.0"
+    },
+    "name": "aws-cloudwatchlogs-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "LogGroup",
+            "match": {},
+            "matchStrategyMatrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-cloudwatchlogs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "kmsKeyRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "matchStrategyMatrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kms-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21280 

## Description
This PR adds relationship JSON definitions to link components in the aws-cloudwatchlogs-controller model back to their parent Key component.

This enables automatic configuration patching on the design canvas for:

LogGroup → Key (via kmsKeyRef field)
Following best practices and schema constraints (relationships.meshery.io/v1beta2):

Spec reference fields (kmsKeyRef.from.name) are prioritized per ACK best practice.
Used matchStrategyMatrix in camelCase to ensure schema compatibility.

- [x] Yes, I signed my commits.

## screenshot

<img width="3376" height="1970" alt="Screenshot 2026-08-12 at 4 56 23 PM" src="https://github.com/user-attachments/assets/b4b394a2-665c-45b0-9cde-76a63d517a5c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting Amazon CloudWatch Logs log groups with AWS Key Management Service (KMS) keys.
  - Log groups can now reference the KMS key used for encryption.
  - KMS key names are surfaced clearly in the relationship view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->