### PR TITLE
chore(ui): remove CASL, replace with lightweight permission checker

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@casl/ability": "^7.0.0",
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-yaml": "^6.1.3",
         "@codemirror/lint": "^6.9.7",
@@ -551,18 +550,6 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
-      }
-    },
-    "node_modules/@casl/ability": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-7.0.0.tgz",
-      "integrity": "sha512-QhwRflkTucpdS2uw1XScrzLWbgLYJGvPoq2Xm5OjeRci3dwtPixxnjUKJ04Ss1ivNS9tZQ8y4sjWeelWsrwo4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@ucast/mongo2js": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -4250,41 +4237,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@ucast/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-4XVx6LzPXZGvnZO5jp39cm/G4UvuwvEdtmg+9+4+zl6uFkCcB7UJacvtMYeBE56GJVT99Zqy6Pii7dGJq3Kz9Q==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@ucast/js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-4.0.1.tgz",
-      "integrity": "sha512-9O5xPBvwEWQk2WvO69Eh2WJB8QljVZ2vRVdFvfnKjlZwWXcYxp1lqLBhwXBU1AtuSgCvKhJPkXdjKJggUmAmQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ucast/core": "2.0.0"
-      }
-    },
-    "node_modules/@ucast/mongo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-3.0.0.tgz",
-      "integrity": "sha512-kwuSH+kdB4GCR0LGhy/PEDm4PCflur89AlK82kNiYD0FvsA8A/p+0sx7m+/R8mMFAlmlkAd3VXp7sM/cLLYWYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ucast/core": "2.0.0"
-      }
-    },
-    "node_modules/@ucast/mongo2js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-2.0.0.tgz",
-      "integrity": "sha512-vNBZzRnsfLr/TSxEoxz6W6hHQ5tmWsfEeC0nCq5z8RezC1AqIRy3cfHm8AGvlGtcn+cTSFQcZremfqnz6wm+nQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ucast/core": "2.0.0",
-        "@ucast/js": "4.0.1",
-        "@ucast/mongo": "3.0.0"
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,6 @@
   "repository": "https://github.com/meshery/meshery",
   "license": "Apache-2.0",
   "dependencies": {
-    "@casl/ability": "^7.0.0",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-yaml": "^6.1.3",
     "@codemirror/lint": "^6.9.7",

--- a/ui/utils/__tests__/can.test.ts
+++ b/ui/utils/__tests__/can.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-// The `can.ts` module wires `@casl/ability` together with the redux store and
-// sistent's `createCanShow`. We mock the store + sistent's create helper so we
-// can unit-test the `CAN` permission function and verify that `CanShow` is
-// built with the right callbacks.
+// The `can.ts` module wires a lightweight permission checker together with the
+// redux store and sistent's `createCanShow`. We mock the store + sistent's
+// create helper so we can unit-test the `CAN` permission function and verify
+// that `CanShow` is built with the right callbacks.
 
 const hoisted = vi.hoisted(() => ({
   createCanShowMock: vi.fn(() => 'mocked-can-show'),
@@ -60,13 +60,6 @@ describe('ability + CAN', () => {
   it('returns false when the rule does not match the action', () => {
     ability.update([{ action: 'read', subject: 'pattern' }]);
     expect(CAN('write', 'pattern')).toBe(false);
-  });
-
-  it('supports manage as an aggregate', () => {
-    ability.update([{ action: 'manage', subject: 'design' }]);
-    expect(CAN('read', 'design')).toBe(true);
-    expect(CAN('update', 'design')).toBe(true);
-    expect(CAN('delete', 'design')).toBe(true);
   });
 });
 

--- a/ui/utils/can.ts
+++ b/ui/utils/can.ts
@@ -1,11 +1,24 @@
-import { Ability } from '@casl/ability';
 import { createCanShow } from '@sistent/sistent';
 import _ from 'lodash';
 import { ProviderUiAccessControl } from './disabledComponents';
 import { store } from '../store';
 import { mesheryEventBus } from './eventBus';
 
-export const ability = new Ability([]);
+type AbilityRule = { action: string; subject: string };
+
+class SimpleAbility {
+  private rules: AbilityRule[] = [];
+
+  update(rules: AbilityRule[]) {
+    this.rules = rules;
+  }
+
+  can(action: string, subject: string) {
+    return this.rules.some((rule) => rule.action === action && rule.subject === subject);
+  }
+}
+
+export const ability = new SimpleAbility();
 
 export default function CAN(action, subject) {
   return ability.can(action, _.lowerCase(subject));


### PR DESCRIPTION
fixes #

## Description
Removes the `@casl/ability` dependency from the UI and replaces it with a small, hand-rolled permission checker (`SimpleAbility`) that supports the same `can(action, subject)` / `update(rules)` interface.

CASL usage was already fairly contained thanks to the existing "CASL adapter" pattern in `_app.tsx` — `userHasPermission` and `updateAbility` are the only two call sites feeding into `ability`, and both already went through PermissionProvider/PermissionShield. This meant the swap didn't require touching any component-level permission checks.

## Changes Included
- `ui/utils/can.ts`: replaced CASL's `Ability` class with a small `SimpleAbility` class (exact-match `{ action, subject }` lookup). `CAN()` and `CanShow` are unchanged.
- `ui/package.json` / `package-lock.json`: removed `@casl/ability` dependency.
- `ui/utils/__tests__/can.test.ts`: updated outdated comment referencing CASL; removed the test for CASL's `manage` wildcard aggregate behavior, since no real permission key in `server/permissions/keys.csv` uses `manage` as an action — it's always a UUID.
- No changes needed in `pages/_app.tsx` or `rtk-query/ability.tsx` — both only call `ability.can()` / `ability.update()` by name, which `SimpleAbility` still supports.

## Verification
- `can.test.ts` — 5/5 tests passing
- Confirmed via repo-wide search that no component calls `CAN()` or `@casl/ability` directly outside of `utils/can.ts`


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced the previous permission-checking library with a lightweight built-in permission checker.
  * Permissions now support exact action-and-subject matching and can be updated dynamically.
* **Tests**
  * Updated permission-checking tests to reflect the new behavior.
  * Removed coverage for aggregate `manage` actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->