### PR TITLE
[UI] Move edit control above tabs on dashboard

### DIFF
--- a/ui/components/dashboard/components.test.tsx
+++ b/ui/components/dashboard/components.test.tsx
@@ -44,6 +44,18 @@ vi.mock('@sistent/sistent', () => ({
   ),
   DeleteIcon: (props: any) => <svg data-testid="delete-icon" data-fill={props.fill} />,
   DragIcon: (props: any) => <svg data-testid="drag-icon" data-fill={props.fill} />,
+  styled: (Component: any) => () => (props: any) => {
+    if (typeof Component === 'string') {
+      const Tag = Component as any;
+      return <Tag {...props} />;
+    }
+    return <Component {...props} />;
+  },
+  Paper: ({ children }: any) => <div>{children}</div>,
+  Tab: ({ children }: any) => <div>{children}</div>,
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  gray: {},
+  charcoal: {},
 }));
 
 vi.mock('css/icons.styles', () => ({

--- a/ui/components/dashboard/components.tsx
+++ b/ui/components/dashboard/components.tsx
@@ -9,13 +9,13 @@ import {
   Card,
   CardContent,
   CustomTooltip,
-  Button,
   DeleteIcon,
   DragIcon,
   type Theme,
 } from '@sistent/sistent';
 
 import { iconMedium } from 'css/icons.styles';
+import { ActionButton } from './style';
 
 type Widget = {
   key: string;
@@ -29,6 +29,12 @@ const layoutIconProps = (theme: Theme) => ({
   primaryFill: theme.palette.background.neutral.default,
   width: '30',
   height: '30',
+});
+
+const actionIconProps = (theme: Theme) => ({
+  fill: theme.palette.background.neutral.default,
+  primaryFill: theme.palette.background.neutral.default,
+  ...iconMedium,
 });
 
 type AddWidgetsToLayoutPanelProps = {
@@ -155,8 +161,8 @@ type LayoutActionButtonProps = {
   Icon: React.ComponentType<{
     fill?: string;
     primaryFill?: string;
-    width?: string;
-    height?: string;
+    width?: string | number;
+    height?: string | number;
   }>;
   label: React.ReactNode;
   action: () => void;
@@ -172,23 +178,18 @@ export const LayoutActionButton = ({
   isShown,
 }: LayoutActionButtonProps) => {
   const theme = useTheme();
-  const iconsProps = layoutIconProps(theme);
+  const iconsProps = actionIconProps(theme);
 
   if (!isShown) {
     return null;
   }
 
   return (
-    <Button
-      variant="text"
-      style={{ color: iconsProps.fill }}
-      onClick={action}
-      endIcon={<Icon {...iconsProps} />}
-    >
-      <CustomTooltip title={description} fontSize="1rem" variant="standard">
+    <ActionButton variant="text" onClick={action} endIcon={<Icon {...iconsProps} />}>
+      <CustomTooltip title={description} variant="standard">
         <div>{label}</div>
       </CustomTooltip>
-    </Button>
+    </ActionButton>
   );
 };
 

--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -23,7 +23,7 @@ import {
   useTheme,
   ErrorBoundary,
 } from '@sistent/sistent';
-import { WrapperPaper } from './style';
+import { DashboardActionsContainer, WrapperPaper } from './style';
 import _ from 'lodash';
 import { AddWidgetsToLayoutPanel, LayoutActionButton, LayoutWidget } from './components';
 import { Responsive } from 'react-grid-layout/legacy';
@@ -296,7 +296,7 @@ const Dashboard = () => {
     },
   };
 
-  const topBarActions = Object.entries(_.omit(LayoutActions, 'START_EDIT'))
+  const topBarActions = Object.entries(LayoutActions)
     .filter(([, action]) => action.isShown)
     .map(([key, layoutAction]) => ({ key, ...layoutAction }));
 
@@ -339,6 +339,23 @@ const Dashboard = () => {
   return (
     <>
       <>
+        {resourceCategory === 'Overview' && (
+          <DashboardActionsContainer>
+            <Stack
+              direction="row"
+              useFlexGap
+              spacing={{ xs: 1, sm: 2 }}
+              justifyContent="flex-end"
+              alignItems="center"
+              flexWrap="wrap-reverse"
+            >
+              {topBarActions.map(({ key, ...layoutAction }) => (
+                <LayoutActionButton {...layoutAction} key={key} />
+              ))}
+            </Stack>
+          </DashboardActionsContainer>
+        )}
+
         <WrapperPaper>
           <Tabs
             sx={{
@@ -386,18 +403,6 @@ const Dashboard = () => {
         <TabPanel value={resourceCategory} index={'Overview'}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <Box sx={{ padding: 0, width: '100%' }}>
-              <Stack
-                direction="row"
-                useFlexGap
-                gap="0rem 2rem"
-                justifyContent="end"
-                flexWrap={'wrap-reverse'}
-              >
-                {topBarActions.map(({ key, ...layoutAction }) => (
-                  <LayoutActionButton {...layoutAction} key={key} />
-                ))}
-              </Stack>
-
               <ResponsiveReactGridLayout
                 layouts={constrainedLayouts}
                 resizeHandles={availableHandles}
@@ -433,7 +438,6 @@ const Dashboard = () => {
                   );
                 })}
               </ResponsiveReactGridLayout>
-              <LayoutActionButton {...LayoutActions.START_EDIT} />
             </Box>
             <AddWidgetsToLayoutPanel
               editMode={isEditMode}

--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -347,7 +347,7 @@ const Dashboard = () => {
               spacing={{ xs: 1, sm: 2 }}
               justifyContent="flex-end"
               alignItems="center"
-              flexWrap="wrap-reverse"
+              flexWrap="wrap"
             >
               {topBarActions.map(({ key, ...layoutAction }) => (
                 <LayoutActionButton {...layoutAction} key={key} />

--- a/ui/components/dashboard/style.ts
+++ b/ui/components/dashboard/style.ts
@@ -1,4 +1,14 @@
-import { Typography, Paper, styled, Tab, Tabs, gray, charcoal, Card } from '@sistent/sistent';
+import {
+  Typography,
+  Paper,
+  styled,
+  Tab,
+  Tabs,
+  gray,
+  charcoal,
+  Card,
+  Button,
+} from '@sistent/sistent';
 
 export const DashboardSection = styled(Card)(({ theme }) => ({
   backgroundColor:
@@ -117,6 +127,33 @@ export const ErrorContainer = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
   marginTop: '1rem',
   borderRadius: 4,
+}));
+
+export const ActionButton = styled(Button)(({ theme }) => ({
+  color: theme.palette.background.neutral.default,
+  textTransform: 'none',
+  fontSize: theme.typography.body1.fontSize,
+  fontWeight: 500,
+  padding: theme.spacing(0.5, 1),
+  minWidth: 'auto',
+  gap: theme.spacing(0.75),
+  '&:hover': {
+    backgroundColor: 'transparent',
+    opacity: 0.8,
+  },
+}));
+
+export const DashboardActionsContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+  width: '100%',
+  marginTop: theme.spacing(-3),
+  marginBottom: theme.spacing(1.5),
+  [theme.breakpoints.down('sm')]: {
+    marginTop: theme.spacing(-1.5),
+    marginBottom: theme.spacing(1),
+  },
 }));
 
 export const WrapperPaper = styled(Paper)({


### PR DESCRIPTION
Fixes #21478

**Notes for Reviewers**

- Relocated the dashboard `Edit` control (and layout action toolbar) from the bottom of the Overview grid to the top-right above the resource tabs, matching the Layer5 Cloud dashboard layout.
- Created theme-aware styled components (`DashboardActionsContainer` and `ActionButton`) in `style.ts` leveraging Sistent tokens and responsive breakpoints.
- Replaced hardcoded icon dimensions with shared `iconMedium` tokens from `css/icons.styles`.
- Verified with ESLint (0 errors) and Vitest dashboard unit tests (73 suites, 267 tests passing).

### Visual Changes (Before vs After)

| Before | After |
| :---: | :---: |
| *<img width="1512" height="982" alt="Screenshot 2026-08-19 at 10 40 36 AM" src="https://github.com/user-attachments/assets/691de477-b563-4ad2-812b-3b69ac36aa39" />* | *<img width="1512" height="982" alt="Screenshot 2026-08-19 at 11 57 59 AM" src="https://github.com/user-attachments/assets/b87b0a4c-1af4-4bff-8c36-839c23d94116" />* |

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive action bar to the dashboard Overview tab.
  * Moved the Edit action into the top-bar action list for easier access.
  * Improved dashboard action button styling, spacing, hover states, and icon sizing.

* **Tests**
  * Updated component mocks to support dashboard action and layout component testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->