### PR TITLE
[Models] Add ECS Service and CapacityProvider to Cluster reference relationships

### DIFF
--- a/models/aws-ecs-controller/v1.5.0/v1.0.0/relationships/edge-non-binding-reference-cluster.json
+++ b/models/aws-ecs-controller/v1.5.0/v1.0.0/relationships/edge-non-binding-reference-cluster.json
@@ -1,0 +1,169 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.5.0"
+    },
+    "name": "aws-ecs-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "matchStrategyMatrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ecs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Service",
+            "match": {},
+            "matchStrategyMatrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ecs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Cluster",
+            "match": {},
+            "matchStrategyMatrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ecs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "CapacityProvider",
+            "match": {},
+            "matchStrategyMatrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ecs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "clusterRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-ecs-controller/v1.5.0/v1.0.0/relationships/edge-non-binding-reference-cluster.json
+++ b/models/aws-ecs-controller/v1.5.0/v1.0.0/relationships/edge-non-binding-reference-cluster.json
@@ -32,7 +32,7 @@
             "id": null,
             "kind": "Cluster",
             "match": {},
-            "matchStrategyMatrix": null,
+            "match_strategy_matrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
@@ -60,7 +60,7 @@
             "id": null,
             "kind": "Service",
             "match": {},
-            "matchStrategyMatrix": null,
+            "match_strategy_matrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
@@ -100,7 +100,7 @@
             "id": null,
             "kind": "Cluster",
             "match": {},
-            "matchStrategyMatrix": null,
+            "match_strategy_matrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",
@@ -128,7 +128,7 @@
             "id": null,
             "kind": "CapacityProvider",
             "match": {},
-            "matchStrategyMatrix": null,
+            "match_strategy_matrix": null,
             "model": {
               "displayName": "",
               "id": "00000000-0000-0000-0000-000000000000",

--- a/models/aws-ecs-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-cluster.json
+++ b/models/aws-ecs-controller/v1.5.1/v1.0.0/relationships/edge-non-binding-reference-cluster.json
@@ -15,7 +15,7 @@
     "displayName": "",
     "id": "00000000-0000-0000-0000-000000000000",
     "model": {
-      "version": "v1.5.0"
+      "version": "v1.5.1"
     },
     "name": "aws-ecs-controller",
     "registrant": {


### PR DESCRIPTION
## Notes for Reviewers
Add `edge-non-binding-reference-cluster.json` wiring `Service` and `CapacityProvider` to the `Cluster` provider through each consumer's `spec.clusterRef.from.name` reference field.

* This PR fixes #21293  

## Validation

- `git diff --check` — passed
- `mesheryctl model build aws-ecs-controller --path ./models` — passed
- Verified the relationship JSON against existing AWS relationship definitions (eks `Cluster → Addon` analog).
- Verified both required relationships:
  - `Service` → `Cluster`
  - `CapacityProvider` → `Cluster`
- End-to-end: reimported the model to a running server and evaluated a design with the relationships present and `clusterRef` unset — the engine auto-drew the relationship edge and patched `configuration.spec.clusterRef.from.name` on both `Service` and `CapacityProvider` to match the connected `Cluster` component's name.
- Note on orientation: per the AWS Model Relationship Reference Guide, the default Rego engine requires the provider (`Cluster`, holding `mutatorRef`) in `from` and the consumer (`Service`/`CapacityProvider`, holding `mutatedRef`) in `to` for non-binding edges — the Go engine is orientation-agnostic, but this file follows the stricter Rego convention so it works correctly on both.

## Kanvas Demo

- [Kanvas design](https://playground.meshery.io/extension/meshmap?mode=design&design=3a262f9c-806d-4d8b-a850-1ca7acb2f8a2)

## Screenshot
<img width="1498" height="600" alt="Screenshot 2026-08-16 at 5 51 05 PM" src="https://github.com/user-attachments/assets/b5976b5f-2386-4c03-b0a5-d5318dac3104" />

- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining non-binding references between ECS clusters and services.
  * Added support for linking ECS clusters with capacity providers.
  * Cluster associations can now be populated using the cluster’s display name and reference configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->