### PR TITLE
[UI] Align icons in catalog action menu

### DIFF
--- a/ui/components/designs/patterns/ActionButton.tsx
+++ b/ui/components/designs/patterns/ActionButton.tsx
@@ -99,7 +99,19 @@ export default function ActionButton({
                     option.onClick(event, index);
                   }}
                 >
-                  <div style={{ marginRight: '0.5rem' }}>{option.icon}</div>
+                  <div
+                    style={{
+                      marginRight: '0.5rem',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: 20,
+                      height: 20,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {option.icon}
+                  </div>
                   {option.label}
                 </MenuItem>
               ))}


### PR DESCRIPTION
### Notes for Reviewers

This PR fixes #21457

## Changes

The `Deploy` and `Evaluate` menu items in the catalog action menu use `@sistent/sistent` icons (`DoneAllIcon`, `AccountTreeIcon`) that render wider than the project's local icons, causing the shield-style icon to overlap its label.

Each menu item icon is now rendered inside a fixed 20x20 flex box that is centered and shrink-resistant, so all icons stay aligned with their labels regardless of the source.

## Signed commits

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alignment and sizing of option icons in action buttons for more consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->