### PR TITLE
[Docs] Make immutable-releases image responsive

### DIFF
--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -14,7 +14,7 @@ Meshery’s build and release system incorporates many tools, organized into dif
 Today, Meshery and Meshery adapters are released as Docker container images, available on Docker Hub. Meshery adapters are out-of-process adapters (meaning not compiled into the main Meshery binary), and as such, are independent build artifacts and Helm charts. The Docker images are created and tagged with the git commit SHA, then pushed to Docker Hub automatically using GitHub Actions. Subsequently, when contributions containing content for the Helm charts of Meshery and Meshery Adapter are linted and merged, they will be pushed and released to [meshery.io](https://github.com/meshery/meshery.io) Github page by GitHub Action automatically.
 
 All repositories under the `github.com/meshery` and `github.com/meshery-extensions` organizations use immutable releases.
-<img width="954" height="166" alt="immutable-releases-setting" src="https://github.com/user-attachments/assets/4435086f-db09-449e-a154-70979b8b01d1" />
+<img alt="immutable-releases-setting" src="https://github.com/user-attachments/assets/4435086f-db09-449e-a154-70979b8b01d1" style="max-width: 100%; height: auto;" />
 
 
 ### Artifact Repositories


### PR DESCRIPTION
### Notes for Reviewers

This PR fixes #21383

## Changes

Removed the hardcoded `width`/`height` attributes on the immutable-releases setting image in the Build & Release docs page. The fixed size caused the image to overflow the page layout on mobile. Using `max-width: 100%" and auto height lets it scale cleanly across all screen sizes.

**Before (mobile):** image overflows the container
**After (mobile):** image scales to fit the viewport

## Signed commits

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the immutable-releases image in the build and release guide so it scales responsively across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->