### PR TITLE
fix(ui): correct totalTables property case in DatabaseSummary

### DIFF
--- a/ui/components/DatabaseSummary.tsx
+++ b/ui/components/DatabaseSummary.tsx
@@ -101,7 +101,7 @@ const DatabaseSummary: FC<DatabaseSummaryProps> = (props) => {
     fixedHeader: true,
     serverSide: true,
     rowsPerPage: rowsPerPage,
-    count: databaseSummary?.total_tables,
+    count: databaseSummary?.totalTables,
     page: page,
     onChangePage: debounce((p) => setPage(p), 200),
     onChangeRowsPerPage: debounce((p) => setRowsPerPage(p), 200),


### PR DESCRIPTION
### Description

This PR fixes #21469 

Fixes the incorrect pagination metadata displayed in the Database Summary table.
The table was reading `databaseSummary.total_tables`, while the API response uses the camelCase `totalTables` property. As a result, `count` was passed to the server-side data table as `undefined`, causing the pagination component to fall back to the current `data.length`. 


### Changes
- Updated `DatabaseSummary` to use `databaseSummary.totalTables` for the pagination `count`.
- No changes were made to Sistent or the shared pagination component.

### Screen recording:
https://github.com/user-attachments/assets/bd7faeb0-fda8-498a-9d5d-f25007ab62ca

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the database summary table count so it displays accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->