### PR TITLE
[Test] Automate mesheryctl platform selection prompt

### DIFF
--- a/mesheryctl/tests/e2e/010-installation/00-cli-install-platform-prompt.bats
+++ b/mesheryctl/tests/e2e/010-installation/00-cli-install-platform-prompt.bats
@@ -4,9 +4,13 @@ setup() {
     INSTALLER="$BATS_TEST_TMPDIR/meshery-install.sh"
     HARNESS="$BATS_TEST_TMPDIR/platform-prompt.sh"
 
-    curl -fsSL https://meshery.io/install -o "$INSTALLER"
+    curl -fsSL --connect-timeout 10 --max-time 60 https://meshery.io/install -o "$INSTALLER"
 
-    awk '/^####### COMMON FUNCTIONS/{exit} {print}' "$INSTALLER" > "$HARNESS"
+    awk '
+    /^####### COMMON FUNCTIONS/ { found = 1; exit }
+    { print }
+    END { exit !found }
+' "$INSTALLER" > "$HARNESS" || return 1
 
     cat >> "$HARNESS" <<'EOF'
 printf 'SELECTED_PLATFORM=%s\n' "$PLATFORM"

--- a/mesheryctl/tests/e2e/010-installation/00-cli-install-platform-prompt.bats
+++ b/mesheryctl/tests/e2e/010-installation/00-cli-install-platform-prompt.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+setup() {
+    INSTALLER="$BATS_TEST_TMPDIR/meshery-install.sh"
+    HARNESS="$BATS_TEST_TMPDIR/platform-prompt.sh"
+
+    curl -fsSL https://meshery.io/install -o "$INSTALLER"
+
+    awk '/^####### COMMON FUNCTIONS/{exit} {print}' "$INSTALLER" > "$HARNESS"
+
+    cat >> "$HARNESS" <<'EOF'
+printf 'SELECTED_PLATFORM=%s\n' "$PLATFORM"
+EOF
+}
+
+@test "installer accepts docker platform selection" {
+    run expect -c "
+        set timeout 20
+        spawn bash \"$HARNESS\"
+
+        expect {
+            \"Enter a platform to deploy Meshery\" {
+                send \"docker\r\"
+            }
+            timeout {
+                exit 1
+            }
+        }
+
+        expect {
+            \"SELECTED_PLATFORM=docker\" {
+                exit 0
+            }
+            timeout {
+                exit 1
+            }
+        }
+    "
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Enter a platform to deploy Meshery"* ]]
+    [[ "$output" == *"SELECTED_PLATFORM=docker"* ]]
+}
+
+@test "installer rejects invalid platform and accepts kubernetes" {
+    run expect -c "
+        set timeout 20
+        spawn bash \"$HARNESS\"
+
+        expect {
+            \"Enter a platform to deploy Meshery\" {
+                send \"invalid\r\"
+            }
+            timeout {
+                exit 1
+            }
+        }
+
+        expect {
+            \"Invalid platform\" {
+                send \"kubernetes\r\"
+            }
+            timeout {
+                exit 1
+            }
+        }
+
+        expect {
+            \"SELECTED_PLATFORM=kubernetes\" {
+                exit 0
+            }
+            timeout {
+                exit 1
+            }
+        }
+    "
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Invalid platform"* ]]
+    [[ "$output" == *"SELECTED_PLATFORM=kubernetes"* ]]
+}


### PR DESCRIPTION
## Description

Automates Test #3 from #21078 by covering the interactive platform-selection flow in the Meshery installer.

## What changed

- Added Bats coverage under `mesheryctl/tests/e2e/010-installation/`.
- Verifies that the installer prompts for a deployment platform.
- Verifies a valid `docker` selection is accepted.
- Verifies an invalid selection is rejected and the installer accepts a subsequent valid `kubernetes` selection.
- Isolates the installer prompt block before installation side effects.
- Uses `expect` to exercise the installer's interactive prompt deterministically.

## Validation

Local test result:

```text
1..2
ok 1 installer accepts docker platform selection
ok 2 installer rejects invalid platform and accepts kubernetes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the Meshery installation platform prompt.
  * Verified successful Docker and Kubernetes selections.
  * Verified invalid platform input is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->