### PR TITLE
[UI] Prevent duplicate design download notifications

### DIFF
--- a/ui/components/designs/patterns/MesheryPatternGridView.tsx
+++ b/ui/components/designs/patterns/MesheryPatternGridView.tsx
@@ -174,7 +174,12 @@ function MesheryPatternGrid({
       let id = design.id;
       let name = design.name;
       downloadContent({ id, name, type: 'pattern', source_type, params });
-      notify({ message: `"${name}" design downloaded`, event_type: EVENT_TYPES.INFO });
+      if (source_type) {
+        notify({
+          message: `"${name}" design downloaded`,
+          event_type: EVENT_TYPES.INFO,
+        });
+      }
     } catch (e) {
       console.error(e);
     }

--- a/ui/components/designs/patterns/patterns-actions.test.tsx
+++ b/ui/components/designs/patterns/patterns-actions.test.tsx
@@ -188,7 +188,7 @@ describe('createPatternsActions', () => {
     expect(deps.setSelectedRowData).toHaveBeenCalledWith(null);
   });
 
-  it('handleDownload triggers download and notifies', () => {
+  it('handleDownload notifies for legacy source-type downloads', () => {
     const deps = baseDeps();
     const actions = createPatternsActions(deps);
     const stop = vi.fn();
@@ -208,6 +208,31 @@ describe('createPatternsActions', () => {
       params: { param: 'v' },
     });
     expect(deps.notify).toHaveBeenCalled();
+  });
+
+  it('handleDownload does not notify for canonical downloads', () => {
+    const deps = baseDeps();
+    const actions = createPatternsActions(deps);
+    const stop = vi.fn();
+
+    actions.handleDownload(
+      { stopPropagation: stop } as any,
+      { id: 'd1', name: 'Design 1' },
+      undefined,
+      'export=Kubernetes%20Manifest',
+    );
+
+    expect(stop).toHaveBeenCalled();
+
+    expect(downloadContent).toHaveBeenCalledWith({
+      id: 'd1',
+      name: 'Design 1',
+      type: 'pattern',
+      source_type: undefined,
+      params: 'export=Kubernetes%20Manifest',
+    });
+
+    expect(deps.notify).not.toHaveBeenCalled();
   });
 
   it('handleError surfaces the failure as a notification', () => {

--- a/ui/components/designs/patterns/patterns-actions.test.tsx
+++ b/ui/components/designs/patterns/patterns-actions.test.tsx
@@ -218,7 +218,7 @@ describe('createPatternsActions', () => {
     actions.handleDownload(
       { stopPropagation: stop } as any,
       { id: 'd1', name: 'Design 1' },
-      undefined,
+      null,
       'export=Kubernetes%20Manifest',
     );
 
@@ -228,7 +228,7 @@ describe('createPatternsActions', () => {
       id: 'd1',
       name: 'Design 1',
       type: 'pattern',
-      source_type: undefined,
+      source_type: null,
       params: 'export=Kubernetes%20Manifest',
     });
 

--- a/ui/components/designs/patterns/patterns-actions.ts
+++ b/ui/components/designs/patterns/patterns-actions.ts
@@ -373,7 +373,12 @@ export function createPatternsActions(deps) {
       let name = design.name;
       downloadContent({ id, name, type: 'pattern', source_type, params });
       updateProgress({ showProgress: false });
-      notify({ message: `"${name}" design downloaded`, event_type: EVENT_TYPES.INFO });
+      if (source_type) {
+        notify({
+          message: `"${name}" design downloaded`,
+          event_type: EVENT_TYPES.INFO,
+        });
+      }
     } catch (e) {
       console.error(e);
     }

--- a/ui/components/workspaces/SpacesSwitcher/hooks.test.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/hooks.test.tsx
@@ -274,7 +274,7 @@ describe('useContentDelete', () => {
 });
 
 describe('useContentDownload', () => {
-  it('handleDesignDownload calls downloadContent and notifies', () => {
+  it('handleDesignDownload notifies for legacy source-type downloads', () => {
     const { result } = renderHook(() => useContentDownload());
     const ev = { stopPropagation: vi.fn() } as any;
     result.current.handleDesignDownload(ev, { id: 'd-1', name: 'a' }, 'src', {});
@@ -285,6 +285,30 @@ describe('useContentDownload', () => {
       message: '"a" design downloaded',
       event_type: 'INFO',
     });
+  });
+
+  it('handleDesignDownload does not notify for canonical downloads', () => {
+    const { result } = renderHook(() => useContentDownload());
+    const ev = { stopPropagation: vi.fn() } as any;
+
+    result.current.handleDesignDownload(
+      ev,
+      { id: 'd-1', name: 'a' },
+      undefined,
+      'export=Kubernetes%20Manifest',
+    );
+
+    expect(downloadContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'd-1',
+        name: 'a',
+        type: 'pattern',
+        source_type: undefined,
+        params: 'export=Kubernetes%20Manifest',
+      }),
+    );
+
+    expect(notify).not.toHaveBeenCalled();
   });
 
   it('handleDesignDownload supports an array of designs', () => {

--- a/ui/components/workspaces/SpacesSwitcher/hooks.tsx
+++ b/ui/components/workspaces/SpacesSwitcher/hooks.tsx
@@ -228,7 +228,12 @@ export const useContentDownload = () => {
         let name = design.name;
         downloadContent({ id, name, type: 'pattern', source_type, params });
         updateProgress({ showProgress: false });
-        notify({ message: `"${name}" design downloaded`, event_type: EVENT_TYPES.INFO });
+        if (source_type) {
+          notify({
+            message: `"${name}" design downloaded`,
+            event_type: EVENT_TYPES.INFO,
+          });
+        }
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21379 
- Fix duplicate design download notifications by relying on the canonical `DesignDownloadEvent` for standard downloads while preserving legacy source-type notifications. Added regression tests to verify exactly one notification for canonical downloads.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

## Before
<img width="1512" height="896" alt="Screenshot 2026-08-12 at 2 16 55 AM" src="https://github.com/user-attachments/assets/a333d133-6749-4529-addb-d2bd6bc8da2a" />

## After
<img width="1282" height="684" alt="Screenshot 2026-08-14 at 1 49 54 AM" src="https://github.com/user-attachments/assets/326425e3-cb8f-48ce-ab22-19780fcacccf" />

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Download notifications now appear only for downloads with a specified source type.
  * Canonical downloads continue to work without unnecessary notifications.
  * Download parameters are preserved across supported download flows.

* **Tests**
  * Added coverage for legacy and canonical download notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->