### PR TITLE
[Docs] fix typo in Meshery Adapters documentation

### DIFF
--- a/docs/content/en/concepts/architecture/adapters.md
+++ b/docs/content/en/concepts/architecture/adapters.md
@@ -7,7 +7,7 @@ aliases:
 
 ## What are Meshery Adapters?
 
-Part of Meshery's extensibility as a platform, Meshery Adapters are purpopse-built to address an area in need of management that is either considered optional to the platform and/or is considered an area in which additional depth of control is needed. Adapters extend Meshery's management capabilities in any number of ways, including lifecycle, configuration, performance, governance, identity and so on. Meshery Adapters come in different form factors, and depending on their purpose, deliver different sets or capabilities. Each Adapter registers its capabilities with Meshery Server. Meshery Server, in-turn, exposes those capabilities for you to control.
+Part of Meshery's extensibility as a platform, Meshery Adapters are purpose-built to address an area in need of management that is either considered optional to the platform and/or is considered an area in which additional depth of control is needed. Adapters extend Meshery's management capabilities in any number of ways, including lifecycle, configuration, performance, governance, identity and so on. Meshery Adapters come in different form factors, and depending on their purpose, deliver different sets or capabilities. Each Adapter registers its capabilities with Meshery Server. Meshery Server, in-turn, exposes those capabilities for you to control.
 
 ## Meshery Adapters for Lifecycle Management
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the Meshery Adapters documentation.

The word `purpopse` was incorrectly used instead of `purpose` in the **What are Meshery Adapters?** section.
<img width="1224" height="479" alt="Screenshot From 2026-08-16 20-09-09" src="https://github.com/user-attachments/assets/876476db-a328-463c-933d-df2234507abd" />


### Changes

* Changed `purpopse-built` to `purpose-built` in `docs/content/en/concepts/architecture/adapters.md`.

### Validation

* Verified the documentation source after making the change.
* Confirmed that the change is limited to the intended typo correction.

### Related Issue

Fixes #21430


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the Meshery Adapters overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->