### PR TITLE
[Docs] Add extension trust and hardening to production deployment guidance

### DIFF
--- a/docs/content/en/installation/production/_index.md
+++ b/docs/content/en/installation/production/_index.md
@@ -63,7 +63,7 @@ reference material.
 | **[Infrastructure, Sizing & Performance]({{< ref "installation/production/infrastructure-sizing-and-performance.md" >}})** | Resource requirements per component, capacity planning, MeshSync tiered discovery, Broker throughput, scalability levers, and known performance bounds. |
 | **[High Availability & Resiliency]({{< ref "installation/production/high-availability-and-resiliency.md" >}})** | Replication, health probes, failure modes and recovery, the ephemeral database, Remote Provider persistence, and backup & disaster recovery posture. |
 | **[Networking & Connectivity]({{< ref "installation/production/networking-and-connectivity.md" >}})** | Network port and directional-flow matrix, ingress and Emissary configuration, secure WebSocket support, CDN and edge caching of the UI, Broker exposure, egress, and network policies. |
-| **[Security Hardening]({{< ref "installation/production/security-hardening.md" >}})** | RBAC and least privilege, pod and container security contexts, secret and kubeconfig handling, TLS, supply-chain integrity, and namespace isolation. |
+| **[Security Hardening]({{< ref "installation/production/security-hardening.md" >}})** | RBAC and least privilege, pod and container security contexts, secret and kubeconfig handling, TLS, supply-chain integrity, namespace isolation, and [trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}}). |
 | **[Authentication, Authorization & Identity]({{< ref "installation/production/authentication-and-identity.md" >}})** | Why to preselect a Remote Provider over the Local Provider, OAuth callback configuration, identity providers, and keys/permissions. |
 | **[Multi-Cluster & Multi-Cloud Operations]({{< ref "installation/production/multi-cluster-and-multi-cloud.md" >}})** | Managed vs. unmanaged cluster connections, one Operator per cluster, kubeconfig and context management, MeshSync modes, and cloud-specific guidance. |
 | **[Monitoring, Observability & Health KPIs]({{< ref "installation/production/monitoring-observability-and-kpis.md" >}})** | Health endpoints, the key performance indicators of Meshery's health, metrics, tracing, centralized logging, and alerting. |
@@ -90,6 +90,12 @@ deployment decisions:
    out-of-cluster and multi-cloud topologies.
 5. **Observe the management plane itself.** Meshery exposes health endpoints and
    metrics; treat them as first-class signals and alert on them.
+6. **Treat every enabled extension as trusted code.** Meshery's
+   [extension points]({{< ref "reference/extensibility/_index.md" >}}) - adapters,
+   Providers, models and integrations, and UI extensions - run inside your
+   deployment's trust boundary, without a sandbox between them and Meshery. Enable
+   only what you need, from publishers you trust, at versions you pin. See
+   [Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}}).
 
 ## Before you begin
 

--- a/docs/content/en/installation/production/authentication-and-identity.md
+++ b/docs/content/en/installation/production/authentication-and-identity.md
@@ -125,6 +125,14 @@ authorization is expressed through the provider model. Production notes:
 - `SKIP_DOWNLOAD_EXTENSIONS` controls whether provider extension packages are
   downloaded/refreshed; existing local packages can still be used.
 
+{{% alert title="Choosing a provider is also an extension-trust decision" color="warning" %}}
+The capabilities document does more than enable features: it names the **extension
+package** Meshery downloads and loads, whose UI components run in Meshery UI's own browser
+context and whose server-side plugin, if present, runs in-process inside Meshery Server.
+Selecting a Remote Provider therefore decides whose code runs inside your deployment. See
+[Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}}).
+{{% /alert %}}
+
 ## Keys and permissions
 
 Meshery seeds a set of keys/permissions used by its role-based access controls.

--- a/docs/content/en/installation/production/operational-readiness-checklist.md
+++ b/docs/content/en/installation/production/operational-readiness-checklist.md
@@ -189,6 +189,24 @@ Work through these before going live. Each group links to its source page.
 - [ ] Secrets (kubeconfig, provider, pull) sourced from Secrets/external manager.
 - [ ] Images pinned to immutable tags from a trusted/mirrored registry.
 
+### Extensions
+
+- [ ] Every enabled extension attributed to a publisher you trust, and reviewed
+      before it reached production.
+      [Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}})
+- [ ] Unused extension points left disabled; adapters enabled only where needed
+      (`ADAPTER_URLS`, chart adapter subcharts off by default).
+- [ ] Adapters given scoped ServiceAccounts (`serviceAccountNameOverride`) rather
+      than sharing `meshery-server`, and reachable only from Meshery Server.
+- [ ] Extension packages pinned (`SKIP_DOWNLOAD_EXTENSIONS`), and the capability
+      set pinned (`PROVIDER_CAPABILITIES_FILEPATH`) where it should not drift.
+      [Providers reference]({{< ref "reference/extensibility/providers/index.md#runtime-configuration-options" >}})
+- [ ] Extension versions validated against the Meshery version you run.
+      [Extension compatibility]({{< ref "reference/extensibility/verify-compatibility.md" >}})
+- [ ] Egress policy covers every destination an enabled extension requires.
+- [ ] Rollback path known: removing a server-side extension requires a Meshery
+      Server restart, not just a configuration change.
+
 ### Multi-cluster & multi-cloud
 
 - [ ] One least-privilege kubeconfig context per cluster.

--- a/docs/content/en/installation/production/security-hardening.md
+++ b/docs/content/en/installation/production/security-hardening.md
@@ -3,8 +3,8 @@ title: Security Hardening
 linkTitle: Security Hardening
 description: >-
   RBAC and least privilege, pod and container security contexts, secret and
-  kubeconfig handling, TLS, supply-chain integrity, Broker exposure risk, and
-  namespace isolation for hardening Meshery in production.
+  kubeconfig handling, TLS, supply-chain integrity, Broker exposure risk,
+  namespace isolation, and extension trust for hardening Meshery in production.
 categories: [installation]
 weight: 50
 aliases:
@@ -183,6 +183,159 @@ the cluster so the Server can reach it. Treat that exposure deliberately:
   [Meshery Helm chart]({{< ref "installation/kubernetes/helm.md" >}}) and review values you
   override.
 
+## Trusting an extension
+
+Meshery is extensible by design. [Adapters]({{< ref "extensions/adapters/_index.md" >}}),
+[Providers]({{< ref "reference/extensibility/providers/index.md" >}}),
+[models and integrations]({{< ref "extensions/models/_index.md" >}}), and
+[UI extension points]({{< ref "reference/extensibility/ui.md" >}}) are how a deployment
+grows past the core platform. See the
+[Extensibility reference]({{< ref "reference/extensibility/_index.md" >}}) for the full set
+of extension points and [meshery.io/extensions](https://meshery.io/extensions) for what is
+available.
+
+Extensibility is a capability, not a sandbox.
+
+{{% alert title="Enabled extensions are trusted code" color="warning" %}}
+**Every extension you enable runs inside your deployment's trust boundary.** Meshery
+provides no sandbox, no privilege separation, and no capability restriction between an
+extension and itself. Enabling an extension is a trust decision of the same magnitude as
+granting Meshery its cluster credentials, and it deserves the same scrutiny.
+{{% /alert %}}
+
+### What each extension point can reach
+
+| Extension point | Where it runs | What it can reach |
+| :--- | :--- | :--- |
+| **Provider extension package, server plugin** | In-process inside Meshery Server, as a native Go plugin | The Meshery datastore, the Broker connection, the MeshSync channel, the Kubernetes connection tracker, and the ability to serve its own HTTP routes under `/api/provider/extension/server/` |
+| **Provider extension package, UI components** | In the browser, inside Meshery UI's own origin and JavaScript context | The DOM, the session cookie, and any API the signed-in user is able to call |
+| **[Adapters]({{< ref "extensions/adapters/_index.md" >}})** | A separate process, reached from Meshery Server over gRPC | The managed cluster, using the adapter's own credentials. By default adapters share the `meshery-server` ServiceAccount, so an adapter inherits the Server's Kubernetes reach |
+| **[Remote Provider]({{< ref "reference/extensibility/providers/index.md" >}})** | An external service you select | Identity, authorization, and durable persistence for the entire deployment. It also names the extension package that Meshery downloads and loads |
+| **[Models and integrations]({{< ref "extensions/models/_index.md" >}})** | Registry data inside Meshery Server | The component and relationship definitions Meshery designs and deploys from |
+| **[Build-time content]({{< ref "reference/extensibility/build-time.md" >}})** | Baked into your container image | Whatever the image can reach, and it is present before Meshery starts |
+
+The first two rows are the ones most often underestimated. A provider extension package is
+not configuration; it is code, and it runs with the privileges of the process that loads
+it.
+
+### How a provider extension package is delivered
+
+Understanding the delivery path is what makes the trust decision concrete:
+
+1. **The provider's capabilities document names the package.** After you sign in, the
+   Remote Provider returns a capabilities document that carries the package URL and
+   version, along with the extension points to wire up.
+2. **Meshery downloads and extracts it.** The package is a `.tar.gz`/`.tgz` archive,
+   extracted under `~/.meshery/provider/<provider-name>/<package-version>`. Downloads occur
+   at login and on capability refresh.
+3. **UI components are served to Meshery UI** from that package and load into the same
+   browser origin and JavaScript context as Meshery UI itself.
+4. **A server plugin, if the package contains one, is loaded into Meshery Server** and its
+   entry point is handed the database handler, the Broker connection, the MeshSync channel,
+   and the Kubernetes connection tracker.
+
+Two consequences follow directly, and both are operationally relevant:
+
+- **Selecting a Remote Provider is the trust decision.** The package origin comes from the
+  provider you chose, so vetting the provider is what vets the code. Prefer first-party and
+  maintained providers, and treat adding an unfamiliar provider as you would adding an
+  unfamiliar binary to a production host. This is a further reason to preselect a provider
+  with `PROVIDER` rather than leaving the choice to whoever signs in first. See
+  [Authentication, Authorization & Identity]({{< ref "installation/production/authentication-and-identity.md" >}})
+  and
+  [Recommended Production Deployment Settings]({{< ref "reference/extensibility/providers/index.md#recommended-production-deployment-settings" >}}).
+- **A loaded server plugin stays loaded for the life of the process.** Go plugins cannot be
+  unloaded, so removing or rolling back a server-side extension means restarting Meshery
+  Server, not just changing a setting.
+
+### Before you enable an extension
+
+Answer these before an extension reaches production, and record the answers where your
+change management can find them later:
+
+- [ ] **Who publishes it, and are they someone you would grant cluster credentials?** That
+      is the equivalent level of trust.
+- [ ] **Is it maintained?** Check recent releases, open security issues, and whether the
+      publisher has a disclosure process.
+- [ ] **Does it need a server-side plugin, or only UI components?** UI-only extensions carry
+      a smaller blast radius than in-process server plugins.
+- [ ] **What version are you pinning to,** and can you reproduce that exact package later?
+- [ ] **What new egress does it introduce,** and is that egress allowed by your network
+      policy? See
+      [Networking & Connectivity]({{< ref "installation/production/networking-and-connectivity.md" >}}).
+- [ ] **Has it been reviewed against the Meshery version you run?** Extension and platform
+      versions move independently; see
+      [Ensuring Extension Compatibility]({{< ref "reference/extensibility/verify-compatibility.md" >}}).
+- [ ] **Do you actually need it enabled?** The cheapest hardening is not enabling what you
+      will not use.
+
+### Constraining what an extension can do
+
+Meshery cannot restrict an extension's privileges once it is loaded, so the controls
+available to you are about **what gets loaded, from where, and what the surrounding
+environment permits**:
+
+- **Pin the extension package.** Set `SKIP_DOWNLOAD_EXTENSIONS=true` to stop Meshery
+  downloading and refreshing provider extension packages. Existing packages still load, so
+  this pins you to a package you have already vetted rather than accepting whatever the
+  provider publishes next. See
+  [SKIP_DOWNLOAD_EXTENSIONS]({{< ref "reference/extensibility/providers/index.md#skip_download_extensions" >}}).
+- **Pin the capabilities document.** `PROVIDER_CAPABILITIES_FILEPATH` loads capabilities
+  from a local file instead of the provider's endpoint, which fixes the extension set for a
+  deployment. Use it deliberately: it pins capabilities rather than tracking the provider's
+  current set. See
+  [PROVIDER_CAPABILITIES_FILEPATH]({{< ref "reference/extensibility/providers/index.md#provider_capabilities_filepath" >}}).
+- **Pre-package for air-gapped and regulated environments.** Ship a reviewed extension
+  package in your own container image with
+  [build-time extensibility]({{< ref "reference/extensibility/build-time.md" >}}), so what runs
+  is what your pipeline approved.
+- **Enable only the adapters you use.** Adapters are opt-in through `ADAPTER_URLS`, and the
+  Helm chart ships every adapter subchart disabled by default. Leave it that way for
+  adapters you do not need.
+- **Give adapters their own ServiceAccount.** By default an adapter shares the
+  `meshery-server` ServiceAccount and therefore the Server's Kubernetes reach. Use
+  `serviceAccountNameOverride` with a scoped role so enabling an adapter does not extend
+  cluster-admin-equivalent rights to it. See
+  [Least-privilege RBAC](#least-privilege-rbac) above.
+- **Isolate the adapter channel.** Meshery Server reaches adapters over gRPC without mutual
+  TLS today, so treat that channel as trusted-network-only: co-locate adapters in the
+  Meshery namespace and use NetworkPolicy to allow adapter ports only from Meshery Server.
+  See
+  [Networking & Connectivity]({{< ref "installation/production/networking-and-connectivity.md" >}}).
+- **Control egress.** An extension inherits the network reach of the process it runs in.
+  Apply egress policy so a server-side extension can only reach the destinations your
+  deployment requires.
+- **Keep the container hardening on.** The
+  [pod and container security context](#pod-and-container-security-context) above bounds
+  what an in-process extension can do to the host, even though it does not bound what the
+  extension can do inside Meshery.
+- **Review models and integrations you import.** Registry content shapes what Meshery
+  designs and deploys. Prefer the maintained
+  [integrations catalog]({{< ref "extensions/models/_index.md" >}}) over ad-hoc registration.
+
+### Removing an extension, and responding to a bad one
+
+- **To remove a UI extension** delivered by a Remote Provider, the provider stops offering
+  it in the capabilities document; it is no longer loaded on the next session.
+- **To remove a server-side extension**, restart Meshery Server after the package is gone
+  or the capability withdrawn. A loaded Go plugin does not unload in place.
+- **To pin away from a bad version**, set `SKIP_DOWNLOAD_EXTENSIONS=true` and restore the
+  package version you trust under `~/.meshery/provider/<provider-name>/<package-version>`,
+  or pin capabilities with `PROVIDER_CAPABILITIES_FILEPATH`.
+- **Report a suspected vulnerability in a Meshery extension** the same way you would report
+  one in the core platform, through the process in
+  [Security Vulnerabilities]({{< ref "project/security-vulnerabilities.md" >}}). Extensions
+  maintained in the `meshery-extensions` GitHub organization are handled by Meshery
+  maintainers; extensions distributed elsewhere are the responsibility of their publisher,
+  and Meshery has no mechanism to disable an extension in a deployment it does not operate.
+
+{{% alert title="The core project does not vet third-party extensions" color="warning" %}}
+Meshery's maintainers are responsible for the core platform and the extensions published
+under the `meshery-extensions` organization. The security of any other extension is the
+responsibility of its author and of the operator who enables it. Review a third-party
+extension before enabling it, and enable only what your deployment actually needs.
+{{% /alert %}}
+
 ## Hardening checklist
 
 - [ ] Remote Provider preselected; Local Provider disabled in production.
@@ -202,5 +355,12 @@ the cluster so the Server can reach it. Treat that exposure deliberately:
       Security.
 - [ ] Images pinned to immutable version tags from a trusted/mirrored registry
       and scanned.
+- [ ] Every enabled extension reviewed and attributed to a trusted publisher;
+      unused extensions left disabled.
+- [ ] Extension packages pinned (`SKIP_DOWNLOAD_EXTENSIONS`, and
+      `PROVIDER_CAPABILITIES_FILEPATH` where the extension set should be fixed).
+- [ ] Adapters enabled only where needed, given scoped ServiceAccounts
+      (`serviceAccountNameOverride`), and reachable only from Meshery Server.
+- [ ] Egress policy accounts for any destination an enabled extension requires.
 
 {{< related-discussions tag="meshery" >}}

--- a/docs/content/en/reference/extensibility/_index.md
+++ b/docs/content/en/reference/extensibility/_index.md
@@ -25,6 +25,45 @@ A browsable collection of various Meshery extensions is available at [https://me
 
 The following points of extension are currently incorporated into Meshery.
 
-<ul style="margin:0;"> 
-    <li style="list-style-type: inherit; margin: 0"><a href="{{< ref "extensions/adapters/_index.md" >}}">Extensibility: Meshery Adapters</a> - Meshery architecture is extensible. Meshery provides several extension points for working with different cloud native infrastructure via <a href="{{< ref "extensions/adapters/_index.md" >}}">adapters</a>, <a href="{{< ref "reference/extensibility/load-generators.md" >}}">load generators</a> and <a href="{{< ref "reference/extensibility/providers/index.md" >}}">providers.</a></li>
-</ul>
+| Extension point | What it extends | When it is applied |
+| :--- | :--- | :--- |
+| **[Adapters]({{< ref "extensions/adapters/_index.md" >}})** | Per-technology lifecycle, configuration, and performance operations, reached from Meshery Server over gRPC. | Runtime, opt-in |
+| **[Providers]({{< ref "reference/extensibility/providers/index.md" >}})** | Identity, authorization, durable persistence, and the extension package Meshery loads. | Runtime |
+| **[Models and Integrations]({{< ref "extensions/models/_index.md" >}})** | The registry of components and relationships Meshery designs and operates. | Runtime |
+| **[UI extension points]({{< ref "reference/extensibility/ui.md" >}})** | Meshery UI: navigator, account, user preferences, collaborator, and RJSF forms. | Runtime |
+| **[Authorization keys]({{< ref "reference/extensibility/authorization/index.md" >}})** | The keys, keychains, and roles that gate features in Meshery UI. | Runtime |
+| **[Load generators]({{< ref "reference/extensibility/load-generators.md" >}})** | The engines behind Meshery's performance management. | Runtime |
+| **[REST and GraphQL APIs]({{< ref "reference/extensibility/api.md" >}})** | Programmatic access for external systems and automation. | Runtime |
+| **[Schema annotations]({{< ref "reference/extensibility/schemas.md" >}})** | Model and component behavior expressed through `x-annotations`. | Design time |
+| **[Build-time extensibility]({{< ref "reference/extensibility/build-time.md" >}})** | Configuration, data, and packages baked into a custom Meshery container image. | Image build |
+
+When you extend Meshery, also see
+[Ensuring Extension Compatibility]({{< ref "reference/extensibility/verify-compatibility.md" >}})
+for keeping an extension aligned with the platform version it runs against.
+
+## Security and trust model
+
+Extension points are a capability, not a sandbox. **An extension you enable runs inside the
+trust boundary of the deployment that enables it**, and Meshery provides no privilege
+separation between an extension and itself:
+
+- UI extension components load into Meshery UI's own browser origin and JavaScript context,
+  with access to the DOM, the session cookie, and any API the signed-in user can call.
+- A Provider extension package may carry a server-side plugin that is loaded in-process by
+  Meshery Server and handed the datastore, the Broker connection, the MeshSync channel, and
+  the Kubernetes connection tracker.
+- Adapters hold their own cluster credentials and, by default, share the `meshery-server`
+  ServiceAccount.
+
+For operators, this means selecting a Remote Provider and enabling an adapter are security
+decisions, not just functional ones. The production guidance - what to evaluate before
+enabling an extension, how to pin an extension package, how to scope an adapter, and how to
+remove one - lives in
+[Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}})
+within the
+[Production Deployment]({{< ref "installation/production/_index.md" >}}) set.
+
+For extension authors, the security of an extension published outside the
+`meshery-extensions` GitHub organization is the responsibility of its author and of the
+operator who enables it. Report a suspected vulnerability through the process in
+[Security Vulnerabilities]({{< ref "project/security-vulnerabilities.md" >}}).

--- a/docs/content/en/reference/extensibility/build-time.md
+++ b/docs/content/en/reference/extensibility/build-time.md
@@ -113,6 +113,15 @@ When using build-time extensions:
 - **Review Content**: Always review the contents of the `.meshery` directory before building to ensure no sensitive information or malicious content is included.
 - **Secrets Management**: Do not include secrets, passwords, or API keys in the build-time `.meshery` directory. Use environment variables or runtime configuration for sensitive data.
 - **Trust Sources**: Only include content from trusted sources to avoid introducing security vulnerabilities.
+- **Same trust boundary as runtime extensions**: content baked in at build time runs with the same privileges as content loaded at runtime, and is present before Meshery starts. Apply the same review bar described in [Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}}).
+
+{{% alert color="info" title="A build-time package is a supply-chain control" %}}
+Pre-packaging a reviewed provider extension in your own image is the strongest way to fix
+what runs in an air-gapped or regulated deployment: what ships is what your pipeline
+approved, with no runtime download to intercept or drift. Pair it with
+`SKIP_DOWNLOAD_EXTENSIONS=true` so Meshery does not fetch a newer package at login. See
+[Supply-chain integrity]({{< ref "installation/production/security-hardening.md#supply-chain-integrity" >}}).
+{{% /alert %}}
 
 ### Comparison with Runtime Extension Points
 

--- a/docs/content/en/reference/extensibility/providers/index.md
+++ b/docs/content/en/reference/extensibility/providers/index.md
@@ -76,7 +76,16 @@ For production deployments, consider the following security best practices regar
 - **Enforce a specific provider** using the `PROVIDER` environment variable only when you have a clear operational requirement to do so, such as locking a deployment to a particular identity provider.
 - **Use `mesheryctl system provider set`** to explicitly configure a provider for a given context when needed.
 - **Use `mesheryctl system provider reset`** to clear an enforced provider and return to the provider selection UI.
+- **Vet the provider before you allow it.** A Remote Provider's capabilities document names the extension package Meshery downloads and loads, so selecting a provider decides whose code runs in Meshery UI's browser context and, where the package carries a server-side plugin, in-process inside Meshery Server. Prefer first-party and maintained providers, and pin what you have reviewed with [`SKIP_DOWNLOAD_EXTENSIONS`](#skip_download_extensions) and [`PROVIDER_CAPABILITIES_FILEPATH`](#provider_capabilities_filepath). See [Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}}) for the full production guidance.
 
+{{% alert color="warning" title="Provider selection is a code-trust decision" %}}
+Beyond identity and persistence, the provider you select supplies loadable extension code.
+Treat adding an unfamiliar Remote Provider the way you would treat adding an unfamiliar
+binary to a production host. See
+[Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}})
+and
+[Authentication, Authorization & Identity]({{< ref "installation/production/authentication-and-identity.md" >}}).
+{{% /alert %}}
 
 #### AI Provider Usage in Production
 
@@ -229,6 +238,13 @@ Example: `SKIP_DOWNLOAD_EXTENSIONS=true`
 - Release channel updates
 
 When `SKIP_DOWNLOAD_EXTENSIONS` is enabled, existing extension packages will still be loaded if present, but no new versions will be retrieved.
+
+**Security use:** because existing packages continue to load, this variable doubles as a
+pin. Setting it to `true` holds a production deployment on an extension package you have
+already reviewed instead of accepting whatever the provider publishes next. Pair it with
+[`PROVIDER_CAPABILITIES_FILEPATH`](#provider_capabilities_filepath) when the capability set
+itself should not drift, and see
+[Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}}).
 
 ## Design Principles: Meshery Remote Provider Framework
 

--- a/docs/content/en/reference/extensibility/ui.md
+++ b/docs/content/en/reference/extensibility/ui.md
@@ -8,6 +8,17 @@ aliases:
 
 Meshery UI has a number of extension points that allow you to greatly customize both its functional behavior and visual appearance. These extension points come in different types, and this document describes each type, its example use, best practices to consider, and caveats of which to be aware.
 
+{{% alert color="warning" title="UI extensions share Meshery UI's origin and session" %}}
+Extension components are loaded into Meshery UI's own browser origin and JavaScript
+context. They share the DOM, the session cookie, and the ability to call any API the
+signed-in user can call. There is no iframe or sandbox boundary between an extension
+component and the rest of the UI, so an enabled UI extension is trusted code. Operators
+should read
+[Trusting an extension]({{< ref "installation/production/security-hardening.md#trusting-an-extension" >}});
+authors should read
+[Ensuring Extension Compatibility]({{< ref "reference/extensibility/verify-compatibility.md" >}}).
+{{% /alert %}}
+
 ### Extensibility: Customizing Text-based Forms using RJSF Custom Component
 
 RJSFWrapperComponent provides customizations for RJSF forms, overriding the default behavior of meshery-ui rjsf forms. The [Rjsf forms are wrapped](https://github.com/meshery/meshery/blob/0bc68d1cd0ba80a565afa68bce80899c22db9a2e/ui/components/MesheryMeshInterface/PatternService/RJSF.js#L66) in this component to receive custom props from a Meshery extension.


### PR DESCRIPTION
[Docs] Add extension trust and hardening to production deployment guidance

Extensibility is a capability, not a sandbox: an enabled extension runs inside
the deployment's trust boundary with no privilege separation from Meshery
itself. That was not stated anywhere an operator would look.

Adds a "Trusting an extension" section to the production security-hardening
guide covering what each extension point can reach, how a provider extension
package is delivered and loaded, what to evaluate before enabling one, how to
constrain and pin it, and how to remove one. Two facts are now stated plainly:
a provider extension package may carry a native in-process server plugin that
receives the datastore, the broker connection, the MeshSync channel and the
Kubernetes connection tracker and can serve its own HTTP routes; and UI
extension components load into Meshery UI's own browser origin and session.
Because the package origin comes from the provider's capabilities document,
selecting a Remote Provider is itself a code-trust decision.

Threads the same model through the extensibility reference. The extension-point
index gains a linked table of all nine extension points and a security and
trust model section; provider docs frame provider selection as a code-trust
decision and document SKIP_DOWNLOAD_EXTENSIONS as a pin rather than only a
bandwidth saver; UI docs state the shared-origin boundary; build-time docs
frame pre-packaging as a supply-chain control. The production index,
operational readiness checklist and identity page cross-link into it.

Raised during CNCF TOC security self-assessment review (cncf/toc#2264).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for evaluating and trusting extensions in production.
  * Documented extension privileges, trust boundaries, compatibility, package pinning, and supply-chain safeguards.
  * Expanded production-readiness and security checklists with extension review, isolation, egress, and removal considerations.
  * Clarified the security implications of remote providers and UI extensions, including access to browser context and signed-in APIs.
  * Replaced the outdated extension listing with a structured overview of extension points and application timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->