### PR TITLE
[UI] Gate the design configurator on the View Designs permission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,16 @@ make helm-docs      # Generate Helm chart docs
 - Use `@sistent/sistent` design system; fall back to MUI.
 - Redux Toolkit for global state; GraphQL via Relay; REST via Axios.
 - Playwright for E2E tests.
+- **Every content-bearing page needs an *access* gate, not just gated controls.**
+  `const canX = useHasPermission(Keys.X)` from `@sistent/sistent` plus an early
+  `return <DefaultError permissionKey={Keys.X} />`; pass `skip: !canX` to the page's
+  RTK Query hooks so a denied session issues no request. Gating only the buttons
+  leaves the page readable by a member holding zero keys. The Meshery UI dashboard
+  (`/`) is the **single deliberate exception** - it is the post-login landing page, so
+  denying it would strand a newly invited member on an error screen. Pin the **deny**
+  path in a test; an allow-only test passes against an ungated page too. Spellings,
+  the CASL wiring and the exception:
+  [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md).
 
 ### Commits
 
@@ -453,6 +463,7 @@ worked detail behind them — open the one that matches what you are working on.
 | A Go lint rule firing, or adding one | [Go Lint Rules](./docs/content/en/project/contributing/contributing-lint.md) |
 | Releases, CI secrets, the QA dashboard | [Build & Release (CI)](./docs/content/en/project/contributing/build-and-release.md) |
 | Connections and credential secrets | [Connections](./docs/content/en/project/contributing/models/connections.md) |
+| A permission-gated page, control or key | [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md) |
 | UI extensions, Remote Components | [Contributing to Meshery UI](./docs/content/en/project/contributing/ui/ui.md) |
 | `mesheryctl`, golden files | [Contributing to Meshery CLI](./docs/content/en/project/contributing/cli/cli.md) |
 | A docs page, its assets or shortcodes | [Contributing to Meshery Docs](./docs/content/en/project/contributing/contributing-docs/docs.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,14 +228,26 @@ make helm-docs      # Generate Helm chart docs
 - Redux Toolkit for global state; GraphQL via Relay; REST via Axios.
 - Playwright for E2E tests.
 - **Every content-bearing page needs an *access* gate, not just gated controls.**
-  `const canX = useHasPermission(Keys.X)` from `@sistent/sistent` plus an early
-  `return <DefaultError permissionKey={Keys.X} />`; pass `skip: !canX` to the page's
-  RTK Query hooks so a denied session issues no request. Gating only the buttons
-  leaves the page readable by a member holding zero keys. The Meshery UI dashboard
-  (`/`) is the **single deliberate exception** - it is the post-login landing page, so
-  denying it would strand a newly invited member on an error screen. Pin the **deny**
-  path in a test; an allow-only test passes against an ungated page too. Spellings,
-  the CASL wiring and the exception:
+  Read `canX` with `useHasPermission(Keys.X)` from `@sistent/sistent`, render
+  `<DefaultError permissionKey={Keys.X} />` when it is false, and pass `skip: !canX`
+  to the page's RTK Query hooks so a denied session issues no request. Gating only
+  the buttons leaves the page readable by a member holding zero keys. **Where the
+  `DefaultError` goes depends on which layer you are in:**
+  - In the page body **component** (`components/workspaces/index.tsx`,
+    `components/user-preferences/index.tsx`) an early `return <DefaultError …/>` is
+    correct - the page file already wraps it in `MesheryPage`, so the shell survives.
+  - In a **page** under `ui/pages/` (`configuration/designs/configurator.tsx`,
+    `configuration/catalog.tsx`) render it as the alternate branch *inside*
+    `MesheryPage`, never as an early return: returning early skips the shell and
+    loses both the browser tab title and the Redux page title `usePageTitle` sets.
+
+  Also keep tests out of `ui/pages/` - `next.config.js` sets no `pageExtensions`, so
+  anything `.tsx` there becomes a route and breaks `next build`; put them under
+  `ui/__tests__/`. The Meshery UI dashboard (`/`) is the **single deliberate
+  exception** to gating - it is the post-login landing page, so denying it would
+  strand a newly invited member on an error screen. Pin the **deny** path in a test;
+  an allow-only test passes against an ungated page too. Spellings, the CASL wiring
+  and the exception:
   [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md).
 
 ### Commits

--- a/docs/content/en/guides/configuration-management/creating-a-meshery-design.md
+++ b/docs/content/en/guides/configuration-management/creating-a-meshery-design.md
@@ -26,6 +26,8 @@ The Design Configurator is a built-in tool in Meshery UI. It lets you browse inf
 2. Click **+ New Design** (or open an existing design to edit it).  
    The Design Configurator opens with an empty canvas and a component panel on the left.
 
+Opening the configurator requires the **View Designs** permission, the same key the **Designs** page itself requires. Without it, the configurator shows the permission-denied page rather than the canvas. See [Extensibility: Authorization]({{< ref "reference/extensibility/authorization/index.md" >}}).
+
 ### Step 2 — Name Your Design
 
 Give your design a meaningful name in the **Design Name** field at the top of the configurator. This name is used when saving, sharing, or deploying the design.

--- a/docs/content/en/reference/extensibility/authorization/index.md
+++ b/docs/content/en/reference/extensibility/authorization/index.md
@@ -81,24 +81,30 @@ On startup, Meshery Server's [`SeedKeys`](https://github.com/meshery/meshery/blo
 #### Phase 3: Wire Key in the UI
 
 ##### Step 5: Direct Import from Schemas
-Because Meshery UI depends on `@meshery/schemas`, you can gate new UI behavior by importing `Keys` directly from `@meshery/schemas/permissions` instead of adding a manual entry to `ui/utils/permission_constants.ts`. Many existing components still use `permission_constants.ts`, so only those legacy call sites require updates until they are migrated.
+Because Meshery UI depends on `@meshery/schemas`, you gate new UI behavior by importing `Keys` directly from `@meshery/schemas/permissions`. There is no hand-maintained constant map to update: `ui/utils/permission_constants.ts` was removed once every call site had been migrated to the generated keys.
 
 Simply import the `Keys` object directly from `@meshery/schemas/permissions` in your component:
 {{< code code=`import { Keys } from '@meshery/schemas/permissions';` >}}
 
-##### Step 6: Gate the Component using `CAN`
-Pass the schema key's `id` (action) and `function` (subject) to the `CAN` utility to check permissions:
-{{< code code=`import CAN from '@/utils/can';
+##### Step 6: Gate the Component
+Prefer the `useHasPermission` hook from [Sistent](https://github.com/layer5io/sistent), which takes the whole key object:
+{{< code code=`import { useHasPermission } from '@sistent/sistent';
 import { Keys } from '@meshery/schemas/permissions';
 
-const key = Keys.CatalogManagementEvaluateRelationships;
-const canEvaluate = CAN(key.id, key.function);
+const canEvaluate = useHasPermission(Keys.CatalogManagementEvaluateRelationships);
 
 return (
   <Button disabled={!canEvaluate} onClick={handleEvaluate}>
     Evaluate Relationships
   </Button>
 );` >}}
+
+Sistent controls also accept the key directly as a `permissionKey` prop, which is the shortest form when the only effect is to disable the control:
+{{< code code=`<Button permissionKey={Keys.CatalogManagementEvaluateRelationships} onClick={handleEvaluate}>
+  Evaluate Relationships
+</Button>` >}}
+
+See [Gating spellings](#gating-spellings) for when to reach for the older `CAN(...)` utility instead.
 
 ##### Step 7: Verify End-to-End
 1. Run `make ui-lint` to verify that there are no formatting or typescript errors.
@@ -129,12 +135,14 @@ This example shows how the **Evaluate Relationships** key is wired across each l
   }
 }` >}}
 
-3. **React Component Gating**:
-{{< code code=`import CAN from '@/utils/can';
+3. **CASL rule built on login** - `id` becomes the rule's action, `function` its subject:
+{{< code code=`{ action: "c7752be7-5c0f-465d-a8ba-5594acd08b93", subject: "evaluate relationships" }` >}}
+
+4. **React Component Gating** (see [Gating spellings](#gating-spellings) for the other two forms):
+{{< code code=`import { useHasPermission } from '@sistent/sistent';
 import { Keys } from '@meshery/schemas/permissions';
 
-const key = Keys.CatalogManagementEvaluateRelationships;
-const canEvaluate = CAN(key.id, key.function);
+const canEvaluate = useHasPermission(Keys.CatalogManagementEvaluateRelationships);
 return canEvaluate ? <EvaluateRelationshipsButton /> : null;` >}}
 
 ---
@@ -153,7 +161,7 @@ When testing permission keys locally, the main client-side caches are stored und
 | **Redux store** | `state.ui.keys` | Same array as `sessionStorage.keys`. |
 | **RTK Query cache** | `getUserKeys` | Cached response for `/api/identity/orgs/{orgId}/users/keys`. |
 
-On login, Meshery either reuses `sessionStorage.keys` or refetches from the provider, then updates CASL. The static map in [`permission_constants.ts`](https://github.com/meshery/meshery/blob/master/ui/utils/permission_constants.ts) is source code—not browser storage—but `CAN(...)` compares those constants against the CASL rules built from the stored provider keys.
+On login, Meshery either reuses `sessionStorage.keys` or refetches from the provider, then updates CASL. The [`Keys`](https://github.com/meshery/schemas/blob/master/typescript/permissions.ts) object is generated source code—not browser storage—but every gating spelling compares those constants against the CASL rules built from the stored provider keys.
 
 Inspect keys in DevTools (**Application → Session Storage**):
 {{< code code=`JSON.parse(sessionStorage.getItem('keys'))
@@ -170,17 +178,19 @@ Use this checklist when a gated button does not appear, permissions look stale a
 ##### 1. Confirm the provider returned the key
 In DevTools **Network**, check the response for:
 `GET /api/identity/orgs/{orgId}/users/keys`
-Verify your UUID is in the `keys` array. If you're gating via `permission_constants.ts`, `_.lowerCase(function)` from the API should match `_.lowerCase(subject)` passed to `CAN(...)`.
+Verify your UUID is in the `keys` array. The API's `function` is what CASL stores as the rule subject (lower-cased), so it must match the `function` on the `Keys` entry you are gating with.
 
 ##### 2. Clear stale browser cache
 Meshery reuses `sessionStorage.keys` until the org changes or keys are refetched:
 {{< code code=`sessionStorage.removeItem('keys');
 location.reload();` >}}
 
-##### 3. Verify the UI constant map
-In [`permission_constants.ts`](https://github.com/meshery/meshery/blob/master/ui/utils/permission_constants.ts):
-*   `action` = key UUID (`id` from the API)
-*   `subject` = key `function` from the API (capitalization/camelCase differences are normalized by `_.lowerCase` in `CAN`)
+##### 3. Verify the generated key
+In [`Keys`](https://github.com/meshery/schemas/blob/master/typescript/permissions.ts), published by `@meshery/schemas`:
+*   `id` = the key UUID, matched against the CASL rule's action
+*   `function` = the human-readable operation name, matched against the CASL rule's subject (capitalization differences are normalized by `_.lowerCase`)
+
+If the key is missing from `Keys` altogether, it has not made it through the spreadsheet → schemas generation described above; re-run Phase 1 rather than declaring it locally.
 
 ##### 4. Confirm CASL loaded the rules
 *   **Redux DevTools**: check `state.ui.keys` for the expected UUID.
@@ -191,7 +201,7 @@ In [`permission_constants.ts`](https://github.com/meshery/meshery/blob/master/ui
 The key must be in [`server/permissions/keys.csv`](https://github.com/meshery/meshery/blob/master/server/permissions/keys.csv) with **`Local Provider = TRUE`**. Restart Meshery Server (or reset the local DB) after the CSV updates.
 
 ##### 6. Remote Provider: confirm role assignment
-Keys come from roles assigned in the Remote Provider admin UI. An empty API response usually means a role/keychain issue—not a missing `permission_constants.ts` entry alone.
+Keys come from roles assigned in the Remote Provider admin UI. An empty API response usually means a role/keychain issue—not a missing entry in the generated `Keys` alone.
 
 ##### 7. Verify browser cookies and session validity
 Verify that the `token` cookie is set and not expired:
@@ -203,7 +213,7 @@ Verify that the `token` cookie is set and not expired:
 
 | Symptom | Likely cause |
 |---------|----------------|
-| Button never appears | User lacks the key; if gating via `permission_constants.ts`, missing entry; or `CAN(...)` not wired |
+| Button never appears | User lacks the key; the key is missing from the generated `Keys`; or the gate is not wired |
 | New key not visible after merge | Stale `sessionStorage.keys`; missing Local Provider seed row; or only schemas PR merged |
 | Works in one org, not another | Keys are org-scoped—check `currentOrg` and refetch keys |
 | API returns `401` or `403` when fetching keys | Expired or missing `token` cookie; verify browser cookie store |
@@ -222,21 +232,53 @@ Meshery utilizes CASL (JS-based permission framework) to evaluate any given user
 
 [CASL.js](https://casl.js.org) is an isomorphic authorization JavaScript library which restricts what resources a given client is allowed to access. It's designed to be incrementally adoptable and can easily scale between a simple claim based and fully featured subject and attribute based authorization. It makes it easy to manage and share permissions/keys across UI components, API services, and database queries.
 
-An example of how CASL evaluates permissions in the UI:
-{{< code code=`<React.Fragment>
-	{CAN(keys.DELETE_CONNECTION.action, keys.DELETE_CONNECTION.subject) && (
-		<Button id="delete-connection">Delete</Button>
-	)}
-</React.Fragment>` >}}
+Upon user login, the provider returns the list of authorized permission keys. Those keys are used to build and update the CASL ability rules on the frontend, and each key is registered as a rule of `{ action: key.id, subject: lowerCase(key.function) }`. Every gate in Meshery UI is a query against that one ability instance.
 
-Upon user login, the backend returns the list of authorized permissions. These permissions are then used to build and update the CASL ability rules on the frontend. The UI maintains a constant file containing all allowed permissions (referred to as keys). With the help of these keys, the `CAN` function evaluates permissions at runtime and renders the UI accordingly.
+### Gating spellings
 
-{{% alert color="dark" title="Note" %}}
-It's important to understand not all pages uses CASL authorization, means even if you are not assigned with any role within organization you might access preferences page and Meshery UI dashboard.
+Three spellings exist, and they are equivalent - all three end up calling the same CASL `ability`. Each takes a key from `@meshery/schemas/permissions`, whose entries carry `id`, `function`, `category`, `subcategory` and `description`.
+
+1.  **`useHasPermission` hook** - the usual spelling, and the one to reach for in new code. Pass the whole key object; the hook resolves `id` and `function` for you.
+{{< code code=`import { useHasPermission } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
+
+const canDelete = useHasPermission(Keys.LifecycleManagementDeleteAConnection);
+
+return canDelete ? <Button id="delete-connection">Delete</Button> : null;` >}}
+
+2.  **`permissionKey` prop** - Sistent controls gate themselves. By default the control renders disabled behind a shield icon whose tooltip names the missing key; pass `permissionAction="hide"` to render nothing instead.
+{{< code code=`import { Keys } from '@meshery/schemas/permissions';
+
+<Button id="delete-connection" permissionKey={Keys.LifecycleManagementDeleteAConnection}>
+  Delete
+</Button>` >}}
+
+3.  **`CAN(...)` utility** - the original spelling, still used where a hook cannot be called (outside a component, or inside a callback). It takes the two fields separately rather than the key object.
+{{< code code=`import CAN from '@/utils/can';
+import { Keys } from '@meshery/schemas/permissions';
+
+const key = Keys.LifecycleManagementDeleteAConnection;
+const canDelete = CAN(key.id, key.function);` >}}
+
+### Access gating and control gating
+
+CASL gates Meshery UI at two levels, and they are not the same thing:
+
+*   **Access gating** replaces a page's whole content with the permission-denied page when your session lacks the key that page requires.
+*   **Control gating** renders the page, and hides or disables only the individual affordances within it - a button, a link, a menu item - that you lack the key for.
+
+Every content-bearing page in Meshery UI is access-gated. Where the page owns RTK Query hooks, pass `skip` on the same flag so a denied session issues no request at all.
+
+{{% alert color="dark" title="Note: the Meshery UI dashboard is a deliberate exception" %}}
+The **Meshery UI dashboard** (`/`) is control-gated only. It renders for an organization member holding no keys at all, with the links they cannot follow disabled in place, rather than replacing itself with the permission-denied page.
+
+This is by design, not an oversight: `/` is where Meshery lands you after login, so access-gating it would strand a newly invited member on an error screen before anyone has assigned them a role. Every other content-bearing page - including the design configurator and the user preferences page - is access-gated.
 {{% /alert %}}
+
+Access gating is a presentation control, not an enforcement boundary. Meshery Server authenticates every request, and authorization is decided by the configured [Remote Provider]({{< ref "reference/extensibility/providers/index.md" >}}) and enforced per handler on the server. An ungated page therefore never implies an ungated API.
 
 ## Authorization using Local Provider
 
-Meshery's built-in identity provider, "Local" Provider, operates with a large set of predefined keys interspersed throughout Meshery UI and persisted in [Meshery Database]({{< ref "concepts/architecture/database/index.md" >}}). These keys are used to evaluate the permissions of a given user and render the UI accordingly. The keys are grouped into three categories: `action`, `subject`, and `object`.
+Meshery's built-in identity provider, "Local" Provider, operates with a large set of predefined keys interspersed throughout Meshery UI and persisted in [Meshery Database]({{< ref "concepts/architecture/database/index.md" >}}). These keys are used to evaluate the permissions of a given user and render the UI accordingly. Each persisted key carries an `id`, a `function` (the operation it permits), and a `category`/`subcategory` pair that places it in a domain - the same shape the Remote Provider returns, so the UI gates identically under either provider.
 
 {{< discuss >}}

--- a/docs/content/en/reference/extensibility/authorization/index.md
+++ b/docs/content/en/reference/extensibility/authorization/index.md
@@ -129,9 +129,10 @@ This example shows how the **Evaluate Relationships** key is wired across each l
 {{< code code=`export const Keys = {
   CatalogManagementEvaluateRelationships: {
     id: "c7752be7-5c0f-465d-a8ba-5594acd08b93",
-    function: "Evaluate Relationships",
     category: "Catalog Management",
-    subcategory: "Designs"
+    subcategory: "Designs",
+    function: "Evaluate Relationships",
+    description: "Evaluate relationships inside a design"
   }
 }` >}}
 

--- a/docs/content/en/reference/extensibility/authorization/index.md
+++ b/docs/content/en/reference/extensibility/authorization/index.md
@@ -81,7 +81,7 @@ On startup, Meshery Server's [`SeedKeys`](https://github.com/meshery/meshery/blo
 #### Phase 3: Wire Key in the UI
 
 ##### Step 5: Direct Import from Schemas
-Because Meshery UI depends on `@meshery/schemas`, you gate new UI behavior by importing `Keys` directly from `@meshery/schemas/permissions`. There is no hand-maintained constant map to update: `ui/utils/permission_constants.ts` was removed once every call site had been migrated to the generated keys.
+Because Meshery UI depends on `@meshery/schemas`, you can gate new UI behavior by importing `Keys` directly from `@meshery/schemas/permissions`. There is no hand-maintained constant map to update: `ui/utils/permission_constants.ts` was removed once every call site had been migrated to the generated keys.
 
 Simply import the `Keys` object directly from `@meshery/schemas/permissions` in your component:
 {{< code code=`import { Keys } from '@meshery/schemas/permissions';` >}}
@@ -268,7 +268,7 @@ CASL gates Meshery UI at two levels, and they are not the same thing:
 *   **Access gating** replaces a page's whole content with the permission-denied page when your session lacks the key that page requires.
 *   **Control gating** renders the page, and hides or disables only the individual affordances within it - a button, a link, a menu item - that you lack the key for.
 
-Every content-bearing page in Meshery UI is access-gated. Where the page owns RTK Query hooks, pass `skip` on the same flag so a denied session issues no request at all.
+Every content-bearing page in Meshery UI except the landing page (`/`) is access-gated; that one exception is described below. Where the page owns RTK Query hooks, pass `skip` on the same flag so a denied session issues no request at all.
 
 {{% alert color="dark" title="Note: the Meshery UI dashboard is a deliberate exception" %}}
 The **Meshery UI dashboard** (`/`) is control-gated only. It renders for an organization member holding no keys at all, with the links they cannot follow disabled in place, rather than replacing itself with the permission-denied page.

--- a/ui/__tests__/pages/configuration/designs/configurator.test.tsx
+++ b/ui/__tests__/pages/configuration/designs/configurator.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/components/general/error-404', () => ({
   ),
 }));
 
-import DesignConfiguratorPage from './configurator';
+import DesignConfiguratorPage from '../../../../pages/configuration/designs/configurator';
 
 describe('DesignConfiguratorPage access gate', () => {
   beforeEach(() => {

--- a/ui/pages/configuration/designs/configurator.test.tsx
+++ b/ui/pages/configuration/designs/configurator.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Keys } from '@meshery/schemas/permissions';
+
+/**
+ * Access-gate coverage for the design configurator route.
+ *
+ * The configurator gated its individual save/update/delete controls but
+ * rendered the model browser and the design JSON in full for any authenticated
+ * session, including an organization member holding zero permission keys - the
+ * one page missed by 69db7bd7de64 ("Enforce permission guards on unguarded
+ * pages"). See meshery/meshery#21492.
+ *
+ * The deny path is what these tests exist to pin: an allow-only test would have
+ * passed against the ungated page too. The allow path is asserted alongside it
+ * so a regression to a blanket deny is caught as well.
+ *
+ * `DesignConfigurator` owns cytoscape, xstate and a live meshmodel fetch, so it
+ * is stubbed here (as its own suite records, it is not unit-renderable); this
+ * suite is scoped to the branch the page itself owns.
+ */
+
+const { useHasPermission } = vi.hoisted(() => ({ useHasPermission: vi.fn() }));
+
+vi.mock('@sistent/sistent', () => ({ useHasPermission }));
+
+vi.mock('@/components/general/MesheryPage', () => ({
+  MesheryPage: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="meshery-page">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/designs/configurator/MeshModel', () => ({
+  default: () => <div data-testid="design-configurator" />,
+}));
+
+vi.mock('@/components/general/error-404', () => ({
+  default: ({ permissionKey }: { permissionKey: { id: string } }) => (
+    <div data-testid="default-error">{permissionKey?.id}</div>
+  ),
+}));
+
+import DesignConfiguratorPage from './configurator';
+
+describe('DesignConfiguratorPage access gate', () => {
+  beforeEach(() => {
+    useHasPermission.mockReset();
+  });
+
+  it('replaces the configurator with the permission-denied page when the key is absent', () => {
+    useHasPermission.mockReturnValue(false);
+
+    render(<DesignConfiguratorPage />);
+
+    expect(screen.queryByTestId('design-configurator')).not.toBeInTheDocument();
+    expect(screen.getByTestId('default-error')).toHaveTextContent(
+      Keys.CatalogManagementViewDesigns.id,
+    );
+  });
+
+  it('renders the configurator when the key is held', () => {
+    useHasPermission.mockReturnValue(true);
+
+    render(<DesignConfiguratorPage />);
+
+    expect(screen.getByTestId('design-configurator')).toBeInTheDocument();
+    expect(screen.queryByTestId('default-error')).not.toBeInTheDocument();
+  });
+
+  it('gates on View Designs - the same key as the designs list and navigator entry', () => {
+    useHasPermission.mockReturnValue(true);
+
+    render(<DesignConfiguratorPage />);
+
+    expect(useHasPermission).toHaveBeenCalledWith(Keys.CatalogManagementViewDesigns);
+  });
+});

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -8,58 +8,21 @@ import { MesheryPage } from '@/components/general/MesheryPage';
 /**
  * Access gate for the design configurator.
  *
- * Four call sites navigate here:
+ * Gated on `CatalogManagementViewDesigns` - the same key that gates the designs
+ * list and the Designs navigator entry. The configurator reads and writes full
+ * design JSON, so a read-only browsing key is deliberately not accepted here;
+ * that would grant more than the designs list itself does.
  *
- * 1. `components/designs/patterns/MesheryPatternsToolbar.tsx:61` - the create
- *    new design toolbar button. This is the only one exclusive to the designs
- *    page.
- * 2. `components/designs/patterns/MesheryPatterns.tsx:365` -
- *    `handleOpenInConfigurator`, behind the table view's "Edit" row actions
- *    (`MesheryPatterns.columns.tsx:50` and `:72`). It is NOT exclusive to the
- *    designs page: `buildPatternColumns` is never passed `arePatternsReadOnly`
- *    and the toolbar's `ViewSwitch` renders whenever no design detail is open,
- *    so the same action is reachable in table view on `/configuration/catalog`.
- *    Both row actions key on `CatalogManagementEditDesign`, not ViewDesigns.
- * 3. `components/designs/patterns/MesheryPatternCard.tsx:103` - "Edit In
- *    Configurator" on the design card, the grid-view counterpart of the above
- *    and likewise reachable from `/configuration/catalog`, which gates on
- *    `CatalogManagementViewCatalog` rather than ViewDesigns.
- *    `arePatternsReadOnly` does not suppress that button: the `isReadOnly`
- *    guard at `MesheryPatternCard.tsx:441` covers a different block, so the
- *    button renders whenever `userCanEdit` (holds `CatalogManagementEditDesign`,
- *    or owns the design).
- * 4. `components/workspaces/SpacesSwitcher/MainDesignsContent.tsx:176` - the
- *    workspace design open, which falls back to the configurator when the
- *    Kanvas designer is unavailable.
- *
- * So three of the four can originate from a page that is not gated on
- * ViewDesigns - the catalog card button, the catalog table row action, and the
- * workspace Kanvas fallback.
- *
- * `CatalogManagementViewDesigns` is nonetheless the correct single key. It is
- * what already gates the designs list (`MesheryPatterns.tsx:72`) and the
- * Designs navigator entry
- * (`components/layout/Navigator/navigatorComponents.tsx:159`), and no built-in
- * keychain in `server/permissions/keys.csv` holds `Edit Design`, `View Catalog`
- * or `View Workspace` without also holding `View Designs` - verified per role
- * column across User, Team Admin, Academy Admin, Leaner, Workspace Admin, Org
- * Billing Manager, Org Admin and Provider Admin. No default role can reach a
- * deny page from those three; only a custom keychain can.
- *
- * Where a custom keychain does make that dead end reachable, the fix belongs at
- * the entry points - a control that leads to a permission-denied page should
- * not render - and not in widening this gate. Note that this means fixing both
- * spellings: `MesheryPatternCard.tsx` for grid view AND
- * `MesheryPatterns.columns.tsx` for table view, or the table path still dead
- * ends. The configurator reads and writes full design JSON, whereas
- * `CatalogManagementViewCatalog` grants only read-only published browsing, so
- * accepting it here would grant more than the designs list itself does. That
- * entry-point fix is deliberately out of scope here and raised as a separate
- * product question.
+ * Several controls outside the designs page also navigate here, some gated on
+ * other keys, so a session can reach this page and be denied. No built-in
+ * keychain can: where a custom one does, the fix belongs at the entry-point
+ * controls, not in widening this gate. The call-site analysis behind both
+ * decisions is in https://github.com/meshery/meshery/issues/21492, which is the
+ * place to update when those controls move.
  *
  * Gating here rather than inside `DesignConfigurator` keeps the component from
- * mounting at all, so the unconditional `useMeshModelComponents` category fetch
- * never fires for a user who may not read designs.
+ * mounting at all, so its unconditional model-category fetch never fires for a
+ * user who may not read designs.
  *
  * This is a presentation control. Authorization is decided by the configured
  * provider and enforced per handler on Meshery Server; the gate exists so the

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -1,11 +1,34 @@
 import React from 'react';
+import { useHasPermission } from '@sistent/sistent';
+import { Keys } from '@meshery/schemas/permissions';
 import DesignConfigurator from '@/components/designs/configurator/MeshModel';
+import DefaultError from '@/components/general/error-404';
 import { MesheryPage } from '@/components/general/MesheryPage';
 
+/**
+ * Access gate for the design configurator.
+ *
+ * `CatalogManagementViewDesigns` is the same key that gates the designs list
+ * (`components/designs/patterns/MesheryPatterns.tsx`) and the Designs navigator
+ * entry, which are the only ways into this route. Gating here rather than
+ * inside `DesignConfigurator` keeps the component from mounting at all, so the
+ * unconditional `useMeshModelComponents` category fetch never fires for a user
+ * who may not read designs.
+ *
+ * This is a presentation control. Authorization is decided by the configured
+ * provider and enforced per handler on Meshery Server; the gate exists so the
+ * UI is consistent about what an unpermitted session is shown.
+ */
 function DesignConfiguratorPage() {
+  const canViewDesigns = useHasPermission(Keys.CatalogManagementViewDesigns);
+
   return (
     <MesheryPage title="Configure Design" headTitle="Designs Configurator">
-      <DesignConfigurator />
+      {canViewDesigns ? (
+        <DesignConfigurator />
+      ) : (
+        <DefaultError permissionKey={Keys.CatalogManagementViewDesigns} />
+      )}
     </MesheryPage>
   );
 }

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -10,13 +10,20 @@ import { MesheryPage } from '@/components/general/MesheryPage';
  *
  * Four call sites navigate here:
  *
- * 1. `components/designs/patterns/MesheryPatterns.tsx:365` - the designs list
- *    row action.
- * 2. `components/designs/patterns/MesheryPatternsToolbar.tsx:61` - the create
- *    new design toolbar button.
+ * 1. `components/designs/patterns/MesheryPatternsToolbar.tsx:61` - the create
+ *    new design toolbar button. This is the only one exclusive to the designs
+ *    page.
+ * 2. `components/designs/patterns/MesheryPatterns.tsx:365` -
+ *    `handleOpenInConfigurator`, behind the table view's "Edit" row actions
+ *    (`MesheryPatterns.columns.tsx:50` and `:72`). It is NOT exclusive to the
+ *    designs page: `buildPatternColumns` is never passed `arePatternsReadOnly`
+ *    and the toolbar's `ViewSwitch` renders whenever no design detail is open,
+ *    so the same action is reachable in table view on `/configuration/catalog`.
+ *    Both row actions key on `CatalogManagementEditDesign`, not ViewDesigns.
  * 3. `components/designs/patterns/MesheryPatternCard.tsx:103` - "Edit In
- *    Configurator" on the design card, reachable from `/configuration/catalog`,
- *    which gates on `CatalogManagementViewCatalog` rather than ViewDesigns.
+ *    Configurator" on the design card, the grid-view counterpart of the above
+ *    and likewise reachable from `/configuration/catalog`, which gates on
+ *    `CatalogManagementViewCatalog` rather than ViewDesigns.
  *    `arePatternsReadOnly` does not suppress that button: the `isReadOnly`
  *    guard at `MesheryPatternCard.tsx:441` covers a different block, so the
  *    button renders whenever `userCanEdit` (holds `CatalogManagementEditDesign`,
@@ -25,23 +32,30 @@ import { MesheryPage } from '@/components/general/MesheryPage';
  *    workspace design open, which falls back to the configurator when the
  *    Kanvas designer is unavailable.
  *
- * `CatalogManagementViewDesigns` is the same key that gates the first two: the
- * designs list (`MesheryPatterns.tsx:72`) and the Designs navigator entry
- * (`components/layout/Navigator/navigatorComponents.tsx:159`). It remains the
- * single correct key despite the last two, because no built-in keychain in
- * `server/permissions/keys.csv` holds `Edit Design`, `View Catalog` or
- * `View Workspace` without also holding `View Designs` - verified per role
+ * So three of the four can originate from a page that is not gated on
+ * ViewDesigns - the catalog card button, the catalog table row action, and the
+ * workspace Kanvas fallback.
+ *
+ * `CatalogManagementViewDesigns` is nonetheless the correct single key. It is
+ * what already gates the designs list (`MesheryPatterns.tsx:72`) and the
+ * Designs navigator entry
+ * (`components/layout/Navigator/navigatorComponents.tsx:159`), and no built-in
+ * keychain in `server/permissions/keys.csv` holds `Edit Design`, `View Catalog`
+ * or `View Workspace` without also holding `View Designs` - verified per role
  * column across User, Team Admin, Academy Admin, Leaner, Workspace Admin, Org
  * Billing Manager, Org Admin and Provider Admin. No default role can reach a
- * deny page from those buttons; only a custom keychain can.
+ * deny page from those three; only a custom keychain can.
  *
  * Where a custom keychain does make that dead end reachable, the fix belongs at
- * the entry-point buttons - a button that leads to a permission-denied page
- * should not render - and not in widening this gate. The configurator reads and
- * writes full design JSON, whereas `CatalogManagementViewCatalog` grants only
- * read-only published browsing, so accepting it here would grant more than the
- * designs list itself does. That button-side fix is deliberately out of scope
- * here and raised as a separate product question.
+ * the entry points - a control that leads to a permission-denied page should
+ * not render - and not in widening this gate. Note that this means fixing both
+ * spellings: `MesheryPatternCard.tsx` for grid view AND
+ * `MesheryPatterns.columns.tsx` for table view, or the table path still dead
+ * ends. The configurator reads and writes full design JSON, whereas
+ * `CatalogManagementViewCatalog` grants only read-only published browsing, so
+ * accepting it here would grant more than the designs list itself does. That
+ * entry-point fix is deliberately out of scope here and raised as a separate
+ * product question.
  *
  * Gating here rather than inside `DesignConfigurator` keeps the component from
  * mounting at all, so the unconditional `useMeshModelComponents` category fetch

--- a/ui/pages/configuration/designs/configurator.tsx
+++ b/ui/pages/configuration/designs/configurator.tsx
@@ -8,12 +8,44 @@ import { MesheryPage } from '@/components/general/MesheryPage';
 /**
  * Access gate for the design configurator.
  *
- * `CatalogManagementViewDesigns` is the same key that gates the designs list
- * (`components/designs/patterns/MesheryPatterns.tsx`) and the Designs navigator
- * entry, which are the only ways into this route. Gating here rather than
- * inside `DesignConfigurator` keeps the component from mounting at all, so the
- * unconditional `useMeshModelComponents` category fetch never fires for a user
- * who may not read designs.
+ * Four call sites navigate here:
+ *
+ * 1. `components/designs/patterns/MesheryPatterns.tsx:365` - the designs list
+ *    row action.
+ * 2. `components/designs/patterns/MesheryPatternsToolbar.tsx:61` - the create
+ *    new design toolbar button.
+ * 3. `components/designs/patterns/MesheryPatternCard.tsx:103` - "Edit In
+ *    Configurator" on the design card, reachable from `/configuration/catalog`,
+ *    which gates on `CatalogManagementViewCatalog` rather than ViewDesigns.
+ *    `arePatternsReadOnly` does not suppress that button: the `isReadOnly`
+ *    guard at `MesheryPatternCard.tsx:441` covers a different block, so the
+ *    button renders whenever `userCanEdit` (holds `CatalogManagementEditDesign`,
+ *    or owns the design).
+ * 4. `components/workspaces/SpacesSwitcher/MainDesignsContent.tsx:176` - the
+ *    workspace design open, which falls back to the configurator when the
+ *    Kanvas designer is unavailable.
+ *
+ * `CatalogManagementViewDesigns` is the same key that gates the first two: the
+ * designs list (`MesheryPatterns.tsx:72`) and the Designs navigator entry
+ * (`components/layout/Navigator/navigatorComponents.tsx:159`). It remains the
+ * single correct key despite the last two, because no built-in keychain in
+ * `server/permissions/keys.csv` holds `Edit Design`, `View Catalog` or
+ * `View Workspace` without also holding `View Designs` - verified per role
+ * column across User, Team Admin, Academy Admin, Leaner, Workspace Admin, Org
+ * Billing Manager, Org Admin and Provider Admin. No default role can reach a
+ * deny page from those buttons; only a custom keychain can.
+ *
+ * Where a custom keychain does make that dead end reachable, the fix belongs at
+ * the entry-point buttons - a button that leads to a permission-denied page
+ * should not render - and not in widening this gate. The configurator reads and
+ * writes full design JSON, whereas `CatalogManagementViewCatalog` grants only
+ * read-only published browsing, so accepting it here would grant more than the
+ * designs list itself does. That button-side fix is deliberately out of scope
+ * here and raised as a separate product question.
+ *
+ * Gating here rather than inside `DesignConfigurator` keeps the component from
+ * mounting at all, so the unconditional `useMeshModelComponents` category fetch
+ * never fires for a user who may not read designs.
  *
  * This is a presentation control. Authorization is decided by the configured
  * provider and enforced per handler on Meshery Server; the gate exists so the


### PR DESCRIPTION
## Summary

`ui/pages/configuration/designs/configurator.tsx` rendered the model/component browser and the design JSON in full for any authenticated session, including an organization member holding **zero** permission keys. It gated its individual Save/Update/Delete controls but never gated access to the page itself.

That made it the one page missed by `69db7bd7de64` ("Enforce permission guards on unguarded pages", 2026-08-16), which gated the other 16.

Closes https://github.com/meshery/meshery/issues/21492.

## Scope, stated plainly

This is a **presentation control, not an enforcement boundary.** Meshery Server authenticates every request but does not itself evaluate permission keys - authorization is decided by the configured provider and enforced per handler on the server. This change is about UI consistency and documentation accuracy. **No server-side authorization was changed, and their absence here is intended, not an omission.** Please do not read this as closing a security hole.

## Part 1 - the gate

Gates on `Keys.CatalogManagementViewDesigns` - the same key that already gates the designs list (`MesheryPatterns.tsx:72`) and the Designs navigator entry (`navigatorComponents.tsx:159`).

The gate lives in the **page**, not in `DesignConfigurator`, so the component never mounts and `useMeshModelComponents`' unconditional `fetchCategories()` never fires for a denied session - the page-level equivalent of the `skip: !canX` the precedent commit applied to RTK queries. `DefaultError` renders *inside* `MesheryPage` rather than as an early return, so the browser tab title and the Redux page title survive.

A test pins the **deny** path (`ui/__tests__/pages/configuration/designs/configurator.test.tsx`). That is the point: an allow-only test would have passed against the ungated page too. Verified by restoring the pre-fix page and re-running - 2 of the 3 assertions fail, then pass again once restored.

## Parts 2 and 3 - the documentation

`docs/content/en/reference/extensibility/authorization/index.md` claimed:

> not all pages uses CASL authorization, means even if you are not assigned with any role within organization you might access preferences page and Meshery UI dashboard

Wrong in two directions: `preferences` was gated on 2026-08-16, and the configurator was ungated but unnamed. The replacement separates **access gating** (whole page replaced by the permission-denied page) from **control gating** (individual affordances disabled in place), and records the **Meshery UI dashboard (`/`) as a deliberate exception** - it is the post-login landing page, so access-gating it would strand a newly invited member on an error screen before anyone has assigned them a role.

The same block had drifted out of date more broadly, fixed in the same pass:

- The `CAN(keys.DELETE_CONNECTION.action, …)` example used a shape that has not existed since `ui/utils/permission_constants.ts` was removed on 2026-07-07 (`b6df4c9eeccd`). Replaced with the three real spellings - `useHasPermission`, the `permissionKey` prop, and `CAN` - noting they all query the same CASL ability.
- Seven `permission_constants.ts` references, three of them dead links to a deleted file.
- The Local Provider claim that keys are "grouped into three categories: `action`, `subject`, and `object`" - the persisted `Key` (schemas `models/v1beta2/key`, seeded from `server/permissions/keys.csv`) has no such fields.

`AGENTS.md` records the access-gate rule and the dashboard exception so the next page added does not repeat the gap.

## Known limitation, deliberately not fixed here

Four routes reach this page, and three can originate from a page **not** gated on `ViewDesigns`:

| Entry point | Gated on |
|---|---|
| `MesheryPatterns.tsx:365` - designs list row action | `CatalogManagementViewDesigns` (but also reachable from the catalog's table view) |
| `MesheryPatternsToolbar.tsx:61` - create new design | `CatalogManagementViewDesigns` |
| `MesheryPatternCard.tsx:103` - "Edit In Configurator", from `/configuration/catalog` | page: `ViewCatalog`; button: `EditDesign` |
| `MainDesignsContent.tsx:176` - workspace design open, falls back here when Kanvas is unavailable | `WorkspaceManagementViewWorkspace` |

Widening the gate to `canViewDesigns || canViewCatalog` (as `MesheryPatterns.tsx:74` does for the listing) was considered and **rejected**: the configurator reads *and writes* full design JSON, whereas `ViewCatalog` grants only read-only published browsing - the catalog mounts `MesheryPatterns` with `arePatternsReadOnly={true}`. Accepting it as sufficient to open a read/write design editor would grant more than the designs list itself does, on a change whose purpose is closing a gate.

**The correct fix for that dead end is at the entry-point buttons, not the gate: a button that leads to a permission-denied page should not render.** That is a product decision about button visibility, raised separately rather than folded in here.

It is not reachable by default. Every built-in keychain in `server/permissions/keys.csv` holding `Edit Design`, `View Catalog` or `View Workspace` also holds `View Designs` - checked per role column across User, Team Admin, Academy Admin, Leaner, Workspace Admin, Org Billing Manager, Org Admin and Provider Admin. Only a custom keychain can reach it.

## Why the branch carries a `-2` suffix, and why this supersedes #21493

There is no abandoned work and no stray remote branch. A first validation run's automated fix rounds committed under the wrong identity without a `Signed-off-by` trailer; correcting that is a history rewrite, and the local validation gate had pinned its branch ref to the failed run's commit, so no corrected state could fast-forward onto it. Using a new branch name was the only exit. The commits are unchanged by the rename.

This PR supersedes #21493, which carried these same commits from this same branch but was opened under the wrong account. Nothing was reviewed there; it is closed in favour of this one. Its thread holds the full validation-pipeline output if that history is useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based access control to the Design Configurator.
  * Users without the required View Designs permission now see a permission-denied page instead of the configurator.
* **Documentation**
  * Expanded authorization guidance for page access, controls, request handling, generated permission keys, and dashboard behavior.
  * Documented the permission requirement for opening the Design Configurator.
  * Added contributor guidance for implementing and testing gated pages.
* **Tests**
  * Added coverage for authorized and unauthorized configurator access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->