### PR TITLE
fix(ui): correct credentials page rendering on page reload

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -66,7 +66,7 @@ const nextConfig = {
       '/management/adapter': { page: '/management/adapter' },
       '/management/environments': { page: '/management/environments' },
       '/management/connections': { page: '/management/connections' },
-      '/management/credentials': { page: '/management/connections' },
+      '/management/credentials': { page: '/management/credentials' },
       '/telemetry/metrics': { page: '/telemetry/metrics' },
       '/telemetry/charts': { page: '/telemetry/charts' },
       '/management/workspaces': { page: '/management/workspaces' },


### PR DESCRIPTION
**Notes for Reviewers**
Fixes the issue where the credentials page was showing the connections page on page reload. The exportPathMap was mapped incorrectly.


- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected navigation for the `/management/credentials` route so it opens the Credentials page instead of the Connections page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->