### PR TITLE
[UI] Show error page button labels on mobile

### DIFF
--- a/ui/components/general/style.tsx
+++ b/ui/components/general/style.tsx
@@ -42,9 +42,6 @@ export const EditButton = styled(Button)(({ theme }) => ({
 export const TextButton = styled('span')(({ style }) => ({
   marginLeft: '0.5rem',
   display: 'block',
-  '@media (max-width: 853px)': {
-    display: 'none',
-  },
   ...style,
 }));
 


### PR DESCRIPTION
### Notes for Reviewers

This PR fixes #21328

## Changes

The `TextButton` style used by the error-page `Get Help` and `Try Again` buttons hid its text label below `853px`, so on mobile the buttons collapsed and were not fully visible. Removed that media query so the labels render at every screen size, matching the desktop behavior.

This style is only consumed by the error-page `ErrorBoundary`, so the change has no effect on other UI.

## Signed commits

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text buttons now remain visible at viewport widths around 853px instead of being hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->