### PR TITLE
Gate Reset tab with reset-database permission

### DIFF
--- a/ui/components/settings/MesherySettings.test.tsx
+++ b/ui/components/settings/MesherySettings.test.tsx
@@ -223,10 +223,12 @@ describe('MesherySettings', () => {
     expect(screen.queryByTestId('adapter-config')).not.toBeInTheDocument();
   });
 
-  it('disables the Reset tab when the reset-database permission is denied', () => {
+  it('disables the Reset tab and its content when the reset-database permission is denied', () => {
     permissionOverrides.set(Keys.MesherySystemResetDatabase.id, false);
+    routerState.query = { settingsCategory: 'Reset' };
     render(<MesherySettings />);
 
     expect(screen.getByTestId('tab-Reset')).toBeDisabled();
+    expect(screen.queryByTestId('database-summary')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/settings/MesherySettings.test.tsx
+++ b/ui/components/settings/MesherySettings.test.tsx
@@ -222,4 +222,11 @@ describe('MesherySettings', () => {
     expect(screen.getByTestId('tab-Adapters')).toBeDisabled();
     expect(screen.queryByTestId('adapter-config')).not.toBeInTheDocument();
   });
+
+  it('disables the Reset tab when the reset-database permission is denied', () => {
+    permissionOverrides.set(Keys.MesherySystemResetDatabase.id, false);
+    render(<MesherySettings />);
+
+    expect(screen.getByTestId('tab-Reset')).toBeDisabled();
+  });
 });

--- a/ui/components/settings/MesherySettings.tsx
+++ b/ui/components/settings/MesherySettings.tsx
@@ -118,6 +118,7 @@ const MesherySettings = () => {
   const canViewSettings = useHasPermission(Keys.MesherySystemViewSettings);
   const canViewInfra = useHasPermission(Keys.InfrastructureManagementViewCloudNativeInfrastructure);
   const canViewRegistry = useHasPermission(Keys.MesherySystemViewRegistry);
+  const canResetDatabase = useHasPermission(Keys.MesherySystemResetDatabase);
   const router = useRouter();
   const { selectedSettingsCategory } = settingsRouter(router);
   const theme = useTheme();
@@ -276,7 +277,7 @@ const MesherySettings = () => {
                     data-testid="settings-tab-reset"
                     // tab="systemReset"
                     value={RESET}
-                    // disabled={!CAN(Keys.VIEW_SYSTEM_RESET.id, Keys.VIEW_SYSTEM_RESET.function)} TODO: uncomment when key get seeded
+                    disabled={!canResetDatabase}
                   />
                 </CustomTooltip>
               </Tabs>

--- a/ui/components/settings/MesherySettings.tsx
+++ b/ui/components/settings/MesherySettings.tsx
@@ -348,7 +348,7 @@ const MesherySettings = () => {
               </TabContainer>
             )}
 
-            {tabVal === RESET && (
+            {tabVal === RESET && canResetDatabase && (
               <TabContainer>
                 <DatabaseSummary promptRef={systemResetPromptRef} />
               </TabContainer>


### PR DESCRIPTION
## Summary

The Reset tab was available even when a user did not have permission to reset the Meshery database. This change uses the existing reset-database permission to disable that tab for unauthorized users.

The Reset content is also gated, preventing an unauthorized user from reaching it through a direct settings URL. The stale TODO is removed and the regression test now covers this route.

## Testing

- Focused Vitest suite passed: 7 tests.
- Targeted ESLint check passed.
- Git whitespace check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Reset settings tab is now disabled when database reset permission is unavailable.
  * Reset-related content no longer appears when access is restricted.
* **Tests**
  * Added coverage to verify permission-based restrictions for the Reset settings tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->