### PR TITLE
feat(mesheryctl): support selecting a single model from CSV directory…

### DIFF
--- a/docs/content/en/reference/references/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/model/generate.md
@@ -46,21 +46,12 @@ mesheryctl model generate --file [URL] --template [path-to-template.json] --skip
 </div>
 </pre> 
 
-Generate a specific model from a CSV directory
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl model generate -f [path-to-csv-directory] -m [model-name]
-
-</div>
-</pre> 
-
 ## Options
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
   -f, --file string         Specify path to the file or directory
   -h, --help                help for generate
-  -m, --model string        Generate only the specified model from CSV input
       --skip-registration   Skip registration of the model (default is false)
   -t, --template string     Specify path to the template JSON file
 

--- a/docs/content/en/reference/references/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/model/generate.md
@@ -46,12 +46,21 @@ mesheryctl model generate --file [URL] --template [path-to-template.json] --skip
 </div>
 </pre> 
 
+Generate a specific model from a CSV directory
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+mesheryctl model generate -f [path-to-csv-directory] -m [model-name]
+
+</div>
+</pre> 
+
 ## Options
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
   -f, --file string         Specify path to the file or directory
   -h, --help                help for generate
+  -m, --model string        Generate only the specified model from CSV input
       --skip-registration   Skip registration of the model (default is false)
   -t, --template string     Specify path to the template JSON file
 
@@ -62,7 +71,7 @@ mesheryctl model generate --file [URL] --template [path-to-template.json] --skip
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
+      --config string   path to config file (default "/home/omkar/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/content/en/reference/references/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/model/generate.md
@@ -71,7 +71,7 @@ mesheryctl model generate -f [path-to-csv-directory] -m [model-name]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-      --config string   path to config file (default "/home/omkar/.meshery/config.yaml")
+      --config string   path to config file (default "/home/runner/.meshery/config.yaml")
   -v, --verbose         verbose output
 
 </div>

--- a/docs/data/mesheryctlcommands/cmds.yml
+++ b/docs/data/mesheryctlcommands/cmds.yml
@@ -909,6 +909,9 @@ model:
         template:
           name: --template, -t
           description: Specify the path to the template JSON file (only required for URLs).
+        model:
+          name: --model, -m
+          description: Generate only the specified model when the input is a CSV directory.
         skip-registration:
           name: --skip-registration
           description: Skip registration of the model (default is false).    

--- a/docs/data/mesheryctlcommands/cmds.yml
+++ b/docs/data/mesheryctlcommands/cmds.yml
@@ -911,7 +911,7 @@ model:
           description: Specify the path to the template JSON file (only required for URLs).
         model:
           name: --model, -m
-          description: Generate only the specified model when the input is a CSV directory.
+          description: Specify a unique model selection from a CSV directory.
         skip-registration:
           name: --skip-registration
           description: Skip registration of the model (default is false).    

--- a/mesheryctl/helpers/component_info.json
+++ b/mesheryctl/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "mesheryctl",
   "type": "client",
-  "next_error_code": 1254
+  "next_error_code": 1255
 }

--- a/mesheryctl/internal/cli/root/model/error.go
+++ b/mesheryctl/internal/cli/root/model/error.go
@@ -16,6 +16,7 @@ const (
 	ErrModelUnsupportedVersionCode      = "mesheryctl-1149"
 	ErrModelBuildCode                   = "mesheryctl-1151"
 	ErrDeleteModelCode                  = "mesheryctl-1200"
+	ErrModelNotFoundInCSVCode           = "mesheryctl-1254"
 
 	// Error Constants
 	errBuildUsage                    = "Usage:\nmesheryctl model build [model-name]\nor\nmesheryctl model build [model-name]/[model-version]\n\nRun 'mesheryctl model build --help' to see detailed help message"
@@ -80,4 +81,12 @@ func ErrDeleteModel(err error, nameOrID string) error {
 		[]string{fmt.Sprintf("Failed to delete model with name or ID '%s': %s", nameOrID, err.Error())},
 		[]string{"The specified model name or ID may not exist"},
 		[]string{"Verify the model name or ID using 'mesheryctl model list' and try again"})
+}
+
+func ErrModelNotFoundInCSV(modelName string) error {
+	return errors.New(ErrModelNotFoundInCSVCode, errors.Alert,
+		[]string{"Selected model not found"},
+		[]string{fmt.Sprintf("The model %q provided via --model was not found in the CSV input", modelName)},
+		[]string{"The model name does not match any entry in the CSV's \"model\" column, or contains a typo"},
+		[]string{"Check the model name against the \"model\" column in your Models CSV, or omit --model to generate all eligible models"})
 }

--- a/mesheryctl/internal/cli/root/model/error.go
+++ b/mesheryctl/internal/cli/root/model/error.go
@@ -16,7 +16,7 @@ const (
 	ErrModelUnsupportedVersionCode      = "mesheryctl-1149"
 	ErrModelBuildCode                   = "mesheryctl-1151"
 	ErrDeleteModelCode                  = "mesheryctl-1200"
-	ErrModelNotFoundInCSVCode           = "mesheryctl-1254"
+	ErrModelNotFoundCode                = "mesheryctl-1254"
 
 	// Error Constants
 	errBuildUsage                    = "Usage:\nmesheryctl model build [model-name]\nor\nmesheryctl model build [model-name]/[model-version]\n\nRun 'mesheryctl model build --help' to see detailed help message"
@@ -83,8 +83,8 @@ func ErrDeleteModel(err error, nameOrID string) error {
 		[]string{"Verify the model name or ID using 'mesheryctl model list' and try again"})
 }
 
-func ErrModelNotFoundInCSV(modelName string) error {
-	return errors.New(ErrModelNotFoundInCSVCode, errors.Alert,
+func ErrModelNotFound(modelName string) error {
+	return errors.New(ErrModelNotFoundCode, errors.Alert,
 		[]string{"Selected model not found"},
 		[]string{fmt.Sprintf("The model %q provided via --model was not found in the CSV input", modelName)},
 		[]string{"The model name does not match any entry in the CSV's \"model\" column, or contains a typo"},

--- a/mesheryctl/internal/cli/root/model/generate.go
+++ b/mesheryctl/internal/cli/root/model/generate.go
@@ -175,7 +175,7 @@ func (c *CsvModelGenerator) Generate() error {
 	err = registerModel(modelData, componentData, relationshipData, "model.csv", "csv", "", c.ModelName, !c.SkipRegister)
 	if err != nil {
 		if c.ModelName != "" && strings.Contains(err.Error(), "not found in CSV input") {
-			return ErrModelNotFoundInCSV(c.ModelName)
+			return ErrModelNotFound(c.ModelName)
 		}
 		return err
 	}

--- a/mesheryctl/internal/cli/root/model/generate.go
+++ b/mesheryctl/internal/cli/root/model/generate.go
@@ -84,7 +84,9 @@ mesheryctl model generate -f [path-to-csv-directory] -m [model-name]
 			if modelGenerateFlags.Template == "" {
 				return ErrTemplateFileNotPresent()
 			}
-
+			if strings.TrimSpace(modelGenerateFlags.Model) != "" {
+				return utils.ErrInvalidArgument(fmt.Errorf("--model is supported only for CSV directory input"))
+			}
 			urlModelGenerator := &UrlModelGenerator{
 				TemplateFile: modelGenerateFlags.Template,
 				Url:          path,
@@ -172,6 +174,9 @@ func (c *CsvModelGenerator) Generate() error {
 
 	err = registerModel(modelData, componentData, relationshipData, "model.csv", "csv", "", c.ModelName, !c.SkipRegister)
 	if err != nil {
+		if c.ModelName != "" && strings.Contains(err.Error(), "not found in CSV input") {
+			return ErrModelNotFoundInCSV(c.ModelName)
+		}
 		return err
 	}
 

--- a/mesheryctl/internal/cli/root/model/generate.go
+++ b/mesheryctl/internal/cli/root/model/generate.go
@@ -15,6 +15,7 @@ import (
 type cmdModelGenerateFlags struct {
 	File             string `json:"file" validate:"omitempty,dirpath|filepath|url"`
 	Template         string `json:"template" validate:"omitempty,filepath"`
+	Model            string `json:"model" validate:"omitempty"`
 	SkipRegistration bool   `json:"skip-registration" validate:"boolean"`
 }
 
@@ -32,6 +33,7 @@ type CsvModelGenerator struct {
 	ModelFile        string
 	ComponentFile    string
 	RelationshipFile string
+	ModelName        string
 	SkipRegister     bool
 }
 
@@ -51,6 +53,9 @@ mesheryctl model generate -f [URL] -t [path-to-template.json]
 
 // Generate a model from a URL based on a JSON template skipping registration
 mesheryctl model generate --file [URL] --template [path-to-template.json] --skip-registration
+
+// Generate a specific model from a CSV directory
+mesheryctl model generate -f [path-to-csv-directory] -m [model-name]
 	`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return mesheryctlflags.ValidateCmdFlags(cmd, &modelGenerateFlags)
@@ -104,6 +109,7 @@ mesheryctl model generate --file [URL] --template [path-to-template.json] --skip
 			ModelFile:        modelcsvpath,
 			ComponentFile:    componentcsvpath,
 			RelationshipFile: relationshipcsvpath,
+			ModelName:        strings.TrimSpace(modelGenerateFlags.Model),
 			SkipRegister:     modelGenerateFlags.SkipRegistration,
 		}
 
@@ -118,6 +124,7 @@ func init() {
 
 	generateModelCmd.Flags().StringVarP(&modelGenerateFlags.File, "file", "f", "", "Specify path to the file or directory")
 	generateModelCmd.Flags().StringVarP(&modelGenerateFlags.Template, "template", "t", "", "Specify path to the template JSON file")
+	generateModelCmd.Flags().StringVarP(&modelGenerateFlags.Model, "model", "m", "", "Generate only the specified model from CSV input")
 	generateModelCmd.Flags().BoolVar(&modelGenerateFlags.SkipRegistration, "skip-registration", false, "Skip registration of the model (default is false)")
 
 }
@@ -130,7 +137,7 @@ func (u *UrlModelGenerator) Generate() error {
 		return utils.ErrFileRead(err)
 	}
 
-	err = registerModel(fileData, nil, nil, "", "url", u.Url, !u.SkipRegister)
+	err = registerModel(fileData, nil, nil, "", "url", u.Url, "", !u.SkipRegister)
 	if err != nil {
 		return err
 	}
@@ -163,7 +170,7 @@ func (c *CsvModelGenerator) Generate() error {
 		}
 	}
 
-	err = registerModel(modelData, componentData, relationshipData, "model.csv", "csv", "", !c.SkipRegister)
+	err = registerModel(modelData, componentData, relationshipData, "model.csv", "csv", "", c.ModelName, !c.SkipRegister)
 	if err != nil {
 		return err
 	}

--- a/mesheryctl/internal/cli/root/model/generate_test.go
+++ b/mesheryctl/internal/cli/root/model/generate_test.go
@@ -1,7 +1,9 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
 	"runtime"
@@ -13,6 +15,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestModelGenerate(t *testing.T) {
@@ -41,6 +44,7 @@ func TestModelGenerate(t *testing.T) {
 		ExpectErr        bool
 		RaisedError      error
 		HttpCode         int
+		AssertRequest    func(t *testing.T, body []byte)
 	}
 
 	tests := []tc{
@@ -69,18 +73,29 @@ func TestModelGenerate(t *testing.T) {
 			HttpCode:         200,
 		},
 		{
-			Name: "model generate: specific model from CSV directory",
-			Args: []string{
-				"generate",
-				"--file",
-				filepath.Join(fixturesDir, "templates", "template-csvs"),
-				"--model",
-				"couchbase",
-			},
-			ExpectedResponse: "generate.dir.model.output.golden",
+			Name:             "model generate: from CSV directory with selected model",
+			Args:             []string{"generate", "--file", filepath.Join(fixturesDir, "templates", "template-csvs"), "--model", "couchbase"},
+			ExpectedResponse: "generate.dir.skip-register.output.golden",
 			URL:              apiURL,
 			Fixture:          "generate.api.ok.response.golden",
 			HttpCode:         200,
+			AssertRequest: func(t *testing.T, body []byte) {
+				t.Helper()
+				var payload struct {
+					UploadType string `json:"uploadType"`
+					ImportBody struct {
+						Model struct {
+							Model string `json:"model"`
+						} `json:"model"`
+					} `json:"importBody"`
+				}
+				err := json.Unmarshal(body, &payload)
+				if err != nil {
+					t.Fatalf("failed to unmarshal request body: %v", err)
+				}
+				assert.Equal(t, "csv", payload.UploadType)
+				assert.Equal(t, "couchbase", payload.ImportBody.Model.Model)
+			},
 		},
 	}
 
@@ -105,6 +120,13 @@ func TestModelGenerate(t *testing.T) {
 				apiResponse := utils.NewGoldenFile(t, tt.Fixture, fixturesDir).LoadByte()
 
 				httpmock.RegisterResponder("POST", testContext.BaseURL+tt.URL, func(req *http.Request) (*http.Response, error) {
+					if tt.AssertRequest != nil {
+						reqBody, err := io.ReadAll(req.Body)
+						if err != nil {
+							t.Fatalf("failed to read request body: %v", err)
+						}
+						tt.AssertRequest(t, reqBody)
+					}
 
 					return httpmock.NewBytesResponse(tt.HttpCode, apiResponse), nil
 				})

--- a/mesheryctl/internal/cli/root/model/generate_test.go
+++ b/mesheryctl/internal/cli/root/model/generate_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestModelGenerate(t *testing.T) {
@@ -93,8 +92,12 @@ func TestModelGenerate(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to unmarshal request body: %v", err)
 				}
-				assert.Equal(t, "csv", payload.UploadType)
-				assert.Equal(t, "couchbase", payload.ImportBody.Model.Model)
+				if payload.UploadType != "csv" {
+					t.Errorf("expected uploadType %q, got %q", "csv", payload.UploadType)
+				}
+				if payload.ImportBody.Model.Model != "couchbase" {
+					t.Errorf("expected model %q, got %q", "couchbase", payload.ImportBody.Model.Model)
+				}
 			},
 		},
 	}

--- a/mesheryctl/internal/cli/root/model/generate_test.go
+++ b/mesheryctl/internal/cli/root/model/generate_test.go
@@ -68,6 +68,20 @@ func TestModelGenerate(t *testing.T) {
 			ExpectedResponse: "generate.dir.skipped.output.golden",
 			HttpCode:         200,
 		},
+		{
+			Name: "model generate: specific model from CSV directory",
+			Args: []string{
+				"generate",
+				"--file",
+				filepath.Join(fixturesDir, "templates", "template-csvs"),
+				"--model",
+				"couchbase",
+			},
+			ExpectedResponse: "generate.dir.model.output.golden",
+			URL:              apiURL,
+			Fixture:          "generate.api.ok.response.golden",
+			HttpCode:         200,
+		},
 	}
 
 	var resetFlags func(*cobra.Command, *testing.T)

--- a/mesheryctl/internal/cli/root/model/import.go
+++ b/mesheryctl/internal/cli/root/model/import.go
@@ -71,7 +71,7 @@ mesheryctl model import --file [path-to-csv-directory]
 		}
 
 		if utils.IsValidUrl(path) {
-			return registerModel(nil, nil, nil, "", "urlImport", path, true)
+			return registerModel(nil, nil, nil, "", "urlImport", path, "", true)
 		}
 
 		hasCSVs := hasCSVs(path)
@@ -93,7 +93,7 @@ mesheryctl model import --file [path-to-csv-directory]
 				if err != nil {
 					return utils.ErrFileRead(err)
 				}
-				err = registerModel(modelData, componentData, relationshipData, "model.csv", "csv", "", true)
+				err = registerModel(modelData, componentData, relationshipData, "model.csv", "csv", "", "", true)
 				if err != nil {
 					return err
 				}
@@ -131,7 +131,7 @@ mesheryctl model import --file [path-to-csv-directory]
 			fileName = filepath.Base(path)
 		}
 
-		err = registerModel(tarData, nil, nil, fileName, "file", "", true)
+		err = registerModel(tarData, nil, nil, fileName, "file", "", "", true)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func hasCSVs(path string) bool {
 	return false
 }
 
-func registerModel(data []byte, componentData []byte, relationshipData []byte, filename string, dataType string, sourceURI string, register bool) error {
+func registerModel(data []byte, componentData []byte, relationshipData []byte, filename string, dataType string, sourceURI string, selectedModel string, register bool) error {
 	urlPath := "api/registry/register"
 	var importRequest schemav1beta1.ImportRequest
 	importRequest.UploadType = dataType
@@ -162,6 +162,7 @@ func registerModel(data []byte, componentData []byte, relationshipData []byte, f
 		importRequest.ImportBody.ModelCsv = "data:text/csv;base64," + base64.StdEncoding.EncodeToString(data)
 		importRequest.ImportBody.ComponentCsv = "data:text/csv;base64," + base64.StdEncoding.EncodeToString(componentData)
 		importRequest.ImportBody.RelationshipCSV = "data:text/csv;base64," + base64.StdEncoding.EncodeToString(relationshipData)
+		importRequest.ImportBody.Model.Model = strings.TrimSpace(selectedModel)
 	case "file":
 		importRequest.ImportBody.ModelFile = data
 	default:

--- a/mesheryctl/internal/cli/root/model/testdata/generate.dir.skip-register.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/generate.dir.skip-register.output.golden
@@ -1,0 +1,7 @@
+Generating model from CSV files
+SUMMARY: Imported model couchbase (1 component and 1 relationship)
+
+MODEL: couchbase
+  RELATIONSHIP: Kind of edge, sub type firewall and type binding
+Model can be accessed from .meshery/models
+Logs for the csv generation can be accessed .meshery/logs/registry

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1086,9 +1086,9 @@ func (h *Handler) RegisterMeshmodels(rw http.ResponseWriter, r *http.Request, _ 
 			h.log.Error(models.ErrSeedingComponents(err))
 		}
 		if selectedModel != "" && len(modelDirPaths) == 0 {
-			notFoundErr := fmt.Errorf("model %q not found in CSV input", selectedModel)
-			writeMeshkitError(rw, notFoundErr, http.StatusBadRequest)
-			h.sendErrorEvent(userID, provider, notFoundErr.Error(), notFoundErr, token)
+			err := ErrModelNotFound(selectedModel)
+			writeMeshkitError(rw, err, http.StatusBadRequest)
+			h.sendErrorEvent(userID, provider, err.Error(), err, token)
 			return
 		}
 		h.sendEventForImport(userID, provider, 0, "", true, token)

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1081,11 +1081,18 @@ func (h *Handler) RegisterMeshmodels(rw http.ResponseWriter, r *http.Request, _ 
 			return
 		}
 
-		h.sendEventForImport(userID, provider, 0, "", true, token)
 		modelDirPaths, err := models.GetModelDirectoryPaths(tempDir)
 		if err != nil {
 			h.log.Error(models.ErrSeedingComponents(err))
 		}
+		if selectedModel != "" && len(modelDirPaths) == 0 {
+			notFoundErr := fmt.Errorf("model %q not found in CSV input", selectedModel)
+			writeMeshkitError(rw, notFoundErr, http.StatusBadRequest)
+			h.sendErrorEvent(userID, provider, notFoundErr.Error(), notFoundErr, token)
+			return
+		}
+		h.sendEventForImport(userID, provider, 0, "", true, token)
+
 		if importRequest.Register {
 			for _, dirPath := range modelDirPaths {
 				dir := registration.NewDir(dirPath)

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -32,9 +32,9 @@ import (
 	_models "github.com/meshery/meshkit/models/meshmodel/core/v1beta1"
 	"github.com/meshery/schemas/models/v1alpha3/relationship"
 	schemav1beta1 "github.com/meshery/schemas/models/v1beta1"
-	"github.com/meshery/schemas/models/v1beta3/component"
 	"github.com/meshery/schemas/models/v1beta1/connection"
 	_model "github.com/meshery/schemas/models/v1beta1/model"
+	"github.com/meshery/schemas/models/v1beta3/component"
 
 	"github.com/meshery/meshkit/models/meshmodel/entity"
 	"github.com/meshery/meshkit/models/meshmodel/registry"
@@ -84,10 +84,10 @@ func (h *Handler) GetMeshmodelModelsByCategories(rw http.ResponseWriter, r *http
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -140,10 +140,10 @@ func (h *Handler) GetMeshmodelModelsByCategoriesByModel(rw http.ResponseWriter, 
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -200,10 +200,10 @@ func (h *Handler) GetMeshmodelModels(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -257,10 +257,10 @@ func (h *Handler) GetMeshmodelModelsByName(rw http.ResponseWriter, r *http.Reque
 	}
 
 	res := models.MeshmodelsDuplicateAPIResponse{
-		Page:     page,
-		PageSize: int(pgSize),
-		TotalCount:    count,
-		Models:   models.FindDuplicateModels(modelDefs),
+		Page:       page,
+		PageSize:   int(pgSize),
+		TotalCount: count,
+		Models:     models.FindDuplicateModels(modelDefs),
 	}
 
 	if err := enc.Encode(res); err != nil {
@@ -300,7 +300,7 @@ func (h *Handler) GetMeshmodelCategories(rw http.ResponseWriter, r *http.Request
 	res := models.MeshmodelCategoriesAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Categories: categories,
 	}
 
@@ -342,7 +342,7 @@ func (h *Handler) GetMeshmodelCategoriesByName(rw http.ResponseWriter, r *http.R
 	res := models.MeshmodelCategoriesAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Categories: categories,
 	}
 
@@ -396,7 +396,7 @@ func (h *Handler) GetMeshmodelComponentsByNameByModelByCategory(rw http.Response
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -448,7 +448,7 @@ func (h *Handler) GetMeshmodelComponentsByNameByCategory(rw http.ResponseWriter,
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -501,7 +501,7 @@ func (h *Handler) GetMeshmodelComponentsByNameByModel(rw http.ResponseWriter, r 
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -552,7 +552,7 @@ func (h *Handler) GetAllMeshmodelComponentsByName(rw http.ResponseWriter, r *htt
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -603,7 +603,7 @@ func (h *Handler) GetMeshmodelComponentByModel(rw http.ResponseWriter, r *http.R
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -654,7 +654,7 @@ func (h *Handler) GetMeshmodelComponentByModelByCategory(rw http.ResponseWriter,
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -703,7 +703,7 @@ func (h *Handler) GetMeshmodelComponentByCategory(rw http.ResponseWriter, r *htt
 	response := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -752,7 +752,7 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 	res := models.MeshmodelComponentsDuplicateAPIResponse{
 		Page:       page,
 		PageSize:   int(pgSize),
-		TotalCount:      count,
+		TotalCount: count,
 		Components: models.FindDuplicateComponents(comps),
 	}
 
@@ -837,7 +837,7 @@ func (h *Handler) GetMeshmodelRegistrants(rw http.ResponseWriter, r *http.Reques
 	res := models.MeshmodelRegistrantsAPIResponse{
 		Page:        page,
 		PageSize:    int(pgSize),
-		TotalCount:       count,
+		TotalCount:  count,
 		Registrants: hosts,
 	}
 
@@ -1073,8 +1073,8 @@ func (h *Handler) RegisterMeshmodels(rw http.ResponseWriter, r *http.Request, _ 
 				h.log.Error(err)
 			}
 		}()
-
-		err = meshkitRegistryUtils.InvokeGenerationFromSheet(&wg, tempDir, 0, 0, "", "", modelCsvFile.Name(), componentCsvFile.Name(), "", relationshipCsvFile.Name(), 0, nil)
+		selectedModel := strings.TrimSpace(importRequest.ImportBody.Model.Model)
+		err = meshkitRegistryUtils.InvokeGenerationFromSheet(&wg, tempDir, 0, 0, "", selectedModel, modelCsvFile.Name(), componentCsvFile.Name(), "", relationshipCsvFile.Name(), 0, nil)
 		if err != nil {
 			h.handleError(rw, err, "Error invoking generation from sheet")
 			h.sendErrorEvent(userID, provider, "Error invoking generation from sheet", err, token)

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -1087,7 +1087,7 @@ func (h *Handler) RegisterMeshmodels(rw http.ResponseWriter, r *http.Request, _ 
 		}
 		if selectedModel != "" && len(modelDirPaths) == 0 {
 			err := ErrModelNotFound(selectedModel)
-			writeMeshkitError(rw, err, http.StatusBadRequest)
+			writeMeshkitError(rw, err, http.StatusNotFound)
 			h.sendErrorEvent(userID, provider, err.Error(), err, token)
 			return
 		}

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -216,6 +216,7 @@ const (
 	ErrTelemetryPrometheusAuthCode         = "meshery-server-1435"
 	ErrMeshsyncReconcileCode               = "meshery-server-1442"
 	ErrUnsafeFilePathCode                  = "meshery-server-1443"
+	ErrModelNotFoundCode                   = "meshery-server-1484"
 	// Environment, workspace, organization, user and key operations previously
 	// reported every failure as ErrGetResult ("unable to get result", probable
 	// cause "Result Identifier provided is not valid") - a performance-results
@@ -1231,4 +1232,15 @@ func ErrResetInProgress() error {
 		[]string{"Seeding from a previous reset has not finished; starting another would drop tables mid-seed"},
 		[]string{"A reset was requested while an earlier one was still seeding keys, catalog designs, or components"},
 		[]string{"Wait for the in-flight reset to finish, then retry"})
+}
+
+func ErrModelNotFound(modelName string) error {
+	return errors.New(
+		ErrModelNotFoundCode,
+		errors.Alert,
+		[]string{"Model not found"},
+		[]string{fmt.Sprintf("Model %q was not found in the provided CSV input", modelName)},
+		[]string{"The requested model is not present in the CSV input"},
+		[]string{"Verify that the requested model exists in the CSV input"},
+	)
 }

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1484
+  "next_error_code": 1485
 }


### PR DESCRIPTION

## What this does

Adds `--model` / `-m` flag to `mesheryctl model generate` to select a single model when generating from a CSV directory.

## Changes

- mesheryctl: added `--model`/`-m` flag, applied only for CSV-directory input
- server: fixed `RegisterMeshmodels` (CSV case) to actually pass the selected model to `InvokeGenerationFromSheet` (was hardcoded to `""`, so filtering never worked even though meshkit already supported it)
- docs: documented the new flag
- tests: added test case + golden file for model-specific generation

## Testing

Manually tested against a local server with real CSVs:
- `--model gcp` → only gcp generated (216 components)
- `--model aws` → only aws generated (309 components)
- `--model meshery-core` → only meshery-core generated (16 components)

<img width="1486" height="715" alt="Screenshot 2026-08-17 055610" src="https://github.com/user-attachments/assets/173ea52f-66ad-4f0e-9f85-7e8802b8bc1f" />
<img width="1479" height="707" alt="Screenshot 2026-08-17 055710" src="https://github.com/user-attachments/assets/869a9e58-f455-41b5-a9af-8e385d04d2e0" />
<img width="1466" height="702" alt="Screenshot 2026-08-17 055833" src="https://github.com/user-attachments/assets/31d09af6-885c-4613-8113-3df002d39cb0" />


Fixes #21400

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--model`/`-m` to `mesheryctl model generate`.
  * Generate a specific model from a CSV directory instead of processing all available models.
  * Model selection is supported across CSV-based generation and import workflows.

* **Bug Fixes**
  * Improved model-name handling during component generation and CSV imports.
  * Added clear guidance when the selected model is missing from CSV input.
  * Standardized response formatting across model, category, component, and registrant operations.

* **Documentation**
  * Added usage instructions and examples for selecting a model during CSV generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->