### PR TITLE
[fix]: add install to sparse checkout to support Go validation

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -37,7 +37,9 @@ jobs:
           # entire repository, which materially cuts checkout IO. There are no
           # submodules, so submodule fetching is intentionally omitted.
           filter: blob:none
-          sparse-checkout: docs
+          sparse-checkout: |
+            install
+            docs
           sparse-checkout-cone-mode: true
       - name: Checkout gh-pages for preview retention
         if: github.event.action != 'closed'


### PR DESCRIPTION
**Root Cause**

The `build-production` target in `docs/Makefile` depends on the `check-go` prerequisite. This prerequisite delegates Go validation to the top-level repository `Makefile` via the command:
```bash
$(MAKE) -C .. check-go
```

Because the root `Makefile` explicitly includes `install/Makefile.show-help.mk`, invoking it requires the `install/` directory to be present on the runner. Since the previous sparse checkout configuration only pulled the `docs/` directory (along with top-level root files), `make` instantly failed with a *"No such file or directory"* error when attempting to parse the root Makefile's includes.


**The Fix**

Added `install` to the sparse-checkout configuration alongside `docs`. This provides the root `Makefile` with its required dependencies so the Go validation can execute properly, allowing the downstream Hugo build to complete successfully.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the documentation deployment checkout process for faster, more efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->