### PR TITLE
docs: fix typos in guides and extensions

### DIFF
--- a/docs/content/en/extensions/models/brigade/index.md
+++ b/docs/content/en/extensions/models/brigade/index.md
@@ -13,7 +13,7 @@ components-count: 0
 relationships: 
 relationship-count: 0
 featureList: [
-  "Designed to quickly and efficently handle large volumes of events.",
+  "Designed to quickly and efficiently handle large volumes of events.",
   "Offers full management of user and service account authorization/authentication.",
   "Enables high event throughput via its backing message queue."
 ]

--- a/docs/content/en/extensions/models/open-service-mesh/index.md
+++ b/docs/content/en/extensions/models/open-service-mesh/index.md
@@ -21,7 +21,7 @@ components:
   whiteIcon: /extensions/models/open-service-mesh/components/mesh-federation/icons/white/mesh-federation-white.svg
   description: 
 featureList: [
-  "Configuration an simplier understanding of your Open Service Mesh deployments and microservices",
+  "Configuration an simpler understanding of your Open Service Mesh deployments and microservices",
   "Configure and chain Envoy WASM filters",
   "Conformance to Service Mesh Interface specifications"
 ]

--- a/docs/content/en/extensions/models/open-service-mesh/index.md
+++ b/docs/content/en/extensions/models/open-service-mesh/index.md
@@ -21,7 +21,7 @@ components:
   whiteIcon: /extensions/models/open-service-mesh/components/mesh-federation/icons/white/mesh-federation-white.svg
   description: 
 featureList: [
-  "Configuration an simpler understanding of your Open Service Mesh deployments and microservices",
+  "Configuration and simpler understanding of your Open Service Mesh deployments and microservices",
   "Configure and chain Envoy WASM filters",
   "Conformance to Service Mesh Interface specifications"
 ]

--- a/docs/content/en/guides/configuration-management/exporting-models/index.md
+++ b/docs/content/en/guides/configuration-management/exporting-models/index.md
@@ -54,4 +54,4 @@ This Meshery model will include components, relationships.
 
 <a href="./images/ExportModel.gif"><img alt="Export-Model" style="width:500px;height:auto;" src="./images/ExportModel.gif" /></a>
 
-Once the Meshery model has been exported, you can export your model anytime back using `Import` on UI and then visualize in Meshery, operate and observe your components that are geneated from the crd. You can also use Meshery to deploy your Meshery Model in form of a design to any of your connected kubernetes clusters. For more information, see [connections]({{< ref "installation/kubernetes/_index.md" >}})
+Once the Meshery model has been exported, you can export your model anytime back using `Import` on UI and then visualize in Meshery, operate and observe your components that are generated from the crd. You can also use Meshery to deploy your Meshery Model in form of a design to any of your connected kubernetes clusters. For more information, see [connections]({{< ref "installation/kubernetes/_index.md" >}})

--- a/docs/content/en/guides/configuration-management/importing-models/index.md
+++ b/docs/content/en/guides/configuration-management/importing-models/index.md
@@ -6,7 +6,7 @@ categories: [configuration]
 
 Import your existing Models and existing custom resource definition (CRD) into Meshery. The platform supports a variety of application definition formats, and you can import designs using either the Meshery CLI or the Meshery UI.
 
-**Note:** A [Model]({{< ref "concepts/logical/models/index.md" >}}) can be only imported if it contains atleast a valid [Component]({{< ref "concepts/logical/components.md" >}}) or [Relationship]({{< ref "concepts/logical/relationships/index.md" >}}).
+**Note:** A [Model]({{< ref "concepts/logical/models/index.md" >}}) can be only imported if it contains at least a valid [Component]({{< ref "concepts/logical/components.md" >}}) or [Relationship]({{< ref "concepts/logical/relationships/index.md" >}}).
 
 ## Import Models Using Meshery CLI
 

--- a/docs/content/en/guides/infrastructure-management/gitops-with-meshery/index.md
+++ b/docs/content/en/guides/infrastructure-management/gitops-with-meshery/index.md
@@ -23,7 +23,7 @@ See [Extension: Meshery Snapshot]({{< ref "extensions/extensions/kubectl-meshsyn
 - Baseline and analyze the performance of your services is key to efficient operation of any application
   - Meshery is the canonical implementation of the Cloud Native Performance specification
 - Define your performance profiles upfront. See statistical analysis with microservice latency and throughput quartiles
-- Meshery includes your choice of load generator, so that you can meausure your way
+- Meshery includes your choice of load generator, so that you can measure your way
 - Meshery packages all these features into an easy-to-use GitHub Action
 
 Measuring and managing the performance of your infrastructure is key to efficient operation. You can choose from multiple load generators and use a highly configurable set of load profiles with variable tunable facets to run a performance test. Meshery packages all these features into an easy-to-use GitHub Action.

--- a/docs/content/en/guides/mesheryctl/system-commands/index.md
+++ b/docs/content/en/guides/mesheryctl/system-commands/index.md
@@ -4,7 +4,7 @@ categories: [mesheryctl]
 description: Mesheryctl system commands for managing Meshery deployments.
 ---
 
-Let's get familiar with mesheryctl system commands. The syntax of the mesheryctl commands goes as follws : `mesheryctl <Main_command> <Argument> <Flags>`
+Let's get familiar with mesheryctl system commands. The syntax of the mesheryctl commands goes as follows : `mesheryctl <Main_command> <Argument> <Flags>`
 
 ## Main_command : system
 ### start 

--- a/docs/content/en/guides/mesheryctl/working-with-mesheryctl.md
+++ b/docs/content/en/guides/mesheryctl/working-with-mesheryctl.md
@@ -4,7 +4,7 @@ categories: [mesheryctl]
 description: Guides for common tasks while using Meshery's CLI, mesheryctl.
 ---
 
-Meshery's command line interface is `mesheryctl`. Use `mesheryctl` to both manage the lifecyle of Meshery itself and to access and invoke any of Meshery's application and cloud native management functions. `mesheryctl` commands can be categorized as follows:
+Meshery's command line interface is `mesheryctl`. Use `mesheryctl` to both manage the lifecycle of Meshery itself and to access and invoke any of Meshery's application and cloud native management functions. `mesheryctl` commands can be categorized as follows:
 
 - `mesheryctl` - Global overrides and flags
 - `mesheryctl app` - Cloud Native Application Management

--- a/docs/content/en/guides/performance-management/performance-management/index.md
+++ b/docs/content/en/guides/performance-management/performance-management/index.md
@@ -17,7 +17,7 @@ _Meshery dashboard_
 
 <a href="images/smi-dashboard.png"><img alt="Meshery Dashboard" src="images/smi-dashboard.png" /></a>
 
-If you are looking to run performance benchmarks on cloud native infrastructur, you can use Meshery's cloud native infrastructurelifecycle management capabilities to deploy all kinds of cloud native infrastructure on Kubernets. With Meshery's performance benchmarking feature, you can also deploy you application off the mesh and compare the performance and determine the overhead when the app runs on the mesh.
+If you are looking to run performance benchmarks on cloud native infrastructur, you can use Meshery's cloud native infrastructurelifecycle management capabilities to deploy all kinds of cloud native infrastructure on Kubernetes. With Meshery's performance benchmarking feature, you can also deploy you application off the mesh and compare the performance and determine the overhead when the app runs on the mesh.
 
 Next, we navigate to the main Performance Testing dashboard. See [Performance Management]({{< ref "guides/performance-management/managing-performance/index.md" >}}) to learn more about performance profiles, load generators, Kubernetes cluster, and all kinds of cloud native infrastructure metrics.
 

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -40,9 +40,9 @@ Each Meshery Operator controller offers a health status that you can use to unde
 - **UNDEPLOYED:** Custom Resource not deployed.
 - **CONNECTED:** Deployed, sending data to Meshery Server.
 
-### When a controller reports UNKOWN
+### When a controller reports UNKNOWN
 
-Any of the three can instead report **UNKOWN** (spelled that way on the wire). It is not a health state: it means Meshery made no observation of that controller on this cluster, so it is asserting nothing about it. All three report it at once when the connection's kubeconfig could not be read or its Kubernetes client could not be created, since nothing about the cluster was observable. The cards stay visible on purpose - the reason is in the connection's [Diagnostics](#diagnostics-in-the-connection-detail-view) and in the events feed, not in the status itself.
+Any of the three can instead report **UNKNOWN** (spelled that way on the wire). It is not a health state: it means Meshery made no observation of that controller on this cluster, so it is asserting nothing about it. All three report it at once when the connection's kubeconfig could not be read or its Kubernetes client could not be created, since nothing about the cluster was observable. The cards stay visible on purpose - the reason is in the connection's [Diagnostics](#diagnostics-in-the-connection-detail-view) and in the events feed, not in the status itself.
 
 ## Meshery Operator Deployment Scenarios
 

--- a/docs/content/en/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/index.md
+++ b/docs/content/en/guides/tutorials/aws/deploy-aws-ec2-instances-with-meshery/index.md
@@ -113,7 +113,7 @@ To get the filtered view shown above, click the filter icon and adjust the follo
 
 - For `view Selector` select `single namespace`
 - For `Kinds` select `Deployment, Pod, secret`
-- For `namspace` select `ack-system`
+- For `namespace` select `ack-system`
 
 ### 3. Deploy the VPC Workflow
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes verified spelling and typographical errors across Meshery's Guides and Extensions/Models documentation.

### Changes

#### Guides

- Fixed `meausure` to `measure`.
- Fixed `UNKOWN` to `UNKNOWN`.
- Fixed `geneated` to `generated`.
- Fixed `atleast` to `at least`.
- Fixed `lifecyle` to `lifecycle`.
- Fixed `follws` to `follows`.
- Fixed `namspace` to `namespace`.
- Fixed `Kubernets` to `Kubernetes`.

#### Extensions / Models

- Fixed `efficently` to `efficiently`.
- Fixed `simplier` to `simpler`.

No functional or behavioral changes are introduced.

### Testing

- Reviewed each affected Markdown file in context.
- Verified that the changes are limited to documentation text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling, grammar, and terminology throughout model, configuration, infrastructure, CLI, performance, troubleshooting, and AWS deployment guides.
  - Improved clarity for Kubernetes deployment instructions, Meshery CLI lifecycle guidance, GitOps performance analysis, and model import/export documentation.
  - Corrected the controller status label from `UNKOWN` to `UNKNOWN`.
  - Fixed terminology and labels for namespaces, generated exports, feature descriptions, and deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->