### PR TITLE
docs: fix typos in contributor and reference docs

### DIFF
--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -212,7 +212,7 @@ The pods passed in “expected_pods” are running in the subsequent namespaces 
 
 ## Automated Builds
 
-All Meshery GitHub repositories are configured with GitHub Actions. Everytime a pull request is submitted against the master branch of any repository, that repository’s GitHub Actions will be invoked (whether the PR is merged or not). Workflows defined in Meshery repository will generally (but not always) perform the following actions:
+All Meshery GitHub repositories are configured with GitHub Actions. Every time a pull request is submitted against the master branch of any repository, that repository’s GitHub Actions will be invoked (whether the PR is merged or not). Workflows defined in Meshery repository will generally (but not always) perform the following actions:
 
 1. trigger a Docker build to build a Docker container image
 1. generate two Docker tags:

--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -56,7 +56,7 @@ cd bats-core
 ./install.sh $HOME
 ```
 
-Some tests could use bats libraries as helpers to create the tests suite.
+Some tests could use bats libraries as helpers to create the test suite.
 
 #### Setup Dependencies
 
@@ -159,7 +159,7 @@ make e2e
 make e2e-no-build
 ```
 
-**Run a specific command tests suite**
+**Run a specific command test suite**
 
 
 ```bash

--- a/docs/content/en/project/contributing/cli/tests.md
+++ b/docs/content/en/project/contributing/cli/tests.md
@@ -56,7 +56,7 @@ cd bats-core
 ./install.sh $HOME
 ```
 
-Some tests could use bats libraires as helpers to create the tests suite.
+Some tests could use bats libraries as helpers to create the tests suite.
 
 #### Setup Dependencies
 
@@ -155,11 +155,11 @@ Make sure you are in `meshery/mesheryctl` directory
 # run tests building mesheryctl binary
 make e2e
 
-# run tests without buiding mesheryctl binary
+# run tests without building mesheryctl binary
 make e2e-no-build
 ```
 
-**Run a specific commmand tests suite**
+**Run a specific command tests suite**
 
 
 ```bash
@@ -175,7 +175,7 @@ make e2e-no-build BATS_FOLDER_PATTERN=002-model
 ```bash
 make e2e-no-build BATS_FOLDER_PATTERN=<test folder name> BATS_FILE_PATTERN=<test command name>
 
-# Example to run mesheryctl model genereate tests
+# Example to run mesheryctl model generate tests
 make e2e-no-build BATS_FOLDER_PATTERN=002-model BATS_FILE_PATTERN=06-model-generate
 ```
 
@@ -329,7 +329,7 @@ The BATS suite runs with `--print-output-on-failure`, so a failing test's captur
 
 #### Test Data
 
-If a command requries a specific id, name or any predefined value ensure that the data is created by your test or another test beforehand. Do not rely on external or uncontrolled data as it will lead to unexpected results.
+If a command requires a specific id, name or any predefined value ensure that the data is created by your test or another test beforehand. Do not rely on external or uncontrolled data as it will lead to unexpected results.
 
 **Example:**
 

--- a/docs/content/en/project/contributing/cli/ux-guide.md
+++ b/docs/content/en/project/contributing/cli/ux-guide.md
@@ -52,7 +52,7 @@ Command line interfaces offer less context to the user, which makes them inheren
 - Add headers to output to give context to the user.
 - As mentioned [above](#flags), similar commands should behave similarly.
 - Confirm steps for risky commands. For example, use the `AskForConfirmation` function which will prompt the user to type in "yes" or "no" to continue.
-- Anticipate user actions. If the user creates a new context with `mesheryctl system context create` then the next action might be `mesheryctl system start` to start Meshery ot `mesheryctl system context switch` to switch context names.
+- Anticipate user actions. If the user creates a new context with `mesheryctl system context create` then the next action might be `mesheryctl system start` to start Meshery or `mesheryctl system context switch` to switch context names.
 - Anticipate user errors. For example, if the user types in `mesheryctl system satrt`, using the inbuilt features with the [cobra library](https://github.com/spf13/cobra), we can correct it to `start` and alert the user.
 
 ## Process

--- a/docs/content/en/project/contributing/contributing-controllers-config.md
+++ b/docs/content/en/project/contributing/contributing-controllers-config.md
@@ -263,7 +263,7 @@ letting the consequence replace the cause degraded the diagnostic on teardown.
 The controller-status snapshot is built from `models.MesheryControllers`, not
 from the attached-handler map, so a connection with a ready FSM context always
 reports exactly one row per controller. A controller with no handler behind it
-reports `UNKOWN` and no version - Meshery made no observation of the cluster, so
+reports `UNKNOWN` and no version - Meshery made no observation of the cluster, so
 any other value would assert something it did not check. Without that the card
 disappears from the UI, because the client replaces its controller state with
 each snapshot wholesale: an unreadable kubeconfig or a failed Kubernetes client,

--- a/docs/content/en/project/contributing/meshery-windows/index.md
+++ b/docs/content/en/project/contributing/meshery-windows/index.md
@@ -118,7 +118,7 @@ The Docker Desktop application for Windows includes a comprehensive set of tools
 This approach can be the most challenging to setup among all and is recommended for users that are very conversant with setting up development environments in Windows.
 make, gcc and the other prerequisites do not come pre-installed on Windows and hence these need to be installed manually. You will also need to set the **Path** in _Environment Variables_ for some of them like _make_ and _gcc_. 
 
-### Installing prerequsites:
+### Installing prerequisites:
 Here are some links and recommendations to install the prerequisites:
 
 #### - make 

--- a/docs/content/en/project/contributing/models/models.md
+++ b/docs/content/en/project/contributing/models/models.md
@@ -39,7 +39,7 @@ _Figure: Model Entity Classification_
 
 ## Meshery Entities and their Lifecycle
 
-This section aids in your understanding of the vernacular of Meshery's internal object model and discusses the difference beteween schemas, definitions, declarations, and instances. The lifecycle of Meshery entities (components, relationships, policies) is represented by the following terms, which are used to describe the various stages of their lifecycle.
+This section aids in your understanding of the vernacular of Meshery's internal object model and discusses the difference between schemas, definitions, declarations, and instances. The lifecycle of Meshery entities (components, relationships, policies) is represented by the following terms, which are used to describe the various stages of their lifecycle.
 
 ### Schema
 
@@ -148,7 +148,7 @@ To simplify the assignment of these capabilities, Meshery organizes these capabi
 <details><summary>Capabilities schema excerpt</summary><pre> {
 "$id": "https://schemas.meshery.io/capability.json",
 "$schema": "http://json-schema.org/draft-07/schema#",
-"description": "Meshery manages entities in accordance with their specific capabilities. This field explicitly identifies those capabilities largely by what actions a given component supports; e.g. metric-scrape, sub-interface, and so on. This field is extensible. Entities may define a broad array of capabilities, which are in-turn dynamically interpretted by Meshery for full lifecycle management.",
+"description": "Meshery manages entities in accordance with their specific capabilities. This field explicitly identifies those capabilities largely by what actions a given component supports; e.g. metric-scrape, sub-interface, and so on. This field is extensible. Entities may define a broad array of capabilities, which are in-turn dynamically interpreted by Meshery for full lifecycle management.",
 "additionalProperties": false,
 "type": "object",
 "required":

--- a/docs/content/en/project/contributing/models/relationships.md
+++ b/docs/content/en/project/contributing/models/relationships.md
@@ -342,9 +342,9 @@ Each policy has a set of evaluation rules defined and the `evaluationQuery` attr
 #### Matching
 
 1. Targets of a Relationship can be specific Components or entire Models.
-1. Values for propoerties like `kind`, `version`, and `model` are case-sensitive.
-1. Absence of a property in the `selector` is interpretted as the wildcard `*`.
-   - For example, a selector with `kind: Pod`, `Model: Kubernetes`, and the absence of the `version` property would be interpretted as `version: *`, which
+1. Values for properties like `kind`, `version`, and `model` are case-sensitive.
+1. Absence of a property in the `selector` is interpreted as the wildcard `*`.
+   - For example, a selector with `kind: Pod`, `Model: Kubernetes`, and the absence of the `version` property would be interpreted as `version: *`, which
      means that all the versions of the Kubernetes Pod resource (k8s.io/v1/betav2) will match the selector.
 1. The `evaluationQuery` property determines the OPA policy to invoke for relationship evaluation, specify the correct rego query.
 

--- a/docs/content/en/reference/extensibility/providers/index.md
+++ b/docs/content/en/reference/extensibility/providers/index.md
@@ -486,7 +486,7 @@ Meshery Server will proxy all requests to remote provider endpoints. Endpoints a
 #### Meshery Server Registration
 
 Every Meshery server is capable of registering itself with the remote provider, considering that remote provider supports this feature as a capability.
-On successful authentication with the remote provider, Meshery server registers itself by sending a POST request to the remote provider through the `persist-connection` capability. The body of the request should include information so as to uniquely indentify Meshery server and its status.
+On successful authentication with the remote provider, Meshery server registers itself by sending a POST request to the remote provider through the `persist-connection` capability. The body of the request should include information so as to uniquely identify Meshery server and its status.
 
 Example of the request body:
 

--- a/docs/content/en/reference/references/graphql-apis.md
+++ b/docs/content/en/reference/references/graphql-apis.md
@@ -973,7 +973,7 @@ Status of Meshery Operator and its controllers.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| <a id="resourcecount"></a>`count` | [`Int!`](#int) | Number of resource. |
+| <a id="resourcecount"></a>`count` | [`Int!`](#int) | Number of resources. |
 | <a id="resourcekind"></a>`kind` | [`String!`](#string) | Name of resource. |
 
 ### `TelemetryComp`

--- a/docs/content/en/reference/references/graphql-apis.md
+++ b/docs/content/en/reference/references/graphql-apis.md
@@ -137,7 +137,7 @@ Query details about Addons available (Eg. Prometheus and Grafana).
 
 ### `Query.getAvailableNamespaces`
 
-Query available Namesapces in your cluster.
+Query available Namespaces in your cluster.
 
 ###### **Returns** [`[NameSpace!]!`](#namespace).
 
@@ -362,7 +362,7 @@ Listen to changes in Data Plane data for a Service Mesh (or all) in your cluster
 
 ### `Subscription.listenToMeshSyncEvents`
 
-Listen to changes in the list of available Namesapces in your cluster.
+Listen to changes in the list of available Namespaces in your cluster.
 
 ###### **Returns** [`OperatorControllerStatusPerK8sContext`](#operatorcontrollerstatusperk8scontext).
 
@@ -881,7 +881,7 @@ Status of Meshery Operator and its controllers.
 | <a id="operatorstatuscontrollers"></a>`controllers` | [`[OperatorControllerStatus!]!`](#operatorcontrollerstatus) | Details about various Controllers of Meshery Operator. |
 | <a id="operatorstatuserror"></a>`error` | [`Error`](#error) | Error Logs encountered by Meshery Operator. |
 | <a id="operatorstatusstatus"></a>`status` | [`Status!`](#status) | Status of Meshery Operator. |
-| <a id="operatorstatusversion"></a>`version` | [`String!`](#string) | Verion of Meshery Operator. |
+| <a id="operatorstatusversion"></a>`version` | [`String!`](#string) | Version of Meshery Operator. |
 
 ### `OperatorStatusPerK8sContext`
 
@@ -973,7 +973,7 @@ Status of Meshery Operator and its controllers.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| <a id="resourcecount"></a>`count` | [`Int!`](#int) | Number of resouce. |
+| <a id="resourcecount"></a>`count` | [`Int!`](#int) | Number of resource. |
 | <a id="resourcekind"></a>`kind` | [`String!`](#string) | Name of resource. |
 
 ### `TelemetryComp`
@@ -1096,7 +1096,7 @@ Input for changing Addon Status.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | <a id="addonstatusinputk8scontextid"></a>`k8scontextID` | [`String!`](#string) | kubernetes context ID. |
-| <a id="addonstatusinputselector"></a>`selector` | [`MeshType`](#meshtype) | Filter by Serice Mesh. |
+| <a id="addonstatusinputselector"></a>`selector` | [`MeshType`](#meshtype) | Filter by Service Mesh. |
 | <a id="addonstatusinputtargetstatus"></a>`targetStatus` | [`Status!`](#status) | Desired Status. |
 
 ### `CatalogSelector`


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes verified spelling and typographical errors across Meshery's Contributor documentation and a hand-written reference page.

### Changes

#### Contributor Documentation

- Fixed `Everytime` to `Every time` in the Build and Release documentation.
- Fixed `UNKOWN` to `UNKNOWN` in the Contributor Controllers Configuration documentation.
- Fixed `libraires` to `libraries` in the CLI Tests documentation.
- Fixed `buiding` to `building` in the CLI Tests documentation.
- Fixed `commmand` to `command` in the CLI Tests documentation.
- Fixed `genereate` to `generate` in the CLI Tests documentation.
- Fixed `everytime` to `every time` in the CLI Tests documentation.
- Fixed `requries` to `requires` in the CLI Tests documentation.
- Fixed `ot` to `or` in the CLI UX Guide.
- Fixed `beteween` to `between` in the Models documentation.
- Fixed `interpretted` to `interpreted` in the Models documentation.
- Fixed `propoerties` to `properties` in the Model Relationships documentation.
- Fixed `interpretted` to `interpreted` in the Model Relationships documentation.
- Fixed `prerequsites` to `prerequisites` in the Meshery Windows documentation.

#### Reference Documentation

- Fixed `indentify` to `identify` in the hand-written Providers reference documentation.

No functional or behavioral changes are introduced.

### Testing

- Reviewed each affected Markdown file in context.
- Verified that the changes are limited to documentation text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling, grammar, and terminology across contribution, setup, model, relationship, provider, and GraphQL API documentation.
  * Clarified local end-to-end testing instructions.
  * Improved guidance on relationship selectors, including wildcard behavior for omitted properties.
  * Corrected command examples, status values, headings, and API descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->