### PR TITLE
connections: add minimal OpenAI Connection/Credential types

### DIFF
--- a/server/models/connections/openai.go
+++ b/server/models/connections/openai.go
@@ -1,0 +1,24 @@
+package connections
+
+// OpenAIConn mirrors the existing PromConn/GrafanaConn pattern.
+type OpenAIConn struct {
+	URL  string `json:"url,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// OpenAICred fixes the secret-exposure gap present in PromCred/GrafanaCred:
+// the raw key is never a marshalable field.
+type OpenAICred struct {
+	Name string `json:"name,omitempty"`
+	apiKeyOrBasicAuth string
+}
+
+func NewOpenAICred(name, secret string) OpenAICred {
+	return OpenAICred{Name: name, apiKeyOrBasicAuth: secret}
+}
+
+// Secret returns the raw key for internal callers only (e.g. building the
+// real provider client). It is never reachable via json.Marshal.
+func (c OpenAICred) Secret() string {
+	return c.apiKeyOrBasicAuth
+}

--- a/server/models/connections/openai_test.go
+++ b/server/models/connections/openai_test.go
@@ -1,0 +1,24 @@
+package connections
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestOpenAICred_SecretNeverMarshaled(t *testing.T) {
+	cred := NewOpenAICred("my-openai-conn", "sk-supersecretvalue123")
+
+	b, err := json.Marshal(cred)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	if strings.Contains(string(b), "supersecretvalue123") {
+		t.Fatalf("secret leaked into marshaled output: %s", b)
+	}
+
+	if cred.Secret() != "sk-supersecretvalue123" {
+		t.Fatalf("Secret() accessor did not return the original value")
+	}
+}


### PR DESCRIPTION
## What this is

A minimal starting point for #20994 (BYOM: Adapter for AI and LLMs) 
`OpenAIConn`/`OpenAICred` following the existing `PromConn`/`PromCred`
pattern in `server/models/connections/connections.go`.

## Why this shape

While reading the existing pattern, I noticed `PromCred` and
`GrafanaCred` expose their secret via an exported, json-tagged field
(`APIKeyOrBasicAuth string \`json:"secret,omitempty"\``)  meaning the
raw credential is reachable through `json.Marshal`. `OpenAICred` fixes
this for the new provider: the secret is unexported and only reachable
via a `Secret()` accessor for internal callers, verified by
`TestOpenAICred_SecretNeverMarshaled`.

This seemed directly relevant to the issue's requirement that "secrets
... never appear in logs or events"  happy to open a separate issue
for the existing Prometheus/Grafana gap if that's useful, rather than
scope-creep it into this PR.

## What's here

- `OpenAIConn` / `OpenAICred` structs
- `Secret()` accessor
- A test proving the secret is absent from marshaled JSON

## What's intentionally not here yet

- No provider client / HTTP calls
- No health-check wiring (would follow the `RegisterAction.Execute`
  pattern used in `server/machines/prometheus/register.go`)
- No UI, no generation path

Opening this as a draft to get early feedback on whether this is the
right shape before extending it  not requesting merge yet.