### PR TITLE
Fix guide reference in mesheryctl model init output

### DIFF
--- a/mesheryctl/internal/cli/root/model/init.go
+++ b/mesheryctl/internal/cli/root/model/init.go
@@ -276,7 +276,7 @@ $ mesheryctl model import {modelFolder}
 To export this model as OCI image:
 $ mesheryctl model build {modelName}/{modelVersion} --path {path}
 
-Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models`
+Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init`
 
 // TODO
 // initModelData fits well for json and yaml format

--- a/mesheryctl/internal/cli/root/model/init.go
+++ b/mesheryctl/internal/cli/root/model/init.go
@@ -276,7 +276,7 @@ $ mesheryctl model import {modelFolder}
 To export this model as OCI image:
 $ mesheryctl model build {modelName}/{modelVersion} --path {path}
 
-Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init`
+Detailed guide: https://docs.meshery.io/reference/references/mesheryctl/model/init/`
 
 // TODO
 // initModelData fits well for json and yaml format

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.aws-dynamodb-controller-in-yaml.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.aws-dynamodb-controller-in-yaml.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test-case-aws-dynamodb-controller
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-dynamodb-controller/v0.1.0 --path .
 
-Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init
+Detailed guide: https://docs.meshery.io/reference/references/mesheryctl/model/init/

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.aws-dynamodb-controller-in-yaml.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.aws-dynamodb-controller-in-yaml.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test-case-aws-dynamodb-controller
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-dynamodb-controller/v0.1.0 --path .
 
-Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models
+Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test-case-aws-ec2-controller
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v0.1.0 --path .
 
-Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init
+Detailed guide: https://docs.meshery.io/reference/references/mesheryctl/model/init/

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test-case-aws-ec2-controller
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v0.1.0 --path .
 
-Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models
+Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir-2.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir-2.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test_case_some_other_custom_dir/with/trailing/separato
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path test_case_some_other_custom_dir/with/trailing/separator
 
-Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init
+Detailed guide: https://docs.meshery.io/reference/references/mesheryctl/model/init/

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir-2.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir-2.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test_case_some_other_custom_dir/with/trailing/separato
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path test_case_some_other_custom_dir/with/trailing/separator
 
-Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models
+Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test_case_some_custom_dir/subdir/one_more_subdir/test-
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path test_case_some_custom_dir/subdir/one_more_subdir
 
-Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models
+Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-dir.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import test_case_some_custom_dir/subdir/one_more_subdir/test-
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path test_case_some_custom_dir/subdir/one_more_subdir
 
-Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init
+Detailed guide: https://docs.meshery.io/reference/references/mesheryctl/model/init/

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-relative-parent-dir.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-relative-parent-dir.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import ../test_case_some_custom_dir/subdir/one_more_subdir/te
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path ../test_case_some_custom_dir/subdir/one_more_subdir
 
-Detailed guide: https://docs.meshery.io/guides/configuration-management/creating-models
+Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init

--- a/mesheryctl/internal/cli/root/model/testdata/model.init.custom-relative-parent-dir.aws-ec2-controller.output.golden
+++ b/mesheryctl/internal/cli/root/model/testdata/model.init.custom-relative-parent-dir.aws-ec2-controller.output.golden
@@ -22,4 +22,4 @@ $ mesheryctl model import ../test_case_some_custom_dir/subdir/one_more_subdir/te
 To export this model as OCI image:
 $ mesheryctl model build test-case-aws-ec2-controller/v1.2.3 --path ../test_case_some_custom_dir/subdir/one_more_subdir
 
-Detailed guide: https://docs.meshery.io/reference/mesheryctl/model/init
+Detailed guide: https://docs.meshery.io/reference/references/mesheryctl/model/init/


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `model init` command’s next-steps link to the current Meshery model initialization guide.
  * Refreshed command output references across supported initialization scenarios to point to the latest documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->