### PR TITLE
fix(ui): gate the design configurator on the View Designs permission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,16 @@ make helm-docs      # Generate Helm chart docs
 - Use `@sistent/sistent` design system; fall back to MUI.
 - Redux Toolkit for global state; GraphQL via Relay; REST via Axios.
 - Playwright for E2E tests.
+- **Every content-bearing page needs an *access* gate, not just gated controls.**
+  `const canX = useHasPermission(Keys.X)` from `@sistent/sistent` plus an early
+  `return <DefaultError permissionKey={Keys.X} />`; pass `skip: !canX` to the page's
+  RTK Query hooks so a denied session issues no request. Gating only the buttons
+  leaves the page readable by a member holding zero keys. The Meshery UI dashboard
+  (`/`) is the **single deliberate exception** - it is the post-login landing page, so
+  denying it would strand a newly invited member on an error screen. Pin the **deny**
+  path in a test; an allow-only test passes against an ungated page too. Spellings,
+  the CASL wiring and the exception:
+  [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md).
 
 ### Commits
 
@@ -453,6 +463,7 @@ worked detail behind them — open the one that matches what you are working on.
 | A Go lint rule firing, or adding one | [Go Lint Rules](./docs/content/en/project/contributing/contributing-lint.md) |
 | Releases, CI secrets, the QA dashboard | [Build & Release (CI)](./docs/content/en/project/contributing/build-and-release.md) |
 | Connections and credential secrets | [Connections](./docs/content/en/project/contributing/models/connections.md) |
+| A permission-gated page, control or key | [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md) |
 | UI extensions, Remote Components | [Contributing to Meshery UI](./docs/content/en/project/contributing/ui/ui.md) |
 | `mesheryctl`, golden files | [Contributing to Meshery CLI](./docs/content/en/project/contributing/cli/cli.md) |
 | A docs page, its assets or shortcodes | [Contributing to Meshery Docs](./docs/content/en/project/contributing/contributing-docs/docs.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,14 +228,26 @@ make helm-docs      # Generate Helm chart docs
 - Redux Toolkit for global state; GraphQL via Relay; REST via Axios.
 - Playwright for E2E tests.
 - **Every content-bearing page needs an *access* gate, not just gated controls.**
-  `const canX = useHasPermission(Keys.X)` from `@sistent/sistent` plus an early
-  `return <DefaultError permissionKey={Keys.X} />`; pass `skip: !canX` to the page's
-  RTK Query hooks so a denied session issues no request. Gating only the buttons
-  leaves the page readable by a member holding zero keys. The Meshery UI dashboard
-  (`/`) is the **single deliberate exception** - it is the post-login landing page, so
-  denying it would strand a newly invited member on an error screen. Pin the **deny**
-  path in a test; an allow-only test passes against an ungated page too. Spellings,
-  the CASL wiring and the exception:
+  Read `canX` with `useHasPermission(Keys.X)` from `@sistent/sistent`, render
+  `<DefaultError permissionKey={Keys.X} />` when it is false, and pass `skip: !canX`
+  to the page's RTK Query hooks so a denied session issues no request. Gating only
+  the buttons leaves the page readable by a member holding zero keys. **Where the
+  `DefaultError` goes depends on which layer you are in:**
+  - In the page body **component** (`components/workspaces/index.tsx`,
+    `components/user-preferences/index.tsx`) an early `return <DefaultError …/>` is
+    correct - the page file already wraps it in `MesheryPage`, so the shell survives.
+  - In a **page** under `ui/pages/` (`configuration/designs/configurator.tsx`,
+    `configuration/catalog.tsx`) render it as the alternate branch *inside*
+    `MesheryPage`, never as an early return: returning early skips the shell and
+    loses both the browser tab title and the Redux page title `usePageTitle` sets.
+
+  Also keep tests out of `ui/pages/` - `next.config.js` sets no `pageExtensions`, so
+  anything `.tsx` there becomes a route and breaks `next build`; put them under
+  `ui/__tests__/`. The Meshery UI dashboard (`/`) is the **single deliberate
+  exception** to gating - it is the post-login landing page, so denying it would
+  strand a newly invited member on an error screen. Pin the **deny** path in a test;
+  an allow-only test passes against an ungated page too. Spellings, the CASL wiring
+  and the exception:
   [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md).
 
 ### Commits

--- a/docs/content/en/guides/configuration-management/creating-a-meshery-design.md
+++ b/docs/content/en/guides/configuration-management/creating-a-meshery-design.md
@@ -26,6 +26,8 @@ The Design Configurator is a built-in tool in Meshery UI. It lets you browse inf
 2. Click **+ New Design** (or open an existing design to edit it).  
    The Design Configurator opens with an empty canvas and a component panel on the left.
 
+Opening the configurator requires the **View Designs** permission, the same key the **Designs** page itself requires. Without it, the configurator shows the permission-denied page rather than the canvas. See [Extensibility: Authorization]({{< ref "reference/extensibility/authorization/index.md" >}}).
+
 ### Step 2 — Name Your Design
 
 Give your design a meaningful name in the **Design Name** field at the top of the configurator. This name is used when saving, sharing, or deploying the design.

--- a/docs/content/en/reference/extensibility/authorization/index.md
+++ b/docs/content/en/reference/extensibility/authorization/index.md
@@ -81,24 +81,30 @@ On startup, Meshery Server's [`SeedKeys`](https://github.com/meshery/meshery/blo
 #### Phase 3: Wire Key in the UI
 
 ##### Step 5: Direct Import from Schemas
-Because Meshery UI depends on `@meshery/schemas`, you can gate new UI behavior by importing `Keys` directly from `@meshery/schemas/permissions` instead of adding a manual entry to `ui/utils/permission_constants.ts`. Many existing components still use `permission_constants.ts`, so only those legacy call sites require updates until they are migrated.
+Because Meshery UI depends on `@meshery/schemas`, you gate new UI behavior by importing `Keys` directly from `@meshery/schemas/permissions`. There is no hand-maintained constant map to update: `ui/utils/permission_constants.ts` was removed once every call site had been migrated to the generated keys.
 
 Simply import the `Keys` object directly from `@meshery/schemas/permissions` in your component:
 {{< code code=`import { Keys } from '@meshery/schemas/permissions';` >}}
 
-##### Step 6: Gate the Component using `CAN`
-Pass the schema key's `id` (action) and `function` (subject) to the `CAN` utility to check permissions:
-{{< code code=`import CAN from '@/utils/can';
+##### Step 6: Gate the Component
+Prefer the `useHasPermission` hook from [Sistent](https://github.com/layer5io/sistent), which takes the whole key object:
+{{< code code=`import { useHasPermission } from '@sistent/sistent';
 import { Keys } from '@meshery/schemas/permissions';
 
-const key = Keys.CatalogManagementEvaluateRelationships;
-const canEvaluate = CAN(key.id, key.function);
+const canEvaluate = useHasPermission(Keys.CatalogManagementEvaluateRelationships);
 
 return (
   <Button disabled={!canEvaluate} onClick={handleEvaluate}>
     Evaluate Relationships
   </Button>
 );` >}}
+
+Sistent controls also accept the key directly as a `permissionKey` prop, which is the shortest form when the only effect is to disable the control:
+{{< code code=`<Button permissionKey={Keys.CatalogManagementEvaluateRelationships} onClick={handleEvaluate}>
+  Evaluate Relationships
+</Button>` >}}
+
+See [Gating spellings](#gating-spellings) for when to reach for the older `CAN(...)` utility instead.
 
 ##### Step 7: Verify End-to-End
 1. Run `make ui-lint` to verify that there are no formatting or typescript errors.
@@ -129,12 +135,14 @@ This example shows how the **Evaluate Relationships** key is wired across each l
   }
 }` >}}
 
-3. **React Component Gating**:
-{{< code code=`import CAN from '@/utils/can';
+3. **CASL rule built on login** - `id` becomes the rule's action, `function` its subject:
+{{< code code=`{ action: "c7752be7-5c0f-465d-a8ba-5594acd08b93", subject: "evaluate relationships" }` >}}
+
+4. **React Component Gating** (see [Gating spellings](#gating-spellings) for the other two forms):
+{{< code code=`import { useHasPermission } from '@sistent/sistent';
 import { Keys } from '@meshery/schemas/permissions';
 
-const key = Keys.CatalogManagementEvaluateRelationships;
-const canEvaluate = CAN(key.id, key.function);
+const canEvaluate = useHasPermission(Keys.CatalogManagementEvaluateRelationships);
 return canEvaluate ? <EvaluateRelationshipsButton /> : null;` >}}
 
 ---
@@ -153,7 +161,7 @@ When testing permission keys locally, the main client-side caches are stored und
 | **Redux store** | `state.ui.keys` | Same array as `sessionStorage.keys`. |
 | **RTK Query cache** | `getUserKeys` | Cached response for `/api/identity/orgs/{orgId}/users/keys`. |
 
-On login, Meshery either reuses `sessionStorage.keys` or refetches from the provider, then updates CASL. The static map in [`permission_constants.ts`](https://github.com/meshery/meshery/blob/master/ui/utils/permission_constants.ts) is source code—not browser storage—but `CAN(...)` compares those constants against the CASL rules built from the stored provider keys.
+On login, Meshery either reuses `sessionStorage.keys` or refetches from the provider, then updates CASL. The [`Keys`](https://github.com/meshery/schemas/blob/master/typescript/permissions.ts) object is generated source code—not browser storage—but every gating spelling compares those constants against the CASL rules built from the stored provider keys.
 
 Inspect keys in DevTools (**Application → Session Storage**):
 {{< code code=`JSON.parse(sessionStorage.getItem('keys'))
@@ -170,17 +178,19 @@ Use this checklist when a gated button does not appear, permissions look stale a
 ##### 1. Confirm the provider returned the key
 In DevTools **Network**, check the response for:
 `GET /api/identity/orgs/{orgId}/users/keys`
-Verify your UUID is in the `keys` array. If you're gating via `permission_constants.ts`, `_.lowerCase(function)` from the API should match `_.lowerCase(subject)` passed to `CAN(...)`.
+Verify your UUID is in the `keys` array. The API's `function` is what CASL stores as the rule subject (lower-cased), so it must match the `function` on the `Keys` entry you are gating with.
 
 ##### 2. Clear stale browser cache
 Meshery reuses `sessionStorage.keys` until the org changes or keys are refetched:
 {{< code code=`sessionStorage.removeItem('keys');
 location.reload();` >}}
 
-##### 3. Verify the UI constant map
-In [`permission_constants.ts`](https://github.com/meshery/meshery/blob/master/ui/utils/permission_constants.ts):
-*   `action` = key UUID (`id` from the API)
-*   `subject` = key `function` from the API (capitalization/camelCase differences are normalized by `_.lowerCase` in `CAN`)
+##### 3. Verify the generated key
+In [`Keys`](https://github.com/meshery/schemas/blob/master/typescript/permissions.ts), published by `@meshery/schemas`:
+*   `id` = the key UUID, matched against the CASL rule's action
+*   `function` = the human-readable operation name, matched against the CASL rule's subject (capitalization differences are normalized by `_.lowerCase`)
+
+If the key is missing from `Keys` altogether, it has not made it through the spreadsheet → schemas generation described above; re-run Phase 1 rather than declaring it locally.
 
 ##### 4. Confirm CASL loaded the rules
 *   **Redux DevTools**: check `state.ui.keys` for the expected UUID.
@@ -191,7 +201,7 @@ In [`permission_constants.ts`](https://github.com/meshery/meshery/blob/master/ui
 The key must be in [`server/permissions/keys.csv`](https://github.com/meshery/meshery/blob/master/server/permissions/keys.csv) with **`Local Provider = TRUE`**. Restart Meshery Server (or reset the local DB) after the CSV updates.
 
 ##### 6. Remote Provider: confirm role assignment
-Keys come from roles assigned in the Remote Provider admin UI. An empty API response usually means a role/keychain issue—not a missing `permission_constants.ts` entry alone.
+Keys come from roles assigned in the Remote Provider admin UI. An empty API response usually means a role/keychain issue—not a missing entry in the generated `Keys` alone.
 
 ##### 7. Verify browser cookies and session validity
 Verify that the `token` cookie is set and not expired:
@@ -203,7 +213,7 @@ Verify that the `token` cookie is set and not expired:
 
 | Symptom | Likely cause |
 |---------|----------------|
-| Button never appears | User lacks the key; if gating via `permission_constants.ts`, missing entry; or `CAN(...)` not wired |
+| Button never appears | User lacks the key; the key is missing from the generated `Keys`; or the gate is not wired |
 | New key not visible after merge | Stale `sessionStorage.keys`; missing Local Provider seed row; or only schemas PR merged |
 | Works in one org, not another | Keys are org-scoped—check `currentOrg` and refetch keys |
 | API returns `401` or `403` when fetching keys | Expired or missing `token` cookie; verify browser cookie store |
@@ -222,21 +232,53 @@ Meshery utilizes CASL (JS-based permission framework) to evaluate any given user
 
 [CASL.js](https://casl.js.org) is an isomorphic authorization JavaScript library which restricts what resources a given client is allowed to access. It's designed to be incrementally adoptable and can easily scale between a simple claim based and fully featured subject and attribute based authorization. It makes it easy to manage and share permissions/keys across UI components, API services, and database queries.
 
-An example of how CASL evaluates permissions in the UI:
-{{< code code=`<React.Fragment>
-	{CAN(keys.DELETE_CONNECTION.action, keys.DELETE_CONNECTION.subject) && (
-		<Button id="delete-connection">Delete</Button>
-	)}
-</React.Fragment>` >}}
+Upon user login, the provider returns the list of authorized permission keys. Those keys are used to build and update the CASL ability rules on the frontend, and each key is registered as a rule of `{ action: key.id, subject: lowerCase(key.function) }`. Every gate in Meshery UI is a query against that one ability instance.
 
-Upon user login, the backend returns the list of authorized permissions. These permissions are then used to build and update the CASL ability rules on the frontend. The UI maintains a constant file containing all allowed permissions (referred to as keys). With the help of these keys, the `CAN` function evaluates permissions at runtime and renders the UI accordingly.
+### Gating spellings
 
-{{% alert color="dark" title="Note" %}}
-It's important to understand not all pages uses CASL authorization, means even if you are not assigned with any role within organization you might access preferences page and Meshery UI dashboard.
+Three spellings exist, and they are equivalent - all three end up calling the same CASL `ability`. Each takes a key from `@meshery/schemas/permissions`, whose entries carry `id`, `function`, `category`, `subcategory` and `description`.
+
+1.  **`useHasPermission` hook** - the usual spelling, and the one to reach for in new code. Pass the whole key object; the hook resolves `id` and `function` for you.
+{{< code code=`import { useHasPermission } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
+
+const canDelete = useHasPermission(Keys.LifecycleManagementDeleteAConnection);
+
+return canDelete ? <Button id="delete-connection">Delete</Button> : null;` >}}
+
+2.  **`permissionKey` prop** - Sistent controls gate themselves. By default the control renders disabled behind a shield icon whose tooltip names the missing key; pass `permissionAction="hide"` to render nothing instead.
+{{< code code=`import { Keys } from '@meshery/schemas/permissions';
+
+<Button id="delete-connection" permissionKey={Keys.LifecycleManagementDeleteAConnection}>
+  Delete
+</Button>` >}}
+
+3.  **`CAN(...)` utility** - the original spelling, still used where a hook cannot be called (outside a component, or inside a callback). It takes the two fields separately rather than the key object.
+{{< code code=`import CAN from '@/utils/can';
+import { Keys } from '@meshery/schemas/permissions';
+
+const key = Keys.LifecycleManagementDeleteAConnection;
+const canDelete = CAN(key.id, key.function);` >}}
+
+### Access gating and control gating
+
+CASL gates Meshery UI at two levels, and they are not the same thing:
+
+*   **Access gating** replaces a page's whole content with the permission-denied page when your session lacks the key that page requires.
+*   **Control gating** renders the page, and hides or disables only the individual affordances within it - a button, a link, a menu item - that you lack the key for.
+
+Every content-bearing page in Meshery UI is access-gated. Where the page owns RTK Query hooks, pass `skip` on the same flag so a denied session issues no request at all.
+
+{{% alert color="dark" title="Note: the Meshery UI dashboard is a deliberate exception" %}}
+The **Meshery UI dashboard** (`/`) is control-gated only. It renders for an organization member holding no keys at all, with the links they cannot follow disabled in place, rather than replacing itself with the permission-denied page.
+
+This is by design, not an oversight: `/` is where Meshery lands you after login, so access-gating it would strand a newly invited member on an error screen before anyone has assigned them a role. Every other content-bearing page - including the design configurator and the user preferences page - is access-gated.
 {{% /alert %}}
+
+Access gating is a presentation control, not an enforcement boundary. Meshery Server authenticates every request, and authorization is decided by the configured [Remote Provider]({{< ref "reference/extensibility/providers/index.md" >}}) and enforced per handler on the server. An ungated page therefore never implies an ungated API.
 
 ## Authorization using Local Provider
 
-Meshery's built-in identity provider, "Local" Provider, operates with a large set of predefined keys interspersed throughout Meshery UI and persisted in [Meshery Database]({{< ref "concepts/architecture/database/index.md" >}}). These keys are used to evaluate the permissions of a given user and render the UI accordingly. The keys are grouped into three categories: `action`, `subject`, and `object`.
+Meshery's built-in identity provider, "Local" Provider, operates with a large set of predefined keys interspersed throughout Meshery UI and persisted in [Meshery Database]({{< ref "concepts/architecture/database/index.md" >}}). These keys are used to evaluate the permissions of a given user and render the UI accordingly. Each persisted key carries an `id`, a `function` (the operation it permits), and a `category`/`subcategory` pair that places it in a domain - the same shape the Remote Provider returns, so the UI gates identically under either provider.
 
 {{< discuss >}}

--- a/docs/content/en/reference/extensibility/authorization/index.md
+++ b/docs/content/en/reference/extensibility/authorization/index.md
@@ -129,9 +129,10 @@ This example shows how the **Evaluate Relationships** key is wired across each l
 {{< code code=`export const Keys = {
   CatalogManagementEvaluateRelationships: {
     id: "c7752be7-5c0f-465d-a8ba-5594acd08b93",
-    function: "Evaluate Relationships",
     category: "Catalog Management",
-    subcategory: "Designs"
+    subcategory: "Designs",
+    function: "Evaluate Relationships",
+    description: "Evaluate relationships inside a design"
   }
 }` >}}
 

--- a/ui/__tests__/pages/configuration/designs/configurator.test.tsx
+++ b/ui/__tests__/pages/configuration/designs/configurator.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/components/general/error-404', () => ({
   ),
 }));
 
-import DesignConfiguratorPage from './configurator';
+import DesignConfiguratorPage from '../../../../pages/configuration/designs/configurator';
 
 describe('DesignConfiguratorPage access gate', () => {
   beforeEach(() => {

--- a/ui/pages/configuration/designs/configurator.test.tsx
+++ b/ui/pages/configuration/designs/configurator.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Keys } from '@meshery/schemas/permissions';
+
+/**
+ * Access-gate coverage for the design configurator route.
+ *
+ * The configurator gated its individual save/update/delete controls but
+ * rendered the model browser and the design JSON in full for any authenticated
+ * session, including an organization member holding zero permission keys - the
+ * one page missed by 69db7bd7de64 ("Enforce permission guards on unguarded
+ * pages"). See meshery/meshery#21492.
+ *
+ * The deny path is what these tests exist to pin: an allow-only test would have
+ * passed against the ungated page too. The allow path is asserted alongside it
+ * so a regression to a blanket deny is caught as well.
+ *
+ * `DesignConfigurator` owns cytoscape, xstate and a live meshmodel fetch, so it
+ * is stubbed here (as its own suite records, it is not unit-renderable); this
+ * suite is scoped to the branch the page itself owns.
+ */
+
+const { useHasPermission } = vi.hoisted(() => ({ useHasPermission: vi.fn() }));
+
+vi.mock('@sistent/sistent', () => ({ useHasPermission }));
+
+vi.mock('@/components/general/MesheryPage', () => ({
+  MesheryPage: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="meshery-page">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/designs/configurator/MeshModel', () => ({
+  default: () => <div data-testid="design-configurator" />,
+}));
+
+vi.mock('@/components/general/error-404', () => ({
+  default: ({ permissionKey }: { permissionKey: { id: string } }) => (
+    <div data-testid="default-error">{permissionKey?.id}</div>
+  ),
+}));
+
+import DesignConfiguratorPage from './configurator';
+
+describe('DesignConfiguratorPage access gate', () => {
+  beforeEach(() => {
+    useHasPermission.mockReset();
+  });
+
+  it('replaces the configurator with the permission-denied page when the key is absent', () => {
+    useHasPermission.mockReturnValue(false);
+
+    render(<DesignConfiguratorPage />);
+
+    expect(screen.queryByTestId('design-configurator')).not.toBeInTheDocument();
+    expect(screen.getByTestId('default-error')).toHaveTextContent(
+      Keys.CatalogManagementViewDesigns.id,
+    );
+  });
+
+  it('renders the configurator when the key is held', () => {
+    useHasPermission.mockReturnValue(true);
+
+    render(<DesignConfiguratorPage />);
+
+    expect(screen.getByTestId('design-configurator')).toBeInTheDocument();
+    expect(screen.queryByTestId('default-error')).not.toBeInTheDocument();
+  });
+
+  it('gates on View Designs - the same key as the designs list and navigator entry', () => {
+    useHasPermission.mockReturnValue(true);
+
+    render(<DesignConfiguratorPage />);
+
+    expect(useHasPermission).toHaveBeenCalledWith(Keys.CatalogManagementViewDesigns);
+  });
+});

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -1,11 +1,34 @@
 import React from 'react';
+import { useHasPermission } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import DesignConfigurator from '@/components/designs/configurator/MeshModel';
+import DefaultError from '@/components/general/error-404';
 import { MesheryPage } from '@/components/general/MesheryPage';
 
+/**
+ * Access gate for the design configurator.
+ *
+ * `CatalogManagementViewDesigns` is the same key that gates the designs list
+ * (`components/designs/patterns/MesheryPatterns.tsx`) and the Designs navigator
+ * entry, which are the only ways into this route. Gating here rather than
+ * inside `DesignConfigurator` keeps the component from mounting at all, so the
+ * unconditional `useMeshModelComponents` category fetch never fires for a user
+ * who may not read designs.
+ *
+ * This is a presentation control. Authorization is decided by the configured
+ * provider and enforced per handler on Meshery Server; the gate exists so the
+ * UI is consistent about what an unpermitted session is shown.
+ */
 function DesignConfiguratorPage() {
+  const canViewDesigns = useHasPermission(Keys.CatalogManagementViewDesigns);
+
   return (
     <MesheryPage title="Configure Design" headTitle="Designs Configurator">
-      <DesignConfigurator />
+      {canViewDesigns ? (
+        <DesignConfigurator />
+      ) : (
+        <DefaultError permissionKey={Keys.CatalogManagementViewDesigns} />
+      )}
     </MesheryPage>
   );
 }

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -10,13 +10,20 @@ import { MesheryPage } from '@/components/general/MesheryPage';
  *
  * Four call sites navigate here:
  *
- * 1. `components/designs/patterns/MesheryPatterns.tsx:365` - the designs list
- *    row action.
- * 2. `components/designs/patterns/MesheryPatternsToolbar.tsx:61` - the create
- *    new design toolbar button.
+ * 1. `components/designs/patterns/MesheryPatternsToolbar.tsx:61` - the create
+ *    new design toolbar button. This is the only one exclusive to the designs
+ *    page.
+ * 2. `components/designs/patterns/MesheryPatterns.tsx:365` -
+ *    `handleOpenInConfigurator`, behind the table view's "Edit" row actions
+ *    (`MesheryPatterns.columns.tsx:50` and `:72`). It is NOT exclusive to the
+ *    designs page: `buildPatternColumns` is never passed `arePatternsReadOnly`
+ *    and the toolbar's `ViewSwitch` renders whenever no design detail is open,
+ *    so the same action is reachable in table view on `/configuration/catalog`.
+ *    Both row actions key on `CatalogManagementEditDesign`, not ViewDesigns.
  * 3. `components/designs/patterns/MesheryPatternCard.tsx:103` - "Edit In
- *    Configurator" on the design card, reachable from `/configuration/catalog`,
- *    which gates on `CatalogManagementViewCatalog` rather than ViewDesigns.
+ *    Configurator" on the design card, the grid-view counterpart of the above
+ *    and likewise reachable from `/configuration/catalog`, which gates on
+ *    `CatalogManagementViewCatalog` rather than ViewDesigns.
  *    `arePatternsReadOnly` does not suppress that button: the `isReadOnly`
  *    guard at `MesheryPatternCard.tsx:441` covers a different block, so the
  *    button renders whenever `userCanEdit` (holds `CatalogManagementEditDesign`,
@@ -25,23 +32,30 @@ import { MesheryPage } from '@/components/general/MesheryPage';
  *    workspace design open, which falls back to the configurator when the
  *    Kanvas designer is unavailable.
  *
- * `CatalogManagementViewDesigns` is the same key that gates the first two: the
- * designs list (`MesheryPatterns.tsx:72`) and the Designs navigator entry
- * (`components/layout/Navigator/navigatorComponents.tsx:159`). It remains the
- * single correct key despite the last two, because no built-in keychain in
- * `server/permissions/keys.csv` holds `Edit Design`, `View Catalog` or
- * `View Workspace` without also holding `View Designs` - verified per role
+ * So three of the four can originate from a page that is not gated on
+ * ViewDesigns - the catalog card button, the catalog table row action, and the
+ * workspace Kanvas fallback.
+ *
+ * `CatalogManagementViewDesigns` is nonetheless the correct single key. It is
+ * what already gates the designs list (`MesheryPatterns.tsx:72`) and the
+ * Designs navigator entry
+ * (`components/layout/Navigator/navigatorComponents.tsx:159`), and no built-in
+ * keychain in `server/permissions/keys.csv` holds `Edit Design`, `View Catalog`
+ * or `View Workspace` without also holding `View Designs` - verified per role
  * column across User, Team Admin, Academy Admin, Leaner, Workspace Admin, Org
  * Billing Manager, Org Admin and Provider Admin. No default role can reach a
- * deny page from those buttons; only a custom keychain can.
+ * deny page from those three; only a custom keychain can.
  *
  * Where a custom keychain does make that dead end reachable, the fix belongs at
- * the entry-point buttons - a button that leads to a permission-denied page
- * should not render - and not in widening this gate. The configurator reads and
- * writes full design JSON, whereas `CatalogManagementViewCatalog` grants only
- * read-only published browsing, so accepting it here would grant more than the
- * designs list itself does. That button-side fix is deliberately out of scope
- * here and raised as a separate product question.
+ * the entry points - a control that leads to a permission-denied page should
+ * not render - and not in widening this gate. Note that this means fixing both
+ * spellings: `MesheryPatternCard.tsx` for grid view AND
+ * `MesheryPatterns.columns.tsx` for table view, or the table path still dead
+ * ends. The configurator reads and writes full design JSON, whereas
+ * `CatalogManagementViewCatalog` grants only read-only published browsing, so
+ * accepting it here would grant more than the designs list itself does. That
+ * entry-point fix is deliberately out of scope here and raised as a separate
+ * product question.
  *
  * Gating here rather than inside `DesignConfigurator` keeps the component from
  * mounting at all, so the unconditional `useMeshModelComponents` category fetch

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -8,12 +8,44 @@ import { MesheryPage } from '@/components/general/MesheryPage';
 /**
  * Access gate for the design configurator.
  *
- * `CatalogManagementViewDesigns` is the same key that gates the designs list
- * (`components/designs/patterns/MesheryPatterns.tsx`) and the Designs navigator
- * entry, which are the only ways into this route. Gating here rather than
- * inside `DesignConfigurator` keeps the component from mounting at all, so the
- * unconditional `useMeshModelComponents` category fetch never fires for a user
- * who may not read designs.
+ * Four call sites navigate here:
+ *
+ * 1. `components/designs/patterns/MesheryPatterns.tsx:365` - the designs list
+ *    row action.
+ * 2. `components/designs/patterns/MesheryPatternsToolbar.tsx:61` - the create
+ *    new design toolbar button.
+ * 3. `components/designs/patterns/MesheryPatternCard.tsx:103` - "Edit In
+ *    Configurator" on the design card, reachable from `/configuration/catalog`,
+ *    which gates on `CatalogManagementViewCatalog` rather than ViewDesigns.
+ *    `arePatternsReadOnly` does not suppress that button: the `isReadOnly`
+ *    guard at `MesheryPatternCard.tsx:441` covers a different block, so the
+ *    button renders whenever `userCanEdit` (holds `CatalogManagementEditDesign`,
+ *    or owns the design).
+ * 4. `components/workspaces/SpacesSwitcher/MainDesignsContent.tsx:176` - the
+ *    workspace design open, which falls back to the configurator when the
+ *    Kanvas designer is unavailable.
+ *
+ * `CatalogManagementViewDesigns` is the same key that gates the first two: the
+ * designs list (`MesheryPatterns.tsx:72`) and the Designs navigator entry
+ * (`components/layout/Navigator/navigatorComponents.tsx:159`). It remains the
+ * single correct key despite the last two, because no built-in keychain in
+ * `server/permissions/keys.csv` holds `Edit Design`, `View Catalog` or
+ * `View Workspace` without also holding `View Designs` - verified per role
+ * column across User, Team Admin, Academy Admin, Leaner, Workspace Admin, Org
+ * Billing Manager, Org Admin and Provider Admin. No default role can reach a
+ * deny page from those buttons; only a custom keychain can.
+ *
+ * Where a custom keychain does make that dead end reachable, the fix belongs at
+ * the entry-point buttons - a button that leads to a permission-denied page
+ * should not render - and not in widening this gate. The configurator reads and
+ * writes full design JSON, whereas `CatalogManagementViewCatalog` grants only
+ * read-only published browsing, so accepting it here would grant more than the
+ * designs list itself does. That button-side fix is deliberately out of scope
+ * here and raised as a separate product question.
+ *
+ * Gating here rather than inside `DesignConfigurator` keeps the component from
+ * mounting at all, so the unconditional `useMeshModelComponents` category fetch
+ * never fires for a user who may not read designs.
  *
  * This is a presentation control. Authorization is decided by the configured
  * provider and enforced per handler on Meshery Server; the gate exists so the


### PR DESCRIPTION
## Intent

Add the missing access gate to the Meshery UI design configurator, and correct the authorization documentation that currently misstates which pages are gated. Tracked as https://github.com/meshery/meshery/issues/21492; the PR must reference and close that issue.

THE PROBLEM. ui/pages/configuration/designs/configurator.tsx rendered its content in full for any authenticated user, including an organization member holding zero permission keys. It gated individual controls (Save/Update/Delete via permissionKey) but never gated access to the page. That is inconsistent with the rest of the UI: commit 69db7bd7de64 ("Enforce permission guards on unguarded pages", 2026-08-16) added access gates to 16 pages, including /user/preferences. The configurator was missed.

SCOPE BOUNDARY, DELIBERATE. This is a presentation control, NOT an enforcement boundary. Meshery Server authenticates every request but does not itself evaluate permission keys - authorization is decided by the configured provider and enforced per-handler on the server. The task is UI consistency and documentation accuracy. Server-side authorization was deliberately NOT changed, and the change must NOT be described as closing a security hole. Reviewers should not expect server-side changes here; their absence is intended, not an omission.

PART 1 - THE GATE. Follow the pattern the 16 pages gated by 69db7bd7de64 already establish; do not invent a new one. Chosen key: Keys.CatalogManagementViewDesigns. Rationale: it is the same key that already gates the designs list (components/designs/patterns/MesheryPatterns.tsx:72) and the Designs navigator entry (components/layout/Navigator/navigatorComponents.tsx:159), which are the only routes into this page. A registry key such as MesherySystemViewRegistry was considered and rejected because it would deny users who legitimately hold design permissions. Gating at the PAGE (ui/pages/configuration/designs/configurator.tsx) rather than inside DesignConfigurator is deliberate: the component never mounts, so useMeshModelComponents' unconditional fetchCategories call never fires for a denied session - the page-level equivalent of the `skip: !canX` the precedent commit applied to RTK queries. The page-level gate precedent is ui/pages/extension/[...component].tsx from the same commit. DefaultError is rendered inside MesheryPage so the tab title and Redux page title stay correct, matching how MesheryPatterns renders it inside its page shell.

PART 1 TEST. A test must pin the DENY path so the gate cannot silently regress; a test that only proves the allow path would have passed before this change too. ui/pages/configuration/designs/configurator.test.tsx asserts (a) deny -> DefaultError carrying Keys.CatalogManagementViewDesigns.id and no configurator, (b) allow -> configurator and no DefaultError, (c) useHasPermission is called with that exact key. This was verified by reverting the page and re-running: 2 of the 3 tests fail against the pre-fix code. DesignConfigurator is stubbed in the test because its own suite (components/designs/configurator/MeshModel/index.test.tsx) records it as not unit-renderable (cytoscape + xstate + redux + RJSF); the suite is deliberately scoped to the branch the page itself owns.

PART 2 - THE CARVE-OUT PARAGRAPH. docs/content/en/reference/extensibility/authorization/index.md said: "It's important to understand not all pages uses CASL authorization, means even if you are not assigned with any role within organization you might access preferences page and Meshery UI dashboard." It was wrong in two directions: preferences was gated on 2026-08-16 so that half is false, and the configurator was ungated but unnamed. The paragraph was explicitly NOT to be deleted - a reader needs to know the dashboard is reachable without a role and that this is intended. The replacement distinguishes access-gating from control-gating, names the Meshery UI dashboard (/) as the deliberate exception with the captain-confirmed reasoning (/ is the landing page; denying it would strand a newly invited member on an error screen), drops the stale preferences claim, and states plainly that access gating is a presentation control rather than an enforcement boundary.

PART 3 - THE CAN EXAMPLE AND ADJACENT DOC ROT. The CAN(...) example used keys.DELETE_CONNECTION.action / .subject. Verified against code: that shape has not existed since ui/utils/permission_constants.ts was removed on 2026-07-07 (b6df4c9eeccd, "migrate to direct schemas imports"); generated Keys carry {id, category, subcategory, function, description}, and the adapter is ability.can(key.id, _.lowerCase(key.function)) (ui/pages/_app.tsx:156). Also verified: 5 files use CAN() vs 63 using useHasPermission and 59 using a permissionKey prop, so teaching CAN as the primary spelling was actively misleading. Replaced with the three real spellings and a note they all query the same CASL ability. Adjacent debt fixed in the same pass (same file, same defect class, three of them dead GitHub links to a deleted file): seven permission_constants.ts references, and the Local Provider claim that keys are "grouped into three categories: action, subject, and object" - the persisted Key (schemas models/v1beta2/key, seeded from server/permissions/keys.csv whose columns are Category/Function/Feature/.../Key ID) has no such fields.

FACT-CHECKING STANDARD. Every factual claim written into the docs was verified against the actually installed packages rather than from memory, because a sibling task needed two correction rounds for writing dependency claims from assumption. Verified at runtime: Keys.CatalogManagementViewDesigns / LifecycleManagementDeleteAConnection / CatalogManagementEvaluateRelationships exist with the stated ids; PermissionAction is 'hide' | 'showShield' with showShield the default; PermissionShield's own docs say it lists every unheld key in its tooltip; _.lowerCase('Evaluate Relationships') === 'evaluate relationships'. One claim drafted and then REMOVED after checking: that gated pages also skip their data fetches on the same key - false for MesheryPatterns, Filters, connections, environments, MesherySettings and performance/Dashboard, so it was softened to guidance rather than stated as fact.

PROJECT MEMORY. AGENTS.md records the access-gate rule (useHasPermission + early DefaultError, skip on the page's RTK queries, pin the deny path in a test) and the dashboard as the single deliberate exception, plus a Further Reading row, so the next page added does not repeat the gap.

VERIFICATION ALREADY PERFORMED. Full ui vitest: 2780 passed, 17 skipped. One failure, __tests__/architecture/sistent-imports-resolve.test.ts, was diagnosed as PRE-EXISTING AND ENVIRONMENTAL, not caused by this change: this worktree's node_modules had @sistent/sistent 0.22.0 while package.json and package-lock.json pin 0.22.4, and 0.22.4 does export the two symbols it reported missing (PermissionSessionContext, useAccessibleOrgs). It matters because PermissionSessionContext sits on this change's deny path via DefaultError -> CurrentSession.tsx. After installing the pinned 0.22.4 (node_modules only; package-lock.json confirmed unchanged) that test and the new gate test both pass. No repo change is needed - CI's npm ci resolves it. eslint and prettier are clean on the changed UI files. AGENTS.md fails prettier both before and after this change (pre-existing, outside ui/, deliberately left alone rather than triggering a large unrelated reformat). The full docs build cannot complete in this sandbox because /usr/local/bin/sass is the broken Ruby gem rather than Dart Sass - the gotcha documented in AGENTS.md - so the page was rendered in a throwaway Hugo site with real Dart Sass 1.102.0: the #gating-spellings anchor resolves from both links, both alert shortcodes render, the ordered lists stay single <ol> elements despite interleaved code shortcodes, and there is zero raw shortcode leakage.

DELIVERY. Commits must be signed off and authored as Mericio "Hablo" Salazar <218162243+simihablo@users.noreply.github.com>, with no AI/assistant attribution anywhere in commits, branch name, or PR body. Commit subjects follow the repo's [component] convention. The PR body must state that it closes https://github.com/meshery/meshery/issues/21492.

DECISIONS ACCEPTED DURING THE FIRST RUN - DO NOT RE-LITIGATE THESE.

1. ENTRY POINTS AND THE GATE KEY. Review correctly established that my original comment's claim that the designs list and navigator entry "are the only ways into this route" was FALSE. Four routes reach this page: `MesheryPatterns.tsx:365` (designs list row action), `MesheryPatternsToolbar.tsx:61` (create new design), `MesheryPatternCard.tsx:103` ("Edit In Configurator", reachable from `/configuration/catalog`, which gates on ViewCatalog), and `MainDesignsContent.tsx:176` (workspace design open, falls back here when the Kanvas designer is unavailable). Three of the four can originate from a page not gated on ViewDesigns, because `buildPatternColumns` never receives `arePatternsReadOnly` and `ViewSwitch` renders unconditionally, so the catalog's table view exposes the same Edit row action. The comment now names all four.

THE GATE ITSELF WAS DELIBERATELY NOT WIDENED, and this was decided explicitly after review raised it. Do NOT propose `|| canViewCatalog` or `|| canViewWorkspace`, and do NOT propose mirroring `MesheryPatterns.tsx:74`'s disjunction. Reason: the configurator reads AND WRITES full design JSON, whereas CatalogManagementViewCatalog grants only read-only published browsing (the catalog mounts MesheryPatterns with `arePatternsReadOnly={true}`). Accepting ViewCatalog as sufficient to open a read/write design editor would grant MORE than the designs list itself does, on a change whose entire purpose is closing a gate - weakening a permission boundary to fix a UX dead end is the wrong direction and the wrong tool. Verified in `server/permissions/keys.csv` per role column (User, Team Admin, Academy Admin, Leaner, Workspace Admin, Org Billing Manager, Org Admin, Provider Admin): every built-in keychain holding Edit Design, View Catalog or View Workspace also holds View Designs, so no default role can reach the deny page - only a custom keychain can. The correct fix for that residual dead end is at the ENTRY-POINT BUTTONS - a button that leads to a permission-denied page should not render - and is deliberately OUT OF SCOPE here, raised separately as a product question. THE PR BODY MUST SAY THIS.

2. TEST LOCATION. The test lives at `ui/__tests__/pages/configuration/designs/configurator.test.tsx`, NOT under `ui/pages/`. This is load-bearing: `ui/next.config.js` sets no `pageExtensions`, so Next's default ['tsx','ts','jsx','js'] makes every .tsx under `pages/` a route; a test there compiles as `/configuration/designs/configurator.test`, has no default export, and fails `next build`, which CI runs via `make ui-build`. Do NOT propose moving it back or co-locating it, and do NOT propose adding a `pageExtensions` setting to work around it - that would change route resolution for the entire app. vitest's `include` already covers `**/__tests__/**`, and the suite passes from the new location.

3. AGENTS.md STATES BOTH GATE SHAPES ON PURPOSE. An early `return <DefaultError/>` is correct only in a page body COMPONENT (components/workspaces/index.tsx, components/user-preferences/index.tsx), whose page file already supplies the MesheryPage shell. In a PAGE under ui/pages/ the DefaultError must render INSIDE MesheryPage as the alternate branch, because MesheryPage calls usePageTitle(title) and renders <Head><title>, both of which an early return would drop. configurator.tsx does the latter, which is why the rule was corrected to distinguish them.

4. COMMIT IDENTITY IS ALREADY CORRECT - DO NOT RE-RAISE IT. The previous run's fix rounds committed as the wrong crew persona with no Signed-off-by; that was verified against git rather than taken on trust, and corrected between runs. All five commits on this branch are now authored AND committed as Mericio "Hablo" Salazar <218162243+simihablo@users.noreply.github.com>, each carrying a Signed-off-by naming that identity, each with a [UI] or [Docs] subject, with no AI attribution anywhere. The rewrite preserved the tip tree byte-for-byte (ea5c0c26a93f) and the two original commits kept their original hashes a3e7f41cecc3 and e050ec2a1573. Nothing has ever been pushed, so no force-push was or will be needed. NOTE for any fix round: this repository's `core.hooksPath` may be repointed away from ui/.husky, silently disabling the commit-msg sign-off check, so always pass `git commit -s` explicitly rather than relying on the hook.

5. KNOWN NON-BLOCKING ENVIRONMENT FACTS. AGENTS.md fails `prettier --check` both before and after this change - pre-existing, outside ui/, deliberately left alone rather than triggering a large unrelated reformat. The full Hugo docs build cannot complete in this sandbox because /usr/local/bin/sass is the broken Ruby gem rather than Dart Sass (the gotcha AGENTS.md documents); the changed page was instead rendered in a throwaway Hugo site with real Dart Sass 1.102.0, confirming the #gating-spellings anchor resolves from both links, both alert shortcodes render, ordered lists stay single <ol> elements, and there is no raw shortcode leakage.

6. WHY THE BRANCH CARRIES A `-2` SUFFIX - THE PR BODY MUST EXPLAIN THIS so a reviewer is not left wondering whether an earlier attempt is lurking somewhere. There is no first PR and no abandoned remote branch: nothing was ever pushed to GitHub under the original name. A first validation run failed after its fix rounds committed as the wrong crew persona without a Signed-off-by trailer. Correcting that is a history rewrite, and the local validation gate had pinned its branch ref to the failed run's commit, so no corrected local state could fast-forward onto it - a known defect in that tooling whose only recorded escape is to use a new branch name. The five commits are unchanged by the rename; the branch tip is byte-identical to what it was before. Nothing was force-pushed, because nothing had been pushed at all.

## What Changed

- `ui/pages/configuration/designs/configurator.tsx` now reads `useHasPermission(Keys.CatalogManagementViewDesigns)` and renders `<DefaultError permissionKey={...} />` inside `MesheryPage` when the key is absent, so a session without View Designs sees the permission-denied page instead of the full configurator. Gating at the page (rather than inside `DesignConfigurator`) keeps the component from mounting, so its unconditional `useMeshModelComponents` category fetch never fires for a denied session. The key matches what already gates the designs list and the Designs navigator entry; an in-file comment records all four routes into the page and why the gate was not widened.
- New `ui/__tests__/pages/configuration/designs/configurator.test.tsx` pins the deny path (`DefaultError` carrying the key id, no configurator), the allow path, and that `useHasPermission` is called with exactly `Keys.CatalogManagementViewDesigns`. It lives under `ui/__tests__/` rather than beside the page because `ui/next.config.js` sets no `pageExtensions`, so any `.tsx` under `pages/` compiles as a route and breaks `next build`.
- `docs/content/en/reference/extensibility/authorization/index.md` replaces the stale carve-out paragraph (it claimed preferences was ungated, which stopped being true when preferences was gated, and never named the configurator) with an access-gating vs control-gating distinction, names the Meshery UI dashboard `/` as the single deliberate exception, and states that access gating is a presentation control rather than an enforcement boundary. The same pass fixes the `CAN(keys.X.action, keys.X.subject)` example, which describes a shape that has not existed since `ui/utils/permission_constants.ts` was removed, documents the three real gating spellings, drops seven references to that deleted file (three of them dead GitHub links), and corrects the Local Provider claim that keys are grouped into `action`/`subject`/`object`. `AGENTS.md` records the access-gate rule and the dashboard exception; the design-creation guide notes the configurator's permission prerequisite.

Closes https://github.com/meshery/meshery/issues/21492.

### Scope notes

- **Not a security fix.** Meshery Server authenticates every request but does not evaluate permission keys itself; authorization is decided by the configured provider and enforced per handler on the server. This change is UI consistency and documentation accuracy. No server-side change was made, and that absence is intended, not an omission.
- **The gate was deliberately not widened.** Three of the four entry points into this page can originate somewhere not gated on View Designs (the catalog's grid and table Edit actions, and the workspace Kanvas fallback), so a custom keychain can reach a denied page. Accepting `CatalogManagementViewCatalog` here would grant read/write design editing off a read-only browsing key, which is the wrong direction on a change whose purpose is closing a gate. Verified against `server/permissions/keys.csv`: every built-in keychain holding Edit Design, View Catalog or View Workspace also holds View Designs, so no default role can reach the deny page. The correct fix for that residual dead end is at the entry-point controls (a button that leads to a permission-denied page should not render) and is raised separately as a product question.
- **Why the branch name carries a `-2` suffix.** There is no earlier PR and no abandoned remote branch; nothing was ever pushed under the original name. A first validation run's fix rounds committed under the wrong identity without a sign-off trailer. Correcting that required a history rewrite, and the local validation tooling had pinned its branch ref to the failed run's commit, so a new branch name was the only way forward. The five commits and the branch tip are unchanged by the rename.

## Risk Assessment

✅ Low: A 12-line page change that copies an existing verified gate pattern exactly, backed by a deny-path test, plus documentation corrections whose every factual claim I verified against source; the only findings are an unpinned test invariant and comment line-number rot, neither of which affects runtime behavior.

## Testing

Installed the missing ui/ dependencies, then ran the new gate suite (3/3 pass) and proved it pins the regression by reverting the page and re-running (2 of 3 fail against the pre-fix code). Ran the adjacent deny-path suites (error-404, sistent-imports-resolve) which also pass once the pinned @sistent/sistent 0.22.4 is installed, confirming the intent's diagnosis that that failure was node_modules drift. For reviewer-visible evidence I mounted the real page module in Chrome through a throwaway harness wired exactly as pages/_app.tsx wires permissions, and captured screenshots of both branches: a zero-key session sees the real permission-denied page naming View Designs with its Catalog Management / Designs chips, and a session holding CatalogManagementViewDesigns sees the configurator with its Save control still shielded; a network capture shows the denied session issues no /api/registry/categories request, which is the stated reason for gating at the page rather than inside DesignConfigurator. The changed docs page was rendered with Hugo using the repo's own shortcode templates - no raw shortcode leakage, the Gating spellings list stays a single ordered list, the #gating-spellings anchor resolves from both links, and the stale preferences claim is gone - and its hard-coded CASL rule UUID plus lower-cased subject were verified at runtime against the installed @meshery/schemas. Two caveats, neither blocking: the Docsy alert shortcode is not in the local Hugo module cache so a minimal equivalent wrapper was supplied (the alert content is the page's own), and next build was not run since CI's make ui-build owns it and the test now lives under ui/__tests__/. All harness and temp files were removed and the worktree is clean at the target commit.

- Evidence: Deny path: design configurator route for an org member holding zero permission keys (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01M0BY4SJVSQ4DWNHZ9FHN63DS/01-deny-no-permission-keys.png</code>)
- Evidence: Allow path: same route for a session holding Keys.CatalogManagementViewDesigns (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01M0BY4SJVSQ4DWNHZ9FHN63DS/02-allow-view-designs-key.png</code>)
- Evidence: Rendered docs: the new &#34;Gating spellings&#34; section (single ordered list across interleaved code shortcodes) (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01M0BY4SJVSQ4DWNHZ9FHN63DS/03-docs-gating-spellings.png</code>)
- Evidence: Rendered docs: access gating vs control gating, with the dashboard carve-out alert (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01M0BY4SJVSQ4DWNHZ9FHN63DS/04-docs-access-gating-carveout.png</code>)
<details>
<summary>Evidence: Full rendered authorization docs page (HTML)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>Extensibility: Authorization</title>
<style>
body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;max-width:900px;margin:2rem auto;padding:0 1.5rem;line-height:1.6;color:#1c1c1c}
h1,h2,h3,h4,h5{line-height:1.25}
h3,h4,h5{margin-top:1.8rem}
pre.codeblock-pre{background:#2d3438;color:#eee;padding:.75rem 1rem;border-radius:6px;overflow:auto}
pre.codeblock-pre code{white-space:pre-wrap}
.alert{border:1px solid #d0d7de;border-left:4px solid #00b39f;background:#f6f8fa;padding:1rem 1.25rem;border-radius:6px;margin:1.25rem 0}
table{border-collapse:collapse}td,th{border:1px solid #d0d7de;padding:.4rem .6rem}
ol>li{margin:.35rem 0}
</style></head><body><h1>Extensibility: Authorization</h1><p>Meshery features an extensible authorization system that offers the ability to deliver fine-grained access control across its web-based user interface, <a href="">Meshery UI</a>.</p>
<h2 id="authorization-keys">Authorization Keys</h2>
<p>The extensible authorization system consists of a large set of keys. Each key uniquely represents a specific capability, for example, the ability to view, edit, or delete a <a href="">Connection</a>. With the help of these keys, the system evaluates permissions at runtime to render the UI, offering both a secure management system and a customizable user experience.</p>
<h3 id="key-naming-and-scoping-conventions">Key Naming and Scoping Conventions</h3>
<p>Permission keys in <code>@meshery/schemas</code> are generated dynamically using the following formula:
<code>PascalCase(Theme) + PascalCase(Function)</code></p>
<ul>
<li><strong>Theme (Domain Capability)</strong>: Represents the high-level business domain/capability that governs the action (e.g. <code>Catalog Management</code>, <code>Lifecycle Management</code>).</li>
<li><strong>Function (Operation)</strong>: Represents the specific operation being performed (e.g. <code>Unpublish Design</code>, <code>Evaluate Relationships</code>).</li>
</ul>
<h4 id="domain-scoping-vs-ui-layout">Domain Scoping vs. UI Layout</h4>
<p>Keys are categorized by their <strong>domain of authority</strong> rather than the UI component or file path where they are used.</p>
<p>For example, the component <code>MesheryPatternCard</code> (which resides in the designs/patterns directory) uses the key <code>CatalogManagementUnpublishDesign</code> because publishing/unpublishing a design is a <strong>Catalog Management</strong> action (making it public or private in the catalog), even though the card itself represents a pattern/design UI element.</p>
<div class="alert alert-info" role="alert">
<h4 class="alert-heading">Note</h4>
The extensible authorization system is available to both Local and Remote Providers. Depending on your chosen <a href="">Remote Provider</a>, you may be offered features such as grouping keys or assigning them to user groups or roles, rather than just individual users.
</div>
<h3 id="adding-a-new-permission-key">Adding a New Permission Key</h3>
<p>Permission keys are defined and managed centrally via an automated Google Spreadsheet workflow. The spreadsheet serves as the authoritative source of truth, while <code>@meshery/schemas</code> compiles and publishes the generated Go and TypeScript artifacts consumed by downstream projects:</p>
<ol>
<li><strong>Spreadsheet Registration</strong>: Keys are registered in the central permissions spreadsheet.</li>
<li><strong>Meshery Schemas Automation</strong>: A GitHub Actions workflow automatically imports the spreadsheet, updates <code>build/permissions.csv</code>, and compiles the definitions into Go and TypeScript libraries.</li>
<li><strong>Dynamic Consumption</strong>: Downstream projects (<code>meshery/meshery</code> backend and React UI) consume the generated models and constants dynamically, removing the need for duplicate, hardcoded constants.</li>
</ol>
<hr>
<h3 id="step-by-step-guide">Step-by-Step Guide</h3>
<p>Follow these steps to generate, register, sync, and wire up a new permission key.</p>
<h4 id="phase-1-define-key-in-spreadsheet">Phase 1: Define Key in Spreadsheet</h4>
<h5 id="step-1-generate-a-uuid-v4">Step 1: Generate a UUID v4</h5>
<p>Generate a unique, lowercase UUID v4 for the new permission key:


<pre class="codeblock-pre">
	<div class="codeblock">
		<code class="clipboardjs">uuidgen | tr &#39;[:upper:]&#39; &#39;[:lower:]&#39;</code>
	</div>
</pre>
</p>
<h5 id="step-2-add-to-the-permissions-spreadsheet">Step 2: Add to the Permissions Spreadsheet</h5>
<p>Add a new row to the authoritative <strong>Permissions Spreadsheet</strong>. Ensure the following columns are set:</p>
<ul>
<li><strong>Theme</strong>: The high-level category (e.g. <code>Catalog Management</code>).</li>
<li><strong>Category</strong>: Specific feature area (e.g. <code>Designs</code>).</li>
<li><strong>Function</strong>: Human-readable operation name (e.g. <code>Evaluate Relationships</code>). This value becomes <code>key.function</code> in the Provider API.</li>
<li><strong>Feature</strong>: Feature description (e.g. <code>Evaluate relationships inside a design</code>).</li>
<li><strong>Key ID</strong>: The generated UUID from Step 1.</li>
<li><strong>Local Provider</strong>: Set to <code>TRUE</code> if this key should be seeded for the Local Provider database.</li>
</ul>
<h5 id="step-3-run-the-schema-sync--generation-workflow">Step 3: Run the Schema Sync &amp; Generation Workflow</h5>
<p>Once added to the spreadsheet, the GitHub Actions workflow <a href="https://github.com/meshery/schemas/blob/master/.github/workflows/generate-artifacts-from-schemas.yml"><code>generate-artifacts-from-schemas.yml</code></a> in <code>meshery/schemas</code> runs automatically on a daily schedule (and can also be triggered manually) to sync the spreadsheet keys to the local <a href="https://github.com/meshery/schemas/blob/master/build/permissions.csv"><code>build/permissions.csv</code></a>.</p>
<p>This workflow automatically executes the generators to produce:</p>
<ul>
<li>Go constants: <a href="https://github.com/meshery/schemas/blob/master/models/permissions/permissions.go"><code>models/permissions/permissions.go</code></a></li>
<li>TypeScript definitions: <a href="https://github.com/meshery/schemas/blob/master/typescript/permissions.ts"><code>typescript/permissions.ts</code></a></li>
</ul>
<p>These generated files are committed to the master branch and published as part of the <code>@meshery/schemas</code> package.</p>
<hr>
<h4 id="phase-2-backend-sync">Phase 2: Backend Sync</h4>
<h5 id="step-4-wait-for-keyscsv-sync-in-meshery">Step 4: Wait for <code>keys.csv</code> Sync in Meshery</h5>
<p>The local database seeds are populated via <code>server/permissions/keys.csv</code> in the <code>meshery/meshery</code> repository. This file is automatically kept in sync with the spreadsheet by the <a href="https://github.com/meshery/meshery/blob/master/.github/workflows/generate_keys.yml"><code>Import Keys</code></a> workflow, which runs daily.</p>
<p>On startup, Meshery Server&rsquo;s <a href="https://github.com/meshery/meshery/blob/master/server/models/keys_helper.go"><code>SeedKeys</code></a> seeds these keys into the database.</p>
<hr>
<h4 id="phase-3-wire-key-in-the-ui">Phase 3: Wire Key in the UI</h4>
<h5 id="step-5-direct-import-from-schemas">Step 5: Direct Import from Schemas</h5>
<p>Because Meshery UI depends on <code>@meshery/schemas</code>, you gate new UI behavior by importing <code>Keys</code> directly from <code>@meshery/schemas/permissions</code>. There is no hand-maintained constant map to update: <code>ui/utils/permission_constants.ts</code> was removed once every call site had been migrated to the generated keys.</p>
<p>Simply import the <code>Keys</code> object directly from <code>@meshery/schemas/permissions</code> in your component:


<pre class="codeblock-pre">
	<div class="codeblock">
		<code class="clipboardjs">import { Keys } from &#39;@meshery/schemas/permissions&#39;;</code>
	</div>
</pre>
</p>
<h5 id="step-6-gate-the-component">Step 6: Gate the Component</h5>
<p>Prefer the <code>useHasPermission</code> hook from <a href="https://github.com/layer5io/sistent">Sist

... [9064 bytes truncated] ...

 <strong><code>Local Provider = TRUE</code></strong>. Restart Meshery Server (or reset the local DB) after the CSV updates.</p>
<h5 id="6-remote-provider-confirm-role-assignment">6. Remote Provider: confirm role assignment</h5>
<p>Keys come from roles assigned in the Remote Provider admin UI. An empty API response usually means a role/keychain issue—not a missing entry in the generated <code>Keys</code> alone.</p>
<h5 id="7-verify-browser-cookies-and-session-validity">7. Verify browser cookies and session validity</h5>
<p>Verify that the <code>token</code> cookie is set and not expired:</p>
<ul>
<li>Open DevTools <strong>Application</strong> -&gt; <strong>Storage</strong> -&gt; <strong>Cookies</strong> and select the Meshery site URL.</li>
<li>Confirm that the <code>token</code> cookie is present. If it is missing or has expired, you will be redirected to the login page or receive a <code>401 Unauthorized</code> response when fetching keys.</li>
<li>Check that the <code>meshery-provider</code> cookie matches the intended provider (e.g., <code>Local</code> or <code>Meshery</code>).</li>
</ul>
<h5 id="common-symptoms">Common symptoms</h5>
<table>
	<thead>
			<tr>
					<th>Symptom</th>
					<th>Likely cause</th>
			</tr>
	</thead>
	<tbody>
			<tr>
					<td>Button never appears</td>
					<td>User lacks the key; the key is missing from the generated <code>Keys</code>; or the gate is not wired</td>
			</tr>
			<tr>
					<td>New key not visible after merge</td>
					<td>Stale <code>sessionStorage.keys</code>; missing Local Provider seed row; or only schemas PR merged</td>
			</tr>
			<tr>
					<td>Works in one org, not another</td>
					<td>Keys are org-scoped—check <code>currentOrg</code> and refetch keys</td>
			</tr>
			<tr>
					<td>API returns <code>401</code> or <code>403</code> when fetching keys</td>
					<td>Expired or missing <code>token</code> cookie; verify browser cookie store</td>
			</tr>
	</tbody>
</table>
<hr>
<h2 id="authorization-framework">Authorization Framework</h2>
<p>Meshery utilizes CASL (JS-based permission framework) to evaluate any given user&rsquo;s set of session keys against the built-in keyhooks populated through each individual Meshery UI page. This allows for granular control over the UI, empowering you to tailor your Meshery experience to your organization&rsquo;s needs by limiting access to specific features and functionalities based on the user&rsquo;s assigned keys.</p>
<a href="./images/permission-in-UI.png">
  <img style="width:min(100%,800px)" src="./images/permission-in-UI.png" />
</a>
<h3 id="introduction-to-casljs">Introduction to CASL.js</h3>
<p><a href="https://casl.js.org">CASL.js</a> is an isomorphic authorization JavaScript library which restricts what resources a given client is allowed to access. It&rsquo;s designed to be incrementally adoptable and can easily scale between a simple claim based and fully featured subject and attribute based authorization. It makes it easy to manage and share permissions/keys across UI components, API services, and database queries.</p>
<p>Upon user login, the provider returns the list of authorized permission keys. Those keys are used to build and update the CASL ability rules on the frontend, and each key is registered as a rule of <code>{ action: key.id, subject: lowerCase(key.function) }</code>. Every gate in Meshery UI is a query against that one ability instance.</p>
<h3 id="gating-spellings">Gating spellings</h3>
<p>Three spellings exist, and they are equivalent - all three end up calling the same CASL <code>ability</code>. Each takes a key from <code>@meshery/schemas/permissions</code>, whose entries carry <code>id</code>, <code>function</code>, <code>category</code>, <code>subcategory</code> and <code>description</code>.</p>
<ol>
<li>
<p><strong><code>useHasPermission</code> hook</strong> - the usual spelling, and the one to reach for in new code. Pass the whole key object; the hook resolves <code>id</code> and <code>function</code> for you.


<pre class="codeblock-pre">
	<div class="codeblock">
		<code class="clipboardjs">import { useHasPermission } from &#39;@sistent/sistent&#39;;
import { Keys } from &#39;@meshery/schemas/permissions&#39;;

const canDelete = useHasPermission(Keys.LifecycleManagementDeleteAConnection);

return canDelete ? &lt;Button id=&#34;delete-connection&#34;&gt;Delete&lt;/Button&gt; : null;</code>
	</div>
</pre>
</p>
</li>
<li>
<p><strong><code>permissionKey</code> prop</strong> - Sistent controls gate themselves. By default the control renders disabled behind a shield icon whose tooltip names the missing key; pass <code>permissionAction=&quot;hide&quot;</code> to render nothing instead.


<pre class="codeblock-pre">
	<div class="codeblock">
		<code class="clipboardjs">import { Keys } from &#39;@meshery/schemas/permissions&#39;;

&lt;Button id=&#34;delete-connection&#34; permissionKey={Keys.LifecycleManagementDeleteAConnection}&gt;
  Delete
&lt;/Button&gt;</code>
	</div>
</pre>
</p>
</li>
<li>
<p><strong><code>CAN(...)</code> utility</strong> - the original spelling, still used where a hook cannot be called (outside a component, or inside a callback). It takes the two fields separately rather than the key object.


<pre class="codeblock-pre">
	<div class="codeblock">
		<code class="clipboardjs">import CAN from &#39;@/utils/can&#39;;
import { Keys } from &#39;@meshery/schemas/permissions&#39;;

const key = Keys.LifecycleManagementDeleteAConnection;
const canDelete = CAN(key.id, key.function);</code>
	</div>
</pre>
</p>
</li>
</ol>
<h3 id="access-gating-and-control-gating">Access gating and control gating</h3>
<p>CASL gates Meshery UI at two levels, and they are not the same thing:</p>
<ul>
<li><strong>Access gating</strong> replaces a page&rsquo;s whole content with the permission-denied page when your session lacks the key that page requires.</li>
<li><strong>Control gating</strong> renders the page, and hides or disables only the individual affordances within it - a button, a link, a menu item - that you lack the key for.</li>
</ul>
<p>Every content-bearing page in Meshery UI is access-gated. Where the page owns RTK Query hooks, pass <code>skip</code> on the same flag so a denied session issues no request at all.</p>
<div class="alert alert-dark" role="alert">
<h4 class="alert-heading">Note: the Meshery UI dashboard is a deliberate exception</h4>
<p>The <strong>Meshery UI dashboard</strong> (<code>/</code>) is control-gated only. It renders for an organization member holding no keys at all, with the links they cannot follow disabled in place, rather than replacing itself with the permission-denied page.</p>
<p>This is by design, not an oversight: <code>/</code> is where Meshery lands you after login, so access-gating it would strand a newly invited member on an error screen before anyone has assigned them a role. Every other content-bearing page - including the design configurator and the user preferences page - is access-gated.</p>
</div>
<p>Access gating is a presentation control, not an enforcement boundary. Meshery Server authenticates every request, and authorization is decided by the configured <a href="">Remote Provider</a> and enforced per handler on the server. An ungated page therefore never implies an ungated API.</p>
<h2 id="authorization-using-local-provider">Authorization using Local Provider</h2>
<p>Meshery&rsquo;s built-in identity provider, &ldquo;Local&rdquo; Provider, operates with a large set of predefined keys interspersed throughout Meshery UI and persisted in <a href="">Meshery Database</a>. These keys are used to evaluate the permissions of a given user and render the UI accordingly. Each persisted key carries an <code>id</code>, a <code>function</code> (the operation it permits), and a <code>category</code>/<code>subcategory</code> pair that places it in a domain - the same shape the Remote Provider returns, so the UI gates identically under either provider.</p>
<div class="alert alert-dark" role="alert">
  <h4 class="alert-heading">Discussion Forum</h4>
  <p>Don't find an answer to your question here? Ask on the <a href="https://discuss.meshery.io/">Discussion Forum</a>.</p>
</div>

</body></html>
```
</details>
<details>
<summary>Evidence: API requests issued per session: no registry fetch on the denied path</summary>

<code>===== DENY - organization member holding zero permission keys =====&#10;GET /api/user/prefs 200&#10;GET /api/identity/orgs? 200&#10;GET /api/identity/orgs/&lt;orgId&gt;/users/keys? 200&#10;&#10;Only the permission-denied page&#39;s own org switcher calls the API.&#10;No GET /api/registry/categories: DesignConfigurator never mounts, so&#10;useMeshModelComponents&#39; unconditional fetchCategories effect never runs.&#10;&#10;===== ALLOW - session holding Keys.CatalogManagementViewDesigns =====&#10;GET /api/registry/categories 200&#10;&#10;The configurator mounts and loads the model registry as before.</code>

```text
Design configurator access gate - requests issued by the page, per session.

The real page module (ui/pages/configuration/designs/configurator.tsx) mounted
with the same permission wiring pages/_app.tsx uses: the CASL `ability` singleton
from ui/utils/can.js, updated with {action: key.id, subject: lowerCase(key.function)},
exposed to Sistent via PermissionProvider's userHasPermission adapter.

===== DENY - organization member holding zero permission keys =====
GET /api/user/prefs                                            200
GET /api/identity/orgs?                                        200
GET /api/identity/orgs/<orgId>/users/keys?                     200

  Only the permission-denied page's own org switcher calls the API.
  No GET /api/registry/categories: DesignConfigurator never mounts, so
  useMeshModelComponents' unconditional fetchCategories effect never runs.

===== ALLOW - session holding Keys.CatalogManagementViewDesigns =====
GET /api/registry/categories                                   200

  The configurator mounts and loads the model registry as before.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ffa78f2f9104cefae168cfaf7bddff680873679e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `ui/__tests__/pages/configuration/designs/configurator.test.tsx:57` - The deny test asserts `default-error` exists anywhere in the tree, not that it renders inside the `MesheryPage` shell. `MesheryPage` is mocked as a pass-through div, so a regression to the exact mistake this change documents as load-bearing - an early `return &lt;DefaultError/&gt;` above `MesheryPage`, which drops `usePageTitle` and the `&lt;Head&gt;&lt;title&gt;` (AGENTS.md:238-242, ui/components/general/MesheryPage.tsx:25-27) - would leave all three tests green. One added assertion pins it: `expect(screen.getByTestId(&#39;meshery-page&#39;)).toContainElement(screen.getByTestId(&#39;default-error&#39;))`. Same for the allow branch at line 66.
- ℹ️ `ui/pages/configuration/designs/configurator.tsx:13` - The 48-line rationale comment hard-codes eight line numbers across six other files (MesheryPatternsToolbar.tsx:61, MesheryPatterns.tsx:365 and :72, MesheryPatterns.columns.tsx:50 and :72, MesheryPatternCard.tsx:103 and :441, MainDesignsContent.tsx:176). All eight resolve correctly today - I checked each - but line numbers drift on the next edit to any of those files and there is nothing that fails when they do. Symbol names alone (`handleOpenInConfigurator`, `editInConfigurator`) would carry the same information durably. Noting only; the decision to name all four entry points is deliberate and correct.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm ci --ignore-scripts` in `ui/` (node_modules was absent; also installs the pinned @sistent/sistent 0.22.4)</code>
- <code>`npx vitest run __tests__/pages/configuration/designs/configurator.test.tsx` - 3/3 pass</code>
- <code>Regression check: restored the base `ui/pages/configuration/designs/configurator.tsx`, re-ran the suite (2 of 3 fail: deny assertion + useHasPermission key assertion), then restored the fixed page</code>
- <code>`npx vitest run __tests__/pages/configuration/designs/configurator.test.tsx __tests__/architecture/sistent-imports-resolve.test.ts components/general/error-404/index.test.tsx` - 10/10 pass</code>
- <code>Manual browser verification: mounted the real `pages/configuration/designs/configurator.tsx` in a throwaway Vite harness wired like `pages/_app.tsx` (CASL `ability` from `utils/can.js` + Sistent `PermissionProvider`), driven with `chrome-devtools-axi`; captured the deny surface (zero keys) and the allow surface (Keys.CatalogManagementViewDesigns)</code>
- <code>`chrome-devtools-axi network` on both scenarios - deny issues no `GET /api/registry/categories`; allow does</code>
- <code>Hugo render of `docs/content/en/reference/extensibility/authorization/index.md` in a throwaway site using the repo&#39;s own `code`/`discuss` shortcodes: 0 raw shortcode delimiters, Gating spellings is one `&lt;ol&gt;` with 3 `&lt;li&gt;`, `id=&#34;gating-spellings&#34;` present with 2 in-page links, stale preferences sentence absent</code>
- <code>Runtime doc fact-check against installed `@meshery/schemas`: `Keys.CatalogManagementEvaluateRelationships.id` matches the UUID printed in the docs and `_.lowerCase(key.function) === &#39;evaluate relationships&#39;`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `AGENTS.md` - AGENTS.md and the two changed docs/ markdown files fail `prettier --check`, both before and after this change. Prettier&#39;s markdown glob is rooted at `ui/`, `make ui-lint` runs eslint only, and no CI workflow lints markdown outside `ui/`, so this is unenforced pre-existing formatting. Left unfixed deliberately: reformatting would produce a large diff unrelated to this change.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added permission-based access control for the Design Configurator.
  - Authorized users can open the configurator; unauthorized users see a permission-denied page instead.

- **Documentation**
  - Expanded authorization guidance, including permission checks, access gating, generated permission keys, and provider behavior.
  - Documented Design Configurator access requirements.

- **Tests**
  - Added coverage for both permitted and denied access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->