### PR TITLE
Add relationship authoring skill and correct kind/type/subType docs

### DIFF
--- a/.agents/skills/gen-relationship/SKILL.md
+++ b/.agents/skills/gen-relationship/SKILL.md
@@ -1,197 +1,174 @@
 ---
 name: gen-relationship
-description: Generate schema-backed relationship definitions for Meshery models between given components.
-tools: ['search/changes', 'search/codebase', 'edit/editFiles', 'vscode/extensions', 'web/fetch', 'web/githubRepo', 'vscode/getProjectSetupInfo', 'vscode/installExtension', 'vscode/newWorkspace', 'vscode/runCommand', 'vscode/openSimpleBrowser', 'read/problems', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/createAndRunTask', 'execute', 'execute/runTask', 'execute/runTests', 'search', 'search/searchResults', 'execute/testFailure', 'search/usages', 'vscode/vscodeAPI', 'github/*', 'memory']
+description: Create and refine schema-backed Meshery relationship definitions. Use when adding, editing, classifying, or reviewing how model components relate, including kind/type/subType taxonomy and mutatorRef/mutatedRef patches.
 ---
 
-# Skill: gen-relationship
+# Create and refine Meshery relationship definitions
 
-Generate schema-backed relationship definitions for Meshery models between given components. This skill ensures that relationships are mathematically accurate, logically sound, and strictly compliant with the canonical `v1beta1` relationship schema.
+Relationships describe how components in the same or different models relate, and whether they affect each other (semantic) or only the designer's mental model (non-semantic).
 
-## Usage
+This skill covers **creating new definitions** and **refining existing ones**. Invoke it for `/gen-relationship`, "add a relationship", "fix this relationship JSON", or "what kind/type/subType should this be?".
 
-Invoke this skill when you need to define a new relationship between two or more components:
-- `/gen-relationship Define a reference relationship between a Deployment and a PersistentVolumeClaim in the kubernetes model.`
-- `/gen-relationship Create a hierarchical parent-inventory relationship between a ServiceMesh and its ControlPlane.`
+## Source of truth
 
-## Instructions
+**[meshery/schemas](https://github.com/meshery/schemas) is SSOT.** Do not invent fields, enums, or path shapes.
 
-1.  **Identify the Components**: Determine the source (`from`) and target (`to`) components. Note their `kind` and the `model` they belong to.
-2.  **Determine the Relationship Type**: Select the appropriate `kind`, `type`, and `subType` based on the desired interaction.
-3.  **Formulate Selectors**: Construct the `selectors` array with `allow` (and optionally `deny`) blocks.
-4.  **Define Patches**: If the relationship involves data flow or configuration binding, define `mutatorRef` and `mutatedRef` as nested arrays of strings.
-5.  **Assign Metadata**: Include UI capabilities and styles to ensure the relationship is rendered correctly in MeshMap.
-6.  **Validate against Schema**: Ensure the output matches the `v1beta1` schema structure rigorously.
+| What | Where |
+|---|---|
+| Relationship object | `schemas/constructs/v1beta3/relationship/relationship.yaml` |
+| Selectors, patch, mutator/mutated | `schemas/constructs/v1beta3/relationship/api.yml` |
+| Starter document | `schemas/constructs/v1beta3/relationship/templates/relationship_template.json` |
+| Human docs | [Concepts: Relationships](https://docs.meshery.io/concepts/logical/relationships), [Contributing to Relationships](https://docs.meshery.io/project/contributing/contributing-relationships) |
+| In-tree corpus | `models/<model>/<model-version>/<definition-version>/relationships/` |
 
-## Technical Context
+New and rewritten definitions use `schemaVersion: "relationships.meshery.io/v1beta3"`. In-tree model files are still mostly `v1beta2` (shape-compatible). When **refining** an existing file, keep its `schemaVersion` unless you are deliberately migrating it.
 
-### Relationship Terminologies
+`kind` is a schema enum: `hierarchical` | `edge` | `sibling`. `type` and `subType` are open strings. The combinations below are the ones Meshery currently visualizes and evaluates. A new `subType` needs a visual paradigm (whiteboard a proposal in Kanvas) and usually an OPA `evaluationQuery`.
 
-- **Kind**:
-    - `hierarchical`: For parent-child or ownership interactions.
-    - `edge`: For peer-to-peer or connective interactions.
-    - `sibling`: For components that occupy the same logical level or group.
-- **Type**:
-    - `Parent`: Defines a strong hierarchical bond where the child belongs to the parent (child is usually discovered within the parent's inventory).
-    - `Binding`: Defines a functional connection between components.
-    - `non-binding`: Defines a logical or informational connection without functional enforcement.
-- **SubType**:
-    - `inventory`: Hierarchical mapping of resources (e.g., used in `Parent` type).
-    - `reference`: Binding based on a property reference (e.g., a Deployment referencing a ConfigMap).
-    - `network`: Connectivity mapping (L3/L4/L7 interactions).
-    - `permission`: Authorization or access control mapping.
-    - `wallet`: Cloud billing or cost mapping.
+Required object fields (v1beta3): `schemaVersion`, `version`, `model`, `kind`, `type`, `subType`, `id`.
 
-### Canonical Schema (v1beta1)
+## When to use which combo
 
-- **schemaVersion**: `relationships.meshery.io/v1beta1`
-- **Selectors**:
-    - `allow`: Contains `from` and `to` arrays of component selectors.
-    - `deny`: (Optional) Excludes specific components from the relationship.
-- **Selector Item**:
-    - `kind`: The kind of the component (e.g., `Deployment`).
-    - `model`: The model name (e.g., `kubernetes`).
-    - `patch`: (Optional) Specifies how properties are mapping.
-- **Path References**:
-    - `mutatorRef`: Source path, formatted as `[["path", "to", "field"]]`.
-    - `mutatedRef`: Target path, formatted as `[["path", "to", "field"]]`.
-    - **CRITICAL**: Both must be nested arrays of strings (e.g., `[["settings", "name"]]`) to pass upstream evaluation.
-- **UI Metadata**:
-    - `metadata.capabilities.designer.edit`: Must be `true` for a relationship to be editable in MeshMap.
-    - `description`: A clear, human-readable description of the relationship's purpose.
+`kind` + `type` + `subType` together pick the visual paradigm and the evaluation policy. Copy an existing combo; do not remix.
 
-## Examples
+| kind | type | subType | Meaning | Example | File |
+|---|---|---|---|---|---|
+| `edge` | `non-binding` | `reference` | Logical name/id pointer; no traffic, mount, or RBAC | Deployment → ConfigMap | [examples/edge-non-binding-reference.json](examples/edge-non-binding-reference.json) |
+| `edge` | `non-binding` | `network` | Documented L3/L4/L7 selection, no provisioned attachment | Service → Deployment | [examples/edge-non-binding-network.json](examples/edge-non-binding-network.json) |
+| `edge` | `non-binding` | `firewall` | Policy that allows/denies traffic between peers | NetworkPolicy → Pod | [examples/edge-non-binding-firewall.json](examples/edge-non-binding-firewall.json) |
+| `edge` | `non-binding` | `permission` | Mentions an identity or role without binding it | IAM Policy → Role | [examples/edge-non-binding-permission.json](examples/edge-non-binding-permission.json) |
+| `edge` | `non-binding` | `alias` | Named stand-in, not nested ownership | Secret → Secret | [examples/edge-non-binding-alias.json](examples/edge-non-binding-alias.json) |
+| `edge` | `non-binding` | `annotation` | Designer-only line; `metadata.isAnnotation: true`; no patch | Shape → Shape | [examples/edge-non-binding-annotation.json](examples/edge-non-binding-annotation.json) |
+| `edge` | `non-binding` | `inventory` | Rare. Peer index/list, not parent-child containment | Cluster → Database | [examples/edge-non-binding-inventory.json](examples/edge-non-binding-inventory.json) |
+| `edge` | `binding` | `permission` | Assigns identities (Role/RoleBinding/ServiceAccount) | Role → ServiceAccount | [examples/edge-binding-permission.json](examples/edge-binding-permission.json) |
+| `edge` | `binding` | `mount` | Storage or device is attached | PVC → Pod | [examples/edge-binding-mount.json](examples/edge-binding-mount.json) |
+| `edge` | `binding` | `network` | Rare. Connecting provisions/rewrites network identity | Listener → Domain | [examples/edge-binding-network.json](examples/edge-binding-network.json) |
+| `hierarchical` | `parent` | `inventory` | Parent scopes/contains children; parent identity patched onto child | `*` → Namespace | [examples/hierarchical-parent-inventory.json](examples/hierarchical-parent-inventory.json) |
+| `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent | Container → Pod | [examples/hierarchical-parent-alias.json](examples/hierarchical-parent-alias.json) |
+| `hierarchical` | `parent` | `wallet` | Child config is held/patched into the parent | WASMFilter → EnvoyFilter | [examples/hierarchical-parent-wallet.json](examples/hierarchical-parent-wallet.json) |
+| `hierarchical` | `sibling` | `matchlabels` | **In-tree tagsets encoding.** Shared labels; no patch | `*` ↔ `*` | [examples/hierarchical-sibling-matchlabels.json](examples/hierarchical-sibling-matchlabels.json) |
+| `sibling` | `matchlabels` | `tagsets` | **Schema-native tagsets.** `kind` enum value `sibling` | `*` ↔ `*` | [examples/sibling-matchlabels.json](examples/sibling-matchlabels.json) |
 
-### 1. Peer-to-Peer Reference (Edge)
-**Reasoning**: The Deployment is the originator of the reference, containing the field that must match the source PVC. The PVC provides its identity (mutator) to the Deployment's volume configuration (mutated).
+`badge` appears in contributing docs as a visual paradigm only. There is no in-tree encoding. Do not invent `subType: badge`.
 
-```json
-{
-  "schemaVersion": "relationships.meshery.io/v1beta1",
-  "kind": "edge",
-  "type": "non-binding",
-  "subType": "reference",
-  "metadata": {
-    "description": "Deployment referencing a PVC via claimName",
-    "capabilities": {
-      "designer": { "edit": true }
-    }
-  },
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "kind": "Deployment",
-            "model": "kubernetes",
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "template", "spec", "volumes", "0", "persistentVolumeClaim", "claimName"]]
-            }
-          }
-        ],
-        "to": [
-          {
-            "kind": "PersistentVolumeClaim",
-            "model": "kubernetes",
-            "patch": {
-             "mutatorRef": [["configuration", "metadata", "name"]]
-            }
-          }
-        ]
-      }
-    }
-  ]
-}
-```
+### Sibling encoding caveat
 
-### 2. Hierarchical Inventory (Parent)
-**Reasoning**: The Namespace is the authoritative parent defining the logical scope. It provides its name (mutator) to be injected into the namespace field of all child components (mutated).
+The schema `kind` enum is `hierarchical | edge | sibling`. Kubernetes in-tree files use `kind: hierarchical`, `type: sibling`, `subType: matchlabels` (see `models/kubernetes/.../relationships/sibling-tagsets.json`).
+
+- **Refining kubernetes (or copying its pattern):** keep `hierarchical` / `sibling` / `matchlabels`.
+- **New model, standardizing on the schema kind:** `kind: sibling` as in `examples/sibling-matchlabels.json`.
+- Never mix both encodings in one model.
+
+### Binding vs non-binding
+
+- `binding`: forming the relationship assigns, mounts, or entitles (lifecycle effect).
+- `non-binding`: the link is real (selector, name reference, policy match) but does not itself provision the attachment.
+
+Most Service → workload edges are `non-binding` / `network`. Mount and RBAC assignment are `binding`.
+
+### Semantic vs annotation
+
+`metadata.isAnnotation: true` (or a shape/annotation component) means Meshery must **not** evaluate or patch. Edge-annotation is the usual encoding. Do not add `mutatorRef`/`mutatedRef` on annotation relationships.
+
+## Hierarchical `from` / `to`
+
+**`from` is the child. `to` is the parent.** Always.
+
+| subType | Data flow |
+|---|---|
+| `inventory` | Parent **mutates** the child (Namespace name → child's `metadata.namespace`) |
+| `alias` | Child **mutates** the parent (Container spec → Pod `spec.containers._`) |
+| `wallet` | Child **mutates** the parent (filter config → EnvoyFilter patch) |
+
+The previous gen-relationship example that put Namespace in `from` was wrong.
+
+## Actions: `mutatorRef` and `mutatedRef`
+
+Defined in `api.yml` as **nested arrays of string path segments** (`string[][]`). Sequence length on both sides must match: index `i` of `mutatorRef` patches onto index `i` of `mutatedRef`.
 
 ```json
-{
-  "schemaVersion": "relationships.meshery.io/v1beta1",
-  "kind": "hierarchical",
-  "type": "parent",
-  "subType": "inventory",
-  "metadata": {
-    "description": "Namespace-level resource containment",
-    "capabilities": {
-      "designer": { "edit": true }
-    }
-  },
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "kind": "Namespace",
-            "model": "kubernetes",
-            "patch": {
-             "mutatorRef": [["configuration", "metadata", "name"]]
-             
-            }
-          }
-        ],
-        "to": [
-          {
-            "kind": "*",
-            "model": "kubernetes",
-            "patch": {
-              "mutatedRef": [["configuration", "metadata", "namespace"]]
-            }
-          }
-        ]
-      }
-    }
-  ]
-}
+"mutatorRef": [["config", "url"], ["config", "name"]],
+"mutatedRef": [["configPatch", "value"], ["name"]]
 ```
 
-### 3. Network Connectivity (Edge)
-**Reasoning**: The Service is the originator of the network connection, defining selection criteria. It provides its selector labels (mutator) to match or be mirrored by the Deployment's pod labels (mutated).
+`[config, url]` is copied onto `[configPatch, value]`; `[config, name]` onto `[name]`.
 
-```json
-{
-  "schemaVersion": "relationships.meshery.io/v1beta1",
-  "kind": "edge",
-  "type": "binding",
-  "subType": "network",
-  "metadata": {
-    "description": "Service targeting deployment pods",
-    "capabilities": {
-      "designer": { "edit": true }
-    }
-  },
-  "selectors": [
-    {
-      "allow": {
-        "from": [
-          {
-            "kind": "Service",
-            "model": "kubernetes",
-            "patch": {
-              "mutatorRef": [["configuration", "spec", "selector"]]
-            }
-          }
-        ],
-        "to": [
-          {
-            "kind": "Deployment",
-            "model": "kubernetes",
-            "patch": {
-              "mutatedRef": [["configuration", "spec", "template", "metadata", "labels"]]
-            }
-          }
-        ]
-      }
-    }
-  ]
-}
+| Field | Role |
+|---|---|
+| `mutatorRef` | **Source.** JSON path of the value to read. |
+| `mutatedRef` | **Sink.** JSONPath of the field to patch. |
+| `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `copy`, `move`, `test`. In-tree kubernetes often uses `replace` (accepted by evaluation even though it is not on the v1beta3 enum). Prefer a schema enum value for new v1beta3 files. |
+
+Paths are relative to the **component document** as Meshery stores it (`configuration`, `displayName`, `component.kind`, …), not the raw Kubernetes YAML root.
+
+Path rules from contributing docs (still true):
+
+1. `_` may mark **only the first** array position in a path. Later arrays must be an explicit index (`0`, `1`, …).
+2. `mutatedRef` currently does not support an array as the patched value itself.
+3. Pair every mutator path with a mutated path. Do not leave an unpaired side.
+4. Verify each path against the **component schema** in `models/<model>/.../components/<Kind>.json` (or the schemas construct). Do not guess.
+
+Some selectors use a nested `match` block (`match.from` / `match.to` / `match.refs`) instead of, or in addition to, `patch`. Tagsets use `match.refs` on labels. Permission/mount often use `match` with `kind: self` plus `mutatorRef`/`mutatedRef` on the match item. When refining, copy the structure already used by that combo in kubernetes.
+
+Omit `patch` entirely when the relationship only matches (tagsets, annotation).
+
+## Selectors
+
+`selectors` (plural) is an array of selector-set items. Each item has `allow` and optional `deny`, each with `from` and `to`.
+
+- One selector-set item = one independent matchmaking rule (OR across items).
+- Inside one item, every `from` entry relates to every `to` entry (AND / 1:many).
+- `deny` subtracts matches. `allow` and `deny` must not describe the same pair.
+- Missing selector fields imply `*` (wildcard). Values for `kind`, `model`, `version` are case-sensitive.
+- `model.name: "*"` on a selector item lets the relationship span models; the relationship-level `model` still names the owning model.
+
+Wrong names you will see in stale docs: `selector` (singular), `core.meshery.io/v1alpha2`. Use `selectors` and `relationships.meshery.io/v1beta3`.
+
+## `evaluationQuery`
+
+Optional. Names the OPA rule that evaluates the relationship. Convention:
+
+```
+{kind}_{type}_{subType}_relationship
 ```
 
-## Guidelines
+Example: `kind: edge`, `type: non-binding`, `subType: network` → `edge_non-binding_network_relationship`.
 
-1.  **Source of Truth**: Always prioritize `v1beta1` schema rules from `meshery/schemas`. Do not copy existing `v1beta2` or older files blindly as they may contain legacy non-compliant structures.
-2.  **Strict Pathing**: Ensure that the `mutatorRef` and `mutatedRef` paths correspond to the actual JSON schema of the components being linked.
-3.  **Logical Consistency**: Match `Kinds`, `Types`, and `subTypes` that corresponds logically to the components being linked (e.g. `inventory` for `Parent`, `network` for `Service` connections).
-4.  **No Guessing**: If component schemas are unavailable, use `grep_search` to find component definitions in `models` to verify valid paths for `patch` operations.
+Reuse an existing policy. Propose a new `.rego` only when no policy can evaluate the combo. Empty string is common in in-tree files and means "use the default for this kind/type/subType".
+
+## Create a new definition
+
+1. Identify the two (or more) component kinds and their models. Confirm they exist under `models/`.
+2. Decide whether they **affect** each other (semantic) or only the diagram (annotation).
+3. Pick `kind` / `type` / `subType` from the table. If none fit, stop and propose a visualization; do not invent a combo.
+4. Set `from` / `to` (hierarchical: child in `from`, parent in `to`).
+5. If values should flow, add paired `mutatorRef` / `mutatedRef` after reading the component JSON schemas. If they should only match, use `match.refs` or omit patch.
+6. Set `evaluationQuery` from the naming convention, `status: enabled`, `schemaVersion: relationships.meshery.io/v1beta3`.
+7. Write one JSON file per relationship (or a small cohesive set) under `models/<model>/<model-version>/<def-version>/relationships/`. Filename convention: `{kind}-{type}-{subType}-<suffix>.json`.
+8. Compare against the matching file in [examples/](examples/) and against a kubernetes in-tree neighbour of the same combo.
+
+## Refine an existing definition
+
+1. Open the in-tree file. Note `schemaVersion`, `kind`, `type`, `subType`. Do not "upgrade" those three unless the classification was wrong.
+2. Keep `from`/`to` direction. Hierarchical files that already have child-in-`from` must stay that way.
+3. Widen or narrow `allow`/`deny` kinds rather than cloning a near-duplicate relationship, unless the patch paths truly differ.
+4. When adding a component kind to `from` or `to`, copy an existing selector item and change `kind` plus patch paths. Re-verify paths.
+5. Do not swap `mutatorRef` and `mutatedRef`. Source vs sink is the usual bug.
+6. Conflicting overlapping definitions union. Complementary overlaps union. Do not add a second relationship that restates the same pair with a different kind.
+7. Leave nil UUIDs (`00000000-0000-0000-0000-000000000000`) as-is; the registry assigns real ids.
+
+## Common mistakes
+
+- `schemaVersion` `v1beta1` or `core.meshery.io/v1alpha2` — wrong. New: `relationships.meshery.io/v1beta3`.
+- Putting the parent in `from` for hierarchical inventory.
+- Using `type: network` with no `subType`, or treating `inventory` as a `kind`.
+- `selector` instead of `selectors`.
+- Flat paths (`"spec.containers[0].name"`) instead of nested arrays (`[["configuration","spec","containers","_","name"]]`).
+- Unpaired mutator/mutated sequences.
+- Guessing JSON paths instead of reading the component schema.
+- Copying v1beta2 boilerplate blindly into a v1beta3 file (or the reverse) without checking required fields.
+- Mixing `kind: sibling` with in-tree `kind: hierarchical, type: sibling` in the same model.
+
+## Output
+
+Return the full relationship JSON (or a unified diff against the existing file). State the `kind` / `type` / `subType` you chose and why, name the mutator and mutated paths, and cite the schema files you used. If the combo is new, stop and say so.

--- a/.agents/skills/gen-relationship/SKILL.md
+++ b/.agents/skills/gen-relationship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gen-relationship
-description: Create and refine schema-backed Meshery relationship definitions. Use when adding, editing, classifying, or reviewing how model components relate, including kind/type/subType taxonomy and mutatorRef/mutatedRef patches.
+description: Create and refine schema-backed Meshery relationship definitions (models/**/relationships/*.json). Use for "add a relationship", "fix this relationship JSON", classifying kind/type/subType, or reviewing selectors and mutatorRef/mutatedRef patches between model components.
 ---
 
 # Create and refine Meshery relationship definitions
@@ -21,7 +21,7 @@ This skill covers **creating new definitions** and **refining existing ones**. I
 | Human docs | [Concepts: Relationships](https://docs.meshery.io/concepts/logical/relationships), [Contributing to Relationships](https://docs.meshery.io/project/contributing/contributing-relationships) |
 | In-tree corpus | `models/<model>/<model-version>/<definition-version>/relationships/` |
 
-New and rewritten definitions use `schemaVersion: "relationships.meshery.io/v1beta3"`. In-tree model files are still mostly `v1beta2` (a few `v1alpha3`). The versions are shape-compatible: Meshery Server reads definitions into its registry and bridges them to the `v1beta2` shape for the policy engine (`server/models/pattern/utils/relationship_version_bridge.go`), so v1beta3-authored files are consumed the same way. When **refining** an existing file, keep its `schemaVersion` unless you are deliberately migrating it.
+`v1beta3` is the authoring target; in-tree model files are still mostly `v1beta2` (a few `v1alpha3`). The version shapes are compatible - Meshery Server bridges registered definitions to the `v1beta2` shape for the policy engine (`server/models/pattern/utils/relationship_version_bridge.go`) - **but the registration gate accepts only `v1beta2`/`v1alpha3` documents until [meshkit#1096](https://github.com/meshery/meshkit/pull/1096) ships in the server's meshkit**. A definition that must register on current servers (in-tree seeding, `mesheryctl model import`) declares `v1beta2`; flip to `v1beta3` once the gate accepts it. When **refining** an existing file, keep its `schemaVersion` unless you are deliberately migrating it.
 
 `kind` is a schema enum: `hierarchical` | `edge` | `sibling`. `type` and `subType` are open strings. The combinations below are the ones Meshery currently visualizes and evaluates. A new `subType` needs a visual paradigm (whiteboard a proposal in Kanvas) and an evaluation policy that understands it.
 
@@ -29,7 +29,7 @@ Required object fields (v1beta3): `schemaVersion`, `version`, `model`, `kind`, `
 
 ## When to use which combo
 
-`kind` + `type` + `subType` together pick the visual paradigm and the evaluation policy. Copy an existing combo; do not remix.
+`kind` + `type` + `subType` together pick the visual paradigm and the evaluation policy. Copy an existing combo; do not remix. Open only the example file for the combo you picked - the others add nothing for your case.
 
 | kind | type | subType | Meaning | Example | File |
 |---|---|---|---|---|---|
@@ -137,7 +137,7 @@ If legacy tooling forces you to name a rule, the historical default is `{kind}_{
 3. Pick `kind` / `type` / `subType` from the table. If none fit, stop and propose a visualization; do not invent a combo.
 4. Set `from` / `to` (hierarchical: child in `from`, parent in `to`).
 5. If values should flow, add paired `mutatorRef` / `mutatedRef` after reading the component JSON schemas. If they should only match, use `match.refs` or omit patch.
-6. Set `evaluationQuery: ""`, `status: enabled`, `schemaVersion: relationships.meshery.io/v1beta3`.
+6. Set `evaluationQuery: ""`, `status: enabled`, and the `schemaVersion` the registration gate accepts (`v1beta2` today; `v1beta3` once meshkit#1096 ships - see Source of truth).
 7. Write one JSON file per relationship (or a small cohesive set) under `models/<model>/<model-version>/<def-version>/relationships/`. Filename convention: `{kind}-{type}-{subType}-<suffix>.json`.
 8. Compare against the matching file in [examples/](examples/) and against a kubernetes in-tree neighbour of the same combo.
 

--- a/.agents/skills/gen-relationship/SKILL.md
+++ b/.agents/skills/gen-relationship/SKILL.md
@@ -21,11 +21,11 @@ This skill covers **creating new definitions** and **refining existing ones**. I
 | Human docs | [Concepts: Relationships](https://docs.meshery.io/concepts/logical/relationships), [Contributing to Relationships](https://docs.meshery.io/project/contributing/contributing-relationships) |
 | In-tree corpus | `models/<model>/<model-version>/<definition-version>/relationships/` |
 
-New and rewritten definitions use `schemaVersion: "relationships.meshery.io/v1beta3"`. In-tree model files are still mostly `v1beta2` (shape-compatible). When **refining** an existing file, keep its `schemaVersion` unless you are deliberately migrating it.
+New and rewritten definitions use `schemaVersion: "relationships.meshery.io/v1beta3"`. In-tree model files are still mostly `v1beta2` (a few `v1alpha3`). The versions are shape-compatible: Meshery Server reads definitions into its registry and bridges them to the `v1beta2` shape for the policy engine (`server/models/pattern/utils/relationship_version_bridge.go`), so v1beta3-authored files are consumed the same way. When **refining** an existing file, keep its `schemaVersion` unless you are deliberately migrating it.
 
-`kind` is a schema enum: `hierarchical` | `edge` | `sibling`. `type` and `subType` are open strings. The combinations below are the ones Meshery currently visualizes and evaluates. A new `subType` needs a visual paradigm (whiteboard a proposal in Kanvas) and usually an OPA `evaluationQuery`.
+`kind` is a schema enum: `hierarchical` | `edge` | `sibling`. `type` and `subType` are open strings. The combinations below are the ones Meshery currently visualizes and evaluates. A new `subType` needs a visual paradigm (whiteboard a proposal in Kanvas) and an evaluation policy that understands it.
 
-Required object fields (v1beta3): `schemaVersion`, `version`, `model`, `kind`, `type`, `subType`, `id`.
+Required object fields (v1beta3): `schemaVersion`, `version`, `model`, `kind`, `type`, `subType`, `id`. In practice every useful definition also carries `status`, `metadata` (with `description`), `selectors`, and an empty `evaluationQuery` — start from the registry template or an [example](examples/), not the bare minimum.
 
 ## When to use which combo
 
@@ -97,7 +97,7 @@ Defined in `api.yml` as **nested arrays of string path segments** (`string[][]`)
 |---|---|
 | `mutatorRef` | **Source.** JSON path of the value to read. |
 | `mutatedRef` | **Sink.** JSONPath of the field to patch. |
-| `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `copy`, `move`, `test`. In-tree kubernetes often uses `replace` (accepted by evaluation even though it is not on the v1beta3 enum). Prefer a schema enum value for new v1beta3 files. |
+| `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `replace`, `copy`, `move`, `test`. The in-tree corpus and the evaluation engine use `replace` exclusively; default to `replace` unless you need different semantics. (`replace` joined the v1beta3 enum in [meshery/schemas#1166](https://github.com/meshery/schemas/pull/1166).) |
 
 Paths are relative to the **component document** as Meshery stores it (`configuration`, `displayName`, `component.kind`, …), not the raw Kubernetes YAML root.
 
@@ -126,15 +126,9 @@ Wrong names you will see in stale docs: `selector` (singular), `core.meshery.io/
 
 ## `evaluationQuery`
 
-Optional. Names the OPA rule that evaluates the relationship. Convention:
+Deprecated (the schema says so). Set it to `""`, as every one of the ~3,860 in-tree definitions does. The evaluation engine enters through the fixed policy package `data.relationship_evaluation_policy` and dispatches on `kind`/`type`/`subType`; it never reads this field.
 
-```
-{kind}_{type}_{subType}_relationship
-```
-
-Example: `kind: edge`, `type: non-binding`, `subType: network` → `edge_non-binding_network_relationship`.
-
-Reuse an existing policy. Propose a new `.rego` only when no policy can evaluate the combo. Empty string is common in in-tree files and means "use the default for this kind/type/subType".
+If legacy tooling forces you to name a rule, the historical default is `{kind}_{subType}_relationship` (lowercase, from `GetDefaultEvaluationQuery()` in meshery/schemas) — note there is no `{type}` segment, and a Rego rule name allows only letters, digits, and underscores, so a hyphenated type such as `non-binding` can never appear in one.
 
 ## Create a new definition
 
@@ -143,7 +137,7 @@ Reuse an existing policy. Propose a new `.rego` only when no policy can evaluate
 3. Pick `kind` / `type` / `subType` from the table. If none fit, stop and propose a visualization; do not invent a combo.
 4. Set `from` / `to` (hierarchical: child in `from`, parent in `to`).
 5. If values should flow, add paired `mutatorRef` / `mutatedRef` after reading the component JSON schemas. If they should only match, use `match.refs` or omit patch.
-6. Set `evaluationQuery` from the naming convention, `status: enabled`, `schemaVersion: relationships.meshery.io/v1beta3`.
+6. Set `evaluationQuery: ""`, `status: enabled`, `schemaVersion: relationships.meshery.io/v1beta3`.
 7. Write one JSON file per relationship (or a small cohesive set) under `models/<model>/<model-version>/<def-version>/relationships/`. Filename convention: `{kind}-{type}-{subType}-<suffix>.json`.
 8. Compare against the matching file in [examples/](examples/) and against a kubernetes in-tree neighbour of the same combo.
 

--- a/.agents/skills/gen-relationship/SKILL.md
+++ b/.agents/skills/gen-relationship/SKILL.md
@@ -163,6 +163,18 @@ If legacy tooling forces you to name a rule, the historical default is `{kind}_{
 - Copying v1beta2 boilerplate blindly into a v1beta3 file (or the reverse) without checking required fields.
 - Mixing `kind: sibling` with in-tree `kind: hierarchical, type: sibling` in the same model.
 
+## Validate and register
+
+Machine-check every definition before shipping it; do not stop at eyeballing.
+
+1. `python3 -m json.tool <file>` — parses.
+2. Package it: `mesheryctl model init <model> --version <ver>` scaffolds `<model>/<ver>/{model.json,components/,relationships/}`; drop your files in `relationships/` (copy the in-tree `model.json`), then `mesheryctl model build <model>/<ver> --path .` produces an OCI tar and fails on malformed documents.
+3. Register it: `mesheryctl model import -f <model>-<ver>.tar` against a running server.
+4. **Verify registration yourself — never trust the import summary.** Query `/api/meshmodels/models/<model>/relationships` (or `mesheryctl relationship view <model>`) and confirm your definitions appear. Until [meshery/schemas#1169](https://github.com/meshery/schemas/pull/1169) ships, importing relationships into a model the server already knows silently orphans them (`model_id` = nil UUID) while the summary reports success.
+5. Prove behavior with an evaluation: POST a design whose component configurations already satisfy the relationship (matching names/paths) to `/api/meshmodels/relationships/evaluate` and confirm your definition appears in the response with `status: approved`.
+
+The strict document validator (meshkit `schema.Validate`) currently rejects corpus-conventional files for reasons unrelated to your authoring (see [meshery/schemas#1167](https://github.com/meshery/schemas/issues/1167)); `model build` + `import` + evaluation are the gates that matter today.
+
 ## Output
 
 Return the full relationship JSON (or a unified diff against the existing file). State the `kind` / `type` / `subType` you chose and why, name the mutator and mutated paths, and cite the schema files you used. If the combo is new, stop and say so.

--- a/.agents/skills/gen-relationship/SKILL.md
+++ b/.agents/skills/gen-relationship/SKILL.md
@@ -36,10 +36,10 @@ Required object fields (v1beta3): `schemaVersion`, `version`, `model`, `kind`, `
 | `edge` | `non-binding` | `reference` | Logical name/id pointer; no traffic, mount, or RBAC | Deployment → ConfigMap | [examples/edge-non-binding-reference.json](examples/edge-non-binding-reference.json) |
 | `edge` | `non-binding` | `network` | Documented L3/L4/L7 selection, no provisioned attachment | Service → Deployment | [examples/edge-non-binding-network.json](examples/edge-non-binding-network.json) |
 | `edge` | `non-binding` | `firewall` | Policy that allows/denies traffic between peers | NetworkPolicy → Pod | [examples/edge-non-binding-firewall.json](examples/edge-non-binding-firewall.json) |
-| `edge` | `non-binding` | `permission` | Mentions an identity or role without binding it | IAM Role → Instance | [examples/edge-non-binding-permission.json](examples/edge-non-binding-permission.json) |
+| `edge` | `non-binding` | `permission` | Mentions an identity or role without binding it | IAM Policy → Role | [examples/edge-non-binding-permission.json](examples/edge-non-binding-permission.json) |
 | `edge` | `non-binding` | `alias` | Named stand-in, not nested ownership | Secret → Secret | [examples/edge-non-binding-alias.json](examples/edge-non-binding-alias.json) |
 | `edge` | `non-binding` | `annotation` | Designer-only line; `metadata.isAnnotation: true`; no patch | Shape → Shape | [examples/edge-non-binding-annotation.json](examples/edge-non-binding-annotation.json) |
-| `edge` | `non-binding` | `inventory` | Rare. Peer index/list, not parent-child containment | Database → NamespacesEventHub | [examples/edge-non-binding-inventory.json](examples/edge-non-binding-inventory.json) |
+| `edge` | `non-binding` | `inventory` | Rare. Peer index/list, not parent-child containment | Cluster → Database | [examples/edge-non-binding-inventory.json](examples/edge-non-binding-inventory.json) |
 | `edge` | `binding` | `permission` | Assigns identities (Role/RoleBinding/ServiceAccount) | Role → ServiceAccount via RoleBinding | [examples/edge-binding-permission.json](examples/edge-binding-permission.json) |
 | `edge` | `binding` | `mount` | Storage or device is attached | PVC → Pod | [examples/edge-binding-mount.json](examples/edge-binding-mount.json) |
 | `edge` | `binding` | `network` | Rare. Connecting provisions/rewrites network identity | Listener → Domain | [examples/edge-binding-network.json](examples/edge-binding-network.json) |
@@ -117,7 +117,7 @@ Omit `patch` entirely when the relationship only matches (tagsets, annotation).
 `selectors` (plural) is an array of selector-set items. Each item has `allow` and optional `deny`, each with `from` and `to`.
 
 - One selector-set item = one independent matchmaking rule (OR across items).
-- Inside one item, every `from` entry relates to every `to` entry (AND / 1:many).
+- Inside one item, every `from` entry relates to every `to` entry - a cross-product, not 1:many.
 - `deny` subtracts matches. `allow` and `deny` must not describe the same pair.
 - Missing selector fields imply `*` (wildcard). Values for `kind`, `model`, `version` are case-sensitive.
 - `model.name: "*"` on a selector item lets the relationship span models; the relationship-level `model` still names the owning model.

--- a/.agents/skills/gen-relationship/SKILL.md
+++ b/.agents/skills/gen-relationship/SKILL.md
@@ -36,11 +36,11 @@ Required object fields (v1beta3): `schemaVersion`, `version`, `model`, `kind`, `
 | `edge` | `non-binding` | `reference` | Logical name/id pointer; no traffic, mount, or RBAC | Deployment → ConfigMap | [examples/edge-non-binding-reference.json](examples/edge-non-binding-reference.json) |
 | `edge` | `non-binding` | `network` | Documented L3/L4/L7 selection, no provisioned attachment | Service → Deployment | [examples/edge-non-binding-network.json](examples/edge-non-binding-network.json) |
 | `edge` | `non-binding` | `firewall` | Policy that allows/denies traffic between peers | NetworkPolicy → Pod | [examples/edge-non-binding-firewall.json](examples/edge-non-binding-firewall.json) |
-| `edge` | `non-binding` | `permission` | Mentions an identity or role without binding it | IAM Policy → Role | [examples/edge-non-binding-permission.json](examples/edge-non-binding-permission.json) |
+| `edge` | `non-binding` | `permission` | Mentions an identity or role without binding it | IAM Role → Instance | [examples/edge-non-binding-permission.json](examples/edge-non-binding-permission.json) |
 | `edge` | `non-binding` | `alias` | Named stand-in, not nested ownership | Secret → Secret | [examples/edge-non-binding-alias.json](examples/edge-non-binding-alias.json) |
 | `edge` | `non-binding` | `annotation` | Designer-only line; `metadata.isAnnotation: true`; no patch | Shape → Shape | [examples/edge-non-binding-annotation.json](examples/edge-non-binding-annotation.json) |
-| `edge` | `non-binding` | `inventory` | Rare. Peer index/list, not parent-child containment | Cluster → Database | [examples/edge-non-binding-inventory.json](examples/edge-non-binding-inventory.json) |
-| `edge` | `binding` | `permission` | Assigns identities (Role/RoleBinding/ServiceAccount) | Role → ServiceAccount | [examples/edge-binding-permission.json](examples/edge-binding-permission.json) |
+| `edge` | `non-binding` | `inventory` | Rare. Peer index/list, not parent-child containment | Database → NamespacesEventHub | [examples/edge-non-binding-inventory.json](examples/edge-non-binding-inventory.json) |
+| `edge` | `binding` | `permission` | Assigns identities (Role/RoleBinding/ServiceAccount) | Role → ServiceAccount via RoleBinding | [examples/edge-binding-permission.json](examples/edge-binding-permission.json) |
 | `edge` | `binding` | `mount` | Storage or device is attached | PVC → Pod | [examples/edge-binding-mount.json](examples/edge-binding-mount.json) |
 | `edge` | `binding` | `network` | Rare. Connecting provisions/rewrites network identity | Listener → Domain | [examples/edge-binding-network.json](examples/edge-binding-network.json) |
 | `hierarchical` | `parent` | `inventory` | Parent scopes/contains children; parent identity patched onto child | `*` → Namespace | [examples/hierarchical-parent-inventory.json](examples/hierarchical-parent-inventory.json) |

--- a/.agents/skills/gen-relationship/SKILL.md
+++ b/.agents/skills/gen-relationship/SKILL.md
@@ -96,7 +96,7 @@ Defined in `api.yml` as **nested arrays of string path segments** (`string[][]`)
 | Field | Role |
 |---|---|
 | `mutatorRef` | **Source.** JSON path of the value to read. |
-| `mutatedRef` | **Sink.** JSONPath of the field to patch. |
+| `mutatedRef` | **Sink.** Path segments of the field to patch. |
 | `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `replace`, `copy`, `move`, `test`. The in-tree corpus and the evaluation engine use `replace` exclusively; default to `replace` unless you need different semantics. (`replace` joined the v1beta3 enum in [meshery/schemas#1166](https://github.com/meshery/schemas/pull/1166).) |
 
 Paths are relative to the **component document** as Meshery stores it (`configuration`, `displayName`, `component.kind`, …), not the raw Kubernetes YAML root.

--- a/.agents/skills/gen-relationship/examples/README.md
+++ b/.agents/skills/gen-relationship/examples/README.md
@@ -2,7 +2,7 @@
 
 One compact, pedagogical example per canonical `kind` / `type` / `subType` combination found in Meshery models, plus the schema-native sibling encoding.
 
-These are teaching fixtures, not drop-in replacements for in-tree `models/**/relationships/*.json`. In-tree files are mostly `relationships.meshery.io/v1beta2` and carry full model/registrant envelopes. New definitions should use `relationships.meshery.io/v1beta3` as in these examples.
+These are teaching fixtures, not drop-in replacements for in-tree `models/**/relationships/*.json`. In-tree files are mostly `relationships.meshery.io/v1beta2` and carry full model/registrant envelopes. These examples declare `relationships.meshery.io/v1beta3` (the authoring target); a definition that must register on current servers declares `v1beta2` until meshkit#1096 ships in the server - the rest of the document is identical.
 
 See `SKILL.md` for when to pick each combo and how `mutatorRef` / `mutatedRef` pair.
 

--- a/.agents/skills/gen-relationship/examples/README.md
+++ b/.agents/skills/gen-relationship/examples/README.md
@@ -1,0 +1,27 @@
+# Relationship definition examples
+
+One compact, pedagogical example per canonical `kind` / `type` / `subType` combination found in Meshery models, plus the schema-native sibling encoding.
+
+These are teaching fixtures, not drop-in replacements for in-tree `models/**/relationships/*.json`. In-tree files are mostly `relationships.meshery.io/v1beta2` and carry full model/registrant envelopes. New definitions should use `relationships.meshery.io/v1beta3` as in these examples.
+
+See `SKILL.md` for when to pick each combo and how `mutatorRef` / `mutatedRef` pair.
+
+| File | kind | type | subType |
+|---|---|---|---|
+| `edge-non-binding-reference.json` | edge | non-binding | reference |
+| `edge-non-binding-network.json` | edge | non-binding | network |
+| `edge-non-binding-firewall.json` | edge | non-binding | firewall |
+| `edge-non-binding-permission.json` | edge | non-binding | permission |
+| `edge-non-binding-alias.json` | edge | non-binding | alias |
+| `edge-non-binding-annotation.json` | edge | non-binding | annotation |
+| `edge-non-binding-inventory.json` | edge | non-binding | inventory |
+| `edge-binding-permission.json` | edge | binding | permission |
+| `edge-binding-mount.json` | edge | binding | mount |
+| `edge-binding-network.json` | edge | binding | network |
+| `hierarchical-parent-inventory.json` | hierarchical | parent | inventory |
+| `hierarchical-parent-alias.json` | hierarchical | parent | alias |
+| `hierarchical-parent-wallet.json` | hierarchical | parent | wallet |
+| `hierarchical-sibling-matchlabels.json` | hierarchical | sibling | matchlabels |
+| `sibling-matchlabels.json` | sibling | matchlabels | tagsets |
+
+`badge` is named in docs as a visual paradigm but has no in-tree `kind`/`type`/`subType` encoding. Do not invent `subType: badge` unless you also propose a visualization and an evaluation policy.

--- a/.agents/skills/gen-relationship/examples/README.md
+++ b/.agents/skills/gen-relationship/examples/README.md
@@ -6,6 +6,8 @@ These are teaching fixtures, not drop-in replacements for in-tree `models/**/rel
 
 See `SKILL.md` for when to pick each combo and how `mutatorRef` / `mutatedRef` pair.
 
+A `model` object inside a selector item is a model *reference* (the schema's `ModelReference`): its outer `version` is the model-definition version, while the nested `model.version` object carries the upstream model version (for example, the Kubernetes release). The `"model": { ... "model": { "version": "" } }` nesting is intentional, not a copy-paste error.
+
 | File | kind | type | subType |
 |---|---|---|---|
 | `edge-non-binding-reference.json` | edge | non-binding | reference |

--- a/.agents/skills/gen-relationship/examples/edge-binding-mount.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-mount.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "binding",
+  "subType": "mount",
+  "status": "enabled",
+  "evaluationQuery": "edge_binding_mount_relationship",
+  "metadata": {
+    "description": "A PersistentVolumeClaim is mounted into a Pod. The claim name is the mutator; the Pod volume claimName is the mutated sink.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "PersistentVolumeClaim",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "metadata", "name"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Pod",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "spec", "volumes", "_", "persistentVolumeClaim", "claimName"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-binding-mount.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-mount.json
@@ -6,7 +6,7 @@
   "type": "binding",
   "subType": "mount",
   "status": "enabled",
-  "evaluationQuery": "edge_binding_mount_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A PersistentVolumeClaim is mounted into a Pod. The claim name is the mutator; the Pod volume claimName is the mutated sink.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-binding-network.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-network.json
@@ -6,7 +6,7 @@
   "type": "binding",
   "subType": "network",
   "status": "enabled",
-  "evaluationQuery": "edge_binding_network_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A binding network edge: connecting the components provisions or rewrites network identity, not just documents a selector match. Rare in-tree; most Service-to-workload links are edge/non-binding/network.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-binding-network.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-network.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "binding",
+  "subType": "network",
+  "status": "enabled",
+  "evaluationQuery": "edge_binding_network_relationship",
+  "metadata": {
+    "description": "A binding network edge: connecting the components provisions or rewrites network identity, not just documents a selector match. Rare in-tree; most Service-to-workload links are edge/non-binding/network.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "aws-elasticsearchservice-controller",
+    "version": "v1.0.0",
+    "displayName": "aws-elasticsearchservice-controller",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v0.0.2" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Listener",
+            "model": { "name": "aws-elasticsearchservice-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "domainName"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Domain",
+            "model": { "name": "aws-elasticsearchservice-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "metadata", "name"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-permission.json
@@ -6,7 +6,7 @@
   "type": "binding",
   "subType": "permission",
   "status": "enabled",
-  "evaluationQuery": "edge_binding_permission_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A Role is bound to a ServiceAccount. Binding edges assign identities.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-permission.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "binding",
+  "subType": "permission",
+  "status": "enabled",
+  "evaluationQuery": "edge_binding_permission_relationship",
+  "metadata": {
+    "description": "A Role is bound to a ServiceAccount. Binding edges assign identities.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Role",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["component", "kind"], ["displayName"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "ServiceAccount",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["component", "kind"], ["displayName"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-permission.json
@@ -8,7 +8,7 @@
   "status": "enabled",
   "evaluationQuery": "",
   "metadata": {
-    "description": "A Role is bound to a ServiceAccount. Binding edges assign identities.",
+    "description": "A Role is bound to a ServiceAccount through a RoleBinding. Binding edges assign identities.",
     "isAnnotation": false
   },
   "model": {
@@ -26,9 +26,22 @@
           {
             "kind": "Role",
             "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [["component", "kind"], ["displayName"]]
+            "match": {
+              "from": [
+                {
+                  "kind": "self",
+                  "mutatorRef": [["component", "kind"], ["displayName"]]
+                }
+              ],
+              "to": [
+                {
+                  "kind": "RoleBinding",
+                  "mutatedRef": [
+                    ["configuration", "spec", "roleRef", "kind"],
+                    ["configuration", "spec", "roleRef", "name"]
+                  ]
+                }
+              ]
             }
           }
         ],
@@ -36,9 +49,21 @@
           {
             "kind": "ServiceAccount",
             "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [["component", "kind"], ["displayName"]]
+            "match": {
+              "from": [
+                {
+                  "kind": "RoleBinding",
+                  "mutatedRef": [
+                    ["configuration", "spec", "subjects", "_", "name"]
+                  ]
+                }
+              ],
+              "to": [
+                {
+                  "kind": "self",
+                  "mutatorRef": [["displayName"]]
+                }
+              ]
             }
           }
         ]

--- a/.agents/skills/gen-relationship/examples/edge-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-binding-permission.json
@@ -8,7 +8,7 @@
   "status": "enabled",
   "evaluationQuery": "",
   "metadata": {
-    "description": "A Role is bound to a ServiceAccount through a RoleBinding. Binding edges assign identities.",
+    "description": "A Role is bound to a ServiceAccount through a mediating RoleBinding: the Role's kind and name land in the RoleBinding's roleRef, and the ServiceAccount's name lands in its subjects. Binding-permission edges use match blocks (kind: self plus the mediator) rather than a direct patch between the endpoints; note roleRef/subjects sit at the top level of the RoleBinding schema, not under spec.",
     "isAnnotation": false
   },
   "model": {
@@ -30,15 +30,18 @@
               "from": [
                 {
                   "kind": "self",
-                  "mutatorRef": [["component", "kind"], ["displayName"]]
+                  "mutatorRef": [
+                    ["component", "kind"],
+                    ["displayName"]
+                  ]
                 }
               ],
               "to": [
                 {
                   "kind": "RoleBinding",
                   "mutatedRef": [
-                    ["configuration", "spec", "roleRef", "kind"],
-                    ["configuration", "spec", "roleRef", "name"]
+                    ["configuration", "roleRef", "kind"],
+                    ["configuration", "roleRef", "name"]
                   ]
                 }
               ]
@@ -54,21 +57,26 @@
                 {
                   "kind": "RoleBinding",
                   "mutatedRef": [
-                    ["configuration", "spec", "subjects", "_", "name"]
+                    ["configuration", "subjects", "_", "name"]
                   ]
                 }
               ],
               "to": [
                 {
                   "kind": "self",
-                  "mutatorRef": [["displayName"]]
+                  "mutatorRef": [
+                    ["displayName"]
+                  ]
                 }
               ]
             }
           }
         ]
       },
-      "deny": { "from": [], "to": [] }
+      "deny": {
+        "from": [],
+        "to": []
+      }
     }
   ]
 }

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-alias.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-alias.json
@@ -6,7 +6,7 @@
   "type": "non-binding",
   "subType": "alias",
   "status": "enabled",
-  "evaluationQuery": "edge_non-binding_alias_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "An edge alias: one component is a named stand-in for another without nesting or ownership.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-alias.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-alias.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "alias",
+  "status": "enabled",
+  "evaluationQuery": "edge_non-binding_alias_relationship",
+  "metadata": {
+    "description": "An edge alias: one component is a named stand-in for another without nesting or ownership.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "aws-secretsmanager-controller",
+    "version": "v1.0.0",
+    "displayName": "aws-secretsmanager-controller",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.4.1" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Secret",
+            "model": { "name": "aws-secretsmanager-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "name"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Secret",
+            "model": { "name": "aws-secretsmanager-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "metadata", "name"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-annotation.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-annotation.json
@@ -1,0 +1,41 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "annotation",
+  "status": "enabled",
+  "evaluationQuery": "edge_non-binding_annotation_relationship",
+  "metadata": {
+    "description": "A designer-drawn connection with no lifecycle effect. metadata.isAnnotation is true; omit patch. Meshery does not mutate either component.",
+    "isAnnotation": true
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "meshery-shapes",
+    "version": "v1.0.0",
+    "displayName": "meshery-shapes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "0.7.2" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Rectangle",
+            "model": { "name": "meshery-shapes", "registrant": { "kind": "github" }, "model": { "version": "" } }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Circle",
+            "model": { "name": "meshery-shapes", "registrant": { "kind": "github" }, "model": { "version": "" } }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-annotation.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-annotation.json
@@ -6,7 +6,7 @@
   "type": "non-binding",
   "subType": "annotation",
   "status": "enabled",
-  "evaluationQuery": "edge_non-binding_annotation_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A designer-drawn connection with no lifecycle effect. metadata.isAnnotation is true; omit patch. Meshery does not mutate either component.",
     "isAnnotation": true

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-firewall.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-firewall.json
@@ -6,7 +6,7 @@
   "type": "non-binding",
   "subType": "firewall",
   "status": "enabled",
-  "evaluationQuery": "edge_non-binding_firewall_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A NetworkPolicy constrains ingress/egress of matching Pods. The policy podSelector is the mutator; the Pod labels are the mutated sink.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-firewall.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-firewall.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "firewall",
+  "status": "enabled",
+  "evaluationQuery": "edge_non-binding_firewall_relationship",
+  "metadata": {
+    "description": "A NetworkPolicy constrains ingress/egress of matching Pods. The policy podSelector is the mutator; the Pod labels are the mutated sink.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "NetworkPolicy",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "podSelector", "matchLabels"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Pod",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "metadata", "labels"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
@@ -6,7 +6,7 @@
   "type": "non-binding",
   "subType": "inventory",
   "status": "enabled",
-  "evaluationQuery": "edge_non-binding_inventory_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A rare edge form of inventory: one component lists or indexes another without parent-child nesting. Prefer hierarchical/parent/inventory for namespace-style containment.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "inventory",
+  "status": "enabled",
+  "evaluationQuery": "edge_non-binding_inventory_relationship",
+  "metadata": {
+    "description": "A rare edge form of inventory: one component lists or indexes another without parent-child nesting. Prefer hierarchical/parent/inventory for namespace-style containment.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "azure-kusto",
+    "version": "v1.0.0",
+    "displayName": "azure-kusto",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.0.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Cluster",
+            "model": { "name": "azure-kusto", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "databaseRef"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Database",
+            "model": { "name": "azure-kusto", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "metadata", "name"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
@@ -8,7 +8,7 @@
   "status": "enabled",
   "evaluationQuery": "",
   "metadata": {
-    "description": "A rare edge form of inventory: a Kusto Database indexes an Event Hub by reference without parent-child nesting. Prefer hierarchical/parent/inventory for containment.",
+    "description": "A rare edge form of inventory: one component lists or indexes another without parent-child nesting. The Database's name (mutator) is written into the Cluster's databaseRef (mutated); the indexed component is never modified.",
     "isAnnotation": false
   },
   "model": {
@@ -17,41 +17,40 @@
     "version": "v1.0.0",
     "displayName": "azure-kusto",
     "registrant": { "kind": "github" },
-    "model": { "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml" }
+    "model": { "version": "v1.0.0" }
   },
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "kind": "Database",
+            "kind": "Cluster",
             "model": { "name": "azure-kusto", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
               "mutatedRef": [
-                ["configuration", "spec", "eventHubResourceReference", "group"],
-                ["configuration", "spec", "eventHubResourceReference", "kind"],
-                ["configuration", "spec", "eventHubResourceReference", "name"]
+                ["configuration", "spec", "databaseRef"]
               ]
             }
           }
         ],
         "to": [
           {
-            "kind": "NamespacesEventHub",
-            "model": { "name": "azure-event-hubs", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "kind": "Database",
+            "model": { "name": "azure-kusto", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
               "mutatorRef": [
-                ["configuration", "group"],
-                ["configuration", "kind"],
-                ["configuration", "spec", "name"]
+                ["displayName"]
               ]
             }
           }
         ]
       },
-      "deny": { "from": [], "to": [] }
+      "deny": {
+        "from": [],
+        "to": []
+      }
     }
   ]
 }

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-inventory.json
@@ -8,7 +8,7 @@
   "status": "enabled",
   "evaluationQuery": "",
   "metadata": {
-    "description": "A rare edge form of inventory: one component lists or indexes another without parent-child nesting. Prefer hierarchical/parent/inventory for namespace-style containment.",
+    "description": "A rare edge form of inventory: a Kusto Database indexes an Event Hub by reference without parent-child nesting. Prefer hierarchical/parent/inventory for containment.",
     "isAnnotation": false
   },
   "model": {
@@ -17,28 +17,36 @@
     "version": "v1.0.0",
     "displayName": "azure-kusto",
     "registrant": { "kind": "github" },
-    "model": { "version": "v1.0.0" }
+    "model": { "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml" }
   },
   "selectors": [
     {
       "allow": {
         "from": [
           {
-            "kind": "Cluster",
+            "kind": "Database",
             "model": { "name": "azure-kusto", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["configuration", "spec", "databaseRef"]]
+              "mutatedRef": [
+                ["configuration", "spec", "eventHubResourceReference", "group"],
+                ["configuration", "spec", "eventHubResourceReference", "kind"],
+                ["configuration", "spec", "eventHubResourceReference", "name"]
+              ]
             }
           }
         ],
         "to": [
           {
-            "kind": "Database",
-            "model": { "name": "azure-kusto", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "kind": "NamespacesEventHub",
+            "model": { "name": "azure-event-hubs", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["configuration", "metadata", "name"]]
+              "mutatorRef": [
+                ["configuration", "group"],
+                ["configuration", "kind"],
+                ["configuration", "spec", "name"]
+              ]
             }
           }
         ]

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-network.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-network.json
@@ -6,7 +6,7 @@
   "type": "non-binding",
   "subType": "network",
   "status": "enabled",
-  "evaluationQuery": "edge_non-binding_network_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A Service selects Pods of a Deployment. The Service selector is the mutator; the Deployment pod-template labels are the mutated sink.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-network.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-network.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "network",
+  "status": "enabled",
+  "evaluationQuery": "edge_non-binding_network_relationship",
+  "metadata": {
+    "description": "A Service selects Pods of a Deployment. The Service selector is the mutator; the Deployment pod-template labels are the mutated sink.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Service",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "selector"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Deployment",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "spec", "template", "metadata", "labels"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "permission",
+  "status": "enabled",
+  "evaluationQuery": "edge_non-binding_permission_relationship",
+  "metadata": {
+    "description": "A non-enforcing permission link: a policy document refers to a role by name without assigning subjects. Contrast with edge/binding/permission.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "aws-iam-controller",
+    "version": "v1.0.0",
+    "displayName": "aws-iam-controller",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.7.3" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Policy",
+            "model": { "name": "aws-iam-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "roleRef", "name"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Role",
+            "model": { "name": "aws-iam-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "metadata", "name"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
@@ -6,7 +6,7 @@
   "type": "non-binding",
   "subType": "permission",
   "status": "enabled",
-  "evaluationQuery": "edge_non-binding_permission_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A non-enforcing permission link: a policy document refers to a role by name without assigning subjects. Contrast with edge/binding/permission.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
@@ -8,7 +8,7 @@
   "status": "enabled",
   "evaluationQuery": "",
   "metadata": {
-    "description": "A non-enforcing permission link: a policy document refers to a role by name without assigning subjects. Contrast with edge/binding/permission.",
+    "description": "A non-binding permission link: an IAM Role supplies identifiers an Instance consumes without the relationship itself assigning subjects. Contrast with edge/binding/permission.",
     "isAnnotation": false
   },
   "model": {
@@ -24,21 +24,27 @@
       "allow": {
         "from": [
           {
-            "kind": "Policy",
+            "kind": "Role",
             "model": { "name": "aws-iam-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["configuration", "spec", "roleRef", "name"]]
+              "mutatorRef": [
+                ["configuration", "spec", "name"],
+                ["configuration", "status", "ackResourceMetadata", "arn"]
+              ]
             }
           }
         ],
         "to": [
           {
-            "kind": "Role",
-            "model": { "name": "aws-iam-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "kind": "Instance",
+            "model": { "name": "ec2-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["configuration", "metadata", "name"]]
+              "mutatedRef": [
+                ["configuration", "spec", "iamInstanceProfile"],
+                ["configuration", "spec", "instanceID"]
+              ]
             }
           }
         ]

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-permission.json
@@ -8,7 +8,7 @@
   "status": "enabled",
   "evaluationQuery": "",
   "metadata": {
-    "description": "A non-binding permission link: an IAM Role supplies identifiers an Instance consumes without the relationship itself assigning subjects. Contrast with edge/binding/permission.",
+    "description": "A non-enforcing permission link: a policy document refers to a role by name without assigning subjects. The Role's name (mutator) is written into the policy document's roleRef (mutated); the Role itself is never modified.",
     "isAnnotation": false
   },
   "model": {
@@ -24,32 +24,33 @@
       "allow": {
         "from": [
           {
-            "kind": "Role",
+            "kind": "Policy",
             "model": { "name": "aws-iam-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [
-                ["configuration", "spec", "name"],
-                ["configuration", "status", "ackResourceMetadata", "arn"]
+              "mutatedRef": [
+                ["configuration", "spec", "roleRef", "name"]
               ]
             }
           }
         ],
         "to": [
           {
-            "kind": "Instance",
-            "model": { "name": "ec2-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "kind": "Role",
+            "model": { "name": "aws-iam-controller", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [
-                ["configuration", "spec", "iamInstanceProfile"],
-                ["configuration", "spec", "instanceID"]
+              "mutatorRef": [
+                ["displayName"]
               ]
             }
           }
         ]
       },
-      "deny": { "from": [], "to": [] }
+      "deny": {
+        "from": [],
+        "to": []
+      }
     }
   ]
 }

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-reference.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-reference.json
@@ -6,7 +6,7 @@
   "type": "non-binding",
   "subType": "reference",
   "status": "enabled",
-  "evaluationQuery": "edge_non-binding_reference_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A Deployment references a ConfigMap by name (envFrom). The ConfigMap provides its identity; the Deployment envFrom.configMapRef.name is patched.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/edge-non-binding-reference.json
+++ b/.agents/skills/gen-relationship/examples/edge-non-binding-reference.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "reference",
+  "status": "enabled",
+  "evaluationQuery": "edge_non-binding_reference_relationship",
+  "metadata": {
+    "description": "A Deployment references a ConfigMap by name (envFrom). The ConfigMap provides its identity; the Deployment envFrom.configMapRef.name is patched.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Deployment",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "spec", "template", "spec", "containers", "_", "envFrom", "0", "configMapRef", "name"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "ConfigMap",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "metadata", "name"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/hierarchical-parent-alias.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-parent-alias.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "hierarchical",
+  "type": "parent",
+  "subType": "alias",
+  "status": "enabled",
+  "evaluationQuery": "hierarchical_parent_alias_relationship",
+  "metadata": {
+    "description": "A Container is an alias for a nested object inside a Pod. The child configuration is patched into the parent containers array. from is the child; to is the parent.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "Container",
+            "model": { "name": "meshery-core", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Pod",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "spec", "containers", "_"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/hierarchical-parent-alias.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-parent-alias.json
@@ -6,7 +6,7 @@
   "type": "parent",
   "subType": "alias",
   "status": "enabled",
-  "evaluationQuery": "hierarchical_parent_alias_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A Container is an alias for a nested object inside a Pod. The child configuration is patched into the parent containers array. from is the child; to is the parent.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/hierarchical-parent-inventory.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-parent-inventory.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "hierarchical",
+  "type": "parent",
+  "subType": "inventory",
+  "status": "enabled",
+  "evaluationQuery": "hierarchical_parent_inventory_relationship",
+  "metadata": {
+    "description": "Namespace containment. Hierarchical convention: from is the child, to is the parent. The Namespace displayName (mutator) is written into each child metadata.namespace (mutated).",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "*",
+            "model": { "name": "*", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "metadata", "namespace"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Namespace",
+            "model": { "name": "kubernetes", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["displayName"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/hierarchical-parent-inventory.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-parent-inventory.json
@@ -6,7 +6,7 @@
   "type": "parent",
   "subType": "inventory",
   "status": "enabled",
-  "evaluationQuery": "hierarchical_parent_inventory_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "Namespace containment. Hierarchical convention: from is the child, to is the parent. The Namespace displayName (mutator) is written into each child metadata.namespace (mutated).",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/hierarchical-parent-wallet.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-parent-wallet.json
@@ -1,0 +1,49 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "hierarchical",
+  "type": "parent",
+  "subType": "wallet",
+  "status": "enabled",
+  "evaluationQuery": "hierarchical_parent_wallet_relationship",
+  "metadata": {
+    "description": "A child carries configuration that is patched into its parent (the parent holds the child). Classic: WASMFilter binary+config into EnvoyFilter.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "istio-base",
+    "version": "v1.0.0",
+    "displayName": "istio-base",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.0.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "WASMFilter",
+            "model": { "name": "istio-base", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatorRef": [["configuration", "spec", "config"], ["configuration", "spec", "wasmFilter"]]
+            }
+          }
+        ],
+        "to": [
+          {
+            "kind": "EnvoyFilter",
+            "model": { "name": "istio-base", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "patch": {
+              "patchStrategy": "replace",
+              "mutatedRef": [["configuration", "spec", "configPatches", "_", "patch", "value"], ["configuration", "metadata", "name"]]
+            }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/hierarchical-parent-wallet.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-parent-wallet.json
@@ -6,9 +6,9 @@
   "type": "parent",
   "subType": "wallet",
   "status": "enabled",
-  "evaluationQuery": "hierarchical_parent_wallet_relationship",
+  "evaluationQuery": "",
   "metadata": {
-    "description": "A child carries configuration that is patched into its parent (the parent holds the child). Classic: WASMFilter binary+config into EnvoyFilter.",
+    "description": "A child carries configuration that is patched into its parent (the parent holds the child). Classic: WASMFilter (meshery-core) config into an Istio EnvoyFilter configPatch.",
     "isAnnotation": false
   },
   "model": {
@@ -25,10 +25,10 @@
         "from": [
           {
             "kind": "WASMFilter",
-            "model": { "name": "istio-base", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "model": { "name": "meshery-core", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatorRef": [["configuration", "spec", "config"], ["configuration", "spec", "wasmFilter"]]
+              "mutatorRef": [["configuration", "config"]]
             }
           }
         ],
@@ -38,7 +38,7 @@
             "model": { "name": "istio-base", "registrant": { "kind": "github" }, "model": { "version": "" } },
             "patch": {
               "patchStrategy": "replace",
-              "mutatedRef": [["configuration", "spec", "configPatches", "_", "patch", "value"], ["configuration", "metadata", "name"]]
+              "mutatedRef": [["configuration", "spec", "configPatches", "_", "patch", "value"]]
             }
           }
         ]

--- a/.agents/skills/gen-relationship/examples/hierarchical-sibling-matchlabels.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-sibling-matchlabels.json
@@ -1,0 +1,43 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "hierarchical",
+  "type": "sibling",
+  "subType": "matchlabels",
+  "status": "enabled",
+  "evaluationQuery": "hierarchical_sibling_matchlabels_relationship",
+  "metadata": {
+    "description": "IN-TREE ENCODING of tagsets. Schema kind enum includes sibling, but kubernetes models encode Match-Labels as kind=hierarchical, type=sibling, subType=matchlabels. Match on labels; no patch.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "*",
+            "model": { "name": "*", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "match": { "refs": [["configuration", "metadata", "labels"]] }
+          }
+        ],
+        "to": [
+          {
+            "kind": "*",
+            "model": { "name": "*", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "match": { "refs": [["configuration", "metadata", "labels"]] }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/hierarchical-sibling-matchlabels.json
+++ b/.agents/skills/gen-relationship/examples/hierarchical-sibling-matchlabels.json
@@ -6,7 +6,7 @@
   "type": "sibling",
   "subType": "matchlabels",
   "status": "enabled",
-  "evaluationQuery": "hierarchical_sibling_matchlabels_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "IN-TREE ENCODING of tagsets. Schema kind enum includes sibling, but kubernetes models encode Match-Labels as kind=hierarchical, type=sibling, subType=matchlabels. Match on labels; no patch.",
     "isAnnotation": false

--- a/.agents/skills/gen-relationship/examples/sibling-matchlabels.json
+++ b/.agents/skills/gen-relationship/examples/sibling-matchlabels.json
@@ -1,0 +1,43 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
+  "version": "v1.0.0",
+  "kind": "sibling",
+  "type": "matchlabels",
+  "subType": "tagsets",
+  "status": "enabled",
+  "evaluationQuery": "sibling_matchlabels_tagsets_relationship",
+  "metadata": {
+    "description": "SCHEMA-NATIVE encoding of tagsets using kind=sibling (the v1beta3 kind enum). Do not mix this with the in-tree hierarchical/sibling/matchlabels encoding in the same model.",
+    "isAnnotation": false
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "v1.35.0" }
+  },
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "kind": "*",
+            "model": { "name": "*", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "match": { "refs": [["configuration", "metadata", "labels"]] }
+          }
+        ],
+        "to": [
+          {
+            "kind": "*",
+            "model": { "name": "*", "registrant": { "kind": "github" }, "model": { "version": "" } },
+            "match": { "refs": [["configuration", "metadata", "labels"]] }
+          }
+        ]
+      },
+      "deny": { "from": [], "to": [] }
+    }
+  ]
+}

--- a/.agents/skills/gen-relationship/examples/sibling-matchlabels.json
+++ b/.agents/skills/gen-relationship/examples/sibling-matchlabels.json
@@ -6,7 +6,7 @@
   "type": "matchlabels",
   "subType": "tagsets",
   "status": "enabled",
-  "evaluationQuery": "sibling_matchlabels_tagsets_relationship",
+  "evaluationQuery": "",
   "metadata": {
     "description": "SCHEMA-NATIVE encoding of tagsets using kind=sibling (the v1beta3 kind enum). Do not mix this with the in-tree hierarchical/sibling/matchlabels encoding in the same model.",
     "isAnnotation": false

--- a/docs/content/en/concepts/logical/relationships/index.md
+++ b/docs/content/en/concepts/logical/relationships/index.md
@@ -100,7 +100,7 @@ The combination of `kind`, `type`, and `subType` uniquely determines the visual 
 | `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent (Container → Pod) |
 | `hierarchical` | `sibling` | `matchlabels` | In-tree tagsets encoding (shared labels). Schema also allows `kind: sibling`. |
 
-The schema lives in [meshery/schemas](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`). See [Contributing to Relationships]({{< ref "project/contributing/models/relationships" >}}) for how to author definitions, including `mutatorRef` and `mutatedRef`.
+The schema lives in [meshery/schemas](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`). In-tree definitions under `models/**/relationships/` are still mostly `v1beta2`; the versions are shape-compatible, and Meshery Server bridges registered definitions to the `v1beta2` shape for its policy engine, so definitions authored as `v1beta3` are consumed the same way. See [Contributing to Relationships]({{< ref "project/contributing/models/relationships" >}}) for how to author definitions, including `mutatorRef` and `mutatedRef`.
 
 ### 1. Edge - Network
 
@@ -250,7 +250,7 @@ When a relationship is semantic, matching components can copy values from one to
 - `mutatorRef` is the **source**: a nested array of path segments from which the value is read.
 - `mutatedRef` is the **sink**: a nested array of path segments (JSONPath) to patch.
 - The two sequences must be the same length. Index `i` of `mutatorRef` is copied onto index `i` of `mutatedRef`.
-- `patchStrategy` controls how the copy is applied (`merge`, `strategic`, `add`, `remove`, `copy`, `move`, `test`).
+- `patchStrategy` controls how the copy is applied (`merge`, `strategic`, `add`, `remove`, `replace`, `copy`, `move`, `test`). The in-tree corpus uses `replace` exclusively.
 
 For hierarchical relationships, `from` is the child and `to` is the parent. Inventory patches parent identity onto the child. Alias and wallet patch child configuration into the parent.
 

--- a/docs/content/en/concepts/logical/relationships/index.md
+++ b/docs/content/en/concepts/logical/relationships/index.md
@@ -81,11 +81,32 @@ The `isAnnotation` attribute of a Relationship or Component determines whether t
 
 The combination of `kind`, `type`, and `subType` uniquely determines the visual paradigm for a given relationship; i.e., relationships with the same `kind`, `type`, and `subType` will share an identical visual representation regardless of the specific components involved in the relationship.
 
+`kind` is a schema enum (`hierarchical`, `edge`, `sibling`). `type` and `subType` are open strings. Established combinations:
+
+| kind | type | subType | Meaning |
+|---|---|---|---|
+| `edge` | `non-binding` | `network` | Documented network selection (Service → Deployment) |
+| `edge` | `binding` | `network` | Connecting provisions or rewrites network identity (rare) |
+| `edge` | `binding` | `mount` | Storage or device attachment (PVC → Pod) |
+| `edge` | `binding` | `permission` | Assigns identities (Role → ServiceAccount) |
+| `edge` | `non-binding` | `permission` | Mentions a role or identity without binding it |
+| `edge` | `non-binding` | `firewall` | Policy that allows or denies traffic (NetworkPolicy → Pod) |
+| `edge` | `non-binding` | `reference` | Logical name/id pointer (Deployment → ConfigMap) |
+| `edge` | `non-binding` | `annotation` | Designer-only connection (`metadata.isAnnotation: true`) |
+| `edge` | `non-binding` | `alias` | Named stand-in, not nested ownership |
+| `edge` | `non-binding` | `inventory` | Rare peer index; prefer hierarchical parent inventory for containment |
+| `hierarchical` | `parent` | `inventory` | Parent contains/scopes children (Namespace → namespaced resources) |
+| `hierarchical` | `parent` | `wallet` | Child configuration is patched into the parent (WASMFilter → EnvoyFilter) |
+| `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent (Container → Pod) |
+| `hierarchical` | `sibling` | `matchlabels` | In-tree tagsets encoding (shared labels). Schema also allows `kind: sibling`. |
+
+The schema lives in [meshery/schemas](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`). See [Contributing to Relationships]({{< ref "project/contributing/models/relationships" >}}) for how to author definitions, including `mutatorRef` and `mutatedRef`.
+
 ### 1. Edge - Network
 
 This Relationship type configures the networking between one or more components.
 
-**Examples**: An edge-network relationship between a Service and a Deployment or an edge-binding relationship between an Ingress and a Service.
+**Examples**: An `edge` / `non-binding` / `network` relationship between a Service and a Deployment, or between an Ingress and a Service.
 
 - Example 1) Service --> Deployment
 - Example 2) IngressController --> Ingress --> Service
@@ -198,7 +219,7 @@ Logical or declarative links between components where one component refers to an
 
 ### 8. Match - Labels (Tagsets)
 
-This relationship type defines the associations between components based on shared Labels or Annotations.
+This relationship type defines the associations between components based on shared Labels or Annotations. In-tree Kubernetes models encode it as `kind: hierarchical`, `type: sibling`, `subType: matchlabels`. The schema `kind` enum also includes `sibling`; do not mix the two encodings in the same model.
 
 **Example**: A label-based tag-set relationship between a NodePort service and an application. 
 
@@ -222,89 +243,87 @@ This relationship depicts connections between components without conveying speci
 <script src="./images/embedded-design-edge-annotation-relationship.js" type="module" ></script>
 </details>
 
+## Actions: mutatorRef and mutatedRef
+
+When a relationship is semantic, matching components can copy values from one to the other.
+
+- `mutatorRef` is the **source**: a nested array of path segments from which the value is read.
+- `mutatedRef` is the **sink**: a nested array of path segments (JSONPath) to patch.
+- The two sequences must be the same length. Index `i` of `mutatorRef` is copied onto index `i` of `mutatedRef`.
+- `patchStrategy` controls how the copy is applied (`merge`, `strategic`, `add`, `remove`, `copy`, `move`, `test`).
+
+For hierarchical relationships, `from` is the child and `to` is the parent. Inventory patches parent identity onto the child. Alias and wallet patch child configuration into the parent.
+
+See [Contributing to Relationships]({{< ref "project/contributing/models/relationships" >}}) for path rules and examples.
+
 ## Selectors in Relationships
 
-In Meshery, a selector is a way to specify which set of components a certain other component should affect or interact with. Selectors provide a flexible and powerful way to manage and orchestrate resources under Meshery's management.
+In Meshery, a selector specifies which components participate in a relationship. The field name is `selectors` (an array of selector-set items). Items in the array are OR; `from` × `to` inside one item is 1:many.
 
-Selectors can be applied to various components, enabling a wide range of relationship definitions. Here are some examples:
+Here are examples of pairs that share a visual paradigm. The ConfigMap pairs are **edge / non-binding / reference**. The WASMFilter pair is **hierarchical / parent / wallet**, not inventory.
 
 <table class="table table-dark table-active">
     <tr>
         <th>Model Component</th>
-        <th>Relationship Kind</th>
-        <th>Relationship SubType</th>
+        <th>Kind / Type / SubType</th>
         <th>Model Component</th>
     </tr>
     <tr>
         <td>Kubernetes ConfigMap</td>
-        <td>Hierarchical</td>
-        <td>Inventory</td>
+        <td>edge / non-binding / reference</td>
         <td>Kubernetes Pod</td>
     </tr>
     <tr>
         <td>Kubernetes ConfigMap</td>
-        <td>Hierarchical</td>
-        <td>Inventory</td>
+        <td>edge / non-binding / reference</td>
         <td>Kubernetes Deployment</td>
     </tr>
     <tr>
         <td>Meshery WASMFilter</td>
-        <td>Hierarchical</td>
-        <td>Inventory</td>
+        <td>hierarchical / parent / wallet</td>
         <td>Istio EnvoyFilter</td>
     </tr>
 </table>
 
-The above relationships pairs have hierarchical inventory relationships, and visual paradigm remain consistent across different components. A snippet of the selector backing this relationship is listed below.
+A snippet of the selector backing the ConfigMap → Pod reference is listed below.
 <details>
 <summary>Example Relationship Selector</summary>
 <code><pre>
-"selector": {
+"selectors": [
+  {
     "allow": {
-        "from": [
-          {
-            "kind": "ConfigMap",
-            "model": "kubernetes",
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatorRef": [
-                [
-                  "name"
-                ]
-              ],
-              "description": "In Kubernetes, ConfigMaps are a versatile resource that can be referenced by various other resources to provide configuration data to applications or other Kubernetes resources.\n\nBy referencing ConfigMaps in these various contexts, you can centralize and manage configuration data more efficiently, allowing for easier updates, versioning, and maintenance of configurations in a Kubernetes environment."
-            }
+      "from": [
+        {
+          "kind": "ConfigMap",
+          "model": { "name": "kubernetes" },
+          "patch": {
+            "patchStrategy": "replace",
+            "mutatorRef": [
+              ["configuration", "metadata", "name"]
+            ]
           }
-        ],
-        "to": [
-          {
-            "kind": "Pod",
-            "model": "kubernetes",
-            "patch": {
-              "patchStrategy": "replace",
-              "mutatedRef": [
-                [
-                  "settings",
-                  "spec",
-                  "containers",
-                  "_",
-                  "envFrom",
-                  "0",
-                  "configMapRef",
-                  "name"
-                ]
-              ],
-              "description": "ConfigMaps can be referenced in the Pod specification to inject configuration data into the Pod's environment.\n\nThe keys from the ConfigMap will be exposed as environment variables to the container within the Pod."
-            }
+        }
+      ],
+      "to": [
+        {
+          "kind": "Pod",
+          "model": { "name": "kubernetes" },
+          "patch": {
+            "patchStrategy": "replace",
+            "mutatedRef": [
+              ["configuration", "spec", "containers", "_", "envFrom", "0", "configMapRef", "name"]
+            ]
           }
-        ]
+        }
+      ]
     }
-}
+  }
+]
 </pre></code>
 
 </details>
 
-The above snippet defines a selector configuration for allowing relationships between `Kubernetes ConfigMap` and `Kubernetes Pod`.
+The snippet allows an edge-reference relationship from a Kubernetes ConfigMap to a Kubernetes Pod: the ConfigMap name (mutator) is written into the Pod's `envFrom.configMapRef.name` (mutated).
 
  <!-- add images -->
 

--- a/docs/content/en/concepts/logical/relationships/index.md
+++ b/docs/content/en/concepts/logical/relationships/index.md
@@ -100,7 +100,7 @@ The combination of `kind`, `type`, and `subType` uniquely determines the visual 
 | `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent (Container → Pod) |
 | `hierarchical` | `sibling` | `matchlabels` | In-tree tagsets encoding (shared labels). Schema also allows `kind: sibling`. |
 
-The schema lives in [meshery/schemas](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`). In-tree definitions under `models/**/relationships/` are still mostly `v1beta2`; the versions are shape-compatible, and Meshery Server bridges registered definitions to the `v1beta2` shape for its policy engine, so definitions authored as `v1beta3` are consumed the same way. See [Contributing to Relationships]({{< ref "project/contributing/models/relationships" >}}) for how to author definitions, including `mutatorRef` and `mutatedRef`.
+The schema lives in [meshery/schemas](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`). In-tree definitions under `models/**/relationships/` are still mostly `v1beta2`; the version shapes are compatible, and Meshery Server bridges registered definitions to the `v1beta2` shape for its policy engine. Registration on current releases accepts `v1beta2`/`v1alpha3` documents, with `v1beta3` acceptance arriving via [meshkit#1096](https://github.com/meshery/meshkit/pull/1096). See [Contributing to Relationships]({{< ref "project/contributing/models/relationships" >}}) for how to author definitions, including `mutatorRef` and `mutatedRef`.
 
 ### 1. Edge - Network
 

--- a/docs/content/en/concepts/logical/relationships/index.md
+++ b/docs/content/en/concepts/logical/relationships/index.md
@@ -258,7 +258,7 @@ See [Contributing to Relationships]({{< ref "project/contributing/models/relatio
 
 ## Selectors in Relationships
 
-In Meshery, a selector specifies which components participate in a relationship. The field name is `selectors` (an array of selector-set items). Items in the array are OR; `from` × `to` inside one item is 1:many.
+In Meshery, a selector specifies which components participate in a relationship. The field name is `selectors` (an array of selector-set items). Items in the array are OR; inside one item, every `from` entry relates to every `to` entry - a cross-product.
 
 Here are examples of pairs that share a visual paradigm. The ConfigMap pairs are **edge / non-binding / reference**. The WASMFilter pair is **hierarchical / parent / wallet**, not inventory.
 

--- a/docs/content/en/concepts/logical/relationships/index.md
+++ b/docs/content/en/concepts/logical/relationships/index.md
@@ -248,7 +248,7 @@ This relationship depicts connections between components without conveying speci
 When a relationship is semantic, matching components can copy values from one to the other.
 
 - `mutatorRef` is the **source**: a nested array of path segments from which the value is read.
-- `mutatedRef` is the **sink**: a nested array of path segments (JSONPath) to patch.
+- `mutatedRef` is the **sink**: a nested array of path segments to patch.
 - The two sequences must be the same length. Index `i` of `mutatorRef` is copied onto index `i` of `mutatedRef`.
 - `patchStrategy` controls how the copy is applied (`merge`, `strategic`, `add`, `remove`, `replace`, `copy`, `move`, `test`). The in-tree corpus uses `replace` exclusively.
 

--- a/docs/content/en/concepts/logical/relationships/index.md
+++ b/docs/content/en/concepts/logical/relationships/index.md
@@ -95,7 +95,7 @@ The combination of `kind`, `type`, and `subType` uniquely determines the visual 
 | `edge` | `non-binding` | `annotation` | Designer-only connection (`metadata.isAnnotation: true`) |
 | `edge` | `non-binding` | `alias` | Named stand-in, not nested ownership |
 | `edge` | `non-binding` | `inventory` | Rare peer index; prefer hierarchical parent inventory for containment |
-| `hierarchical` | `parent` | `inventory` | Parent contains/scopes children (Namespace → namespaced resources) |
+| `hierarchical` | `parent` | `inventory` | Parent contains/scopes children; the parent's identity is patched onto each child (Namespace onto namespaced resources) |
 | `hierarchical` | `parent` | `wallet` | Child configuration is patched into the parent (WASMFilter → EnvoyFilter) |
 | `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent (Container → Pod) |
 | `hierarchical` | `sibling` | `matchlabels` | In-tree tagsets encoding (shared labels). Schema also allows `kind: sibling`. |

--- a/docs/content/en/project/contributing/models/relationships.md
+++ b/docs/content/en/project/contributing/models/relationships.md
@@ -6,7 +6,7 @@ aliases: [/project/contributing/contributing-relationships]
 weight: 20
 ---
 
-**Relationships follow a schema-defined structure.** The [Relationship schema](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`) is the single source of truth for how relationships between components are expressed. Author new definitions against `v1beta3`; the in-tree corpus under `models/**/relationships/` is still mostly `v1beta2`. The versions are shape-compatible — Meshery Server bridges registered definitions to the `v1beta2` shape for its policy engine, so both are consumed the same way. Refer to the schema when defining new relationship types or selectors. See [Contributing to Schemas]({{< ref "project/contributing/contributing-schemas.md" >}}) for details.
+**Relationships follow a schema-defined structure.** The [Relationship schema](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`) is the single source of truth for how relationships between components are expressed. The in-tree corpus under `models/**/relationships/` is still mostly `v1beta2`. The version shapes are compatible - Meshery Server bridges registered definitions to the `v1beta2` shape for its policy engine - but registration on current releases accepts only `v1beta2`/`v1alpha3` documents ([meshkit#1096](https://github.com/meshery/meshkit/pull/1096) adds `v1beta3`), so a definition that must register today declares `v1beta2`. Refer to the schema when defining new relationship types or selectors. See [Contributing to Schemas]({{< ref "project/contributing/contributing-schemas.md" >}}) for details.
 
 Coding agents: use the `gen-relationship` skill in `.agents/skills/gen-relationship/` (one example of every canonical `kind` / `type` / `subType`).
 
@@ -142,7 +142,7 @@ Create a relationship definition as a JSON file, placing this new definition fil
 
 Include:
 
-- `schemaVersion`: `relationships.meshery.io/v1beta3` for new definitions. Keep `v1beta2` when refining an existing in-tree file unless you are deliberately migrating it.
+- `schemaVersion`: `relationships.meshery.io/v1beta3` is the authoring target, but declare `v1beta2` for definitions that must register on current servers (see the note at the top of this page). Keep `v1beta2` when refining an existing in-tree file unless you are deliberately migrating it.
 - `kind`: The genre of relationship (`hierarchical`, `edge`, `sibling`).
 - `type`: The augmentative category (`parent`, `binding`, `non-binding`, `sibling`, …).
 - `subType`: The specific visual paradigm (`inventory`, `mount`, `network`, `wallet`, `reference`, `matchlabels`, …).
@@ -294,7 +294,7 @@ An empty string. The property is deprecated (see the schema's deprecation notice
 #### General
 
 1. Use camelCase on the wire (`subType`, `mutatorRef`, `schemaVersion`).
-2. New definitions use `schemaVersion: relationships.meshery.io/v1beta3`. Do not use `core.meshery.io/v1alpha2` or `v1beta1`.
+2. Author against `relationships.meshery.io/v1beta3` (declare `v1beta2` while current servers require it - see the top of this page). Do not use `core.meshery.io/v1alpha2` or `v1beta1`.
 
 #### Scoping
 

--- a/docs/content/en/project/contributing/models/relationships.md
+++ b/docs/content/en/project/contributing/models/relationships.md
@@ -6,7 +6,7 @@ aliases: [/project/contributing/contributing-relationships]
 weight: 20
 ---
 
-**Relationships follow a schema-defined structure.** The [Relationship schema](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`) is the single source of truth for how relationships between components are expressed. Refer to the schema when defining new relationship types or selectors. See [Contributing to Schemas]({{< ref "project/contributing/contributing-schemas.md" >}}) for details.
+**Relationships follow a schema-defined structure.** The [Relationship schema](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`) is the single source of truth for how relationships between components are expressed. Author new definitions against `v1beta3`; the in-tree corpus under `models/**/relationships/` is still mostly `v1beta2`. The versions are shape-compatible — Meshery Server bridges registered definitions to the `v1beta2` shape for its policy engine, so both are consumed the same way. Refer to the schema when defining new relationship types or selectors. See [Contributing to Schemas]({{< ref "project/contributing/contributing-schemas.md" >}}) for details.
 
 Coding agents: use the `gen-relationship` skill in `.agents/skills/gen-relationship/` (one example of every canonical `kind` / `type` / `subType`).
 
@@ -43,13 +43,24 @@ For example, a Kubernetes `Service` can have a network relationship with a Kuber
 <summary>Relationship Example</summary>
 <pre><code class="language-json highlighter-rouge">
 {
+  "id": "00000000-0000-0000-0000-000000000000",
   "schemaVersion": "relationships.meshery.io/v1beta3",
   "version": "v1.0.0",
   "kind": "edge",
   "type": "non-binding",
   "subType": "network",
+  "status": "enabled",
+  "evaluationQuery": "",
   "metadata": {
     "description": "A Service selects Pods of a Deployment."
+  },
+  "model": {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "name": "kubernetes",
+    "version": "v1.0.0",
+    "displayName": "kubernetes",
+    "registrant": { "kind": "github" },
+    "model": { "version": "" }
   },
   "selectors": [
     {
@@ -136,7 +147,7 @@ Include:
 - `type`: The augmentative category (`parent`, `binding`, `non-binding`, `sibling`, …).
 - `subType`: The specific visual paradigm (`inventory`, `mount`, `network`, `wallet`, `reference`, `matchlabels`, …).
 - `selectors`: The scope of the relationship. One selector-set item is an OR. Inside an item, `from` × `to` is 1:many (AND).
-- `evaluationQuery`: Name of the OPA policy to invoke. Convention: `{kind}_{type}_{subType}_relationship`. Reuse an existing policy. Propose a new `.rego` only when none fits. *(rarely necessary)*
+- `evaluationQuery`: Deprecated. Set it to `""` as every in-tree definition does; the evaluation engine enters through the fixed `data.relationship_evaluation_policy` package and dispatches on `kind`/`type`/`subType`.
 - `metadata.description`: A characterization of the relationship, its purpose, and constraints.
 
 {{% alert title="Use Existing Relationships as Examples" color="info" %}}
@@ -182,7 +193,7 @@ Patches copy values from one component to another when the selector matches. Bot
 |---|---|
 | `mutatorRef` | **Source.** JSON path of the value to read. |
 | `mutatedRef` | **Sink.** JSONPath of the field to patch. |
-| `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `copy`, `move`, `test`. In-tree kubernetes files often use `replace`; prefer a schema enum value for new v1beta3 definitions. |
+| `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `replace`, `copy`, `move`, `test`. The in-tree corpus and the evaluation engine use `replace` exclusively; default to `replace` unless you need different semantics. |
 
 Paths are relative to the Meshery component document (`configuration`, `displayName`, `component.kind`, …), not the raw Kubernetes YAML root. `_` may mark only the first array position in a path; later arrays need an explicit index. Omit `patch` when the relationship only matches (tagsets, annotation).
 
@@ -196,12 +207,11 @@ Paths are relative to the Meshery component document (`configuration`, `displayN
       "from": [
         {
           "kind": "WASMFilter",
-          "model": { "name": "istio-base" },
+          "model": { "name": "meshery-core" },
           "patch": {
             "patchStrategy": "replace",
             "mutatorRef": [
-              ["configuration", "spec", "config"],
-              ["configuration", "spec", "wasmFilter"]
+              ["configuration", "config"]
             ]
           }
         }
@@ -268,17 +278,11 @@ The WASMFilter example is hierarchical parent **wallet** (child config patched i
 
 #### Understanding Relationship Policies and their Evaluation
 
-The `evaluationQuery` property names the policy Meshery's evaluation engine (Open Policy Agent) uses.
+Meshery evaluates designs with Open Policy Agent. The engine enters through the fixed policy package `data.relationship_evaluation_policy` and dispatches on each definition's `kind`, `type`, and `subType`. The policies live under `models/meshery-core/<version>/<definition-version>/policies/`.
 
-**How should you determine the value for `evaluationQuery`**
+**What value should `evaluationQuery` carry?**
 
-Relationship evaluation depends on `kind`, `type`, and `subType`. `evaluationQuery` follows:
-
-`{kind}_{type}_{subType}_relationship`
-
-For `kind: edge`, `type: non-binding`, `subType: network`, use `edge_non-binding_network_relationship`.
-
-Each policy has a main rule; `evaluationQuery` corresponds to that rule. Results are collected from it during evaluation.
+An empty string. The property is deprecated (see the schema's deprecation notice) and the current engine ignores it; every in-tree definition sets `""`. The historical per-relationship rule name was `{kind}_{subType}_relationship` — no `{type}` segment — and any value you do set must be a valid Rego identifier (letters, digits, underscores), so a hyphenated type such as `non-binding` can never appear in one.
 
 ## Postwork
 
@@ -308,7 +312,7 @@ Each policy has a main rule; `evaluationQuery` corresponds to that rule. Results
 #### Matching
 
 1. Targets of a Relationship can be specific Components or entire Models.
-2. The `evaluationQuery` property determines the OPA policy to invoke; specify the correct rego query.
+2. Leave `evaluationQuery` empty (`""`); evaluation dispatches on `kind`, `type`, and `subType`.
 3. `metadata.isAnnotation: true` means Meshery must not evaluate or patch the relationship.
 
 #### Conflicts

--- a/docs/content/en/project/contributing/models/relationships.md
+++ b/docs/content/en/project/contributing/models/relationships.md
@@ -6,9 +6,11 @@ aliases: [/project/contributing/contributing-relationships]
 weight: 20
 ---
 
-**Relationships follow a schema-defined structure.** The [Relationship schema](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1alpha3/relationship) specifies how relationships between components are expressed. Refer to the schema when defining new relationship types or selectors. See [Contributing to Schemas]({{< ref "project/contributing/contributing-schemas.md" >}}) for details.
+**Relationships follow a schema-defined structure.** The [Relationship schema](https://github.com/meshery/schemas/tree/master/schemas/constructs/v1beta3/relationship) (`relationships.meshery.io/v1beta3`) is the single source of truth for how relationships between components are expressed. Refer to the schema when defining new relationship types or selectors. See [Contributing to Schemas]({{< ref "project/contributing/contributing-schemas.md" >}}) for details.
 
-[Relationships]({{< ref "concepts/logical/relationships/index.md" >}}) within [Models]({{< ref "concepts/logical/models/index.md" >}}) play a crucial role in establishing concrete visualisations of efficient data flow between different components of Meshery. These are used to classify the nature of interaction between one or more interconnected [Components]({{< ref "concepts/logical/components.md" >}}).
+Coding agents: use the `gen-relationship` skill in `.agents/skills/gen-relationship/` (one example of every canonical `kind` / `type` / `subType`).
+
+[Relationships]({{< ref "concepts/logical/relationships/index.md" >}}) within [Models]({{< ref "concepts/logical/models/index.md" >}}) classify how [Components]({{< ref "concepts/logical/components.md" >}}) relate and whether they affect each other.
 
 ## Overview of Steps to Create Relationships
 
@@ -33,100 +35,81 @@ weight: 20
 
 ### 1. Characterize the relationship and any specific constraints
 
-Using your domain expertise, define the qualities of this new relationship. Identify and qualify any specific constraints to be enforced between one or more specific components within the same or different models. Let's take an example to understand this better.
+Using your domain expertise, define the qualities of this new relationship. Identify and qualify any specific constraints to be enforced between one or more specific components within the same or different models.
 
-For example, you might know that a Kubernetes `Service` can have a network-based relatinship with a Kubernetes `Pod`. To codify this relationship, you would define the relationship as a `kind: edge` relationship with a `type: network`.
+For example, a Kubernetes `Service` can have a network relationship with a Kubernetes `Deployment`. That is `kind: edge`, `type: non-binding`, `subType: network`.
 
 <details close>
 <summary>Relationship Example</summary>
-<pre><code class="language-yaml highlighter-rouge">
+<pre><code class="language-json highlighter-rouge">
 {
-  "schemaVersion": "core.meshery.io/v1alpha2",
-  "kind": "edge",
-  "type": "network",
+  "schemaVersion": "relationships.meshery.io/v1beta3",
   "version": "v1.0.0",
-  "metadata": {"description": "A relationship that defines network edges between components."}
-  selector: [{
+  "kind": "edge",
+  "type": "non-binding",
+  "subType": "network",
+  "metadata": {
+    "description": "A Service selects Pods of a Deployment."
+  },
+  "selectors": [
+    {
       "allow": {
-         "from": [
-            {
-               "kind": "Service",
-               "model": "kubernetes"
-            }
-         ],
-         "to": [
-            {
-               "kind": "Pod",
-               "model": "kubernetes"
-            }
-         ]
-      },
-      "deny": {}
-   }]
-
-</code></pre>
-</details>
-
-You might *also* know that this relationship is constrained by the presence of a Kubernetes `Deployment` as the parent of the Kubernetes `Pod`. This constraint would be codified in the relationship definition by including the <code>deny</code> function in your selector.
-
-<details close>
-<summary>Example Relationship with Constraints</summary>
-<pre><code class="language-yaml highlighter-rouge">
-selector: [
-   {
-      "allow": {
-         "from": [
-            {
-               "kind": "Service",
-               "model": "kubernetes"
-            }
-         ],
-         "to": [
-            {
-               "kind": "Pod",
-               "model": "kubernetes"
-            }
-         ]
+        "from": [
+          {
+            "kind": "Service",
+            "model": { "name": "kubernetes" }
+          }
+        ],
+        "to": [
+          {
+            "kind": "Deployment",
+            "model": { "name": "kubernetes" }
+          }
+        ]
       },
       "deny": {
-         "from": [
-            {
-               "kind": "Service",
-               "model": "kubernetes"
-            }
-         ],
-         "to": [
-            {
-               "kind": "Pod",
-               "model": "kubernetes",
-               "parent": "Deployment"
-            }
-         ]
+        "from": [],
+        "to": []
       }
-   }
-]
+    }
+  ]
+}
 </code></pre>
 </details>
 
-Codify relationships leveraging your domain expertise. In this example, the relationship between the `Service` and `Pod` components in the Kubernetes model is defined with appropriate consideration of surrounding constraints (e.g. presence of a `Deployment`).
+You might *also* know that this relationship should not form when the destination is not a workload the Service can select. Encode that with `deny` in the same selector-set item.
 
-#### Understand Relationship Classifications
+Codify relationships using your domain expertise. The `kind`, `type`, and `subType` together pick both the visual paradigm and the evaluation policy.
 
-Relationships can be classified into three main categories:
+#### Kind, type, and subType
 
-1. **Hierarchical** relationships involve either an ancestral connection of the components i.e. the creation/ deletion of a Component higher up affects the existence of the Components below in the lineage or a connection that involves the inheritance of features from one Component to the other.
+`kind` is a schema enum: `hierarchical`, `edge`, or `sibling`. `type` and `subType` are open strings. Use an established combination rather than inventing one.
 
-   1. **Parent**: A parent-child relationship implies the requirement of the parent component before the child component can be created. For example, a `Namespace` in Kubernetes can be a parent of `Pods` within that namespace. The namespace must exist before creating pods within it.
-   2. **Inventory**: A hierarchical inventory relationship implies the configuration of a(parent) component is patched with the configuration of other (child) component. For example, Wasm filters can inherit features and functionalities from Envoy filters. This can be used to build on existing functionalities provided by Envoy filters and further extend them using Wasm filters. It enables a modular and scalable approach to customize the behavior of the proxy while maintaining a clear hierarchy of features.
+| kind | type | subType | Meaning |
+|---|---|---|---|
+| `hierarchical` | `parent` | `inventory` | Parent contains/scopes children. Parent identity is patched onto the child (Namespace → namespaced resources). |
+| `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent (Container inside Pod). |
+| `hierarchical` | `parent` | `wallet` | Child configuration is held/patched into the parent (WASMFilter → EnvoyFilter). |
+| `hierarchical` | `sibling` | `matchlabels` | **In-tree tagsets encoding.** Components that share labels. Schema also allows `kind: sibling`; do not mix encodings in one model. |
+| `edge` | `non-binding` | `reference` | Logical name/id pointer (Deployment → ConfigMap). |
+| `edge` | `non-binding` | `network` | Documented network selection without provisioning an attachment (Service → Deployment). |
+| `edge` | `binding` | `network` | Connecting provisions or rewrites network identity. Rare. |
+| `edge` | `non-binding` | `firewall` | Policy that allows or denies traffic (NetworkPolicy → Pod). |
+| `edge` | `binding` | `permission` | Assigns identities (Role → ServiceAccount). |
+| `edge` | `non-binding` | `permission` | Mentions a role or identity without binding it. |
+| `edge` | `binding` | `mount` | Storage or device is attached (PVC → Pod). |
+| `edge` | `non-binding` | `annotation` | Designer-only line. Set `metadata.isAnnotation: true`. No patch. |
+| `edge` | `non-binding` | `alias` | Named stand-in, not nested ownership. |
+| `edge` | `non-binding` | `inventory` | Rare peer index/list. Prefer hierarchical parent inventory for containment. |
 
-2. **Edge** relationships indicate the possibility of traffic flow between two components. They enable communication and interaction between different Components within the system.
+`badge` is a visual paradigm only; there is no in-tree encoding. Propose a visualization before introducing `subType: badge`.
 
-   1. **Mount**: This subtype addresses the storage and access possibility between involved components. For example, a `PersistentVolume` can be mounted to a `Pod` to provide persistent storage for the pod's data.
-   2. **Network**: This deals with IP addresses and DNS names and provides stable endpoints for communication. For example, a `Service` provides a stable endpoint for accessing multiple replicas of a `Deployment`.
-   3. **Firewall**: This acts as an intermediary for communications which include standard networking protocols like TCP and UDP. It can enforce network policies to control traffic between components. For example, a `NetworkPolicy` can be used to manage the traffic flow between different `Pods` in the cluster.
-   4. **Permission**: This defines the permissions for components if they can have a possible relationship with other Components. It ensures that only authorized Components can interact with each other. For example, a `Role` can define permissions for Components to access specific resources.
+**Hierarchical `from` / `to`:** `from` is the child, `to` is the parent.
 
-3. **Sibling** relationships represent connections between components that are at the same hierarchical level or share a common parent. Siblings can have the same or similar functionalities or may interact with each other in specific ways. These relationships facilitate communication and cooperation between components that are in the same group or category. For example, a Service and a Pod in Kubernetes are siblings as they share a common parent and are at the same hierarchical level.
+- Inventory: parent **mutates** the child.
+- Alias and wallet: child **mutates** the parent.
+
+**Binding vs non-binding:** `binding` means forming the relationship assigns, mounts, or entitles. `non-binding` means the link is real (selector, name, policy match) but does not itself provision the attachment.
 
 <a id="relationship-visualizations"></a>
 
@@ -136,7 +119,7 @@ Browse and pick the most appropriate visualization for this relationship by usin
 
 {{< relationships >}}
 
-Once selected, note the relationship's `kind`, `type`, and `subtype` of your selected visualization. Alternatively, if an existing visualization does not seem appropriate for the relationship, please propose a new visualization at-will. Simply use the whiteboard feature of Meshery's extensions to sketch out the relationship and propose it as a new visualization.
+Once selected, note the relationship's `kind`, `type`, and `subType`. If an existing visualization does not seem appropriate, propose a new one. Use the whiteboard feature of Meshery's extensions to sketch the relationship.
 
 ## Development
 
@@ -144,178 +127,158 @@ Once selected, note the relationship's `kind`, `type`, and `subtype` of your sel
 
 ### 3. Create a Relationship Definition as a JSON file
 
-Create a relationship definition as a YAML file, placing this new definition file into its respective model folder (see [Contributing to Models]({{<ref "project/contributing/models" >}})). Relationship definition files are commonly named relationships.yaml as a convention, however, this name is not required. A model may include any number of relationship definitions. Include the following attributes in your relationship definition:
+Create a relationship definition as a JSON file, placing this new definition file into its respective model folder (see [Contributing to Models]({{<ref "project/contributing/models" >}})). A model may include any number of relationship definitions. Filename convention: `{kind}-{type}-{subType}-<suffix>.json`.
 
-- `kind`: The genre of relationship (e.g., hierarchical, edge, sibling).
-- `type`: The augmentative category of the relationship (e.g., binding, non-binding, inventory).
-- `subType`: The specific representative visual paradigm (e.g., parent, mount, network, wallet, badge).
-- `selectors`: The scope of the relationship, including the components involved and any constraints. Selector specify to which component(s) the relationship applies or does not apply (think of in terms of the `AND` operators in a query). Selector Sets are used to combine multiple selectors for more granular control over the logic used when matchmaking (establishing a relationship) between components (think of in terms of the `OR` operators in a query).
-- `evaluationQuery`: Name of the policy or policies (Open Policy Agent rego file(s)) to invoke for relationship evaluation. Identify an existing OPA policy as the `evaluationQuery` suitable to the relationship. If no policy exists, propose a new policy (rego). *(rarely necessary)* Create a new policy for the evaluation of your relationship using Rego. *This step is only necessary and can typically be skipped. Contact a maintainer if the relationship requires a new policy to evaluate the relationship.*
-- `description`: A characterization of the relationship, its purpose, and any constraints or considerations of its application.
+Include:
+
+- `schemaVersion`: `relationships.meshery.io/v1beta3` for new definitions. Keep `v1beta2` when refining an existing in-tree file unless you are deliberately migrating it.
+- `kind`: The genre of relationship (`hierarchical`, `edge`, `sibling`).
+- `type`: The augmentative category (`parent`, `binding`, `non-binding`, `sibling`, …).
+- `subType`: The specific visual paradigm (`inventory`, `mount`, `network`, `wallet`, `reference`, `matchlabels`, …).
+- `selectors`: The scope of the relationship. One selector-set item is an OR. Inside an item, `from` × `to` is 1:many (AND).
+- `evaluationQuery`: Name of the OPA policy to invoke. Convention: `{kind}_{type}_{subType}_relationship`. Reuse an existing policy. Propose a new `.rego` only when none fits. *(rarely necessary)*
+- `metadata.description`: A characterization of the relationship, its purpose, and constraints.
 
 {{% alert title="Use Existing Relationships as Examples" color="info" %}}
-Browse the <a href='https://github.com/meshery/meshery/tree/master/models'>existing relationships in the Meshery repository</a> to find examples of existing relationships, using them as a template. Alternatively, you can review a prior pull request as an example as well, for example <a href='https://github.com/meshery/meshery/pull/9880/files'>PR #9880</a>.
+Browse the <a href='https://github.com/meshery/meshery/tree/master/models'>existing relationships in the Meshery repository</a> and the pedagogical examples in <code>.agents/skills/gen-relationship/examples/</code>. For a prior pull request as a template, see <a href='https://github.com/meshery/meshery/pull/9880/files'>PR #9880</a>.
 {{% /alert %}}
 
-<a class="anchorjs-link" id="relationship-scopes"></a>
+<a id="relationship-scopes"></a>
 
 ### 4. Configuring the Scope of Relationships
 
-The extent to which a relationship affects components within a model or beyond a model is defined and controlled using scopes. Scopes exist at two levels in Meshery relationships. 
+The extent to which a relationship affects components within a model or beyond a model is defined and controlled using scopes.
 
 #### Global Scope
 
-Global scope is defined using the `model` and `version` attributes in the relationship definition.
+Global scope is defined using the `model` attribute in the relationship definition.
 
-Relationships can be confined to a specific model, a specific model version, or can be allowed to affect all models. The relationship schema has a `model` and `version` attribute which facilitates this control. For example, if the model is specified as `aws-ec2-controller`, the relationship will work for those components that belong to the `aws-ec2-controller` model.
+Relationships can be confined to a specific model or allowed to affect all models. For example, if the model is specified as `aws-ec2-controller`, the relationship will work for those components that belong to the `aws-ec2-controller` model.
 
 #### Local Scope
 
-Local scope is defined and controlled via `selectors` attributes in the relationship definition.
+Local scope is defined and controlled via `selectors` in the relationship definition.
 
-Relationship selectors refine the scope of applicability the relationship. It is the details included within the Selector that determines whether there is a match and relationship to be formed. These details include which models and components are involved in the relationship and any constraints in its formation. Selector specify to which component(s) the relationship applies or does not apply (think of in terms of the `AND` operators in a query). Selector Sets are used to combine multiple selectors for more granular control over the logic used when matchmaking (establishing a relationship) between components (think of in terms of the `OR` operators in a query).
+Relationship selectors refine applicability. Selector details determine whether there is a match: which models and components are involved, and any constraints. Selector items combine with AND. Selector **sets** (the `selectors` array) combine with OR.
 
-<!-- @leecalcote: The following needs rewritten using Selector Sets, @MUzairS15 -->
+Selectors are an array. Each entry has `allow` and optional `deny`, each with `from` and `to`. Only components inside the same selector-set item relate to each other: each object in `from` relates to each object in `to`.
 
-Selectors are structured as an array wherein each entry comprises a `from` (self) property and a `to` (others) property. The `from` and `to` combined with the `allow` and `deny` properties delineate between components involved in a particular relationship. These entries define the constraints necessary for the existence of a relationship, thus scoping a relationship. Each item in the selector uniquely defines a relation between the components listed. i.e. `from` and `to` fields are evaluated within the context of the selector.
+When many `from`/`to` combinations would otherwise force a complicated `deny`, split them into additional selector-set items.
 
-Only the components within the same selector relate to each other via 1:many kind of relation between components listed inside the `from` and `to` field. i.e. Each object inside the `from` relates to each item inside the `two` field within a particular selector.
+*Note: When defining Hierarchical relationships, the `from` field represents the child component, while the `to` field represents the parent component.*
 
-When defining relationships that involve a large number of combinations between `from` and `to`, selectors sets provide a mechanism to organize and manage these relationships. This prevents the need for crafting complex deny attributes and facilitates easier maintenance. Use of selector sets enhances flexibility and reusability in the definition and configuration of relationships among components.
+#### Actions: mutatorRef and mutatedRef
 
-*Note: When defining Hierarchical relationships, remember that the `from` field represents the child component, while the `to` field represents the parent component.*
+Patches copy values from one component to another when the selector matches. Both fields are nested arrays of string path segments (`string[][]`). Sequence length must match: index `i` of `mutatorRef` is copied onto index `i` of `mutatedRef`.
+
+```json
+"mutatorRef": [["config", "url"], ["config", "name"]],
+"mutatedRef": [["configPatch", "value"], ["name"]]
+```
+
+`[config, url]` is patched onto `[configPatch, value]`; `[config, name]` onto `[name]`.
+
+| Field | Role |
+|---|---|
+| `mutatorRef` | **Source.** JSON path of the value to read. |
+| `mutatedRef` | **Sink.** JSONPath of the field to patch. |
+| `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `copy`, `move`, `test`. In-tree kubernetes files often use `replace`; prefer a schema enum value for new v1beta3 definitions. |
+
+Paths are relative to the Meshery component document (`configuration`, `displayName`, `component.kind`, …), not the raw Kubernetes YAML root. `_` may mark only the first array position in a path; later arrays need an explicit index. Omit `patch` when the relationship only matches (tagsets, annotation).
 
 <details close>
 <summary>Relationship Selector Example</summary>
 
-<pre><code class="language-yaml highlighter-rouge">
-selector: [
-   {
-      "allow": {
-         "from": [
-            {
-               "kind": "WASMFilter",
-               "model": "istio-base",
-               "patch": {
-                  "patchStrategy": "replace",
-                  "mutatorRef": [
-                     [
-                        "settings",
-                        "config"
-                     ],
-                     [
-                        "settings",
-                        "wasm-filter"
-                     ]
-                  ],
-                  "description": "WASM filter configuration to be applied to Envoy Filter."
-               }
-            },
-            {
-               "kind": "EBPFFilter",
-   .....
-            }
-         ],
-         "to": [
-            {
-               "kind": "EnvoyFilter",
-               "model": "istio-base",
-               "patch": {
-                  "patchStrategy": "replace",
-                  "mutatedRef": [
-                     [
-                        "settings",
-                        "configPatches",
-                        "_",
-                        "patch",
-                        "value"
-                     ]
-                  ],
-                  "description": "Receive the WASM filter configuration."
-               }
-            },
-            {
-               "kind": "WASMPlugin",
-   ....
-            }
-   ...
-         ]
-      },
-      "deny": {
-   ...
-      }
-   },
-   {
-      "allow": {
-         "from": [
-            {
-               "kind": "ConfigMap",
-               "model": "kubernetes",
-               "patch": {
-                  "patchStrategy": "replace",
-                  "mutatorRef": [
-                     [
-                        "name"
-                     ]
-                  ],
-                  "description": "In Kubernetes, ConfigMaps are a versatile resource that can be referenced by various other resources to provide configuration data to applications or other Kubernetes resources.\n\nBy referencing ConfigMaps in these various contexts, you can centralize and manage configuration data more efficiently, allowing for easier updates, versioning, and maintenance of configurations in a Kubernetes environment."
-               }
-            }
-         ],
-         "to": [
-            {
-               "kind": "Deployment",
-               "model": "kubernetes",
-               "patch": {
-                  "patchStrategy": "replace",
-                  "mutatedRef": [
-                     [
-                        "spec",
-                        "containers",
-                        "_",
-                        "envFrom",
-                        "configMapRef",
-                        "name"
-                     ]
-                  ],
-                  "description": "Deployments can reference ConfigMaps to inject configuration data into the Pods they manage. This is useful for maintaining consistent configuration across replica sets.\n\nThe keys from the ConfigMap will be exposed as environment variables to the containers within the pods managed by the Deployment."
-               }
-            },
-            {
-               "kind": "StatefulSets",
-               "model": "kubernetes",
-               "patch": {
-   ....
-               }
-            }
-   ...
-         ]
-      },
-      "deny": {
-   ...
-      }
-   }
+<pre><code class="language-json highlighter-rouge">
+"selectors": [
+  {
+    "allow": {
+      "from": [
+        {
+          "kind": "WASMFilter",
+          "model": { "name": "istio-base" },
+          "patch": {
+            "patchStrategy": "replace",
+            "mutatorRef": [
+              ["configuration", "spec", "config"],
+              ["configuration", "spec", "wasmFilter"]
+            ]
+          }
+        }
+      ],
+      "to": [
+        {
+          "kind": "EnvoyFilter",
+          "model": { "name": "istio-base" },
+          "patch": {
+            "patchStrategy": "replace",
+            "mutatedRef": [
+              ["configuration", "spec", "configPatches", "_", "patch", "value"]
+            ]
+          }
+        }
+      ]
+    },
+    "deny": {
+      "from": [],
+      "to": []
+    }
+  },
+  {
+    "allow": {
+      "from": [
+        {
+          "kind": "ConfigMap",
+          "model": { "name": "kubernetes" },
+          "patch": {
+            "patchStrategy": "replace",
+            "mutatorRef": [
+              ["configuration", "metadata", "name"]
+            ]
+          }
+        }
+      ],
+      "to": [
+        {
+          "kind": "Deployment",
+          "model": { "name": "kubernetes" },
+          "patch": {
+            "patchStrategy": "replace",
+            "mutatedRef": [
+              ["configuration", "spec", "template", "spec", "containers", "_", "envFrom", "0", "configMapRef", "name"]
+            ]
+          }
+        }
+      ]
+    },
+    "deny": {
+      "from": [],
+      "to": []
+    }
+  }
 ]
 </code></pre>
 <br/>
 
-The `selector` defined for the relationship between `WasmFilter` and `EnvoyFilter` components (the first item in the array) is entirely independent of the `selector` identified for the relationship between `ConfigMap` and `Deployment` components. This ensures independence in how these components relate to each other while still permitting similar types of relationships.
-
-This example relationship demonstrates how the `WASMFilter` and `EBPFFilter` components identified in `from` relate to other `EnvoyFilter` `WASMPlugin` components identified in `to` selector. Similarly, `ConfigMap` component identified in the `from` selector corresponds to each `Deployment`, `StatefulSet`, and so on component identified in the `to` selector.
+The first selector-set item (WASMFilter → EnvoyFilter) is independent of the second (ConfigMap → Deployment). Use separate items when the pairs should not cross-match.
 
 </details>
 
+The WASMFilter example is hierarchical parent **wallet** (child config patched into the parent). The ConfigMap example is edge **reference** (a name pointer), not hierarchical inventory.
+
 #### Understanding Relationship Policies and their Evaluation
 
-The `evaluationQuery` property in your relationship definition is used to identity the name of the policy to be used by Meshery's evaluation engine. Meshery embeds Open Policy Agent as it's policy engine
+The `evaluationQuery` property names the policy Meshery's evaluation engine (Open Policy Agent) uses.
 
 **How should you determine the value for `evaluationQuery`**
 
-All relationship definitions are backed by OPA policies and each relationship depends on their `kind`, `type`, and `subType` in order to be properly evaluated. Which evaluation policy or set of policies used during the evaluation moment is defined by the `evaluationQuery` property, which follows the naming convention of combining each of their  `kind`, `type`, and `subType`  properties with an underscore and the word "_relationship", like so: `kind_type_subtype_relationship`.
+Relationship evaluation depends on `kind`, `type`, and `subType`. `evaluationQuery` follows:
 
-So, for example, if you are defining or updating a relationship definition with `kind: edge` and `type: network`, the value for the attribute `evaluationQuery` should be `edge_network_relationship`.
+`{kind}_{type}_{subType}_relationship`
 
-Each policy has a set of evaluation rules defined and the `evaluationQuery` attribute corresponds to the main rule defined inside the policy, during the policy eval the results are collected from this rule.
+For `kind: edge`, `type: non-binding`, `subType: network`, use `edge_non-binding_network_relationship`.
+
+Each policy has a main rule; `evaluationQuery` corresponds to that rule. Results are collected from it during evaluation.
 
 ## Postwork
 
@@ -326,37 +289,34 @@ Each policy has a set of evaluation rules defined and the `evaluationQuery` attr
 
 #### General
 
-1. Use camelCasing as the formatting convention.
+1. Use camelCase on the wire (`subType`, `mutatorRef`, `schemaVersion`).
+2. New definitions use `schemaVersion: relationships.meshery.io/v1beta3`. Do not use `core.meshery.io/v1alpha2` or `v1beta1`.
 
 #### Scoping
 
-1. To configure a relationship to be applied across models, ensure the `model` property for those relationships is set to `*`, to limit the relationships to a specific model, specify the correct `model`(case sensitive).
-1. To configure a relationship to be applied across all versions of a particular model, ensure the `version` property for those relationships is set to `*`, to limit the relationships to a specific version of a model, specify the correct model version.
-1. Specify `version` property as a regex to ensure relationships are applied to a subset of versions of a model.
+1. To apply a relationship across models, set the selector `model.name` to `*`. To limit it to one model, specify that model name (case sensitive).
+2. Absence of a selector property is interpreted as the wildcard `*`.
+3. Values for `kind`, `version`, and `model` are case-sensitive.
 
 #### Actions
 
-1. If a path `mutatedRef/mutatorRef` contains more than one array path then only the first array position can be specified as `\_` for others explicitly mention them as 0
-1. Currently `mutatedRef` doesn’t support having an array.
+1. If a `mutatedRef` / `mutatorRef` path contains more than one array, only the first array position may be `_`; later arrays must be an explicit index (`0`, `1`, …).
+2. `mutatedRef` currently does not support patching an array value itself.
+3. Pair every mutator path with a mutated path. Do not swap source and sink.
+4. Verify each path against the component schema in `models/<model>/.../components/<Kind>.json`.
 
 #### Matching
 
 1. Targets of a Relationship can be specific Components or entire Models.
-1. Values for propoerties like `kind`, `version`, and `model` are case-sensitive.
-1. Absence of a property in the `selector` is interpretted as the wildcard `*`.
-   - For example, a selector with `kind: Pod`, `Model: Kubernetes`, and the absence of the `version` property would be interpretted as `version: *`, which
-     means that all the versions of the Kubernetes Pod resource (k8s.io/v1/betav2) will match the selector.
-1. The `evaluationQuery` property determines the OPA policy to invoke for relationship evaluation, specify the correct rego query.
+2. The `evaluationQuery` property determines the OPA policy to invoke; specify the correct rego query.
+3. `metadata.isAnnotation: true` means Meshery must not evaluate or patch the relationship.
 
 #### Conflicts
 
-1. Ensure that the `deny` selectors and `allow` selectors do not conflict with each other i.e. relations are not getting overlapped for `allow` and `deny` selectors.
-1. In the event of conflicting Relationship Definitions, the union between them is taken.
-   - If we have two Relationships, one from (Component A) to (Component B and Component F), and another
-     from (Component A) to (Component B and Component C), then it is similar to having a Relationship
-     from Component A to Component B, C and F
-1. In the event of an overlapping set of complementary Relationship Definitions, Union.
-1. In the event of an overlapping set of conflicting Relationship Definitions, no relationship type (Kind) is inherently more important than the next one, so will not be any case of conflict.
+1. Ensure `deny` selectors and `allow` selectors do not overlap for the same pair.
+2. In the event of conflicting Relationship Definitions, the union between them is taken.
+   - If we have two Relationships, one from (Component A) to (Component B and Component F), and another from (Component A) to (Component B and Component C), then it is similar to having a Relationship from Component A to Component B, C and F.
+3. No relationship kind is inherently more important than another.
 
 #### Schema Conformance
 
@@ -366,7 +326,7 @@ Every `mutatorRef`/`mutatedRef` path rooted at `configuration.` must resolve aga
 - **Where it runs.** `server/policies/relationship_schema_conformance_test.go`, executed by the policies test workflow on every change under `models/**`.
 - **When it fails, fix the path.** The `knownUnresolvedMutationPaths` allowlist exists only for known pre-existing defects, and cites the open follow-up issue tracking their repair ([#21490](https://github.com/meshery/meshery/issues/21490)). An allowlisted entry must keep failing, so repairing one of those definitions means deleting its line in the same pull request.
 
-<a class="anchorjs-link" id="relationship-contribution"></a>
+<a id="relationship-contribution"></a>
 
 ### 6. Contribute your relationship to the Meshery project
 
@@ -375,7 +335,7 @@ Submit a pull request to the Meshery repository with your new relationship defin
 Keeping your relationship definition in a separate file allows for easier management and review of the relationship(s) you have defined.
 
 {{% alert title="Keeping your custom Relationships private" color="info" %}}
-Alternatively, if you would like to keep the relatioship definition private, you can bundle your relatinship(s) in a custom model, import the custom model into your Meshery deployment. Your private relationship definition(s) will be registered in your Meshery Server's <a href='{{< ref "concepts/logical/registry.md" >}}'>registry</a> and available for use within your Meshery deployment.
+Alternatively, if you would like to keep the relationship definition private, you can bundle your relationship(s) in a custom model and import the custom model into your Meshery deployment. Your private relationship definition(s) will be registered in your Meshery Server's <a href='{{< ref "concepts/logical/registry.md" >}}'>registry</a> and available for use within your Meshery deployment.
 {{% /alert %}}
 
 For more information refer - [Model - Construct Models in Meshery](https://docs.google.com/document/d/16z5hA8qVfSq885of9LXFUVvfom-hQXr-6oTD_GgoFmk/edit)

--- a/docs/content/en/project/contributing/models/relationships.md
+++ b/docs/content/en/project/contributing/models/relationships.md
@@ -98,7 +98,7 @@ Codify relationships using your domain expertise. The `kind`, `type`, and `subTy
 
 | kind | type | subType | Meaning |
 |---|---|---|---|
-| `hierarchical` | `parent` | `inventory` | Parent contains/scopes children. Parent identity is patched onto the child (Namespace → namespaced resources). |
+| `hierarchical` | `parent` | `inventory` | Parent contains/scopes children. Parent identity is patched onto the child: the Namespace's name lands in each namespaced resource's `metadata.namespace`. |
 | `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent (Container inside Pod). |
 | `hierarchical` | `parent` | `wallet` | Child configuration is held/patched into the parent (WASMFilter → EnvoyFilter). |
 | `hierarchical` | `sibling` | `matchlabels` | **In-tree tagsets encoding.** Components that share labels. Schema also allows `kind: sibling`; do not mix encodings in one model. |
@@ -146,7 +146,7 @@ Include:
 - `kind`: The genre of relationship (`hierarchical`, `edge`, `sibling`).
 - `type`: The augmentative category (`parent`, `binding`, `non-binding`, `sibling`, …).
 - `subType`: The specific visual paradigm (`inventory`, `mount`, `network`, `wallet`, `reference`, `matchlabels`, …).
-- `selectors`: The scope of the relationship. One selector-set item is an OR. Inside an item, `from` × `to` is 1:many (AND).
+- `selectors`: The scope of the relationship. One selector-set item is an OR. Inside an item, every `from` entry relates to every `to` entry - a cross-product (AND).
 - `evaluationQuery`: Deprecated. Set it to `""` as every in-tree definition does; the evaluation engine enters through the fixed `data.relationship_evaluation_policy` package and dispatches on `kind`/`type`/`subType`.
 - `metadata.description`: A characterization of the relationship, its purpose, and constraints.
 

--- a/docs/content/en/project/contributing/models/relationships.md
+++ b/docs/content/en/project/contributing/models/relationships.md
@@ -192,7 +192,7 @@ Patches copy values from one component to another when the selector matches. Bot
 | Field | Role |
 |---|---|
 | `mutatorRef` | **Source.** JSON path of the value to read. |
-| `mutatedRef` | **Sink.** JSONPath of the field to patch. |
+| `mutatedRef` | **Sink.** Path segments of the field to patch. |
 | `patchStrategy` | How to apply. Schema enum: `merge`, `strategic`, `add`, `remove`, `replace`, `copy`, `move`, `test`. The in-tree corpus and the evaluation engine use `replace` exclusively; default to `replace` unless you need different semantics. |
 
 Paths are relative to the Meshery component document (`configuration`, `displayName`, `component.kind`, …), not the raw Kubernetes YAML root. `_` may mark only the first array position in a path; later arrays need an explicit index. Omit `patch` when the relationship only matches (tagsets, annotation).


### PR DESCRIPTION
## Summary

- Rewrites `.agents/skills/gen-relationship` against `relationships.meshery.io/v1beta3` (schemas SSOT) so contributors and coding agents can create **and** refine relationship definitions.
- Adds one pedagogical example for every canonical `kind` / `type` / `subType` combination present in-tree, plus the schema-native `kind: sibling` tagsets encoding.
- Corrects contributing and concepts docs: schema URL (`v1beta3`), `selectors` (not `selector`), valid JSON, mutator vs mutated, hierarchical `from`=child / `to`=parent, and the in-tree sibling encoding caveat.

## Taxonomy covered

| kind | type | subType |
|---|---|---|
| edge | non-binding | reference, network, firewall, permission, alias, annotation, inventory |
| edge | binding | permission, mount, network |
| hierarchical | parent | inventory, alias, wallet |
| hierarchical | sibling | matchlabels (in-tree tagsets) |
| sibling | matchlabels | tagsets (schema-native; do not mix with in-tree encoding) |

`badge` remains a visual-paradigm name only; no in-tree encoding.

## Test plan

- [ ] Open `.agents/skills/gen-relationship/SKILL.md` and confirm `/gen-relationship` still resolves.
- [ ] Spot-check examples against kubernetes in-tree neighbours (Namespace inventory, Service→Deployment network, Role→SA permission, sibling-tagsets.json).
- [ ] Preview contributing + concepts relationship pages; taxonomy table and mutator/mutated section render.
- [ ] Confirm schema links point at `schemas/constructs/v1beta3/relationship`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated relationship guidance to use the v1beta3 schema.
  - Clarified supported classifications, selectors, patch strategies, annotations, scope, hierarchy directionality, evaluation queries, and mutator/mutated references.
  - Added workflows for creating, refining, reviewing, and validating relationship definitions.
  - Documented current registration compatibility and authoring conventions.

- **Examples**
  - Added examples covering bindings, references, permissions, networking, firewall rules, aliases, inventories, annotations, siblings, and hierarchical relationships.
  - Added an index documenting schema usage, fixture conventions, and canonical relationship combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->