### PR TITLE
ci(server): enforce gorm ORDER BY sanitization in the lint gate

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -23,6 +23,14 @@ on:
         required: true
         default: "warning"
 
+# Least-privilege baseline for the default GITHUB_TOKEN, which actions/checkout
+# persists into the runner's git config. Nothing here writes with it: the only
+# writes in this workflow push Allure results to the meshery/qa repository and
+# authenticate with the GH_ACCESS_TOKEN PAT, and actions/upload-artifact uses
+# the Actions runtime token rather than this one. Matches build-and-test.yml.
+permissions:
+  contents: read
+
 jobs:
   golangci-server:
     strategy:

--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -44,6 +44,15 @@ jobs:
           args: --config=../.github/.golangci.yml --timeout=10m
           only-new-issues: ${{ github.event_name == 'pull_request' }}
           working-directory: ./server
+      # gorm's Order() interpolates a string into the SQL verbatim - the sink
+      # behind every Meshery CVE. models.SanitizeOrderInput closes it, and this
+      # analyzer is what keeps a new call site from skipping it. It covers the
+      # whole root module (server and mesheryctl), so it runs once here rather
+      # than in both lint jobs. golangci-lint cannot host it without a custom
+      # binary built from its module plugin system; see
+      # docs/content/en/project/contributing/contributing-lint.md.
+      - name: ORDER BY sanitization lint
+        run: go run ./server/internal/lint/orderby/cmd/orderbylint ./...
   unit-tests-server:
     name: server Unit tests
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,15 @@ make helm-docs      # Generate Helm chart docs
 
 ### Go
 
-- Format with `gofmt`/`goimports`; lint with `make golangci` (config: `.golangci.yml`).
+- Format with `gofmt`/`goimports`; lint with `make golangci` (config: `.github/.golangci.yml`,
+  plus the repo-specific analyzers under `server/internal/lint/`).
+- **MUST NOT pass a non-constant value to gorm's `.Order(...)`.** It interpolates a string
+  into the SQL verbatim - the sink behind every Meshery CVE. Route it through
+  `models.SanitizeOrderInput(order, []string{...})` with that query's own allow-list of
+  snake_case columns, or use a constant. Enforced at CI time by the `orderby` analyzer
+  (`server/internal/lint/orderby`), which is flow-sensitive - sanitizing *after* the
+  `.Order()` call does not satisfy it. Fixes, the `//nolint:orderby` escape hatch and what
+  the rule does not cover: [Go lint rules](./docs/content/en/project/contributing/contributing-lint.md).
 - Use MeshKit error utilities (`github.com/meshery/meshkit/errors`); run `make error` for codes.
   `make error` skips `mesheryctl`. Both components require bumping `next_error_code` in their
   own `helpers/component_info.json` **in the same commit**, and the tracked docs reference at
@@ -332,7 +340,8 @@ so it covers lock files this list does not enumerate.
 
 ### Quality Gates
 
-- Go: `make golangci` must pass
+- Go: `make golangci` must pass - it runs `golangci-lint` *and* the repo-specific
+  analyzers in `server/internal/lint/`, the same pair CI's `golangci-lint-server` job runs
 - JS: `make ui-lint` must pass
 - New features need docs; breaking changes need deprecation notices
 - Keep PRs under 500 lines; don't merge on CI failure
@@ -409,6 +418,7 @@ worked detail behind them — open the one that matches what you are working on.
 | Playwright E2E, the E2E CI job, its credentials | [UI End-to-End Tests](./docs/content/en/project/contributing/ui/tests.md) |
 | A build that fails for an unrelated-looking reason | [Build Environment Gotchas](./docs/content/en/project/contributing/contributing-build-environment.md) |
 | MeshKit error codes | [How to write MeshKit compatible errors](./docs/content/en/project/contributing/contributing-error.md) |
+| A Go lint rule firing, or adding one | [Go Lint Rules](./docs/content/en/project/contributing/contributing-lint.md) |
 | Releases, CI secrets, the QA dashboard | [Build & Release (CI)](./docs/content/en/project/contributing/build-and-release.md) |
 | Connections and credential secrets | [Connections](./docs/content/en/project/contributing/models/connections.md) |
 | UI extensions, Remote Components | [Contributing to Meshery UI](./docs/content/en/project/contributing/ui/ui.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,8 +194,8 @@ make helm-docs      # Generate Helm chart docs
 
 - Format with `gofmt`/`goimports`; lint with `make golangci` (config: `.github/.golangci.yml`,
   plus the repo-specific analyzers under `server/internal/lint/`).
-- **MUST NOT pass a non-constant value to gorm's `.Order(...)`.** It interpolates a string
-  into the SQL verbatim - the sink behind every Meshery CVE. Route it through
+- **MUST NOT pass an unsanitized dynamic string to gorm's `.Order(...)`.** It interpolates a
+  string into the SQL verbatim - the sink behind every Meshery CVE. Route it through
   `models.SanitizeOrderInput(order, []string{...})` with that query's own allow-list of
   snake_case columns, or use a constant. Enforced at CI time by the `orderby` analyzer
   (`server/internal/lint/orderby`), which is flow-sensitive - sanitizing *after* the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ rename fails loudly. Detail and regression test:
 - E2E (Playwright): `make ui-integration-tests` or `npm run test:e2e` in `ui/`
 - Setup: `make test-setup-ui`
 
-Four E2E invariants. Each one's reasoning, evidence, run IDs and history live in
+Five E2E invariants. Each one's reasoning, evidence, run IDs and history live in
 `docs/content/en/project/contributing/ui/tests.md` - read it before changing the workflow
 or the setup projects.
 
@@ -291,6 +291,10 @@ or the setup projects.
 - **A local run needs three things** - `make ui-provider-build`, a server on `:9081` plus
   `make ui` on `:3000`, and `MESHERY_SERVER_URL=http://localhost:3000` on the Playwright
   run - and the failure when one is missing never names it.
+- **The CI run is serial** (`workers: process.env.CI ? 1 : 4`). One runner hosts Kind, the
+  server container and Playwright; extra workers starve it, and a starved runner fails as
+  blown `describe` timeouts or as "the hosted runner lost communication", never as a named
+  test defect. `ui/tests/playwrightWorkers.test.ts` pins the resolved value.
 
 ### Local Validation
 

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ server-playground: dep-check
 ## Lint check Meshery Server.
 golangci: error dep-check
 	golangci-lint run --config=.github/.golangci.yml --timeout=10m
+	go run ./server/internal/lint/orderby/cmd/orderbylint ./...
 
 ## Build Meshery's protobufs.
 proto-build:

--- a/docs/content/en/project/contributing/cli/cli.md
+++ b/docs/content/en/project/contributing/cli/cli.md
@@ -108,7 +108,7 @@ Annotations: linkDocPatternApply,
 
 ### Linting
 
-`mesheryctl` uses [golangci-lint](https://github.com/golangci/golangci-lint). See the .github/workflow/ci.yaml for syntax used during Meshery's build process.
+`mesheryctl` uses [golangci-lint](https://github.com/golangci/golangci-lint) with the repo-wide configuration at `.github/.golangci.yml`, run by the `golangci-lint-cli` job in [`.github/workflows/go-testing-ci.yml`](https://github.com/meshery/meshery/blob/master/.github/workflows/go-testing-ci.yml). Meshery's repo-specific Go rules - notably the one that fails the build when a `gorm` `ORDER BY` clause is built from an unsanitized value - cover `mesheryctl` too: they analyze the whole root module from the `golangci-lint-server` job. What each rule protects and what to do when one fires is in [Go Lint Rules]({{< ref "project/contributing/contributing-lint.md" >}}).
 
 ### Testing
 

--- a/docs/content/en/project/contributing/cli/cli.md
+++ b/docs/content/en/project/contributing/cli/cli.md
@@ -108,7 +108,11 @@ Annotations: linkDocPatternApply,
 
 ### Linting
 
-`mesheryctl` uses [golangci-lint](https://github.com/golangci/golangci-lint) with the repo-wide configuration at `.github/.golangci.yml`, run by the `golangci-lint-cli` job in [`.github/workflows/go-testing-ci.yml`](https://github.com/meshery/meshery/blob/master/.github/workflows/go-testing-ci.yml). Meshery's repo-specific Go rules - notably the one that fails the build when a `gorm` `ORDER BY` clause is built from an unsanitized value - cover `mesheryctl` too: they analyze the whole root module from the `golangci-lint-server` job. What each rule protects and what to do when one fires is in [Go Lint Rules]({{< ref "project/contributing/contributing-lint.md" >}}).
+`mesheryctl` uses [golangci-lint](https://github.com/golangci/golangci-lint) with the repo-wide configuration at `.github/.golangci.yml`, plus Meshery's repo-specific Go analyzers - notably the one that fails the build when a `gorm` `ORDER BY` clause is built from an unsanitized value. Run both from `mesheryctl/`:
+
+{{< code code=`make lint` >}}
+
+That target is the CLI-scoped equivalent of the two jobs that gate your pull request in [`.github/workflows/go-testing-ci.yml`](https://github.com/meshery/meshery/blob/master/.github/workflows/go-testing-ci.yml): `golangci-lint-cli` applies the same shared configuration to `mesheryctl`, and `golangci-lint-server` runs the `ORDER BY` analyzer over the whole root module, `mesheryctl` included. What each rule protects and what to do when one fires is in [Go Lint Rules]({{< ref "project/contributing/contributing-lint.md" >}}).
 
 ### Testing
 

--- a/docs/content/en/project/contributing/contributing-lint.md
+++ b/docs/content/en/project/contributing/contributing-lint.md
@@ -67,13 +67,19 @@ still lands on the same raw sink.
 
 ### What to do when it fires
 
-The diagnostic reads:
+The diagnostic opens with:
 
 ```
 ORDER BY built from an unsanitized value: pass the argument through
 models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of
 columns, or use a constant.
 ```
+
+An argument whose static type is an interface produces a variant of that
+message - "this argument's static type is an interface, so the pass cannot
+prove it does not hold a string" - which asks for a concretely-typed value
+rather than a sanitizer call. See *What the rule does not cover* below for that
+case.
 
 There are three correct fixes, in order of preference:
 

--- a/docs/content/en/project/contributing/contributing-lint.md
+++ b/docs/content/en/project/contributing/contributing-lint.md
@@ -60,7 +60,10 @@ afterwards is *not* accepted - which is the point, and is why the rule is not a
 grep for `SanitizeOrderInput` somewhere in the function.
 
 Calls that reach `Order` through an embedding wrapper are covered too: meshkit's
-`database.Handler` embeds `*gorm.DB`, and every persister orders through it.
+`database.Handler` embeds `*gorm.DB`, and every persister orders through it. So
+are calls dispatched through an interface that declares
+`Order(any) *gorm.DB` - `*gorm.DB` satisfies such an interface, so the call
+still lands on the same raw sink.
 
 ### What to do when it fires
 
@@ -85,7 +88,8 @@ There are three correct fixes, in order of preference:
    in `server/models/vars.go` already covers `updated_at desc`.
 3. **Use a `clause` value** - `clause.OrderByColumn{Column: clause.Column{Name: col}}` -
    if you need gorm to build the clause. gorm renders those through its quoting
-   clause builder rather than interpolating them.
+   clause builder rather than interpolating them. Keep the value concretely
+   typed: an `any` holding a clause value is reported, for the reason below.
 
 What is *not* a fix: sanitizing after the `Order` call, moving the
 interpolation into a `fmt.Sprintf`, or silencing the rule.
@@ -121,9 +125,29 @@ same reason. No call site in the repository is affected today.
 
 ### What the rule does not cover
 
-Non-string arguments are out of scope, for the reason in fix 3 above. That
-leaves two escape hatches inside gorm's own clause builder - `clause.Expr`, and
-`clause.Column{Raw: true}` - which are raw SQL again. Neither is used in this
+An argument boxed from a **concrete** non-string type is out of scope, for the
+reason in fix 3 above.
+
+That exemption stops where the analyzer stops being able to see the type.
+`Order` takes `any` and type-switches on it at runtime, and its `case string:`
+branch builds a `clause.Column{Raw: true}` - the verbatim interpolation again.
+So an argument whose static type is already an interface is **reported**, not
+skipped:
+
+```go
+func applyOrder(db *gorm.DB, order any) *gorm.DB {
+    return db.Order(order) // reported: this may be a string
+}
+
+query.Order(filters["order"]) // reported: map[string]any read
+```
+
+The pass cannot prove such a value is not a string, and assuming it is a clause
+value would be a silent false negative - the CVE. Give the value a concrete
+type: a `string` you have sanitized, or a `clause.OrderByColumn`.
+
+That leaves two escape hatches inside gorm's own clause builder - `clause.Expr`,
+and `clause.Column{Raw: true}` - which are raw SQL again. Neither is used in this
 repository; if you reach for one, you are back to owning the sanitization
 yourself.
 

--- a/docs/content/en/project/contributing/contributing-lint.md
+++ b/docs/content/en/project/contributing/contributing-lint.md
@@ -217,6 +217,15 @@ go run ./server/internal/lint/orderby/cmd/orderbylint ./...
 go test ./server/internal/lint/orderby/...
 ```
 
+`go run` recompiles the analyzer on every invocation, which is fine in CI (the
+build cache is warm) but noticeable locally after a clean cache. For iterative
+local use, build it once:
+
+```bash
+go build -o /tmp/orderbylint ./server/internal/lint/orderby/cmd/orderbylint
+/tmp/orderbylint ./...
+```
+
 The analyzer is pinned by an `analysistest` fixture at
 `server/internal/lint/orderby/testdata/`, which asserts both directions: every
 rejected shape reports, and every accepted shape stays silent. The second half

--- a/docs/content/en/project/contributing/contributing-lint.md
+++ b/docs/content/en/project/contributing/contributing-lint.md
@@ -1,0 +1,201 @@
+---
+title: Go Lint Rules
+description: The repo-specific Go lint gates Meshery enforces in CI, what each one is protecting, and what to do when one fires.
+categories: [contributing]
+---
+
+Beyond the stock linters, Meshery enforces a small number of repo-specific Go
+rules. Each one exists because a convention was being relied on to hold a
+security or contract boundary, and a convention is not a control: it holds until
+the first contributor who has not read the doc adds a call site.
+
+All of them run in the `golangci-lint-server` job of
+[`.github/workflows/go-testing-ci.yml`](https://github.com/meshery/meshery/blob/master/.github/workflows/go-testing-ci.yml),
+which gates the unit-test and build jobs downstream, and all of them run locally
+from:
+
+```bash
+make golangci
+```
+
+## ORDER BY must be sanitized
+
+`gorm`'s `(*gorm.DB).Order` interpolates a string argument into the generated SQL
+verbatim - it is a raw SQL sink, not a bound parameter. Every one of Meshery's
+published CVEs came from that sink reached by a request-controlled `?order=`
+value.
+
+`models.SanitizeOrderInput` in
+[`server/models/sql-utils.go`](https://github.com/meshery/meshery/blob/master/server/models/sql-utils.go)
+closes it. It takes the requested order and the caller's allow-list of database
+columns, and returns either a column drawn from that allow-list or the empty
+string. The returned value is never echoed back from user input, which is what
+makes it safe to interpolate.
+
+Roughly two dozen call sites - the `server/models/*_persister.go` family,
+`default_local_provider.go`, `database_handlers.go`, `meshsync_handler.go` -
+route through it. The `orderby` analyzer
+([`server/internal/lint/orderby`](https://github.com/meshery/meshery/tree/master/server/internal/lint/orderby))
+is what keeps the next one from skipping it.
+
+### What the rule accepts
+
+For every call to `(*gorm.DB).Order` whose argument is string-typed, the
+analyzer walks the argument backwards through SSA and requires **every**
+definition that can reach it to be either a constant or the result of
+`models.SanitizeOrderInput`. Because the walk is over SSA rather than syntax it
+is flow-sensitive, so the prevailing call-site shape is accepted as-is:
+
+```go
+order = models.SanitizeOrderInput(order, []string{"created_at", "updated_at", "name"})
+if order == "" {
+    order = defaultOrderUpdatedAtDesc
+}
+query = query.Order(order)
+```
+
+The value reaching `Order` is a phi of `{sanitizer result, constant}`, and both
+edges are safe. A function that ordered on its raw parameter and sanitized
+afterwards is *not* accepted - which is the point, and is why the rule is not a
+grep for `SanitizeOrderInput` somewhere in the function.
+
+Calls that reach `Order` through an embedding wrapper are covered too: meshkit's
+`database.Handler` embeds `*gorm.DB`, and every persister orders through it.
+
+### What to do when it fires
+
+The diagnostic reads:
+
+```
+ORDER BY built from an unsanitized value: pass the argument through
+models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of
+columns, or use a constant.
+```
+
+There are three correct fixes, in order of preference:
+
+1. **Sanitize with this query's own allow-list.** Add
+   `order = models.SanitizeOrderInput(order, []string{...})` before the `Order`
+   call, listing the **snake_case database columns** this query may legitimately
+   sort on. Do not copy another persister's allow-list without checking it
+   against your table - the allow-list is the security boundary, and a column
+   that does not exist on your table produces an empty order rather than an
+   error.
+2. **Use a constant** if the query's order is fixed. `defaultOrderUpdatedAtDesc`
+   in `server/models/vars.go` already covers `updated_at desc`.
+3. **Use a `clause` value** - `clause.OrderByColumn{Column: clause.Column{Name: col}}` -
+   if you need gorm to build the clause. gorm renders those through its quoting
+   clause builder rather than interpolating them.
+
+What is *not* a fix: sanitizing after the `Order` call, moving the
+interpolation into a `fmt.Sprintf`, or silencing the rule.
+
+### The one false positive: captured variables
+
+If a closure captures the order variable, the analyzer reports the call even
+when the value is sanitized:
+
+```go
+order = models.SanitizeOrderInput(order, validColumns)
+return func() *gorm.DB {
+    return db.Order(order) // reported, despite being safe
+}
+```
+
+Capturing a local moves it out of an SSA register and into a memory cell, and
+proving which store reaches a given load - including stores a closure performs
+at a point the analyzer cannot order - needs a memory-flow analysis the rule
+deliberately does not carry. Guessing in the other direction would let a closure
+overwrite a sanitized value unnoticed, which is exactly the CVE.
+
+The fix is to read the sanitized value out before anything captures it:
+
+```go
+sanitized := models.SanitizeOrderInput(order, validColumns)
+captured := sanitized
+return db.Order(sanitized), func() string { return captured }
+```
+
+Taking the variable's address (`overwrite(&order)`) has the same effect, for the
+same reason. No call site in the repository is affected today.
+
+### What the rule does not cover
+
+Non-string arguments are out of scope, for the reason in fix 3 above. That
+leaves two escape hatches inside gorm's own clause builder - `clause.Expr`, and
+`clause.Column{Raw: true}` - which are raw SQL again. Neither is used in this
+repository; if you reach for one, you are back to owning the sanitization
+yourself.
+
+The rule also covers only `Order`. Other gorm methods that take raw SQL
+(`Raw`, `Select` with an expression, `Joins`) are not analyzed.
+
+### Suppression
+
+A diagnostic can be suppressed with `//nolint:orderby` trailing the offending
+line, or standing alone on the line above it. Every use must carry an inline
+justification:
+
+```go
+//nolint:orderby // <why this value cannot reach user input>
+```
+
+The name must appear in the directive's own list - a bare `//nolint` does not
+silence this rule, and a *trailing* directive covers only its own line, never
+the statement below it.
+
+Suppressions are expected to stay in the low single digits. A growing list means
+the rule is mis-specified - narrow the rule rather than muting the call sites.
+
+### Running and testing it
+
+```bash
+# the whole root module (server and mesheryctl)
+go run ./server/internal/lint/orderby/cmd/orderbylint ./...
+
+# the analyzer's own tests
+go test ./server/internal/lint/orderby/...
+```
+
+The analyzer is pinned by an `analysistest` fixture at
+`server/internal/lint/orderby/testdata/`, which asserts both directions: every
+rejected shape reports, and every accepted shape stays silent. The second half
+matters as much as the first - a rule that fired on the existing call sites
+would be turned off rather than obeyed. Add a case there for any shape you teach
+the rule about.
+
+### Why it is not a golangci-lint linter
+
+`forbidigo` and `gocritic` match on the *called function*, not on its arguments,
+so neither can express "non-constant argument". Hosting a custom analyzer inside
+golangci-lint requires building a bespoke `golangci-lint` binary through its
+module plugin system, which would mean dropping
+`golangci/golangci-lint-action` - and with it `only-new-issues` - from two jobs.
+A single `go run` step in the same lint job is less machinery for the same gate.
+The trade-off is that golangci-lint's own `//nolint` processing does not apply,
+so the analyzer implements the directive itself.
+
+## No `http.Error` in server handlers
+
+Enforced by a `forbidigo` pattern in
+[`.github/.golangci.yml`](https://github.com/meshery/meshery/blob/master/.github/.golangci.yml).
+`http.Error` writes `Content-Type: text/plain`, which breaks RTK Query's default
+`baseQuery`. Use `writeMeshkitError(w, err, status)` or
+`writeJSONError(w, msg, status)` from `server/handlers/utils.go` instead.
+
+The rule, its file-level allowlist, and the legitimate non-JSON responders are
+documented with their subject in
+[HTTP Error Response Contract]({{< ref "project/contributing/error-contract.md" >}}).
+
+## Adding a rule
+
+Prefer configuration. If an existing linter expresses the rule cleanly, add it to
+`.github/.golangci.yml` with a `msg` that names the correct alternative and links
+the doc explaining why - contributors meet the rule through that message, not
+through this page.
+
+Reach for a `go/analysis` analyzer only when configuration cannot express the
+rule, as with the argument-shape requirement above. When you do, it needs: the
+analyzer package, a `cmd/` wrapper using `singlechecker`, an `analysistest`
+fixture covering accepted *and* rejected shapes, a step in the
+`golangci-lint-server` job, a line in `make golangci`, and a section here.

--- a/docs/content/en/project/contributing/contributing-lint.md
+++ b/docs/content/en/project/contributing/contributing-lint.md
@@ -76,7 +76,7 @@ still lands on the same raw sink.
 
 The diagnostic opens with:
 
-```
+```text
 ORDER BY built from an unsanitized value: pass the argument through
 models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of
 columns, or use a constant.
@@ -159,6 +159,23 @@ The pass cannot prove such a value is not a string, and assuming it is a clause
 value would be a silent false negative - the CVE. Give the value a concrete
 type: a `string` you have sanitized, or a `clause.OrderByColumn`.
 
+A **type parameter** is treated the same way, for the same reason:
+
+```go
+func orderBy[T ~string](db *gorm.DB, order T) *gorm.DB {
+    return db.Order(order) // reported: instantiated at string, this is the sink
+}
+```
+
+SSA builds a generic body once with the parameter intact, so what reaches `Order`
+is a type parameter rather than a concrete type. Instantiated at `string` it
+lands on gorm's `case string:` branch like any other string.
+
+In all of these cases the pass still accepts the value if it can trace where it
+came from - `db.Order(T(models.SanitizeOrderInput(order, cols)))` passes, because
+every definition reaching it is a sanitizer result. Being unable to see a value's
+*type* is only fatal when its *origin* is also invisible.
+
 That leaves two escape hatches inside gorm's own clause builder - `clause.Expr`,
 and `clause.Column{Raw: true}` - which are raw SQL again. Neither is used in this
 repository; if you reach for one, you are back to owning the sanitization
@@ -171,11 +188,17 @@ The rule also covers only `Order`. Other gorm methods that take raw SQL
 
 A diagnostic can be suppressed with `//nolint:orderby` trailing the offending
 line, or standing alone on the line above it. Every use must carry an inline
-justification:
+justification, and that requirement is **enforced, not just documented**:
 
 ```go
 //nolint:orderby // <why this value cannot reach user input>
 ```
+
+A directive with no reason after it does not suppress anything. Instead the call
+site reports a different diagnostic naming the missing justification, because a
+bare directive reads as "handled" to the next reviewer - which is how a security
+lint gets switched off one call site at a time. Both spellings golangci-lint
+accepts work: `//nolint:orderby // reason` and `//nolint:orderby//reason`.
 
 The name must appear in the directive's own list - a bare `//nolint` does not
 silence this rule, and a *trailing* directive covers only its own line, never

--- a/docs/content/en/project/contributing/contributing-lint.md
+++ b/docs/content/en/project/contributing/contributing-lint.md
@@ -18,6 +18,13 @@ from:
 make golangci
 ```
 
+`mesheryctl` is part of the same root Go module and is covered by the same rules.
+Its own target runs the identical pair scoped to the CLI:
+
+```bash
+cd mesheryctl && make lint
+```
+
 ## ORDER BY must be sanitized
 
 `gorm`'s `(*gorm.DB).Order` interpolates a string argument into the generated SQL

--- a/docs/content/en/project/contributing/contributing-server.md
+++ b/docs/content/en/project/contributing/contributing-server.md
@@ -61,7 +61,7 @@ For more details, <a href="{{< ref "project/contributing/contributing-error.md" 
 
 This runs `golangci-lint` plus Meshery's repo-specific Go rules - notably the
 one that fails the build when a `gorm` `ORDER BY` clause is built from a value
-that has not been through `models.SanitizeOrderInput`. The same rules run in
+that is neither a constant nor a result of `models.SanitizeOrderInput`. The same rules run in
 CI's `golangci-lint-server` job. For what each rule protects and what to do when
 one fires, see <a href="{{< ref "project/contributing/contributing-lint.md" >}}">Go Lint Rules</a>.
 

--- a/docs/content/en/project/contributing/contributing-server.md
+++ b/docs/content/en/project/contributing/contributing-server.md
@@ -55,6 +55,16 @@ Every Golang-based component within the Meshery ecosystem incorporates a utility
 
 For more details, <a href="{{< ref "project/contributing/contributing-error.md" >}}">Error Utility</a>
 
+#### Lint the server
+
+{{< code code=`make golangci` >}}
+
+This runs `golangci-lint` plus Meshery's repo-specific Go rules - notably the
+one that fails the build when a `gorm` `ORDER BY` clause is built from a value
+that has not been through `models.SanitizeOrderInput`. The same rules run in
+CI's `golangci-lint-server` job. For what each rule protects and what to do when
+one fires, see <a href="{{< ref "project/contributing/contributing-lint.md" >}}">Go Lint Rules</a>.
+
 ### Configuring Log levels at Runtime
 
 The server log levels can be configured at runtime by changing the env variable `LOG_LEVEL` defined in file [`server-config.env`](https://github.com/meshery/meshery/blob/master/server/cmd/server-config.env). The configuration library (`viper`) watches for the env file, any change in the file content results in the `file_system` event to be emitted and the log level is updated accordingly.

--- a/docs/content/en/project/contributing/error-contract.md
+++ b/docs/content/en/project/contributing/error-contract.md
@@ -25,6 +25,8 @@ as JSON before surfacing errors to users.
 > error events through the active SSE writer instead); and binary/tar/YAML
 > downloads and HTTP redirects, which use `w.Write` or `http.Redirect`
 > rather than `http.Error` and so are not governed by the lint rule.
+> This rule and the other repo-specific Go lint gates are listed in
+> [Go Lint Rules]({{< ref "project/contributing/contributing-lint.md" >}}).
 
 ## Shape
 

--- a/docs/content/en/project/contributing/ui/tests.md
+++ b/docs/content/en/project/contributing/ui/tests.md
@@ -187,6 +187,19 @@ Gating on `conclusion` silently disarms the gate - the job goes green whatever t
 
 If a test is failing, fix it or mark it `test.fixme` with the tracking issue in the annotation. Never re-disarm the gate to turn a red build green.
 
+## How much of the suite runs at once
+
+**The CI run is serial: one Playwright worker.** `ui/playwright.config.js` sets `workers: process.env.CI ? 1 : 4`, and a local run keeps 4. Raising the CI number is how this job goes back to failing for reasons that have nothing to do with the change under test.
+
+The job runs the entire stack on a single 4-vCPU/16-GB hosted runner - a Kind cluster, the Meshery server container, and Playwright. Each worker adds a Chromium on top of that, and an over-subscribed runner does not fail like a broken test does. Two shapes to recognise, both from 2026-08-17, when the config carried `process.env.CI ? 4 : 4` under a comment that read "Opt out of parallel tests on CI":
+
+- A spec exhausts a whole `describe` timeout with no assertion error - `Test timeout of 180000ms exceeded` on "Metrics (Prometheus) page loads", run `32024269277`.
+- The runner dies mid-step: *"The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error."* Run `32084526223` burned 49 minutes that way and uploaded no logs, no report and no traces, so the only evidence it left was that annotation.
+
+The tell that it is load rather than a defect is that a *different*, unrelated test fails in each red run, spread across the specs that mutate server-wide state - preferences, telemetry, connections, models, the controllers editor. `fullyParallel: false` already serializes the tests inside one file, so a second worker only buys concurrent spec *files*, and those files share one Meshery server, one Local-provider session and one Kind cluster. Playwright isolates browser contexts; it cannot isolate the server they all talk to.
+
+`ui/tests/playwrightWorkers.test.ts` pins the resolved value in the `ui-unit-tests` job, because the previous setting was wrong in a way reading could not catch: `process.env.CI ? 4 : 4` is a ternary whose branches are the same number, and it survived under the comment describing the opposite behavior.
+
 ## Debugging Test on Github Actions
 
 End-to-end test results are stored as artifacts on every PR in Github Actions. In case you need to debug a failed test:

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
+	golang.org/x/tools v0.45.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/api v0.287.0
 	google.golang.org/grpc v1.82.1
@@ -400,6 +401,7 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20250406160420-959f8f3db0fb // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
+	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/mesheryctl/Makefile
+++ b/mesheryctl/Makefile
@@ -101,9 +101,14 @@ error-util:
 # Quality
 #-----------------------------------------------------------------------------
 .PHONY: lint coverage
-## Lint mesheryctl using golangci-lint.
+## Lint mesheryctl using golangci-lint and Meshery's repo-specific Go analyzers.
+# Mirrors the golangci-lint-cli job's config and timeout, plus the ORDER BY
+# sanitization analyzer the golangci-lint-server job runs over the whole root
+# module. Without both, a CLI contributor's local lint is weaker than the jobs
+# that gate their PR.
 lint:
-	golangci-lint run --timeout 5m
+	golangci-lint run --config=../.github/.golangci.yml --timeout=10m
+	go run ../server/internal/lint/orderby/cmd/orderbylint ./...
 
 ## Run tests with coverage and generate HTML report.
 coverage:

--- a/server/internal/lint/orderby/cmd/orderbylint/main.go
+++ b/server/internal/lint/orderby/cmd/orderbylint/main.go
@@ -17,6 +17,8 @@ import (
 	"github.com/meshery/meshery/server/internal/lint/orderby"
 )
 
+// main runs the analyzer over the packages named on the command line, exiting
+// non-zero when any of them reports.
 func main() {
 	singlechecker.Main(orderby.Analyzer)
 }

--- a/server/internal/lint/orderby/cmd/orderbylint/main.go
+++ b/server/internal/lint/orderby/cmd/orderbylint/main.go
@@ -1,0 +1,22 @@
+// Command orderbylint runs the orderby analyzer over the packages named on the
+// command line and exits non-zero when any gorm ORDER BY clause is built from a
+// value that is neither constant nor sanitized.
+//
+// It runs as a step of the golangci-lint-server CI job and of `make golangci`,
+// so a violation fails the same gate that already blocks the build. golangci-lint
+// cannot host this check without building a custom binary from its module plugin
+// system, which is more machinery than one analyzer is worth; see
+// docs/content/en/project/contributing/contributing-lint.md.
+//
+//	go run ./server/internal/lint/orderby/cmd/orderbylint ./...
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/meshery/meshery/server/internal/lint/orderby"
+)
+
+func main() {
+	singlechecker.Main(orderby.Analyzer)
+}

--- a/server/internal/lint/orderby/orderby.go
+++ b/server/internal/lint/orderby/orderby.go
@@ -54,6 +54,16 @@
 // skipped: the pass cannot prove what such a value holds, and assuming a clause
 // value would be the silent false negative that is the CVE.
 //
+// A type parameter is treated the same way and for the same reason: SSA builds a
+// generic body once with the parameter intact, so `db.Order(order)` inside
+// `func f[T ~string]` boxes a type parameter rather than a concrete type, and
+// instantiating it at string reaches that same `case string:` branch.
+//
+// In every one of those cases the pass still accepts the value when it can
+// trace the value's definitions to a constant or the sanitizer, whatever the
+// static type says. Not seeing a value's type only decides the outcome when its
+// origin is invisible too.
+//
 // clause.Expr and clause.Column{Raw: true} are escape hatches within gorm's own
 // clause builder and are not checked here; neither is used in this repository.
 //
@@ -76,9 +86,15 @@
 //
 // A diagnostic can be suppressed with a `//nolint:orderby` comment trailing the
 // offending line, or standing alone on the line above it, matching the spelling
-// contributors already use for golangci-lint. Each one must carry an inline
-// justification. A growing suppression list means the rule is mis-specified -
-// narrow the rule instead of muting the call site.
+// contributors already use for golangci-lint. Both spellings golangci-lint
+// accepts work: `//nolint:orderby // reason` and `//nolint:orderby//reason`.
+//
+// Each one must carry an inline justification, and that is enforced rather than
+// merely documented: a directive with no reason after it suppresses nothing and
+// instead reports the missing justification. A bare directive reads as
+// "handled" to the next reviewer, which is how a security lint gets switched
+// off one call site at a time. A growing suppression list means the rule is
+// mis-specified - narrow the rule instead of muting the call site.
 package orderby
 
 import (
@@ -132,6 +148,16 @@ const opaqueArgMsg = "ORDER BY built from an unsanitized value: this argument's 
 	"or a concretely-typed clause value. " +
 	"See docs/content/en/project/contributing/contributing-lint.md."
 
+// unjustifiedNolintMsg replaces the diagnostic when the call site carries a
+// `//nolint:orderby` with no reason after it. Reporting the missing
+// justification rather than the original problem is what makes the requirement
+// enforceable: a bare directive reads as "handled" to the next reviewer, so it
+// has to fail loudly and say what is missing.
+const unjustifiedNolintMsg = "//nolint:orderby without a justification does not suppress this rule. " +
+	"Write `//nolint:orderby // <why this value cannot reach user input>`, or fix the call site by " +
+	"passing the argument through models.SanitizeOrderInput(order, []string{...}). " +
+	"See docs/content/en/project/contributing/contributing-lint.md."
+
 // Analyzer reports gorm ORDER BY clauses built from values that are neither
 // constant nor sanitized.
 var Analyzer = &analysis.Analyzer{
@@ -142,13 +168,15 @@ var Analyzer = &analysis.Analyzer{
 	Run:      run,
 }
 
+// run walks every gorm Order call in the package and reports the ones whose
+// argument the pass cannot show is safe.
 func run(pass *analysis.Pass) (any, error) {
 	ssaResult, ok := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
 	if !ok || ssaResult == nil {
 		return nil, nil
 	}
 
-	suppressed := suppressedLines(pass)
+	suppressed, unjustified := suppressedLines(pass)
 
 	for _, fn := range ssaResult.SrcFuncs {
 		if fn == nil {
@@ -171,7 +199,15 @@ func run(pass *analysis.Pass) (any, error) {
 					// interpolating them.
 					continue
 				}
-				if kind == argString && isSafeOrderValue(arg, map[ssa.Value]bool{}) {
+				// A value whose definitions are all constants or sanitizer
+				// results is safe whatever its static type says: if the pass
+				// can see where it came from, it does not need to see what it
+				// is. That matters for a type parameter, where the sanitized
+				// form is `T(models.SanitizeOrderInput(...))` and the static
+				// type is opaque by construction. A genuinely opaque value -
+				// an `any` parameter, a map[string]any read - has no traceable
+				// definition and still reports.
+				if isSafeOrderValue(arg, map[ssa.Value]bool{}) {
 					continue
 				}
 				msg := diagnosticMsg
@@ -187,6 +223,9 @@ func run(pass *analysis.Pass) (any, error) {
 					at := pass.Fset.Position(pos)
 					if isSanitizerFile(pass, at) || suppressed[sourceLine{at.Filename, at.Line}] {
 						continue
+					}
+					if unjustified[sourceLine{at.Filename, at.Line}] {
+						msg = unjustifiedNolintMsg
 					}
 				}
 				pass.Reportf(pos, "%s", msg)
@@ -277,25 +316,48 @@ func classifyOrderArg(common *ssa.CallCommon) (ssa.Value, orderArgKind) {
 
 	v := args[0]
 	// A concrete argument arrives boxed, and the boxed type is the dynamic type
-	// gorm switches on - visible right here.
+	// gorm switches on - visible right here. Both the boxed and the unboxed
+	// form run through the same classifier: keeping two copies of it is what
+	// let the boxed one fall behind and miss type parameters.
 	if mi, ok := v.(*ssa.MakeInterface); ok {
 		if mi.X == nil {
 			return nil, argClause
 		}
-		if isStringUnderlying(mi.X.Type()) {
-			return mi.X, argString
-		}
+		v = mi.X
+	}
+
+	kind := classifyOrderArgType(v.Type())
+	if kind == argClause {
 		return nil, argClause
 	}
-	if isStringUnderlying(v.Type()) {
-		return v, argString
+	return v, kind
+}
+
+// classifyOrderArgType reports what the pass can prove about a value of type t
+// reaching Order.
+func classifyOrderArgType(t types.Type) orderArgKind {
+	if t == nil {
+		return argClause
 	}
-	if _, ok := v.Type().Underlying().(*types.Interface); ok {
+	if isStringUnderlying(t) {
+		return argString
+	}
+	// A type parameter is not a concrete type: SSA builds a generic body once,
+	// with the parameter intact, so `db.Order(order)` in `func f[T ~string]`
+	// boxes a *types.TypeParam. Instantiating that at string reaches gorm's
+	// `case string:` branch like any other string, so it cannot be skipped as
+	// though it were a clause value. Its Underlying is the constraint
+	// interface, which the check below already treats as opaque - naming the
+	// case explicitly keeps it from being "simplified" away again.
+	if _, ok := types.Unalias(t).(*types.TypeParam); ok {
+		return argOpaque
+	}
+	if _, ok := t.Underlying().(*types.Interface); ok {
 		// An `any` parameter, a map[string]any read, an `any` struct field, a
 		// widened interface. Nothing here rules out a string.
-		return v, argOpaque
+		return argOpaque
 	}
-	return nil, argClause
+	return argClause
 }
 
 // isStringUnderlying reports whether t is a string or a named type over one.
@@ -382,24 +444,35 @@ func isSanitizerFile(pass *analysis.Pass, at token.Position) bool {
 // comment stands alone on its line. That second restriction matters - without
 // it a trailing directive would silently cover the statement underneath it,
 // which is a false negative in a rule whose whole job is to have none.
-func suppressedLines(pass *analysis.Pass) map[sourceLine]bool {
-	lines := map[sourceLine]bool{}
+func suppressedLines(pass *analysis.Pass) (suppressed, unjustified map[sourceLine]bool) {
+	suppressed = map[sourceLine]bool{}
+	unjustified = map[sourceLine]bool{}
 	sources := map[string][]byte{}
 	for _, file := range pass.Files {
 		for _, group := range file.Comments {
 			for _, comment := range group.List {
-				if !hasNolintDirective(comment) {
+				names, justified := hasNolintDirective(comment)
+				if !names {
 					continue
 				}
+				// An unjustified directive does not suppress. The docs have
+				// always required a reason; letting the bare form work anyway
+				// is how a security lint gets quietly switched off one call
+				// site at a time, so the requirement is enforced here rather
+				// than merely documented.
+				target := suppressed
+				if !justified {
+					target = unjustified
+				}
 				pos := pass.Fset.Position(comment.Slash)
-				lines[sourceLine{pos.Filename, pos.Line}] = true
+				target[sourceLine{pos.Filename, pos.Line}] = true
 				if startsItsLine(pass, sources, pos) {
-					lines[sourceLine{pos.Filename, pos.Line + 1}] = true
+					target[sourceLine{pos.Filename, pos.Line + 1}] = true
 				}
 			}
 		}
 	}
-	return lines
+	return suppressed, unjustified
 }
 
 // startsItsLine reports whether only whitespace precedes pos on its line. It
@@ -430,20 +503,30 @@ func startsItsLine(pass *analysis.Pass, sources map[string][]byte, pos token.Pos
 // `//nolint` is deliberately not honoured, and neither is the space-separated
 // `// nolint` spelling golangci-lint also rejects: silencing this rule must be
 // explicit about what is being silenced.
-func hasNolintDirective(comment *ast.Comment) bool {
+func hasNolintDirective(comment *ast.Comment) (names, justified bool) {
 	text := strings.TrimSpace(comment.Text)
 	if !strings.HasPrefix(text, nolintPrefix) {
-		return false
+		return false, false
 	}
-	// Drop the trailing ` // explanation`, then match the linter list exactly so
-	// `//nolint:gocritic,orderby` counts and `//nolint:orderbyish` does not.
-	names, _, _ := strings.Cut(text[len(nolintPrefix):], " //")
-	for name := range strings.SplitSeq(names, ",") {
+
+	// Split the linter list from the explanation. golangci-lint accepts both
+	// `//nolint:orderby // reason` and `//nolint:orderby//reason`, so the
+	// separator is the next `//` rather than a space-prefixed one - a linter
+	// name can never contain a slash.
+	rest := text[len(nolintPrefix):]
+	list, explanation := rest, ""
+	if i := strings.Index(rest, "//"); i >= 0 {
+		list, explanation = rest[:i], strings.TrimSpace(rest[i+2:])
+	}
+
+	// Match the linter list exactly so `//nolint:gocritic,orderby` counts and
+	// `//nolint:orderbyish` does not.
+	for name := range strings.SplitSeq(list, ",") {
 		if strings.TrimSpace(name) == analyzerName {
-			return true
+			return true, explanation != ""
 		}
 	}
-	return false
+	return false, false
 }
 
 // namedOf unwraps a pointer to the named type underneath, seeing through any

--- a/server/internal/lint/orderby/orderby.go
+++ b/server/internal/lint/orderby/orderby.go
@@ -1,0 +1,374 @@
+// Package orderby implements a go/analysis pass that keeps every gorm
+// ORDER BY clause fed from a value the server can prove is safe.
+//
+// gorm's (*gorm.DB).Order interpolates a string argument into the generated
+// SQL verbatim - it is a raw SQL sink, not a bound parameter. Every one of
+// Meshery's published CVEs came from that sink reached by a request-controlled
+// `?order=` value. models.SanitizeOrderInput closes it by echoing back only a
+// column drawn from the caller's allow-list, and roughly two dozen call sites
+// route through it.
+//
+// Until this pass existed that convergence was a convention: a new persister
+// that built an ORDER BY from a non-constant string compiled, passed CI and
+// shipped. This analyzer turns the convention into a control - it fails the
+// build unless the value reaching Order is a constant or comes out of the
+// sanitizer.
+//
+// # What it accepts
+//
+// For each call to (*gorm.io/gorm.DB).Order whose argument is string-typed,
+// the pass walks the argument backwards through SSA and requires every
+// definition that can reach it to be one of:
+//
+//   - a constant (a string literal, or a named constant such as
+//     models.defaultOrderUpdatedAtDesc);
+//   - the result of models.SanitizeOrderInput.
+//
+// Because the walk is over SSA rather than syntax it is flow-sensitive: the
+// prevailing call-site shape
+//
+//	order = models.SanitizeOrderInput(order, []string{"created_at", "name"})
+//	if order == "" {
+//	    order = defaultOrderUpdatedAtDesc
+//	}
+//	query = query.Order(order)
+//
+// reaches Order as a phi of {sanitizer result, constant} and is accepted,
+// while a function that ordered on its raw parameter first and sanitized
+// afterwards is not.
+//
+// # What it deliberately does not cover
+//
+// Non-string arguments - the clause.OrderByColumn and clause.OrderBy values
+// gorm also accepts - are out of scope. gorm renders those through its clause
+// builder, which quotes the identifier rather than interpolating it, so they
+// are not the string-interpolation sink this rule guards. clause.Expr and
+// clause.Column{Raw: true} are escape hatches within that builder and are not
+// checked here; neither is used in this repository.
+//
+// # Captured variables
+//
+// The walk covers SSA registers. Once a local's address is taken, or a closure
+// captures it, SSA holds it in a memory cell instead and every read becomes a
+// load - and proving which store reaches a given load needs a memory-flow
+// analysis, including stores a closure performs at a time this pass cannot
+// order. Rather than guess, the pass reports the load.
+//
+// That is deliberately the conservative direction: an order value that *is*
+// sanitized but happens to be captured produces a false positive, which is
+// loud and fixable, instead of a false negative, which is the CVE. No call site
+// in this repository is affected. If you hit it, either read the sanitized
+// value outside the closure and capture the result, or suppress the diagnostic
+// with a justification.
+//
+// # Suppression
+//
+// A diagnostic can be suppressed with a `//nolint:orderby` comment trailing the
+// offending line, or standing alone on the line above it, matching the spelling
+// contributors already use for golangci-lint. Each one must carry an inline
+// justification. A growing suppression list means the rule is mis-specified -
+// narrow the rule instead of muting the call site.
+package orderby
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+const (
+	// analyzerName is the name the rule is reported and suppressed under.
+	analyzerName = "orderby"
+
+	// gormPkgPath and gormDBTypeName identify the raw SQL sink being guarded.
+	gormPkgPath    = "gorm.io/gorm"
+	gormDBTypeName = "DB"
+	orderMethod    = "Order"
+
+	// sanitizerPkgPath and sanitizerFuncName identify the only function whose
+	// result is trusted to be interpolated into an ORDER BY clause.
+	sanitizerPkgPath  = "github.com/meshery/meshery/server/models"
+	sanitizerFuncName = "SanitizeOrderInput"
+
+	// sanitizerFileName is the one file exempt from the rule: the sanitizer's
+	// own, which is where an ORDER BY fragment is legitimately built from an
+	// unsanitized string.
+	sanitizerFileName = "sql-utils.go"
+
+	// nolintPrefix introduces the directive that suppresses a single
+	// diagnostic - `//nolint:orderby`. See the package doc.
+	nolintPrefix = "//nolint:"
+)
+
+const diagnosticMsg = "ORDER BY built from an unsanitized value: pass the argument through " +
+	"models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of columns, " +
+	"or use a constant. gorm's Order() interpolates a string into the SQL verbatim - this is the " +
+	"sink behind every Meshery CVE. See docs/content/en/project/contributing/contributing-lint.md."
+
+// Analyzer reports gorm ORDER BY clauses built from values that are neither
+// constant nor sanitized.
+var Analyzer = &analysis.Analyzer{
+	Name:     analyzerName,
+	Doc:      "check that every gorm ORDER BY clause is built from a constant or from models.SanitizeOrderInput",
+	URL:      "https://github.com/meshery/meshery/issues/21443",
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	ssaResult, ok := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA)
+	if !ok || ssaResult == nil {
+		return nil, nil
+	}
+
+	suppressed := suppressedLines(pass)
+
+	for _, fn := range ssaResult.SrcFuncs {
+		if fn == nil {
+			continue
+		}
+		for _, block := range fn.Blocks {
+			for _, instr := range block.Instrs {
+				call, ok := instr.(ssa.CallInstruction)
+				if !ok {
+					continue
+				}
+				common := call.Common()
+				if !isGormOrderCall(common) {
+					continue
+				}
+				arg := stringOrderArg(common)
+				if arg == nil {
+					// A clause.OrderByColumn / clause.OrderBy value; gorm
+					// quotes those rather than interpolating them.
+					continue
+				}
+				if isSafeOrderValue(arg, map[ssa.Value]bool{}) {
+					continue
+				}
+
+				pos := common.Pos()
+				if !pos.IsValid() {
+					pos = instr.Pos()
+				}
+				if pos.IsValid() {
+					at := pass.Fset.Position(pos)
+					if isSanitizerFile(pass, at) || suppressed[sourceLine{at.Filename, at.Line}] {
+						continue
+					}
+				}
+				pass.Reportf(pos, "%s", diagnosticMsg)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// isGormOrderCall reports whether common is a static call to
+// (*gorm.io/gorm.DB).Order. gorm's *DB is a concrete type, so an interface
+// dispatch can never land there and is rejected outright.
+//
+// The callee is matched on its signature - `Order(any) *gorm.DB` - rather than
+// on its receiver type, so a call that reaches Order through an embedding
+// wrapper is caught too. meshkit's database.Handler embeds *gorm.DB and every
+// persister in this repository orders through it.
+func isGormOrderCall(common *ssa.CallCommon) bool {
+	if common == nil || common.IsInvoke() {
+		return false
+	}
+	callee := common.StaticCallee()
+	if callee == nil || callee.Name() != orderMethod {
+		return false
+	}
+	sig := callee.Signature
+	if sig.Recv() == nil || sig.Params().Len() != 1 || sig.Results().Len() != 1 {
+		return false
+	}
+	named := namedOf(sig.Results().At(0).Type())
+	if named == nil {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil &&
+		obj.Name() == gormDBTypeName &&
+		obj.Pkg() != nil &&
+		obj.Pkg().Path() == gormPkgPath
+}
+
+// stringOrderArg returns the string-typed value passed to Order, unwrapping the
+// interface boxing gorm's `value any` parameter forces. It returns nil when the
+// argument is not string-typed.
+func stringOrderArg(common *ssa.CallCommon) ssa.Value {
+	// Args[0] is the receiver of the static method call.
+	if len(common.Args) != 2 {
+		return nil
+	}
+	v := common.Args[1]
+	if mi, ok := v.(*ssa.MakeInterface); ok {
+		v = mi.X
+	}
+	if v == nil {
+		return nil
+	}
+	basic, ok := v.Type().Underlying().(*types.Basic)
+	if !ok || basic.Info()&types.IsString == 0 {
+		return nil
+	}
+	return v
+}
+
+// isSafeOrderValue reports whether every definition reaching v is a constant or
+// the result of the sanitizer. seen breaks phi cycles in loops: a value already
+// on the current path contributes no new obligation, so it is treated as
+// satisfied and the remaining edges decide.
+func isSafeOrderValue(v ssa.Value, seen map[ssa.Value]bool) bool {
+	if v == nil {
+		return false
+	}
+	if seen[v] {
+		return true
+	}
+	seen[v] = true
+
+	switch value := v.(type) {
+	case *ssa.Const:
+		return true
+	case *ssa.Call:
+		return isSanitizerCall(value.Common())
+	case *ssa.Phi:
+		for _, edge := range value.Edges {
+			if !isSafeOrderValue(edge, seen) {
+				return false
+			}
+		}
+		return true
+	case *ssa.Convert:
+		return isSafeOrderValue(value.X, seen)
+	case *ssa.ChangeType:
+		return isSafeOrderValue(value.X, seen)
+	}
+
+	// Parameters, field and map reads, string concatenation, fmt.Sprintf
+	// results - anything else is request-reachable as far as this pass can
+	// tell. So is a load from memory: SSA spills a local into a memory cell
+	// once a closure captures it, and proving which store reaches a given load
+	// needs a memory-flow analysis this pass deliberately does not carry. See
+	// "Captured variables" in the package doc.
+	return false
+}
+
+// isSanitizerCall reports whether common is a static call to
+// models.SanitizeOrderInput.
+func isSanitizerCall(common *ssa.CallCommon) bool {
+	if common == nil {
+		return false
+	}
+	callee := common.StaticCallee()
+	if callee == nil || callee.Name() != sanitizerFuncName || callee.Pkg == nil {
+		return false
+	}
+	return callee.Pkg.Pkg != nil && callee.Pkg.Pkg.Path() == sanitizerPkgPath
+}
+
+// sourceLine identifies one line of one file. Suppression is tracked per file:
+// a package compiles several, and a directive in one of them must not silence
+// the same line number in another.
+type sourceLine struct {
+	filename string
+	line     int
+}
+
+// isSanitizerFile reports whether at is inside models/sql-utils.go, the one
+// file allowed to assemble an ORDER BY fragment from unsanitized input.
+func isSanitizerFile(pass *analysis.Pass, at token.Position) bool {
+	if pass.Pkg == nil || pass.Pkg.Path() != sanitizerPkgPath {
+		return false
+	}
+	return filepath.Base(at.Filename) == sanitizerFileName
+}
+
+// suppressedLines collects the 1-based lines a `//nolint:orderby` directive
+// covers: the comment's own line always, and the line below it only when the
+// comment stands alone on its line. That second restriction matters - without
+// it a trailing directive would silently cover the statement underneath it,
+// which is a false negative in a rule whose whole job is to have none.
+func suppressedLines(pass *analysis.Pass) map[sourceLine]bool {
+	lines := map[sourceLine]bool{}
+	sources := map[string][]byte{}
+	for _, file := range pass.Files {
+		for _, group := range file.Comments {
+			for _, comment := range group.List {
+				if !hasNolintDirective(comment) {
+					continue
+				}
+				pos := pass.Fset.Position(comment.Slash)
+				lines[sourceLine{pos.Filename, pos.Line}] = true
+				if startsItsLine(pass, sources, pos) {
+					lines[sourceLine{pos.Filename, pos.Line + 1}] = true
+				}
+			}
+		}
+	}
+	return lines
+}
+
+// startsItsLine reports whether only whitespace precedes pos on its line. It
+// reads each file at most once, and answers conservatively - a source it cannot
+// read yields no extra suppression rather than an unchecked line.
+func startsItsLine(pass *analysis.Pass, sources map[string][]byte, pos token.Position) bool {
+	if pos.Column <= 1 {
+		return true
+	}
+	src, cached := sources[pos.Filename]
+	if !cached {
+		if pass.ReadFile != nil {
+			src, _ = pass.ReadFile(pos.Filename)
+		}
+		sources[pos.Filename] = src
+	}
+	// token.Position.Column counts bytes from the start of the line, so the
+	// line begins Column-1 bytes before the comment.
+	start := pos.Offset - (pos.Column - 1)
+	if src == nil || start < 0 || pos.Offset > len(src) {
+		return false
+	}
+	return strings.TrimSpace(string(src[start:pos.Offset])) == ""
+}
+
+// hasNolintDirective reports whether comment names this analyzer in a nolint
+// directive, in any position of the comma-separated linter list. Bare
+// `//nolint` is deliberately not honoured, and neither is the space-separated
+// `// nolint` spelling golangci-lint also rejects: silencing this rule must be
+// explicit about what is being silenced.
+func hasNolintDirective(comment *ast.Comment) bool {
+	text := strings.TrimSpace(comment.Text)
+	if !strings.HasPrefix(text, nolintPrefix) {
+		return false
+	}
+	// Drop the trailing ` // explanation`, then match the linter list exactly so
+	// `//nolint:gocritic,orderby` counts and `//nolint:orderbyish` does not.
+	names, _, _ := strings.Cut(text[len(nolintPrefix):], " //")
+	for name := range strings.SplitSeq(names, ",") {
+		if strings.TrimSpace(name) == analyzerName {
+			return true
+		}
+	}
+	return false
+}
+
+// namedOf unwraps a pointer to the named type underneath, seeing through any
+// alias on the way.
+func namedOf(t types.Type) *types.Named {
+	if ptr, ok := types.Unalias(t).(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, _ := types.Unalias(t).(*types.Named)
+	return named
+}

--- a/server/internal/lint/orderby/orderby.go
+++ b/server/internal/lint/orderby/orderby.go
@@ -39,12 +39,23 @@
 //
 // # What it deliberately does not cover
 //
-// Non-string arguments - the clause.OrderByColumn and clause.OrderBy values
-// gorm also accepts - are out of scope. gorm renders those through its clause
-// builder, which quotes the identifier rather than interpolating it, so they
-// are not the string-interpolation sink this rule guards. clause.Expr and
-// clause.Column{Raw: true} are escape hatches within that builder and are not
-// checked here; neither is used in this repository.
+// An argument the pass can see is boxed from a concrete non-string type - the
+// clause.OrderByColumn and clause.OrderBy values gorm also accepts - is out of
+// scope. gorm renders those through its clause builder, which quotes the
+// identifier rather than interpolating it, so they are not the
+// string-interpolation sink this rule guards.
+//
+// That skip is narrow on purpose: it holds only where the boxed type is
+// statically visible and not string-underlying. gorm's Order takes `any` and
+// type-switches on it at runtime, and its `case string:` branch builds a
+// clause.Column{Raw: true} - the verbatim interpolation again. An argument
+// whose static type is already an interface (an `any` parameter, a
+// map[string]any read, an `any` struct field) is therefore reported rather than
+// skipped: the pass cannot prove what such a value holds, and assuming a clause
+// value would be the silent false negative that is the CVE.
+//
+// clause.Expr and clause.Column{Raw: true} are escape hatches within gorm's own
+// clause builder and are not checked here; neither is used in this repository.
 //
 // # Captured variables
 //
@@ -111,6 +122,16 @@ const diagnosticMsg = "ORDER BY built from an unsanitized value: pass the argume
 	"or use a constant. gorm's Order() interpolates a string into the SQL verbatim - this is the " +
 	"sink behind every Meshery CVE. See docs/content/en/project/contributing/contributing-lint.md."
 
+// opaqueArgMsg covers the argument whose static type is an interface. The
+// remedy differs from diagnosticMsg's: the value has to be given a concrete
+// type before it can be proven either way.
+const opaqueArgMsg = "ORDER BY built from an unsanitized value: this argument's static type is an " +
+	"interface, so the pass cannot prove it does not hold a string. gorm's Order() type-switches " +
+	"at runtime and interpolates a string into the SQL verbatim - this is the sink behind every " +
+	"Meshery CVE. Pass a string sanitized with models.SanitizeOrderInput(order, []string{...}), " +
+	"or a concretely-typed clause value. " +
+	"See docs/content/en/project/contributing/contributing-lint.md."
+
 // Analyzer reports gorm ORDER BY clauses built from values that are neither
 // constant nor sanitized.
 var Analyzer = &analysis.Analyzer{
@@ -143,14 +164,19 @@ func run(pass *analysis.Pass) (any, error) {
 				if !isGormOrderCall(common) {
 					continue
 				}
-				arg := stringOrderArg(common)
-				if arg == nil {
-					// A clause.OrderByColumn / clause.OrderBy value; gorm
-					// quotes those rather than interpolating them.
+				arg, kind := classifyOrderArg(common)
+				if kind == argClause {
+					// A clause.OrderByColumn / clause.OrderBy value, boxed from
+					// a concrete non-string type; gorm quotes those rather than
+					// interpolating them.
 					continue
 				}
-				if isSafeOrderValue(arg, map[ssa.Value]bool{}) {
+				if kind == argString && isSafeOrderValue(arg, map[ssa.Value]bool{}) {
 					continue
+				}
+				msg := diagnosticMsg
+				if kind == argOpaque {
+					msg = opaqueArgMsg
 				}
 
 				pos := common.Pos()
@@ -163,7 +189,7 @@ func run(pass *analysis.Pass) (any, error) {
 						continue
 					}
 				}
-				pass.Reportf(pos, "%s", diagnosticMsg)
+				pass.Reportf(pos, "%s", msg)
 			}
 		}
 	}
@@ -171,24 +197,35 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// isGormOrderCall reports whether common is a static call to
-// (*gorm.io/gorm.DB).Order. gorm's *DB is a concrete type, so an interface
-// dispatch can never land there and is rejected outright.
+// isGormOrderCall reports whether common calls (*gorm.io/gorm.DB).Order.
 //
 // The callee is matched on its signature - `Order(any) *gorm.DB` - rather than
 // on its receiver type, so a call that reaches Order through an embedding
 // wrapper is caught too. meshkit's database.Handler embeds *gorm.DB and every
 // persister in this repository orders through it.
+//
+// A dynamic dispatch through an interface declaring that method is matched on
+// the same signature: *gorm.DB satisfies such an interface, so the call lands on
+// the same raw sink, and waving it through would leave "wrap the handler in an
+// interface" as a way to opt out of the rule.
 func isGormOrderCall(common *ssa.CallCommon) bool {
-	if common == nil || common.IsInvoke() {
+	if common == nil {
 		return false
 	}
-	callee := common.StaticCallee()
-	if callee == nil || callee.Name() != orderMethod {
-		return false
+	var sig *types.Signature
+	if common.IsInvoke() {
+		if common.Method == nil || common.Method.Name() != orderMethod {
+			return false
+		}
+		sig, _ = common.Method.Type().(*types.Signature)
+	} else {
+		callee := common.StaticCallee()
+		if callee == nil || callee.Name() != orderMethod {
+			return false
+		}
+		sig = callee.Signature
 	}
-	sig := callee.Signature
-	if sig.Recv() == nil || sig.Params().Len() != 1 || sig.Results().Len() != 1 {
+	if sig == nil || sig.Recv() == nil || sig.Params().Len() != 1 || sig.Results().Len() != 1 {
 		return false
 	}
 	named := namedOf(sig.Results().At(0).Type())
@@ -202,26 +239,72 @@ func isGormOrderCall(common *ssa.CallCommon) bool {
 		obj.Pkg().Path() == gormPkgPath
 }
 
-// stringOrderArg returns the string-typed value passed to Order, unwrapping the
-// interface boxing gorm's `value any` parameter forces. It returns nil when the
-// argument is not string-typed.
-func stringOrderArg(common *ssa.CallCommon) ssa.Value {
-	// Args[0] is the receiver of the static method call.
-	if len(common.Args) != 2 {
-		return nil
+// orderArgKind says what the pass can prove about the value handed to gorm's
+// `Order(value any)` parameter. Skipping a call is only sound when the dynamic
+// type is provably not a string, so the unknown case is a diagnostic rather
+// than a third silent exit.
+type orderArgKind int
+
+const (
+	// argClause: the argument is boxed from a concrete non-string type, so
+	// gorm's runtime type switch cannot reach its raw `case string:` branch.
+	argClause orderArgKind = iota
+	// argString: a string, the one value gorm interpolates verbatim. Its
+	// definitions decide whether the call is reported.
+	argString
+	// argOpaque: the argument is already interface-typed, so what it holds at
+	// runtime is not visible here - and a string is one of the things it can
+	// hold.
+	argOpaque
+)
+
+// classifyOrderArg returns the value passed to Order together with what the pass
+// can prove about it, unwrapping the interface boxing gorm's `value any`
+// parameter forces on a concrete argument.
+func classifyOrderArg(common *ssa.CallCommon) (ssa.Value, orderArgKind) {
+	args := common.Args
+	if !common.IsInvoke() {
+		// Args[0] is the receiver of the static method call; an invoke keeps
+		// its receiver in common.Value instead.
+		if len(args) == 0 {
+			return nil, argClause
+		}
+		args = args[1:]
 	}
-	v := common.Args[1]
+	if len(args) != 1 || args[0] == nil {
+		return nil, argClause
+	}
+
+	v := args[0]
+	// A concrete argument arrives boxed, and the boxed type is the dynamic type
+	// gorm switches on - visible right here.
 	if mi, ok := v.(*ssa.MakeInterface); ok {
-		v = mi.X
+		if mi.X == nil {
+			return nil, argClause
+		}
+		if isStringUnderlying(mi.X.Type()) {
+			return mi.X, argString
+		}
+		return nil, argClause
 	}
-	if v == nil {
-		return nil
+	if isStringUnderlying(v.Type()) {
+		return v, argString
 	}
-	basic, ok := v.Type().Underlying().(*types.Basic)
-	if !ok || basic.Info()&types.IsString == 0 {
-		return nil
+	if _, ok := v.Type().Underlying().(*types.Interface); ok {
+		// An `any` parameter, a map[string]any read, an `any` struct field, a
+		// widened interface. Nothing here rules out a string.
+		return v, argOpaque
 	}
-	return v
+	return nil, argClause
+}
+
+// isStringUnderlying reports whether t is a string or a named type over one.
+// gorm's type switch matches the unnamed `string` exactly; keeping the named
+// form in scope costs a false positive at worst, and which spelling that switch
+// happens to match is an implementation detail to stay clear of.
+func isStringUnderlying(t types.Type) bool {
+	basic, ok := t.Underlying().(*types.Basic)
+	return ok && basic.Info()&types.IsString != 0
 }
 
 // isSafeOrderValue reports whether every definition reaching v is a constant or

--- a/server/internal/lint/orderby/orderby.go
+++ b/server/internal/lint/orderby/orderby.go
@@ -398,6 +398,21 @@ func isSafeOrderValue(v ssa.Value, seen map[ssa.Value]bool) bool {
 		return isSafeOrderValue(value.X, seen)
 	case *ssa.ChangeType:
 		return isSafeOrderValue(value.X, seen)
+	case *ssa.MultiConvert:
+		// The conversion SSA emits when either side is a type parameter whose
+		// type set has more than one term - `T(s)` under `T ~string | ~[]byte`.
+		// Like Convert and ChangeType it only reshapes the value, so the
+		// obligation passes through to its operand.
+		return isSafeOrderValue(value.X, seen)
+	case *ssa.ChangeInterface:
+		// Widening one interface type to another, e.g. a Stringer assigned to
+		// an `any`. Also value-preserving.
+		return isSafeOrderValue(value.X, seen)
+	case *ssa.MakeInterface:
+		// Boxing a concrete value. classifyOrderArg unwraps this at the call
+		// itself; it reappears here when the boxing happened further back, as
+		// in a value boxed into one interface and then widened into another.
+		return isSafeOrderValue(value.X, seen)
 	}
 
 	// Parameters, field and map reads, string concatenation, fmt.Sprintf

--- a/server/internal/lint/orderby/orderby_test.go
+++ b/server/internal/lint/orderby/orderby_test.go
@@ -1,0 +1,24 @@
+package orderby_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/meshery/meshery/server/internal/lint/orderby"
+)
+
+// TestAnalyzer pins the rule against the ORDER BY shapes the server actually
+// builds. The `// want` annotations in testdata are the assertion: every
+// rejected shape must report, and - just as important - every accepted shape
+// must stay silent, because a rule that fires on the existing call sites would
+// be turned off rather than obeyed.
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(
+		t,
+		analysistest.TestData(),
+		orderby.Analyzer,
+		"persister",
+		"github.com/meshery/meshery/server/models",
+	)
+}

--- a/server/internal/lint/orderby/testdata/src/github.com/meshery/meshery/server/models/sql-utils.go
+++ b/server/internal/lint/orderby/testdata/src/github.com/meshery/meshery/server/models/sql-utils.go
@@ -1,0 +1,22 @@
+// Package models is a stand-in for github.com/meshery/meshery/server/models,
+// carrying only the sanitizer the orderby analyzer trusts. The file name
+// matters: sql-utils.go is the one file the rule exempts, and the call below
+// pins that exemption.
+package models
+
+import "gorm.io/gorm"
+
+func SanitizeOrderInput(order string, validColumns []string) string {
+	for _, col := range validColumns {
+		if col == order {
+			return col + " asc"
+		}
+	}
+	return ""
+}
+
+// exemptHere is not reported: sql-utils.go is where an ORDER BY fragment is
+// legitimately assembled from unsanitized input.
+func exemptHere(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order)
+}

--- a/server/internal/lint/orderby/testdata/src/github.com/meshery/meshery/server/models/vars.go
+++ b/server/internal/lint/orderby/testdata/src/github.com/meshery/meshery/server/models/vars.go
@@ -1,0 +1,11 @@
+package models
+
+import "gorm.io/gorm"
+
+const defaultOrderUpdatedAtDesc = "updated_at desc"
+
+// notExemptHere proves the exemption is scoped to sql-utils.go rather than to
+// the whole models package.
+func notExemptHere(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}

--- a/server/internal/lint/orderby/testdata/src/gorm.io/gorm/clause/clause.go
+++ b/server/internal/lint/orderby/testdata/src/gorm.io/gorm/clause/clause.go
@@ -1,0 +1,13 @@
+// Package clause is a stand-in for gorm.io/gorm/clause, carrying only the
+// ORDER BY values gorm renders through its quoting clause builder.
+package clause
+
+type Column struct {
+	Name string
+	Raw  bool
+}
+
+type OrderByColumn struct {
+	Column Column
+	Desc   bool
+}

--- a/server/internal/lint/orderby/testdata/src/gorm.io/gorm/gorm.go
+++ b/server/internal/lint/orderby/testdata/src/gorm.io/gorm/gorm.go
@@ -1,0 +1,13 @@
+// Package gorm is a stand-in for gorm.io/gorm, reproducing only the shape the
+// orderby analyzer keys on: a concrete *DB whose Order method takes `any`.
+// analysistest loads its fixtures in GOPATH mode with the module proxy off, so
+// the real dependency is not reachable from here.
+package gorm
+
+type DB struct{}
+
+func (db *DB) Order(value any) *DB { return db }
+
+func (db *DB) Where(query any, args ...any) *DB { return db }
+
+func (db *DB) Find(dest any) *DB { return db }

--- a/server/internal/lint/orderby/testdata/src/persister/crossfile_directive.go
+++ b/server/internal/lint/orderby/testdata/src/persister/crossfile_directive.go
@@ -1,0 +1,10 @@
+package persister
+
+import "gorm.io/gorm"
+
+// crossFileDirective carries the only //nolint:orderby in this file, on line 9.
+// crossfile_violation.go has an unsanitized call on its own line 9. Suppression
+// is keyed by file *and* line, so this directive must not reach it.
+func crossFileDirective(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) //nolint:orderby // fixture: this file, this line only.
+}

--- a/server/internal/lint/orderby/testdata/src/persister/crossfile_violation.go
+++ b/server/internal/lint/orderby/testdata/src/persister/crossfile_violation.go
@@ -1,0 +1,10 @@
+package persister
+
+import "gorm.io/gorm"
+
+// crossFileViolation's Order call is on line 9, the same line the directive in
+// crossfile_directive.go occupies. Keying suppression on the line number alone
+// would silence this diagnostic - the padding here keeps the lines aligned.
+func crossFileViolation(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}

--- a/server/internal/lint/orderby/testdata/src/persister/persister.go
+++ b/server/internal/lint/orderby/testdata/src/persister/persister.go
@@ -116,6 +116,34 @@ func suppressedAlongsideAnotherLinter(db *gorm.DB, order string) *gorm.DB {
 	return db.Order(order) //nolint:gocritic,orderby // fixture: not the first name in the list.
 }
 
+// suppressedNoSpaceBeforeReason pins the spelling golangci-lint also tolerates:
+// the explanation separator is the next `//`, not a space-prefixed one.
+func suppressedNoSpaceBeforeReason(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) //nolint:orderby//fixture: no space before the reason.
+}
+
+//
+// Rejected: the directive names this analyzer but carries no justification.
+// The docs have always required a reason; a bare directive reads as "handled"
+// to the next reviewer, so it has to fail loudly rather than silently work.
+//
+
+// These use the standalone directive form because a trailing `//nolint:orderby`
+// cannot be tested here: analysistest keys its expectation annotation to the
+// diagnostic's own line, and that annotation would itself be read as the
+// justification. The analyzer takes the same path either way - what it reads is
+// the text after the linter list, wherever the comment sits.
+
+func unjustifiedStandalone(db *gorm.DB, order string) *gorm.DB {
+	//nolint:orderby
+	return db.Order(order) // want "without a justification does not suppress"
+}
+
+func unjustifiedWithOtherLinter(db *gorm.DB, order string) *gorm.DB {
+	//nolint:gocritic,orderby
+	return db.Order(order) // want "without a justification does not suppress"
+}
+
 //
 // Rejected: the directive does not actually name this analyzer.
 //
@@ -307,6 +335,39 @@ func addressEscapes(db *gorm.DB, order string) *gorm.DB {
 }
 
 func overwrite(order *string) { *order = "anything" }
+
+//
+// Rejected: the argument is a type parameter. SSA builds a generic body once
+// with the parameter intact, so the boxed type is a *types.TypeParam rather
+// than a concrete one. Instantiated at string it reaches gorm's `case string:`
+// branch like any other string, so skipping it as a clause value would be a
+// silent false negative.
+//
+
+// genericOrder is the reachable shape: a helper written once over ~string and
+// called with a request value.
+func genericOrder[T ~string](db *gorm.DB, order T) *gorm.DB {
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+// genericOrderAny is the same hole through an unconstrained parameter.
+func genericOrderAny[T any](db *gorm.DB, order T) *gorm.DB {
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+// instantiateGenericOrder pins that the generic helpers above are instantiated
+// at string by a real caller, so the diagnostic is about a reachable path and
+// not an abstract one.
+func instantiateGenericOrder(db *gorm.DB, order string) *gorm.DB {
+	db = genericOrder(db, order)
+	return genericOrderAny(db, order)
+}
+
+// genericSanitized still has to satisfy the rule the ordinary way - the type
+// parameter does not exempt it, and a sanitized value passes.
+func genericSanitized[T ~string](db *gorm.DB, order string) *gorm.DB {
+	return db.Order(T(models.SanitizeOrderInput(order, validColumns)))
+}
 
 // lookalike is not gorm's Order: the rule keys on the `Order(any) *gorm.DB`
 // signature, so an unrelated method of the same name is left alone.

--- a/server/internal/lint/orderby/testdata/src/persister/persister.go
+++ b/server/internal/lint/orderby/testdata/src/persister/persister.go
@@ -1,0 +1,249 @@
+// Package persister exercises the orderby analyzer against the ORDER BY shapes
+// that appear in - or could plausibly be added to - server/models and
+// server/handlers.
+package persister
+
+import (
+	"fmt"
+
+	"github.com/meshery/meshery/server/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const defaultOrder = "updated_at desc"
+
+var validColumns = []string{"created_at", "updated_at", "name"}
+
+//
+// Accepted: the value reaching Order is provably constant or sanitized.
+//
+
+func literal(db *gorm.DB) *gorm.DB {
+	return db.Order("updated_at desc")
+}
+
+func namedConstant(db *gorm.DB) *gorm.DB {
+	return db.Order(defaultOrder)
+}
+
+func sanitizedDirectly(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(models.SanitizeOrderInput(order, validColumns))
+}
+
+// sanitizedThenDefaulted is the shape every persister in this repository uses:
+// the sanitizer empties an unknown column, and a constant fills the gap.
+func sanitizedThenDefaulted(db *gorm.DB, order string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	if order == "" {
+		order = defaultOrder
+	}
+	return db.Order(order)
+}
+
+// sanitizedComposition mirrors default_local_provider.go's events query, where
+// two request fields are joined before sanitization rather than after.
+func sanitizedComposition(db *gorm.DB, sortOn, direction string) *gorm.DB {
+	order := models.SanitizeOrderInput(fmt.Sprintf("%s %s", sortOn, direction), validColumns)
+	return db.Order(order)
+}
+
+// sanitizedInLoop keeps a phi cycle in play: every edge reaching Order is still
+// either the constant seed or a sanitizer result.
+func sanitizedInLoop(db *gorm.DB, candidates []string) *gorm.DB {
+	order := defaultOrder
+	for _, candidate := range candidates {
+		order = models.SanitizeOrderInput(candidate, validColumns)
+	}
+	return db.Order(order)
+}
+
+// clauseValue is out of scope: gorm renders clause values through its quoting
+// clause builder rather than interpolating them.
+func clauseValue(db *gorm.DB, order string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	return db.Order(clause.OrderByColumn{Column: clause.Column{Name: order}, Desc: true})
+}
+
+// promotedThroughEmbedding mirrors meshkit's database.Handler, which embeds
+// *gorm.DB so persisters call Order on the handler.
+type handler struct {
+	*gorm.DB
+}
+
+func promotedSanitized(h *handler, order string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	return h.Order(order)
+}
+
+func suppressed(db *gorm.DB, order string) *gorm.DB {
+	//nolint:orderby // fixture: proves the directive is honoured.
+	return db.Order(order)
+}
+
+func suppressedTrailing(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) //nolint:orderby // fixture: trailing form.
+}
+
+func suppressedAlongsideAnotherLinter(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) //nolint:gocritic,orderby // fixture: not the first name in the list.
+}
+
+//
+// Rejected: the directive does not actually name this analyzer.
+//
+
+func notSuppressedByOtherLinter(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) //nolint:gocritic // want "ORDER BY built from an unsanitized value"
+}
+
+func notSuppressedByBareNolint(db *gorm.DB, order string) *gorm.DB {
+	//nolint
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+func notSuppressedByPrefixMatch(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) //nolint:orderbyish // want "ORDER BY built from an unsanitized value"
+}
+
+// notSuppressedByTrailingDirectiveAbove pins the line+1 rule to standalone
+// directives: a trailing one excuses its own call, never the next.
+func notSuppressedByTrailingDirectiveAbove(db *gorm.DB, first, second string) *gorm.DB {
+	db.Order(first)         //nolint:orderby // fixture: excuses this line only.
+	return db.Order(second) // want "ORDER BY built from an unsanitized value"
+}
+
+//
+// Rejected: the value reaching Order is request-reachable.
+//
+
+func rawParameter(db *gorm.DB, order string) *gorm.DB {
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+func concatenated(db *gorm.DB, column string) *gorm.DB {
+	return db.Order(column + " desc") // want "ORDER BY built from an unsanitized value"
+}
+
+func formatted(db *gorm.DB, column, direction string) *gorm.DB {
+	return db.Order(fmt.Sprintf("%s %s", column, direction)) // want "ORDER BY built from an unsanitized value"
+}
+
+// orderedBeforeSanitizing is the case a syntactic "does this function call the
+// sanitizer?" check would wave through.
+func orderedBeforeSanitizing(db *gorm.DB, order string) *gorm.DB {
+	query := db.Order(order) // want "ORDER BY built from an unsanitized value"
+	order = models.SanitizeOrderInput(order, validColumns)
+	_ = order
+	return query
+}
+
+// partiallySanitized falls back to a caller-supplied string rather than a
+// constant, so one edge into Order is still request-reachable.
+func partiallySanitized(db *gorm.DB, order, fallback string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	if order == "" {
+		order = fallback
+	}
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+type filter struct {
+	SortOn string
+}
+
+func structField(db *gorm.DB, f filter) *gorm.DB {
+	return db.Order(f.SortOn) // want "ORDER BY built from an unsanitized value"
+}
+
+func mapValue(db *gorm.DB, params map[string]string) *gorm.DB {
+	return db.Order(params["order"]) // want "ORDER BY built from an unsanitized value"
+}
+
+// unsanitizedInLoop exercises the same phi cycle as sanitizedInLoop, with an
+// edge the pass cannot vouch for.
+func unsanitizedInLoop(db *gorm.DB, candidates []string) *gorm.DB {
+	order := defaultOrder
+	for _, candidate := range candidates {
+		if candidate != "" {
+			order = candidate
+		}
+	}
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+func promotedUnsanitized(h *handler, order string) *gorm.DB {
+	return h.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+// inClosure pins that the pass descends into anonymous functions - gorm scopes
+// are routinely built inside one.
+func inClosure(db *gorm.DB, order string) func() *gorm.DB {
+	return func() *gorm.DB {
+		return db.Order(order) // want "ORDER BY built from an unsanitized value"
+	}
+}
+
+// sanitizedInClosure pins the pass's one known false positive. Capturing
+// `order` moves it out of an SSA register and into a memory cell, and the pass
+// will not guess which store reaches the load - see "Captured variables" in the
+// package doc. Reporting a sanitized value here is the deliberate trade: it is
+// loud and fixable, where the opposite error is the CVE.
+func sanitizedInClosure(db *gorm.DB, order string) func() *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	return func() *gorm.DB {
+		return db.Order(order) // want "ORDER BY built from an unsanitized value"
+	}
+}
+
+// capturedElsewhere is the same limitation seen from outside: the Order call is
+// not in the closure, but capturing `order` anywhere in the function is what
+// put it in memory.
+func capturedElsewhere(db *gorm.DB, order string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	if order == "" {
+		order = defaultOrder
+	}
+	logOrder := func() string { return order }
+	_ = logOrder
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+// capturedThenRead is the fix for both of the above: read the sanitized value
+// out before anything captures it, and capture the copy.
+func capturedThenRead(db *gorm.DB, order string) (*gorm.DB, func() string) {
+	sanitized := models.SanitizeOrderInput(order, validColumns)
+	captured := sanitized
+	logOrder := func() string { return captured }
+	return db.Order(sanitized), logOrder
+}
+
+// rewrittenInsideClosure is the case the conservative treatment buys: the
+// sanitizer runs, and then a closure overwrites the same variable with request
+// input at a point no register-level walk would see.
+func rewrittenInsideClosure(db *gorm.DB, order, raw string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	override := func() { order = raw }
+	override()
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+// addressEscapes hands the variable to a function that could write anything
+// into it, so the pass refuses to vouch for what comes back out.
+func addressEscapes(db *gorm.DB, order string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	overwrite(&order)
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+func overwrite(order *string) { *order = "anything" }
+
+// lookalike is not gorm's Order: the rule keys on the `Order(any) *gorm.DB`
+// signature, so an unrelated method of the same name is left alone.
+type sorter struct{}
+
+func (s sorter) Order(by string) string { return by }
+
+func lookalike(s sorter, by string) string {
+	return s.Order(by)
+}

--- a/server/internal/lint/orderby/testdata/src/persister/persister.go
+++ b/server/internal/lint/orderby/testdata/src/persister/persister.go
@@ -369,6 +369,36 @@ func genericSanitized[T ~string](db *gorm.DB, order string) *gorm.DB {
 	return db.Order(T(models.SanitizeOrderInput(order, validColumns)))
 }
 
+// multiTermConstraint pins the conversion SSA emits when a type parameter's
+// type set has more than one term: `T(s)` under `T ~string | ~[]byte` becomes a
+// MultiConvert rather than a ChangeType. It reshapes the value like any other
+// conversion, so a sanitized operand still has to be accepted.
+func multiTermConstraint[T ~string | ~[]byte](db *gorm.DB, order string) *gorm.DB {
+	return db.Order(T(models.SanitizeOrderInput(order, validColumns)))
+}
+
+func instantiateMultiTermConstraint(db *gorm.DB, order string) *gorm.DB {
+	return multiTermConstraint[string](db, order)
+}
+
+// sortKey is a named string type carrying a method, so a value of it can be
+// held in a narrower interface and then widened.
+type sortKey string
+
+func (s sortKey) String() string { return string(s) }
+
+type stringish interface{ String() string }
+
+// widenedInterface pins ChangeInterface: the sanitized value is boxed into
+// `stringish` and then widened to `any` on the way into Order. That widening is
+// value-preserving, so the sanitizer result still has to be traceable through
+// it.
+func widenedInterface(db *gorm.DB, order string) *gorm.DB {
+	var narrow stringish = sortKey(models.SanitizeOrderInput(order, validColumns))
+	var widened any = narrow
+	return db.Order(widened)
+}
+
 // lookalike is not gorm's Order: the rule keys on the `Order(any) *gorm.DB`
 // signature, so an unrelated method of the same name is left alone.
 type sorter struct{}

--- a/server/internal/lint/orderby/testdata/src/persister/persister.go
+++ b/server/internal/lint/orderby/testdata/src/persister/persister.go
@@ -65,6 +65,33 @@ func clauseValue(db *gorm.DB, order string) *gorm.DB {
 	return db.Order(clause.OrderByColumn{Column: clause.Column{Name: order}, Desc: true})
 }
 
+// clauseVariable pins the same skip when the clause value reaches Order through
+// a variable: what takes it out of scope is the boxed type being concrete and
+// not a string, not the argument being a composite literal in the call.
+func clauseVariable(db *gorm.DB, order string) *gorm.DB {
+	order = models.SanitizeOrderInput(order, validColumns)
+	column := clause.OrderByColumn{Column: clause.Column{Name: order}, Desc: true}
+	return db.Order(column)
+}
+
+// boxedSanitized is the other half of that contract: the boxed type is visible
+// and it *is* a string, so the value's definitions still have to be safe.
+func boxedSanitized(db *gorm.DB, order string) *gorm.DB {
+	var value any = models.SanitizeOrderInput(order, validColumns)
+	return db.Order(value)
+}
+
+// orderer is the shape a persister would reach Order through if it abstracted
+// the handler behind an interface. *gorm.DB satisfies it, so the call lands on
+// the same sink and the argument is checked the same way.
+type orderer interface {
+	Order(value any) *gorm.DB
+}
+
+func throughInterfaceSanitized(o orderer, order string) *gorm.DB {
+	return o.Order(models.SanitizeOrderInput(order, validColumns))
+}
+
 // promotedThroughEmbedding mirrors meshkit's database.Handler, which embeds
 // *gorm.DB so persisters call Order on the handler.
 type handler struct {
@@ -158,6 +185,49 @@ func structField(db *gorm.DB, f filter) *gorm.DB {
 
 func mapValue(db *gorm.DB, params map[string]string) *gorm.DB {
 	return db.Order(params["order"]) // want "ORDER BY built from an unsanitized value"
+}
+
+//
+// Rejected: the argument's static type is an interface, so the pass cannot see
+// what it holds. gorm's Order type-switches at runtime and its `case string:`
+// branch builds a clause.Column{Raw: true} - the verbatim interpolation - so
+// assuming these are clause values would be a silent false negative.
+//
+
+// anyMapValue is the reachable shape: the `filter` query parameter decodes into
+// a map[string]any, and the order is read straight back out of it.
+func anyMapValue(db *gorm.DB, filters map[string]any) *gorm.DB {
+	return db.Order(filters["order"]) // want "ORDER BY built from an unsanitized value"
+}
+
+// anyParameter is the shared-helper shape: one function forwarding both strings
+// and clause values keeps the string case invisible to every caller.
+func anyParameter(db *gorm.DB, order any) *gorm.DB {
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+type anyFilter struct {
+	SortOn any
+}
+
+func anyStructField(db *gorm.DB, f anyFilter) *gorm.DB {
+	return db.Order(f.SortOn) // want "ORDER BY built from an unsanitized value"
+}
+
+// namedInterface widens one interface into another rather than boxing a
+// concrete value, and a named string type can satisfy it.
+type orderStringer interface {
+	String() string
+}
+
+func namedInterface(db *gorm.DB, order orderStringer) *gorm.DB {
+	return db.Order(order) // want "ORDER BY built from an unsanitized value"
+}
+
+// throughInterfaceUnsanitized pins that abstracting the handler behind an
+// interface is not a way out of the rule.
+func throughInterfaceUnsanitized(o orderer, order string) *gorm.DB {
+	return o.Order(order) // want "ORDER BY built from an unsanitized value"
 }
 
 // unsanitizedInLoop exercises the same phi cycle as sanitizedInLoop, with an

--- a/ui/playwright.config.js
+++ b/ui/playwright.config.js
@@ -19,8 +19,30 @@ module.exports = defineConfig({
     timeout: BASE_TIMEOUT,
   },
   retries: 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : 4,
+  /* Opt out of parallel tests on CI.
+   *
+   * This said "opt out" while running four workers - `process.env.CI ? 4 : 4`,
+   * a ternary whose branches are the same number - and the CI job is the one
+   * place that cannot afford them. It puts the whole stack on a single
+   * 4-vCPU/16-GB hosted runner: a Kind cluster, the Meshery server container,
+   * and Playwright. Four workers add four Chromium instances on top of that,
+   * and the suite then fails in the shapes a starved runner produces rather
+   * than the shape a broken test produces. Both are on record for 2026-08-17:
+   * a test burning a whole 180s describe timeout with no assertion error
+   * ("Metrics (Prometheus) page loads", run 32024269277), and the runner
+   * itself dying mid-step - "The hosted runner lost communication with the
+   * server ... starves it for CPU/Memory" - after 49 minutes with no logs and
+   * no artifacts (run 32084526223). A different, unrelated test failed in each
+   * red run that day; that spread is the signature of load and of specs racing
+   * each other, not of one broken assertion.
+   *
+   * `fullyParallel: false` already serializes the tests within a file, so a
+   * second worker buys only concurrent spec *files* - run against one Meshery
+   * server, one Local-provider session and one Kind cluster, which is the
+   * state those specs mutate. Serial on CI costs wall clock and buys a verdict
+   * that means something. Local runs keep 4.
+   */
+  workers: process.env.CI ? 1 : 4,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   // reporter: process.env.CI ? "./tests/e2e/custom-playwright-reporter.js" : "list",
   reporter: [

--- a/ui/tests/playwrightWorkers.test.ts
+++ b/ui/tests/playwrightWorkers.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The E2E job runs Kind, the Meshery server container and Playwright on one
+ * 4-vCPU hosted runner. Every extra worker is another Chromium on that runner,
+ * and the failures it produces do not look like test failures: a spec blows a
+ * whole 180s describe timeout with no assertion error, or the runner itself
+ * dies mid-step ("The hosted runner lost communication with the server").
+ *
+ * `workers` is what Playwright actually reads, so this loads the real config
+ * module the CI command loads and asserts the value it resolves to, rather
+ * than the expression that produced it - `process.env.CI ? 4 : 4` read as
+ * "opt out of parallel tests on CI" for as long as nobody evaluated it.
+ */
+const loadConfig = async () => {
+  vi.resetModules();
+  return (await import('../playwright.config.js')).default;
+};
+
+describe('Playwright worker allocation', () => {
+  beforeEach(() => {
+    vi.stubEnv('CI', undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('runs the suite serially on CI', async () => {
+    vi.stubEnv('CI', 'true');
+
+    await expect(loadConfig()).resolves.toMatchObject({ workers: 1 });
+  });
+
+  it('keeps a local run parallel', async () => {
+    await expect(loadConfig()).resolves.toMatchObject({ workers: 4 });
+  });
+
+  it('keeps tests within a spec file serial, so workers only add concurrent files', async () => {
+    vi.stubEnv('CI', 'true');
+
+    await expect(loadConfig()).resolves.toMatchObject({ fullyParallel: false });
+  });
+});


### PR DESCRIPTION
## Intent

Enforce Meshery's query-ordering sanitization so a new call site cannot reintroduce the SQL-injection class that produced all five of Meshery's CVEs. Tracking issue: https://github.com/meshery/meshery/issues/21443 (referenced in the PR).

BACKGROUND: server/models/sql-utils.go provides SanitizeOrderInput. Roughly two dozen call sites route through it - server/models/*_persister.go, server/models/default_local_provider.go, server/handlers/database_handlers.go, server/handlers/meshsync_handler.go - each passing its own allow-list of valid columns. Unit coverage of the sanitizer is in server/models/sql-utils_test.go; server/models/default_local_provider_test.go pins a regression for one endpoint that had already been missed once. The gap: a new persister that builds an ORDER BY from a non-constant string without the sanitizer compiles, passes CI, and ships. The convergence is a convention, not a control. Raised during CNCF TOC incubation review (cncf/toc#2264).

WHAT TO BUILD: A CI-enforced check that fails on a `.Order(` call taking a non-constant argument anywhere outside server/models/sql-utils.go. Inspect the repo's existing lint configuration (.golangci.yml or equivalent) FIRST and follow the established pattern. Prefer expressing this through an existing linter (forbidigo with a pattern, gocritic) if one does it cleanly; write a small go/analysis analyzer only if configuration cannot. Least new machinery wins; do not introduce a parallel lint system.

ACCEPTANCE CRITERIA:
- A deliberately unsafe call site (.Order(someNonConstantString) outside sql-utils.go) fails the lint job.
- Every existing legitimate call site passes. If any need a suppression, keep them few and justify each inline. A wholesale suppression list means the rule is mis-specified - narrow the rule instead.
- The rule runs inside the standard lint job CI already executes, not as an optional make target.
- A test demonstrates the rule firing: analysistest with a testdata fixture for a custom analyzer, or a fixture file plus a CI assertion for a config-only approach.
- Contributor lint/testing documentation states the rule exists and what to do when it fires. If a secure-coding or security doc covers the sanitizer, note the enforcement there too.

CONSTRAINTS:
- Do NOT change SanitizeOrderInput's behavior or any call site's semantics. This task adds enforcement only.
- If an existing unsanitized .Order( call site is found, that is a real finding: fix it, call it out prominently in the PR body, and add a regression test. Never silently suppress it.
- Do NOT attempt the typed-query-builder redesign listed as option 2 in the issue. Deliberately out of scope.

DECISIONS AND TRADEOFFS MADE WHILE DOING THE WORK (deliberate; not oversights):

1. Config-only was evaluated first and rejected on evidence, not preference. The repo already has an established forbidigo rule in .github/.golangci.yml (blocking http.Error) and that pattern was followed where it could be. But forbidigo and gocritic match on the CALLED FUNCTION, never on its arguments, so neither can express "non-constant argument". Banning `.Order` outright would require ~25 suppressions, which the acceptance criteria explicitly calls mis-specified. gocritic's ruleguard DSL has no dataflow and cannot negate a whole match. Hence a small go/analysis analyzer, which the task sanctions as the fallback.

2. The analyzer runs as one `go run` step inside the EXISTING golangci-lint-server job in .github/workflows/go-testing-ci.yml (the gate that already blocks unit-tests-server and build-mesheryctl), and as a line in `make golangci` so local and CI match. It is deliberately NOT wired in via golangci-lint's custom module plugin system: that requires building a bespoke golangci-lint binary in CI and dropping golangci/golangci-lint-action from two jobs, losing only-new-issues. A single go run step is less machinery for the same gate. The accepted cost of that choice is that golangci-lint's own //nolint processing does not apply, so the analyzer implements `//nolint:orderby` itself.

3. The rule is SSA-based and flow-sensitive, not syntactic. For each (*gorm.DB).Order call with a string argument it walks the argument backwards through SSA and requires every definition reaching it to be a constant or a models.SanitizeOrderInput result. The prevailing call-site shape (sanitize, then default to a constant when the sanitizer empties the value) reaches Order as a phi of two safe edges and is accepted; a function that ordered on its raw parameter and sanitized afterwards is rejected. A grep-style "does this function call the sanitizer somewhere" check was deliberately not used.

4. The callee is matched on its `Order(any) *gorm.DB` SIGNATURE rather than on its receiver type. Every persister orders through meshkit's database.Handler, which embeds *gorm.DB, so a receiver-type check would have missed all of them. This was verified by injecting a violation into a real persister and confirming the gate fires through that path.

5. Suppression is keyed by FILE AND LINE, not line alone, and a trailing //nolint directive covers only its own line while a standalone one also covers the line below. Both were bugs found and fixed during development; each is pinned by a testdata fixture that fails if the fix is reverted.

6. KNOWN, DELIBERATE CONSERVATIVE CASE (not a bug, and documented in the package doc, the fixtures and contributing-lint.md): capturing the order variable in a closure, or taking its address, moves it out of an SSA register into a memory cell, and the pass reports the load rather than guess which store reaches it. A precise version (reaching definitions over memory plus closure-write modelling) was built and then deliberately reverted, because getting it wrong in the other direction is a silent false negative, which is the CVE. Reporting a sanitized-but-captured value is a loud, fixable false positive. No call site in the repository is affected today. Fixtures sanitizedInClosure and capturedElsewhere intentionally carry `// want` annotations for this reason.

7. Non-string arguments to Order (clause.OrderByColumn, clause.OrderBy) are intentionally out of scope: gorm renders those through its quoting clause builder rather than interpolating them. clause.Expr and clause.Column{Raw: true} remain raw-SQL escape hatches inside that builder and are documented as uncovered; neither is used in this repo.

8. NO unsanitized call site was found. The two files lacking SanitizeOrderInput (server/models/smiresults_persister.go, server/models/test_profiles_persister.go) both pass the package constant defaultOrderUpdatedAtDesc, which is correct. All 25 existing call sites pass with ZERO suppressions. No call-site semantics were changed anywhere; the commit is additive plus docs.

9. golang.org/x/tools was promoted to a direct dependency in the root go.mod (it was already in the module graph at v0.45.0); `go mod tidy` added golang.org/x/mod as indirect. The analyzer was deliberately NOT put in its own nested Go module: this repo's existing nested module (server/policies/wasm/go.mod) has been a lockstep-bump hazard.

10. Docs: a new docs/content/en/project/contributing/contributing-lint.md consolidates this rule together with the pre-existing http.Error forbidigo gate, which until now was documented only inside error-contract.md. It is cross-linked from error-contract.md and contributing-server.md, and AGENTS.md gained a MUST-NOT rule plus a Further Reading entry. SECURITY-INSIGHTS.yml was deliberately left alone: it has no static-analysis section, it is schema-validated by osps-baseline.yml, and adding one is a security-file change outside this task's scope. No existing secure-coding doc covers the sanitizer, so the enforcement note lives in the new lint doc.

11. AGENTS.md's stated config path for golangci was corrected from `.golangci.yml` to `.github/.golangci.yml`, which is where the file actually lives.

## What Changed

- Adds `server/internal/lint/orderby`, a flow-sensitive go/analysis SSA pass (plus the `orderbylint` command that runs it), which fails when a string argument reaching `(*gorm.DB).Order` is not provably a constant or a `models.SanitizeOrderInput` result. It matches the callee on its `Order(any) *gorm.DB` signature so calls through meshkit's `database.Handler` are covered, reports interface-typed arguments rather than assuming they hold a `clause` value, skips statically-visible non-string `clause` arguments as out of scope, and implements its own `//nolint:orderby` suppression keyed by file and line. `orderby_test.go` pins the behavior with `analysistest` fixtures under `testdata/` covering accepted shapes, rejected shapes, cross-file suppression, and the deliberately conservative captured/closure cases.
- Wires the analyzer into the gates that already run: a `go run ./server/internal/lint/orderby/cmd/orderbylint ./...` step in the existing `golangci-lint-server` job of `.github/workflows/go-testing-ci.yml`, and the same line in `make golangci`. `mesheryctl/Makefile`'s `lint` target was converged onto the shared `--config=../.github/.golangci.yml --timeout=10m` and the same analyzer, so a CLI contributor's local lint is no longer weaker than the jobs gating their PR. `golang.org/x/tools` is promoted to a direct dependency in the root `go.mod` (`golang.org/x/mod` added as indirect).
- Documents the rule in a new `docs/content/en/project/contributing/contributing-lint.md`, which also consolidates the pre-existing `http.Error` forbidigo gate, cross-linked from `error-contract.md`, `contributing-server.md` and `cli/cli.md`. `AGENTS.md` gains a MUST-NOT rule for non-constant `.Order(...)` arguments, a Further Reading entry, and a correction of the golangci config path to `.github/.golangci.yml`.

No unsanitized call site was found: all existing `.Order(` call sites pass with zero suppressions, and no call-site semantics or `SanitizeOrderInput` behavior were changed. Tracking issue: https://github.com/meshery/meshery/issues/21443 (raised in CNCF TOC incubation review cncf/toc#2264).

## Risk Assessment

✅ Low: The change is additive - a new go/analysis analyzer, its analysistest fixtures, one CI step, a Makefile line and docs - with no production code or call-site semantics touched, all 26 existing Order call sites statically confirmed to reach a sanitizer result or constant with zero suppressions, and the only residual issue an unreachable precision gap in the analyzer itself.

## Testing

`Ran the analyzer's analysistest suite and then exercised the gate the way a contributor would: the committed repo lints clean (exit 0, 25 Order call sites, zero suppressions), a temporarily injected unsafe persister produced exactly four diagnostics at exit 1 while the correctly-sanitized method in the same file stayed silent, and deleting SanitizeOrderInput from the real keys_persister.go fired the rule through meshkit's embedded *gorm.DB path before I restored it. The documented //nolint:orderby escape hatch silences that same line. Confirmed the rule runs in the pre-existing golangci-server CI job that gates unit-tests-server and build-mesheryctl by parsing the workflow into a semantic model, and that make golangci expands to the identical command. SanitizeOrderInput's own tests and the default_local_provider regression still pass, confirming the change is additive. Built the docs site with Hugo (which validates the new {{< ref >}} cross-links, since a broken ref fails the build) and captured screenshots of the rendered Go Lint Rules page. Two local environment problems surfaced and were fixed rather than worked around - a stale GOROOT and a broken Ruby sass shadowing Dart Sass - neither related to the change. All transient build output was removed; the worktree is clean.`

<details>
<summary>Evidence: orderby gate CLI transcript (clean pass, both injected violations, suppression, make wiring)</summary>

<code>== 1. Repository as committed: the gate is clean ==&#10;$ go run ./server/internal/lint/orderby/cmd/orderbylint ./...&#10;exit=0 (25 .Order( call sites, 0 //nolint:orderby suppressions in non-testdata code)&#10;&#10;== 2. A new persister that skips the sanitizer: gate fires ==&#10;$ go run ./server/internal/lint/orderby/cmd/orderbylint ./... -&gt; exit 1&#10;server/models/zz_orderby_gate_demo.go:19:22: ORDER BY built from an unsanitized value: pass the argument through models.SanitizeOrderInput(order, []string{...}) with this query&#39;s allow-list of columns, or use a constant. gorm&#39;s Order() interpolates a string into the SQL verbatim - this is the sink behind every Meshery CVE. See docs/content/en/project/contributing/contributing-lint.md.&#10;server/models/zz_orderby_gate_demo.go:27:22: ... (sanitized after the Order call)&#10;server/models/zz_orderby_gate_demo.go:36:22: ... (fmt.Sprintf composition)&#10;server/models/zz_orderby_gate_demo.go:43:22: ORDER BY built from an unsanitized value: this argument&#39;s static type is an interface, so the pass cannot prove it does not hold a string. ...&#10;exit status 3&#10;&#10;== 3. Sanitizer removed from an existing persister: gate fires ==&#10;server/models/keys_persister.go:25:60: ORDER BY built from an unsanitized value: ...&#10;exit status 3&#10;&#10;== 4. Documented escape hatch on that same line: gate silent ==&#10;//nolint:orderby // demo: documented escape hatch -&gt; exit 0, no output&#10;&#10;== 5. make golangci runs the same command locally as CI does ==&#10;$ make -n golangci&#10;go run github.com/meshery/meshkit/cmd/errorutil -d . analyze -i ./server/helpers -o ./server/helpers --skip-dirs mesheryctl&#10;golangci-lint run --config=.github/.golangci.yml --timeout=10m&#10;go run ./server/internal/lint/orderby/cmd/orderbylint ./...</code>

```text
== 1. Repository as committed: the gate is clean ==
$ go run ./server/internal/lint/orderby/cmd/orderbylint ./...
exit=0  (25 .Order( call sites, 0 //nolint:orderby suppressions in non-testdata code)

== 2. A new persister that skips the sanitizer: gate fires ==
(server/models/zz_orderby_gate_demo.go added temporarily, then removed)
$ go run ./server/internal/lint/orderby/cmd/orderbylint ./...  -> exit 1
server/models/zz_orderby_gate_demo.go:19:22: ORDER BY built from an unsanitized value: pass the argument through models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of columns, or use a constant. gorm's Order() interpolates a string into the SQL verbatim - this is the sink behind every Meshery CVE. See docs/content/en/project/contributing/contributing-lint.md.
server/models/zz_orderby_gate_demo.go:27:22: ORDER BY built from an unsanitized value: pass the argument through models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of columns, or use a constant. gorm's Order() interpolates a string into the SQL verbatim - this is the sink behind every Meshery CVE. See docs/content/en/project/contributing/contributing-lint.md.
server/models/zz_orderby_gate_demo.go:36:22: ORDER BY built from an unsanitized value: pass the argument through models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of columns, or use a constant. gorm's Order() interpolates a string into the SQL verbatim - this is the sink behind every Meshery CVE. See docs/content/en/project/contributing/contributing-lint.md.
server/models/zz_orderby_gate_demo.go:43:22: ORDER BY built from an unsanitized value: this argument's static type is an interface, so the pass cannot prove it does not hold a string. gorm's Order() type-switches at runtime and interpolates a string into the SQL verbatim - this is the sink behind every Meshery CVE. Pass a string sanitized with models.SanitizeOrderInput(order, []string{...}), or a concretely-typed clause value. See docs/content/en/project/contributing/contributing-lint.md.
exit status 3

== 3. Sanitizer removed from an existing persister: gate fires ==
(SanitizeOrderInput deleted from server/models/keys_persister.go GetUsersKeys, then restored)
$ go run ./server/internal/lint/orderby/cmd/orderbylint ./...  -> exit 1
server/models/keys_persister.go:25:60: ORDER BY built from an unsanitized value: pass the argument through models.SanitizeOrderInput(order, []string{...}) with this query's allow-list of columns, or use a constant. gorm's Order() interpolates a string into the SQL verbatim - this is the sink behind every Meshery CVE. See docs/content/en/project/contributing/contributing-lint.md.
exit status 3

== 4. Documented escape hatch on that same line: gate silent ==
//nolint:orderby // demo: documented escape hatch  -> exit 0, no output

== 5. make golangci runs the same command locally as CI does ==
$ make -n golangci
go run github.com/meshery/meshkit/cmd/errorutil -d . analyze -i ./server/helpers -o ./server/helpers --skip-dirs mesheryctl
golangci-lint run --config=.github/.golangci.yml --timeout=10m
go run ./server/internal/lint/orderby/cmd/orderbylint ./...
```
</details>
- Evidence: Rendered docs: &#39;What to do when it fires&#39; - the contributor remedy for the diagnostic (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01M08QYJ5XHNJAY8Q7CT6W671G/docs-lint-what-to-do-when-it-fires.png</code>)
- Evidence: Rendered docs: Go Lint Rules page in the Meshery docs theme, Contributing section (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01M08QYJ5XHNJAY8Q7CT6W671G/docs-lint-page-top.png</code>)
- Evidence: Rendered docs: full Go Lint Rules page (all sections) (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01M08QYJ5XHNJAY8Q7CT6W671G/docs-lint-page-fullpage.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4b281cfcba192c3ab23fc68347659892342251dd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `server/internal/lint/orderby/orderby.go:220` - stringOrderArg silently skips any Order argument whose static type is an interface. It only unwraps *ssa.MakeInterface; for a value that is already interface-typed (a map[string]interface{} lookup, an `any` parameter, an `any` struct field), v.Type().Underlying() is *types.Interface, not *types.Basic, so it returns nil and run() `continue`s under the comment &#34;A clause.OrderByColumn / clause.OrderBy value&#34; - with no diagnostic. That assumption does not hold: gorm&#39;s Order takes `any` and its runtime type switch has a `case string:` branch that builds clause.Column{Raw: true}, i.e. verbatim interpolation. Concrete reachable path: `query.Order(filterMap[&#34;order&#34;])` where filterMap is the map[string]interface{} decoded from the request&#39;s `filter` JSON - exactly the shape server/models/environment_persister.go:244 already builds a few lines above its own `query.Order(order)` - or a shared helper `func applyOrder(db *gorm.DB, order any) { db.Order(order) }` that accepts both strings and clause values. Either compiles, ships, and is accepted by the gate, which is the CVE class the rule exists to block, while AGENTS.md and contributing-lint.md now assert the sink is enforced. Fix in the conservative direction the package doc already commits to: skip only when the argument is a MakeInterface of a provably non-string type, and report every other interface-typed value (including *ssa.ChangeInterface); add a persister.go fixture for `Order(anyValue)`. No existing call site is affected - the only non-string site (server/handlers/database_handlers.go:44) passes a clause.OrderByColumn composite literal, which stays correctly skipped - so tightening this costs zero suppressions.

🔧 Fix: Report interface-typed and interface-dispatched gorm Order arguments
1 info still open:
- ℹ️ `server/internal/lint/orderby/orderby.go:288` - classifyOrderArg&#39;s MakeInterface branch still exits silently (`return nil, argClause`) for anything that is not string-underlying, but a type parameter is not &#34;provably non-string&#34;: go/types returns the constraint interface from (*types.TypeParam).Underlying(), so isStringUnderlying is false for it. Concrete shape: `func listBy[T ~string](db *gorm.DB, order T) *gorm.DB { return db.Order(order) }` - SSA boxes the T-typed value with MakeInterface, mi.X.Type() is *types.TypeParam, so the call is skipped with no diagnostic; instantiated with `string` it lands on gorm&#39;s `case string:` branch, which builds clause.Column{Raw: true} - the verbatim interpolation. That is the same silent-false-negative class the round just closed for interface-typed arguments, and it contradicts the contract the package doc now states (&#34;that skip ... holds only where the boxed type is statically visible and not string-underlying&#34;). Fix in the same conservative direction: in the MakeInterface branch, when types.Unalias(mi.X.Type()) is a *types.TypeParam, return argOpaque (or argString when every term of the type set is string-underlying) rather than argClause, and add a generic fixture in testdata/src/persister/ with a `// want &#34;ORDER BY built from an unsanitized value&#34;` annotation. Reachability today is nil - the server has no generic gorm helpers (only a test helper uses type params) - so tightening this costs zero suppressions and no existing call site regresses.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test ./server/internal/lint/orderby/...` - analysistest over the testdata fixtures (accepted and rejected shapes, cross-file nolint directives)</code>
- <code>`go run ./server/internal/lint/orderby/cmd/orderbylint ./...` on the repo as committed - exit 0, no diagnostics</code>
- <code>Manual injection: added `server/models/zz_orderby_gate_demo.go` with 4 unsafe Order shapes (raw param, sanitize-after-Order, fmt.Sprintf, map[string]any read) plus 1 correct one; re-ran the lint command - exit 1 with exactly 4 diagnostics, the safe method silent; file removed afterwards</code>
- <code>Manual regression: deleted the `SanitizeOrderInput` call from `server/models/keys_persister.go` `GetUsersKeys`; re-ran the lint command - exit 1 at keys_persister.go:25 through meshkit `database.Handler`&#39;s embedded *gorm.DB; file restored from backup</code>
- <code>Manual suppression check: added `//nolint:orderby` to that same regressed line - `go run ./server/internal/lint/orderby/cmd/orderbylint ./server/models/...` exit 0</code>
- <code>`make -n golangci` - confirmed the recipe expands to the same `go run ./server/internal/lint/orderby/cmd/orderbylint ./...` argv CI runs</code>
- <code>Semantic parse of `.github/workflows/go-testing-ci.yml` (PyYAML + shlex tokenization of each `run` line, not substring matching): analyzer step is in job `golangci-server` alongside golangci-lint-action, has no `if`/`continue-on-error`, and `unit-tests-server` + `build-mesheryctl` list it in `needs`</code>
- <code>`go test ./server/models/ -run &#39;TestSanitizeOrderInput|Order|SortOn&#39; -v` - sanitizer behavior and the default_local_provider credentials regression unchanged</code>
- <code>Nested-module coverage check: `docs`, `install/docker-extension`, `server/policies/wasm` contain no `.Order(` call sites, so root-module `./...` covers every gorm call site in the repo</code>
- <code>`hugo -s docs` full-site build (with a temp Dart Sass binary) - built with zero errors, which validates the new `{{&lt; ref &gt;}}` cross-links; confirmed `error-contract` and `contributing-server` both emit `href=&#34;/project/contributing/contributing-lint/&#34;`</code>
- <code>Browser render of `http://localhost:1313/project/contributing/contributing-lint/` via chrome-devtools-axi at 1440x1000 - screenshots of the page top and the &#39;What to do when it fires&#39; section</code>
- <code>Compared the rendered TOC inline-code styling against the pre-existing `contributing-build-environment` page to confirm it is theme behavior, not a regression from this change</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 2 infos</summary>

- ⚠️ `mesheryctl/Makefile:105` - mesheryctl&#39;s own lint target (mesheryctl/Makefile:105) runs `golangci-lint run --timeout 5m` with neither `--config=../.github/.golangci.yml` nor the new orderby analyzer, so a CLI contributor&#39;s local lint is weaker than the `golangci-lint-cli` and `golangci-lint-server` jobs that gate their PR: neither the forbidigo http.Error rule nor the ORDER BY rule fires locally. I documented the CI reality in docs/content/en/project/contributing/cli/cli.md, but closing the divergence means editing mesheryctl/Makefile, which is a functional change outside this documentation/lint pass.

🔧 Fix: Converge mesheryctl lint target with CI gates
2 infos still open:
- ℹ️ `server/handlers/credentials_handlers_test.go:78` - Running the shared config against ./server (`golangci-lint run --config=../.github/.golangci.yml`) reports 6 pre-existing staticcheck SA5011 diagnostics in server/handlers/credentials_handlers_test.go (lines 78/81, 145/148, 178/181): staticcheck does not treat `t.Fatal(...)` inside the subtest closure as terminating, so each `if x == nil { t.Fatal(...) }` guard followed by a deref reads as a possible nil dereference. These predate the base commit (last touched in baa98b5480b, an ancestor of 437fbcb4031) and are untouched by this branch, so they do not gate the PR - both lint jobs set only-new-issues on pull requests. They do mean `make golangci` is red locally for the server. The safe fix is a bare `return` after each `t.Fatal(...)` (no behavior change; t.Fatal already terminates the goroutine). Not applied: editing an unrelated server test file would be a second scope widening beyond the mesheryctl Makefile convergence that was authorized.
- ℹ️ `mesheryctl/Makefile:105` - Not a defect - a carry-forward requirement from the round-1 authorization. The commit message and PR body must state plainly that the mesheryctl/Makefile lint-target change is a deliberate widening beyond this PR&#39;s stated scope (enforcement only), that it was explicitly authorized, and why it belongs here: the divergence predates this PR - mesheryctl&#39;s lint target never passed --config=../.github/.golangci.yml, so the pre-existing forbidigo http.Error rule did not fire locally either; adding the ORDER BY rule only made the gap visible.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated checks to detect potentially unsafe dynamic database sort expressions.
  - Added approved sanitization guidance and support for justified lint suppressions.
  - CI end-to-end tests now run with a single worker for improved reliability.

- **Documentation**
  - Expanded contributor guidance for server and CLI linting, SQL safety, error handling, and quality checks.

- **Tests**
  - Added comprehensive coverage for safe, unsafe, and exempt sort-expression patterns.
  - Added validation for CI and local test worker configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Known-red target: `make golangci` (pre-existing, not caused by this branch)

Converging `mesheryctl`'s lint target onto the shared `.github/.golangci.yml` surfaced 6
pre-existing staticcheck `SA5011` diagnostics in `server/handlers/credentials_handlers_test.go`
(lines 78/81, 145/148, 178/181): staticcheck does not treat `t.Fatal(...)` inside a subtest
closure as terminating, so each `if x == nil { t.Fatal(...) }` guard followed by a deref reads
as a possible nil dereference.

These predate this branch's base commit (last touched in `baa98b5480b`, an ancestor of
`437fbcb4031`) and are untouched here - this change **surfaced** them rather than caused them.
They do not gate this PR, because both lint jobs set `only-new-issues` on pull requests, but
they do mean `make golangci` is currently red for the server.

Tracked separately in meshery/meshery#21453. Deliberately not fixed here: editing an unrelated
test file would be a further widening of this PR's scope.

## Also in this PR: Playwright CI worker count (unrelated to the lint rule)

A reader should not be surprised to find CI parallelism changes in a lint PR, so
calling it out explicitly: `dcd17c5a` also changes `ui/playwright.config.js` from
`workers: process.env.CI ? 4 : 4` to `process.env.CI ? 1 : 4`, with
`ui/tests/playwrightWorkers.test.ts` pinning the resolved value and the reasoning
recorded in `docs/content/en/project/contributing/ui/tests.md`.

It rode in on a CI-fix round rather than arriving with the lint work, and it was
assessed on its merits rather than kept because it was already in the commit:

- The previous value was `process.env.CI ? 4 : 4` - a ternary whose branches are the
  same number - under a comment reading *"Opt out of parallel tests on CI"*. The
  stated intent was serial on CI; the code never did it. This restores the
  documented behavior rather than changing it.
- `fullyParallel: false` already serializes tests within a file, so extra workers buy
  only concurrent spec *files* - run against one Meshery server, one Local-provider
  session and one Kind cluster, which is the state those specs mutate. Playwright
  isolates browser contexts, not the server they share.
- The failures it fixes have the signature of load, not of a defect: a different
  unrelated test failing in each red run, a whole 180s `describe` timeout with no
  assertion error (run `32024269277`), and the runner itself dying with *"The hosted
  runner lost communication with the server ... starves it for CPU/Memory"* after 49
  minutes with no logs or artifacts (run `32084526223`).

The trade is wall-clock for a verdict that means something. The honest caveat is that
serial execution is a mitigation for a single-runner topology - the durable fix is
sharding the suite across runners, which is out of scope here.

