### PR TITLE
Add CloudWatch MetricStream Firehose relationship

### DIFF
--- a/models/aws-cloudwatch-controller/v1.7.0/v1.0.0/relationships/edge-non-binding-reference-firehose.json
+++ b/models/aws-cloudwatch-controller/v1.7.0/v1.0.0/relationships/edge-non-binding-reference-firehose.json
@@ -30,38 +30,6 @@
         "from": [
           {
             "id": null,
-            "kind": "MetricStream",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": "v1.7.0"
-              },
-              "name": "aws-cloudwatch-controller",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "spec",
-                  "firehoseRef",
-                  "from",
-                  "name"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
             "kind": "DeliveryStream",
             "match": {},
             "match_strategy_matrix": null,
@@ -78,9 +46,41 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "MetricStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.7.0"
+              },
+              "name": "aws-cloudwatch-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "firehoseRef",
+                  "from",
+                  "name"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/aws-cloudwatch-controller/v1.7.0/v1.0.0/relationships/edge-non-binding-reference-firehose.json
+++ b/models/aws-cloudwatch-controller/v1.7.0/v1.0.0/relationships/edge-non-binding-reference-firehose.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.7.0"
+    },
+    "name": "aws-cloudwatch-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": "v1.7.0"
+              },
+              "name": "aws-cloudwatch-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "firehoseRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "DeliveryStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-firehose-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## Notes for Reviewers

* This PR fixes #21278
* Adds a non-binding reference relationship from `MetricStream` to `DeliveryStream` using `spec.firehoseRef.from.name`.
* The relationship targets `aws-firehose-controller` and follows the existing ACK relationship conventions.
* The model builds successfully with `mesheryctl model build aws-cloudwatch-controller/v1.7.0 --path ./models`.
* Kanvas design: https://playground.meshery.io/extension/meshmap?mode=design&design=fe445988-a243-405c-a1f7-8ebf3b1167fc

### Validation

* JSON validation passed.
* Meshery model build passed.
* Local model import recognized the new `MetricStream → DeliveryStream` relationship.
* `v1.6.1` remains untouched.


https://github.com/user-attachments/assets/55cc6c3b-2414-4e7b-b3c8-8c039c39da52



### Signed commits

* [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a CloudWatch relationship connecting DeliveryStream resources with MetricStream resources.
  * Firehose references and destination display names are now surfaced in the relationship view.
  * Improved visibility into how delivery streams map to metric streams, making related resource connections easier to understand and navigate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->