### PR TITLE
[Docs] Add left padding to code blocks on mesheryctl reference pages

### DIFF
--- a/docs/assets/scss/_clipboard.scss
+++ b/docs/assets/scss/_clipboard.scss
@@ -23,6 +23,9 @@ pre.codeblock-pre {
   color: #f8f9fa;
   margin: 0px;
   padding: 0px;
+  &:not(:has(.clipboardjs)) {
+    padding: 0.5rem 0.75rem;
+  }
 }
 .clipboardjs {
   width: 100%;


### PR DESCRIPTION
### Notes for Reviewers

This PR fixes #21496

## Changes

The auto-generated `mesheryctl` command reference pages place command text directly inside `.codeblock` without the `.clipboardjs` wrapper that supplies the standard `0.5rem / 0.75rem` padding. As a result, code sits flush against the left edge of the block, unlike the well-aligned code blocks on other docs pages.

Added the same padding to any `.codeblock` that does not contain a `.clipboardjs` element, so reference-page code lines up with the rest of the docs — without regenerating the generated pages (which would bake in local paths per the build env gotchas).

## Signed commits

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code block spacing so padding is applied appropriately when clipboard controls are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->