### PR TITLE
[Server] Optional at-rest encryption for credentials and kubeconfigs

### DIFF
--- a/docs/content/en/concepts/logical/credentials.md
+++ b/docs/content/en/concepts/logical/credentials.md
@@ -34,10 +34,45 @@ Credentials can be:
 
 Meshery takes several measures to protect your credentials:
 
-- Credentials are encrypted at rest
+- Support for application-layer AES-256-GCM encryption at rest
 - Access is controlled through fine-grained permissions
 - Credentials are never exposed in logs or API responses
 - Support for secret management integration
+
+### At-Rest Encryption
+
+Meshery provides optional application-layer encryption at rest for sensitive data (API keys, authentication tokens, and Kubernetes contexts stored in the datastore) using AES-256-GCM.
+
+#### Enabling Encryption
+
+At-rest encryption is activated by setting an environment variable before starting Meshery Server:
+
+- `MESHERY_ENCRYPTION_KEY`: A 32-byte key in 64-character hexadecimal format (generate with `openssl rand -hex 32`) or 44-character base64 format (generate with `openssl rand -base64 32`).
+- `MESHERY_ENCRYPTION_KEY_FILE`: Path to a file containing the 32-byte key (recommended for Kubernetes Secrets mounted as files).
+
+When enabled:
+- Credential secrets in the `credentials` table and kubeconfig `auth` and `cluster` sections in the `k8s_contexts` table are encrypted using AES-256-GCM before writing to the datastore.
+- Each value uses a unique cryptographic nonce generated at encryption time.
+- Key material is never stored in the database.
+- If neither environment variable is set, encryption is disabled and existing plaintext credentials continue to function with zero migration required.
+
+#### Migrating Existing Datastores
+
+Existing unencrypted credentials and kubeconfigs can be encrypted in-place using `mesheryctl`:
+
+```bash
+# Ensure Meshery server is stopped first
+mesheryctl system encrypt-datastore --key <your-32-byte-hex-key>
+
+# Or with a key file
+mesheryctl system encrypt-datastore --key-file /path/to/key.txt
+
+# Preview changes without modifying the database
+mesheryctl system encrypt-datastore --dry-run --key <your-32-byte-hex-key>
+
+# To decrypt existing data back to plaintext:
+mesheryctl system encrypt-datastore --decrypt --key <your-32-byte-hex-key>
+```
 
 ### Using Credentials with Connections
 

--- a/docs/content/en/installation/production/security-hardening.md
+++ b/docs/content/en/installation/production/security-hardening.md
@@ -102,6 +102,15 @@ and providers.
 - **In-cluster credentials.** When Meshery runs in-cluster and manages its own
   cluster, it can use the in-cluster ServiceAccount rather than a kubeconfig
   file—one fewer long-lived secret to manage.
+- **At-rest encryption for credentials and kubeconfigs.** Meshery supports
+  optional application-layer AES-256-GCM encryption at rest for sensitive data
+  in its SQLite datastore (`credentials.secret`, `k8s_contexts.auth`, and
+  `k8s_contexts.cluster`). Enable it by passing `MESHERY_ENCRYPTION_KEY`
+  (64-character hex key) or mounting a secret file via
+  `MESHERY_ENCRYPTION_KEY_FILE`. Existing datastores can be migrated in-place:
+  **stop Meshery Server first**, then run
+  `mesheryctl system encrypt-datastore --key <key>`. Key material is never
+  persisted to the datastore.
 - **Provider and OAuth secrets.** Keep Remote Provider configuration and any
   client secrets in Kubernetes Secrets (or an external secrets manager), not in
   plaintext values files committed to source control.

--- a/docs/data/errorref/meshery-server_errors_export.json
+++ b/docs/data/errorref/meshery-server_errors_export.json
@@ -4223,6 +4223,51 @@
         "short_description": "A database reset is already in progress",
         "probable_cause": "A reset was requested while an earlier one was still seeding keys, catalog designs, or components",
         "suggested_remediation": "Wait for the in-flight reset to finish, then retry"
+      },
+      "1482": {
+        "name": "ErrEncryptionInitCode",
+        "code": "1482",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Failed to initialise at-rest encryption service",
+        "probable_cause": "The value of MESHERY_ENCRYPTION_KEY or MESHERY_ENCRYPTION_KEY_FILE is invalid",
+        "suggested_remediation": "Generate a valid 32-byte key: openssl rand -hex 32. Set MESHERY_ENCRYPTION_KEY=<64-char hex> or point MESHERY_ENCRYPTION_KEY_FILE to a file containing the key"
+      },
+      "1483": {
+        "name": "ErrEncryptSecretCode",
+        "code": "1483",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Failed to encrypt credential secret before persisting",
+        "probable_cause": "Internal encryption error",
+        "suggested_remediation": "Ensure the encryption key is valid and has not been rotated mid-operation"
+      },
+      "1484": {
+        "name": "ErrDecryptSecretCode",
+        "code": "1484",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Failed to decrypt stored credential secret",
+        "probable_cause": "The stored credential may have been encrypted with a different key. The credential row may be corrupted",
+        "suggested_remediation": "Verify that MESHERY_ENCRYPTION_KEY or MESHERY_ENCRYPTION_KEY_FILE matches the key used when the credential was saved. Restore the original encryption key to access encrypted credentials"
+      },
+      "1485": {
+        "name": "ErrEncryptK8sContextCode",
+        "code": "1485",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Failed to encrypt Kubernetes context fields before persisting",
+        "probable_cause": "Internal encryption error for kubeconfig data",
+        "suggested_remediation": "Ensure the encryption key is valid and has not been rotated mid-operation"
+      },
+      "1486": {
+        "name": "ErrDecryptK8sContextCode",
+        "code": "1486",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Failed to decrypt Kubernetes context fields after reading",
+        "probable_cause": "The stored kubeconfig data may have been encrypted with a different key. The k8s_contexts row may be corrupted",
+        "suggested_remediation": "Verify that MESHERY_ENCRYPTION_KEY or MESHERY_ENCRYPTION_KEY_FILE matches the key used when the context was saved. Restore the original encryption key to access encrypted Kubernetes contexts"
       }
     }
   }

--- a/mesheryctl/internal/cli/root/system/encrypt_datastore.go
+++ b/mesheryctl/internal/cli/root/system/encrypt_datastore.go
@@ -1,0 +1,329 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshery/server/pkg/encryption"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var (
+	encKeyFlag     string
+	encKeyFileFlag string
+	dbPathFlag     string
+	dryRunFlag     bool
+	decryptFlag    bool
+)
+
+var linkDocEncryptDatastore = map[string]string{
+	"link":    "https://docs.meshery.io/reference/references/mesheryctl/system/encrypt-datastore",
+	"caption": "Usage of mesheryctl system encrypt-datastore",
+}
+
+// encryptDatastoreCmd represents the command to encrypt or decrypt sensitive data at rest
+var encryptDatastoreCmd = &cobra.Command{
+	Use:   "encrypt-datastore",
+	Short: "Encrypt or decrypt sensitive credential and kubeconfig data at rest in the Meshery datastore",
+	Long: `Encrypt or decrypt sensitive columns (credential secrets and kubeconfig auth/cluster sections)
+in the Meshery SQLite datastore in-place using AES-256-GCM.
+
+Before running this command, ensure the Meshery server is STOPPED to prevent concurrent database access.
+
+To encrypt:
+  mesheryctl system encrypt-datastore --key <64-char-hex>
+  mesheryctl system encrypt-datastore --key-file /path/to/key.txt
+
+To decrypt (restore plaintext):
+  mesheryctl system encrypt-datastore --decrypt --key <64-char-hex>
+
+To preview changes without modifying the database:
+  mesheryctl system encrypt-datastore --dry-run --key <64-char-hex>`,
+	Example: `
+// Encrypt datastore with an explicit hex key
+mesheryctl system encrypt-datastore --key 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+// Encrypt datastore using a key stored in a file
+mesheryctl system encrypt-datastore --key-file ~/.meshery/key.txt
+
+// Dry-run preview
+mesheryctl system encrypt-datastore --dry-run --key-file ~/.meshery/key.txt
+
+// Decrypt datastore back to plaintext
+mesheryctl system encrypt-datastore --decrypt --key-file ~/.meshery/key.txt
+`,
+	Annotations: linkDocEncryptDatastore,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runEncryptDatastore()
+	},
+}
+
+func init() {
+	encryptDatastoreCmd.Flags().StringVar(&encKeyFlag, "key", "", "32-byte AES-256 key in hex (64 chars) or base64 format")
+	encryptDatastoreCmd.Flags().StringVar(&encKeyFileFlag, "key-file", "", "Path to a file containing the 32-byte key")
+	encryptDatastoreCmd.Flags().StringVar(&dbPathFlag, "db-path", "", "Path to the mesherydb.sql file (defaults to ~/.meshery/config/mesherydb.sql)")
+	encryptDatastoreCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview changes without modifying the datastore")
+	encryptDatastoreCmd.Flags().BoolVar(&decryptFlag, "decrypt", false, "Decrypt existing encrypted rows back to plaintext")
+}
+
+func runEncryptDatastore() error {
+	// 1. Resolve key
+	if encKeyFlag != "" {
+		_ = os.Setenv(encryption.EncryptionKeyEnv, encKeyFlag)
+	}
+	if encKeyFileFlag != "" {
+		_ = os.Setenv(encryption.EncryptionKeyFileEnv, encKeyFileFlag)
+	}
+
+	svc, err := encryption.NewFromEnv()
+	if err != nil {
+		return errors.Wrap(err, "invalid encryption key")
+	}
+	if svc == nil {
+		return fmt.Errorf("no encryption key specified. Provide --key, --key-file, or set %s", encryption.EncryptionKeyEnv)
+	}
+
+	// 2. Resolve database path
+	dbPath := dbPathFlag
+	if dbPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return errors.Wrap(err, "unable to find user home directory")
+		}
+		dbPath = filepath.Join(home, ".meshery", "config", "mesherydb.sql")
+	}
+
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return fmt.Errorf("database file does not exist at %s", dbPath)
+	}
+
+	action := "Encrypting"
+	if decryptFlag {
+		action = "Decrypting"
+	}
+	if dryRunFlag {
+		utils.Log.Infof("[DRY-RUN] %s datastore at %s...", action, dbPath)
+	} else {
+		if !utils.SilentFlag {
+			prompt := fmt.Sprintf("%s datastore at %s. Please ensure Meshery server is stopped. Continue?", action, dbPath)
+			if !utils.AskForConfirmation(prompt) {
+				utils.Log.Info("Operation cancelled.")
+				return nil
+			}
+		}
+		utils.Log.Infof("%s datastore at %s...", action, dbPath)
+	}
+
+	// 3. Connect to database
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to open database at %s", dbPath)
+	}
+
+	// 4. Migrate credentials table
+	credCount, err := migrateCredentialsTable(db, svc, decryptFlag, dryRunFlag)
+	if err != nil {
+		return errors.Wrap(err, "error processing credentials table")
+	}
+
+	// 5. Migrate k8s_contexts table
+	k8sCount, err := migrateK8sContextsTable(db, svc, decryptFlag, dryRunFlag)
+	if err != nil {
+		return errors.Wrap(err, "error processing k8s_contexts table")
+	}
+
+	verb := "Encrypted"
+	if decryptFlag {
+		verb = "Decrypted"
+	}
+	if dryRunFlag {
+		verb = "Would have " + verb
+	}
+
+	utils.Log.Infof("Migration complete: %s %d credential(s) and %d Kubernetes context(s).", verb, credCount, k8sCount)
+	return nil
+}
+
+// rawCredential holds raw row data from the credentials table.
+type rawCredential struct {
+	ID     string `gorm:"column:id;primaryKey"`
+	Secret string `gorm:"column:secret"`
+}
+
+func (rawCredential) TableName() string {
+	return "credentials"
+}
+
+func migrateCredentialsTable(db *gorm.DB, svc *encryption.Service, decrypt bool, dryRun bool) (int, error) {
+	if !db.Migrator().HasTable("credentials") {
+		return 0, nil
+	}
+
+	var rows []rawCredential
+	if err := db.Find(&rows).Error; err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, row := range rows {
+		if row.Secret == "" {
+			continue
+		}
+
+		var secretMap map[string]interface{}
+		if err := json.Unmarshal([]byte(row.Secret), &secretMap); err != nil {
+			return count, fmt.Errorf("credentials row %s: column secret is not a valid JSON map: %w", row.ID, err)
+		}
+
+		if decrypt {
+			if !svc.IsEncrypted(secretMap) {
+				continue // Already plaintext
+			}
+			decrypted, err := svc.DecryptMap(secretMap)
+			if err != nil {
+				return count, fmt.Errorf("failed to decrypt credential %s: %w", row.ID, err)
+			}
+			if !dryRun {
+				bytes, _ := json.Marshal(decrypted)
+				if err := db.Model(&rawCredential{}).Where("id = ?", row.ID).Update("secret", string(bytes)).Error; err != nil {
+					return count, err
+				}
+			}
+			count++
+		} else {
+			if svc.IsEncrypted(secretMap) {
+				continue // Already encrypted
+			}
+			encrypted, err := svc.EncryptMap(secretMap)
+			if err != nil {
+				return count, fmt.Errorf("failed to encrypt credential %s: %w", row.ID, err)
+			}
+			if !dryRun {
+				bytes, _ := json.Marshal(encrypted)
+				if err := db.Model(&rawCredential{}).Where("id = ?", row.ID).Update("secret", string(bytes)).Error; err != nil {
+					return count, err
+				}
+			}
+			count++
+		}
+	}
+
+	return count, nil
+}
+
+// rawK8sContext holds raw row data from the k8s_contexts table.
+type rawK8sContext struct {
+	ID      string `gorm:"column:id;primaryKey"`
+	Auth    string `gorm:"column:auth"`
+	Cluster string `gorm:"column:cluster"`
+}
+
+func (rawK8sContext) TableName() string {
+	return "k8s_contexts"
+}
+
+func migrateK8sContextsTable(db *gorm.DB, svc *encryption.Service, decrypt bool, dryRun bool) (int, error) {
+	if !db.Migrator().HasTable("k8s_contexts") {
+		return 0, nil
+	}
+
+	var rows []rawK8sContext
+	if err := db.Find(&rows).Error; err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, row := range rows {
+		modified := false
+		newAuth := row.Auth
+		newCluster := row.Cluster
+
+		// Handle Auth column
+		if row.Auth != "" {
+			var authMap map[string]interface{}
+			if err := json.Unmarshal([]byte(row.Auth), &authMap); err != nil {
+				return count, fmt.Errorf("k8s_contexts row %s: column auth is not a valid JSON map: %w", row.ID, err)
+			}
+			if decrypt && svc.IsEncrypted(authMap) {
+				decrypted, err := svc.DecryptMap(authMap)
+				if err != nil {
+					return count, fmt.Errorf("failed to decrypt auth for context %s: %w", row.ID, err)
+				}
+				b, _ := json.Marshal(decrypted)
+				newAuth = string(b)
+				modified = true
+			} else if !decrypt && !svc.IsEncrypted(authMap) {
+				encrypted, err := svc.EncryptMap(authMap)
+				if err != nil {
+					return count, fmt.Errorf("failed to encrypt auth for context %s: %w", row.ID, err)
+				}
+				b, _ := json.Marshal(encrypted)
+				newAuth = string(b)
+				modified = true
+			}
+		}
+
+		// Handle Cluster column
+		if row.Cluster != "" {
+			var clusterMap map[string]interface{}
+			if err := json.Unmarshal([]byte(row.Cluster), &clusterMap); err != nil {
+				return count, fmt.Errorf("k8s_contexts row %s: column cluster is not a valid JSON map: %w", row.ID, err)
+			}
+			if decrypt && svc.IsEncrypted(clusterMap) {
+				decrypted, err := svc.DecryptMap(clusterMap)
+				if err != nil {
+					return count, fmt.Errorf("failed to decrypt cluster for context %s: %w", row.ID, err)
+				}
+				b, _ := json.Marshal(decrypted)
+				newCluster = string(b)
+				modified = true
+			} else if !decrypt && !svc.IsEncrypted(clusterMap) {
+				encrypted, err := svc.EncryptMap(clusterMap)
+				if err != nil {
+					return count, fmt.Errorf("failed to encrypt cluster for context %s: %w", row.ID, err)
+				}
+				b, _ := json.Marshal(encrypted)
+				newCluster = string(b)
+				modified = true
+			}
+		}
+
+		if modified {
+			if !dryRun {
+				updates := map[string]interface{}{
+					"auth":    newAuth,
+					"cluster": newCluster,
+				}
+				if err := db.Model(&rawK8sContext{}).Where("id = ?", row.ID).Updates(updates).Error; err != nil {
+					return count, err
+				}
+			}
+			count++
+		}
+	}
+
+	return count, nil
+}

--- a/mesheryctl/internal/cli/root/system/encrypt_datastore_test.go
+++ b/mesheryctl/internal/cli/root/system/encrypt_datastore_test.go
@@ -1,0 +1,238 @@
+package system
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/meshery/meshery/server/pkg/encryption"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newTestEncryptionService(t *testing.T) *encryption.Service {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	svc, err := encryption.New(key)
+	if err != nil {
+		t.Fatalf("encryption.New: %v", err)
+	}
+	return svc
+}
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbFile := filepath.Join(t.TempDir(), "test_mesherydb.sql")
+	db, err := gorm.Open(sqlite.Open(dbFile), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+
+	if err := db.AutoMigrate(&rawCredential{}, &rawK8sContext{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+
+	return db
+}
+
+func TestMigrateCredentialsTable(t *testing.T) {
+	db := setupTestDB(t)
+	svc := newTestEncryptionService(t)
+
+	// Insert test credentials
+	originalSecret := map[string]interface{}{
+		"apiKey": "super-secret-token-12345",
+	}
+	secretBytes, _ := json.Marshal(originalSecret)
+	cred := rawCredential{
+		ID:     "cred-1",
+		Secret: string(secretBytes),
+	}
+	if err := db.Create(&cred).Error; err != nil {
+		t.Fatalf("db.Create: %v", err)
+	}
+
+	// 1. Dry run encryption
+	count, err := migrateCredentialsTable(db, svc, false, true)
+	if err != nil {
+		t.Fatalf("migrateCredentialsTable (dry-run encrypt): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 credential to be affected, got %d", count)
+	}
+	var afterDryRun rawCredential
+	if err := db.First(&afterDryRun, "id = ?", "cred-1").Error; err != nil {
+		t.Fatalf("db.First: %v", err)
+	}
+	if afterDryRun.Secret != string(secretBytes) {
+		t.Error("dry-run modified the database")
+	}
+
+	// 2. Perform encryption
+	count, err = migrateCredentialsTable(db, svc, false, false)
+	if err != nil {
+		t.Fatalf("migrateCredentialsTable (encrypt): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 credential encrypted, got %d", count)
+	}
+
+	var encryptedRow rawCredential
+	if err := db.First(&encryptedRow, "id = ?", "cred-1").Error; err != nil {
+		t.Fatalf("db.First: %v", err)
+	}
+	var encMap map[string]interface{}
+	if err := json.Unmarshal([]byte(encryptedRow.Secret), &encMap); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !svc.IsEncrypted(encMap) {
+		t.Fatal("expected credential row to be encrypted")
+	}
+
+	// Re-encrypting should be a no-op (count = 0)
+	count, err = migrateCredentialsTable(db, svc, false, false)
+	if err != nil {
+		t.Fatalf("migrateCredentialsTable (second encrypt): %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 credentials to be re-encrypted, got %d", count)
+	}
+
+	// 3. Perform decryption
+	count, err = migrateCredentialsTable(db, svc, true, false)
+	if err != nil {
+		t.Fatalf("migrateCredentialsTable (decrypt): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 credential decrypted, got %d", count)
+	}
+
+	var decryptedRow rawCredential
+	if err := db.First(&decryptedRow, "id = ?", "cred-1").Error; err != nil {
+		t.Fatalf("db.First: %v", err)
+	}
+	var decMap map[string]interface{}
+	if err := json.Unmarshal([]byte(decryptedRow.Secret), &decMap); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if svc.IsEncrypted(decMap) {
+		t.Fatal("expected credential row to be decrypted")
+	}
+	if decMap["apiKey"] != "super-secret-token-12345" {
+		t.Errorf("decrypted apiKey = %v, want super-secret-token-12345", decMap["apiKey"])
+	}
+}
+
+func TestMigrateK8sContextsTable(t *testing.T) {
+	db := setupTestDB(t)
+	svc := newTestEncryptionService(t)
+
+	authMap := map[string]interface{}{"token": "bearer-token-abc"}
+	clusterMap := map[string]interface{}{"server": "https://10.0.0.1:6443"}
+	authBytes, err := json.Marshal(authMap)
+	if err != nil {
+		t.Fatalf("json.Marshal auth: %v", err)
+	}
+	clusterBytes, err := json.Marshal(clusterMap)
+	if err != nil {
+		t.Fatalf("json.Marshal cluster: %v", err)
+	}
+
+	k8sCtx := rawK8sContext{
+		ID:      "ctx-1",
+		Auth:    string(authBytes),
+		Cluster: string(clusterBytes),
+	}
+	if err := db.Create(&k8sCtx).Error; err != nil {
+		t.Fatalf("db.Create: %v", err)
+	}
+
+	// 1. Perform encryption
+	count, err := migrateK8sContextsTable(db, svc, false, false)
+	if err != nil {
+		t.Fatalf("migrateK8sContextsTable (encrypt): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 context encrypted, got %d", count)
+	}
+
+	var encryptedRow rawK8sContext
+	if err := db.First(&encryptedRow, "id = ?", "ctx-1").Error; err != nil {
+		t.Fatalf("db.First: %v", err)
+	}
+	var encAuth, encCluster map[string]interface{}
+	if err := json.Unmarshal([]byte(encryptedRow.Auth), &encAuth); err != nil {
+		t.Fatalf("json.Unmarshal auth: %v", err)
+	}
+	if err := json.Unmarshal([]byte(encryptedRow.Cluster), &encCluster); err != nil {
+		t.Fatalf("json.Unmarshal cluster: %v", err)
+	}
+
+	if !svc.IsEncrypted(encAuth) {
+		t.Fatal("expected Auth to be encrypted")
+	}
+	if !svc.IsEncrypted(encCluster) {
+		t.Fatal("expected Cluster to be encrypted")
+	}
+
+	// 2. Perform decryption
+	count, err = migrateK8sContextsTable(db, svc, true, false)
+	if err != nil {
+		t.Fatalf("migrateK8sContextsTable (decrypt): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 context decrypted, got %d", count)
+	}
+
+	var decryptedRow rawK8sContext
+	if err := db.First(&decryptedRow, "id = ?", "ctx-1").Error; err != nil {
+		t.Fatalf("db.First: %v", err)
+	}
+	var decAuth, decCluster map[string]interface{}
+	if err := json.Unmarshal([]byte(decryptedRow.Auth), &decAuth); err != nil {
+		t.Fatalf("json.Unmarshal auth: %v", err)
+	}
+	if err := json.Unmarshal([]byte(decryptedRow.Cluster), &decCluster); err != nil {
+		t.Fatalf("json.Unmarshal cluster: %v", err)
+	}
+
+	if svc.IsEncrypted(decAuth) {
+		t.Fatal("expected Auth to be decrypted")
+	}
+	if svc.IsEncrypted(decCluster) {
+		t.Fatal("expected Cluster to be decrypted")
+	}
+	if decAuth["token"] != "bearer-token-abc" {
+		t.Errorf("decrypted Auth token = %v, want bearer-token-abc", decAuth["token"])
+	}
+}
+
+func TestEncryptDatastoreCmd_FlagDefaults(t *testing.T) {
+	cmd := encryptDatastoreCmd
+	if cmd.Use != "encrypt-datastore" {
+		t.Errorf("unexpected command use: %s", cmd.Use)
+	}
+
+	// Verify flags exist
+	if cmd.Flags().Lookup("key") == nil {
+		t.Error("flag --key missing")
+	}
+	if cmd.Flags().Lookup("key-file") == nil {
+		t.Error("flag --key-file missing")
+	}
+	if cmd.Flags().Lookup("db-path") == nil {
+		t.Error("flag --db-path missing")
+	}
+	if cmd.Flags().Lookup("dry-run") == nil {
+		t.Error("flag --dry-run missing")
+	}
+	if cmd.Flags().Lookup("decrypt") == nil {
+		t.Error("flag --decrypt missing")
+	}
+}

--- a/mesheryctl/internal/cli/root/system/system.go
+++ b/mesheryctl/internal/cli/root/system/system.go
@@ -95,6 +95,7 @@ func init() {
 		tokenCmd,
 		dashboardCmd,
 		deleteCmd,
+		encryptDatastoreCmd,
 	}
 	// --context flag to temporarily change context. This is global to all system commands
 	SystemCmd.PersistentFlags().StringVarP(&tempContext, "context", "c", "", "(optional) temporarily change the current context.")

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/meshery/meshery/server/handlers"
 	"github.com/meshery/meshery/server/helpers"
 	"github.com/meshery/meshery/server/helpers/utils"
+	"github.com/meshery/meshery/server/pkg/encryption"
 	"github.com/meshery/meshery/server/internal/graphql"
 	"github.com/meshery/meshery/server/internal/store"
 	"github.com/meshery/meshery/server/machines"
@@ -250,6 +251,15 @@ func main() {
 		meshsyncDefaultDeploymentMode = connections.MeshsyncDeploymentModeDefault
 	}
 
+	encSvc, err := encryption.NewFromEnv()
+	if err != nil {
+		log.Error(models.ErrEncryptionInit(err))
+		os.Exit(1)
+	}
+	if encSvc != nil {
+		log.Info("At-rest encryption for credentials and kubeconfigs is ENABLED")
+	}
+
 	lProv := &models.DefaultLocalProvider{
 		ProviderBaseURL:                 DefaultProviderURL,
 		MapPreferencePersister:          preferencePersister,
@@ -262,7 +272,7 @@ func main() {
 		MesheryFilterPersister:          &models.MesheryFilterPersister{DB: dbHandler},
 		MesheryApplicationPersister:     &models.MesheryApplicationPersister{DB: dbHandler},
 		MesheryPatternResourcePersister: &models.PatternResourcePersister{DB: dbHandler},
-		MesheryK8sContextPersister:      &models.MesheryK8sContextPersister{DB: dbHandler},
+		MesheryK8sContextPersister:      &models.MesheryK8sContextPersister{DB: dbHandler, EncSvc: encSvc},
 		OrganizationPersister:           &models.OrganizationPersister{DB: dbHandler},
 		ConnectionPersister:             &models.ConnectionPersister{DB: dbHandler},
 		EnvironmentPersister:            &models.EnvironmentPersister{DB: dbHandler},
@@ -272,6 +282,7 @@ func main() {
 		GenericPersister:                dbHandler,
 		Log:                             log,
 		MeshsyncDefaultDeploymentMode:   meshsyncDefaultDeploymentMode,
+		EncSvc:                          encSvc,
 	}
 
 	// Local remote provider is initalized here.

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1482
+  "next_error_code": 1487
 }

--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/pkg/encryption"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshery/server/models/httputil"
 	"github.com/meshery/meshkit/database"
@@ -72,6 +73,13 @@ type DefaultLocalProvider struct {
 	// downloadMu serializes provider package downloads so concurrent installs
 	// don't race on the shared on-disk package location.
 	downloadMu sync.Mutex
+
+	// EncSvc is the optional application-layer encryption service for
+	// credential secrets and kubeconfig fields stored in the database.
+	// When nil (the default), data is stored in plaintext and behaviour is
+	// identical to before this feature was introduced.
+	// Set MESHERY_ENCRYPTION_KEY or MESHERY_ENCRYPTION_KEY_FILE to enable.
+	EncSvc *encryption.Service
 }
 
 // LocalProviderName is the canonical name of the built-in local provider.
@@ -1612,6 +1620,18 @@ func (l *DefaultLocalProvider) SaveUserCredential(token string, credential *Cred
 		}
 		credential.ID = newID
 	}
+
+	// Encrypt the secret before persisting; restore plaintext for the caller.
+	if l.EncSvc != nil && credential.Secret != nil {
+		originalSecret := credential.Secret
+		encrypted, err := l.EncSvc.EncryptMap(credential.Secret)
+		if err != nil {
+			return nil, ErrEncryptSecret(err)
+		}
+		credential.Secret = encrypted
+		defer func() { credential.Secret = originalSecret }()
+	}
+
 	result := l.GetGenericPersister().Table("credentials").Create(&credential)
 	if result.Error != nil {
 		return nil, fmt.Errorf("error saving user credentials: %v", result.Error)
@@ -1628,6 +1648,15 @@ func (l *DefaultLocalProvider) GetCredentialByID(token string, credentialID core
 		}
 		return nil, http.StatusInternalServerError, fmt.Errorf("error retrieving credential with id %s: %v", credentialID, result.Error)
 	}
+
+	if l.EncSvc != nil && credential.Secret != nil {
+		decrypted, err := l.EncSvc.DecryptMap(credential.Secret)
+		if err != nil {
+			return nil, http.StatusInternalServerError, ErrDecryptSecret(err)
+		}
+		credential.Secret = decrypted
+	}
+
 	return credential, http.StatusOK, nil
 }
 
@@ -1658,6 +1687,18 @@ func (l *DefaultLocalProvider) GetUserCredentials(_ *http.Request, userID string
 		}
 	}
 
+	if l.EncSvc != nil {
+		for i := range credentialsList {
+			if credentialsList[i].Secret != nil {
+				decrypted, err := l.EncSvc.DecryptMap(credentialsList[i].Secret)
+				if err != nil {
+					return nil, ErrDecryptSecret(err)
+				}
+				credentialsList[i].Secret = decrypted
+			}
+		}
+	}
+
 	credentialsPage := &CredentialsPage{
 		Credentials: credentialsList,
 		Page:        page,
@@ -1673,6 +1714,17 @@ func (l *DefaultLocalProvider) GetUserCredentials(_ *http.Request, userID string
 
 func (l *DefaultLocalProvider) UpdateUserCredential(_ *http.Request, credential *Credential) (*Credential, error) {
 	updatedCredential := &Credential{}
+
+	if l.EncSvc != nil && credential.Secret != nil {
+		originalSecret := credential.Secret
+		encrypted, err := l.EncSvc.EncryptMap(credential.Secret)
+		if err != nil {
+			return nil, ErrEncryptSecret(err)
+		}
+		credential.Secret = encrypted
+		defer func() { credential.Secret = originalSecret }()
+	}
+
 	db := l.GetGenericPersister().Model(&Credential{}).Where("user_id = ? AND id = ? AND deleted_at is NULL", credential.UserId, credential.ID).Updates(credential)
 	if db.Error != nil {
 		return nil, fmt.Errorf("error updating user credential: %v", db.Error)
@@ -1681,6 +1733,15 @@ func (l *DefaultLocalProvider) UpdateUserCredential(_ *http.Request, credential 
 	if err := l.GetGenericPersister().Where("user_id = ? AND id = ?", credential.UserId, credential.ID).First(updatedCredential).Error; err != nil {
 		return nil, fmt.Errorf("error getting updated user credential: %v", err)
 	}
+
+	if l.EncSvc != nil && updatedCredential.Secret != nil {
+		decrypted, err := l.EncSvc.DecryptMap(updatedCredential.Secret)
+		if err != nil {
+			return nil, ErrDecryptSecret(err)
+		}
+		updatedCredential.Secret = decrypted
+	}
+
 	return updatedCredential, nil
 }
 
@@ -1691,6 +1752,13 @@ func (l *DefaultLocalProvider) DeleteUserCredential(_ *http.Request, credentialI
 	}
 	if err := l.GetGenericPersister().Where("id = ?", credentialID).First(delCredential).Error; err != nil {
 		return nil, err
+	}
+	if l.EncSvc != nil && delCredential.Secret != nil {
+		decrypted, err := l.EncSvc.DecryptMap(delCredential.Secret)
+		if err != nil {
+			return nil, ErrDecryptSecret(err)
+		}
+		delCredential.Secret = decrypted
 	}
 	return delCredential, nil
 }

--- a/server/models/default_local_provider_test.go
+++ b/server/models/default_local_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/pkg/encryption"
 	"github.com/meshery/meshkit/database"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/events"
@@ -376,3 +377,97 @@ func TestDefaultLocalProviderInstallExtension_ReplacesMatchingNavigatorExtension
 		t.Fatalf("expected replacement component to be stored, got %q", provider.Extensions.Navigator[0].Component)
 	}
 }
+
+func TestDefaultLocalProvider_CredentialEncryption(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 42)
+	}
+	encSvc, err := encryption.New(key)
+	if err != nil {
+		t.Fatalf("encryption.New: %v", err)
+	}
+
+	provider := newTestProviderWithCredentialDB(t)
+	provider.EncSvc = encSvc
+
+	userUUID, _ := uuid.NewV4()
+	secret := map[string]interface{}{
+		"token": "secret-auth-token",
+	}
+	cred := &Credential{
+		Name:   "k8s-cred",
+		UserId: userUUID,
+		Secret: secret,
+	}
+
+	// 1. Save with encryption
+	saved, err := provider.SaveUserCredential("tok", cred)
+	if err != nil {
+		t.Fatalf("SaveUserCredential: %v", err)
+	}
+	if saved.Secret["token"] != "secret-auth-token" {
+		t.Errorf("saved secret = %v, want secret-auth-token", saved.Secret["token"])
+	}
+
+	// Verify directly in DB that the column is encrypted
+	var raw struct {
+		ID     string
+		Secret string
+	}
+	if err := provider.GenericPersister.Table("credentials").Where("id = ?", saved.ID).First(&raw).Error; err != nil {
+		t.Fatalf("reading raw credential row: %v", err)
+	}
+	if !strings.Contains(raw.Secret, "__enc__") {
+		t.Errorf("expected DB secret to contain __enc__, got %s", raw.Secret)
+	}
+
+	// 2. Read by ID
+	fetched, status, err := provider.GetCredentialByID("tok", saved.ID)
+	if err != nil {
+		t.Fatalf("GetCredentialByID (%d): %v", status, err)
+	}
+	if fetched.Secret["token"] != "secret-auth-token" {
+		t.Errorf("fetched secret = %v, want secret-auth-token", fetched.Secret["token"])
+	}
+
+	// 3. List
+	page, err := provider.GetUserCredentials(nil, userUUID.String(), 0, 10, "", "")
+	if err != nil {
+		t.Fatalf("GetUserCredentials: %v", err)
+	}
+	if len(page.Credentials) != 1 {
+		t.Fatalf("expected 1 credential, got %d", len(page.Credentials))
+	}
+	if page.Credentials[0].Secret["token"] != "secret-auth-token" {
+		t.Errorf("listed secret = %v, want secret-auth-token", page.Credentials[0].Secret["token"])
+	}
+
+	// 4. Update
+	cred.Secret = map[string]interface{}{
+		"token": "updated-secret-auth-token",
+	}
+	updated, err := provider.UpdateUserCredential(nil, cred)
+	if err != nil {
+		t.Fatalf("UpdateUserCredential: %v", err)
+	}
+	if updated.Secret["token"] != "updated-secret-auth-token" {
+		t.Errorf("updated secret = %v, want updated-secret-auth-token", updated.Secret["token"])
+	}
+
+	// Verify that the updated row is encrypted in the DB
+	var rawAfterUpdate struct {
+		ID     string
+		Secret string
+	}
+	if err := provider.GenericPersister.Table("credentials").Where("id = ?", saved.ID).First(&rawAfterUpdate).Error; err != nil {
+		t.Fatalf("reading raw credential row after update: %v", err)
+	}
+	if !strings.Contains(rawAfterUpdate.Secret, "__enc__") {
+		t.Errorf("expected updated DB secret to contain __enc__, got %s", rawAfterUpdate.Secret)
+	}
+	if strings.Contains(rawAfterUpdate.Secret, "updated-secret-auth-token") {
+		t.Error("updated secret was stored as plaintext in the DB")
+	}
+}
+

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -167,6 +167,13 @@ const (
 	ErrOperatorChartNotPublishedCode      = "meshery-server-1470"
 	ErrOperatorChartSubstitutedCode       = "meshery-server-1471"
 	ErrNoMesheryReleasesFoundCode         = "meshery-server-1472"
+
+	// at-rest encryption error codes (1482–1486)
+	ErrEncryptionInitCode    = "meshery-server-1482"
+	ErrEncryptSecretCode     = "meshery-server-1483"
+	ErrDecryptSecretCode     = "meshery-server-1484"
+	ErrEncryptK8sContextCode = "meshery-server-1485"
+	ErrDecryptK8sContextCode = "meshery-server-1486"
 )
 
 var (
@@ -199,6 +206,69 @@ var (
 	ErrOperationNotAvailable   = errors.New(ErrOperationNotAvailableCode, errors.Alert, []string{"Operation not available"}, []string{}, []string{}, []string{})
 	ErrEmptySession            = errors.New(ErrEmptySessionCode, errors.Alert, []string{"No session found in the request"}, []string{"Unable to find \"token\" cookie in the request."}, []string{"User is not authenticated with the selected Provider.", "Browser might be restricting use of cookies."}, []string{"Choose a Provider and login to establish an active session (receive a new token and cookie). Optionally, try using a private/incognito browser window.", "Verify that your browser settings allow cookies."})
 )
+
+// ErrEncryptionInit is returned when the at-rest encryption service cannot be
+// initialised (e.g. invalid key format or unreadable key file).
+func ErrEncryptionInit(err error) error {
+	return errors.New(ErrEncryptionInitCode, errors.Alert,
+		[]string{"Failed to initialise at-rest encryption service"},
+		[]string{err.Error()},
+		[]string{"The value of MESHERY_ENCRYPTION_KEY or MESHERY_ENCRYPTION_KEY_FILE is invalid"},
+		[]string{
+			"Generate a valid 32-byte key: openssl rand -hex 32",
+			"Set MESHERY_ENCRYPTION_KEY=<64-char hex> or point MESHERY_ENCRYPTION_KEY_FILE to a file containing the key",
+		})
+}
+
+// ErrEncryptSecret is returned when encrypting a credential secret fails.
+func ErrEncryptSecret(err error) error {
+	return errors.New(ErrEncryptSecretCode, errors.Alert,
+		[]string{"Failed to encrypt credential secret before persisting"},
+		[]string{err.Error()},
+		[]string{"Internal encryption error"},
+		[]string{"Ensure the encryption key is valid and has not been rotated mid-operation"})
+}
+
+// ErrDecryptSecret is returned when decrypting a stored credential secret fails.
+func ErrDecryptSecret(err error) error {
+	return errors.New(ErrDecryptSecretCode, errors.Alert,
+		[]string{"Failed to decrypt stored credential secret"},
+		[]string{err.Error()},
+		[]string{
+			"The stored credential may have been encrypted with a different key",
+			"The credential row may be corrupted",
+		},
+		[]string{
+			"Verify that MESHERY_ENCRYPTION_KEY or MESHERY_ENCRYPTION_KEY_FILE matches the key used when the credential was saved",
+			"Restore the original encryption key to access encrypted credentials",
+		})
+}
+
+// ErrEncryptK8sContext is returned when encrypting a Kubernetes context's auth
+// or cluster fields fails.
+func ErrEncryptK8sContext(err error) error {
+	return errors.New(ErrEncryptK8sContextCode, errors.Alert,
+		[]string{"Failed to encrypt Kubernetes context fields before persisting"},
+		[]string{err.Error()},
+		[]string{"Internal encryption error for kubeconfig data"},
+		[]string{"Ensure the encryption key is valid and has not been rotated mid-operation"})
+}
+
+// ErrDecryptK8sContext is returned when decrypting a Kubernetes context's auth
+// or cluster fields fails.
+func ErrDecryptK8sContext(err error) error {
+	return errors.New(ErrDecryptK8sContextCode, errors.Alert,
+		[]string{"Failed to decrypt Kubernetes context fields after reading"},
+		[]string{err.Error()},
+		[]string{
+			"The stored kubeconfig data may have been encrypted with a different key",
+			"The k8s_contexts row may be corrupted",
+		},
+		[]string{
+			"Verify that MESHERY_ENCRYPTION_KEY or MESHERY_ENCRYPTION_KEY_FILE matches the key used when the context was saved",
+			"Restore the original encryption key to access encrypted Kubernetes contexts",
+		})
+}
 
 func ErrCloseIoReader(err error) error {
 	return errors.New(ErrCloseIoReaderCode, errors.Alert,

--- a/server/models/k8s_context_test.go
+++ b/server/models/k8s_context_test.go
@@ -2,11 +2,15 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/pkg/encryption"
+	"github.com/meshery/meshery/server/internal/sql"
 	"github.com/meshery/meshkit/database"
 	mkerrors "github.com/meshery/meshkit/errors"
 	"github.com/meshery/meshkit/logger"
@@ -271,3 +275,93 @@ func TestK8sContextsFromKubeconfigDiscoversAllContexts(t *testing.T) {
 		}
 	}
 }
+
+func TestMesheryK8sContextPersister_Encryption(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 17)
+	}
+	encSvc, err := encryption.New(key)
+	if err != nil {
+		t.Fatalf("encryption.New: %v", err)
+	}
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	if err := db.AutoMigrate(&K8sContext{}); err != nil {
+		t.Fatalf("failed to auto migrate: %v", err)
+	}
+
+	persister := &MesheryK8sContextPersister{
+		DB:     &database.Handler{DB: db},
+		EncSvc: encSvc,
+	}
+
+	ctx := K8sContext{
+		ID:      "test-ctx-1",
+		Name:    "prod-cluster",
+		Auth:    sql.Map{"token": "cluster-admin-token"},
+		Cluster: sql.Map{"server": "https://api.k8s.example.com"},
+	}
+
+	// 1. Save with encryption
+	_, err = persister.SaveMesheryK8sContext(ctx)
+	if err != nil {
+		t.Fatalf("SaveMesheryK8sContext: %v", err)
+	}
+
+	// Verify directly in DB that columns are encrypted
+	var raw struct {
+		ID      string
+		Auth    string
+		Cluster string
+	}
+	if err := db.Table("k8s_contexts").Where("id = ?", "test-ctx-1").First(&raw).Error; err != nil {
+		t.Fatalf("reading raw k8s_contexts row: %v", err)
+	}
+	if !strings.Contains(raw.Auth, "__enc__") {
+		t.Errorf("expected DB auth to contain __enc__, got %s", raw.Auth)
+	}
+	if strings.Contains(raw.Auth, "cluster-admin-token") {
+		t.Error("auth was stored as plaintext in the DB")
+	}
+	if !strings.Contains(raw.Cluster, "__enc__") {
+		t.Errorf("expected DB cluster to contain __enc__, got %s", raw.Cluster)
+	}
+	if strings.Contains(raw.Cluster, "https://api.k8s.example.com") {
+		t.Error("cluster was stored as plaintext in the DB")
+	}
+
+	// 2. Read by ID (should decrypt)
+	fetched, err := persister.GetMesheryK8sContext("test-ctx-1")
+	if err != nil {
+		t.Fatalf("GetMesheryK8sContext: %v", err)
+	}
+	if fetched.Auth["token"] != "cluster-admin-token" {
+		t.Errorf("fetched Auth token = %v, want cluster-admin-token", fetched.Auth["token"])
+	}
+	if fetched.Cluster["server"] != "https://api.k8s.example.com" {
+		t.Errorf("fetched Cluster server = %v, want https://api.k8s.example.com", fetched.Cluster["server"])
+	}
+
+	// 3. List path (GetMesheryK8sContexts decrypts a slice of pointers)
+	listBytes, err := persister.GetMesheryK8sContexts("", "updated_at desc", 0, 10)
+	if err != nil {
+		t.Fatalf("GetMesheryK8sContexts: %v", err)
+	}
+	var listPage MesheryK8sContextPage
+	if err := json.Unmarshal(listBytes, &listPage); err != nil {
+		t.Fatalf("unmarshal GetMesheryK8sContexts response: %v", err)
+	}
+	if len(listPage.Contexts) != 1 {
+		t.Fatalf("expected 1 context in list, got %d", len(listPage.Contexts))
+	}
+	listedAuth := listPage.Contexts[0].Auth
+	if listedAuth["token"] != "cluster-admin-token" {
+		t.Errorf("listed Auth token = %v, want cluster-admin-token", listedAuth["token"])
+	}
+}
+
+

--- a/server/models/meshery_k8scontext_persister.go
+++ b/server/models/meshery_k8scontext_persister.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/meshery/meshery/server/pkg/encryption"
+	"github.com/meshery/meshery/server/internal/sql"
 	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/database"
 	"gorm.io/gorm"
@@ -12,7 +14,8 @@ import (
 // MesheryK8sContextPersister is the persister for persisting
 // applications on the database
 type MesheryK8sContextPersister struct {
-	DB *database.Handler
+	DB     *database.Handler
+	EncSvc *encryption.Service
 }
 
 // MesheryK8sContextPage represents a page of contexts
@@ -45,6 +48,28 @@ func (mkcp *MesheryK8sContextPersister) GetMesheryK8sContexts(search, order stri
 
 	Paginate(uint(page), uint(pageSize))(query).Find(&contexts)
 
+	if mkcp.EncSvc != nil {
+		for _, ctx := range contexts {
+			if ctx == nil {
+				continue
+			}
+			if ctx.Auth != nil {
+				decryptedAuth, err := mkcp.EncSvc.DecryptMap(ctx.Auth)
+				if err != nil {
+					return nil, ErrDecryptK8sContext(err)
+				}
+				ctx.Auth = sql.Map(decryptedAuth)
+			}
+			if ctx.Cluster != nil {
+				decryptedCluster, err := mkcp.EncSvc.DecryptMap(ctx.Cluster)
+				if err != nil {
+					return nil, ErrDecryptK8sContext(err)
+				}
+				ctx.Cluster = sql.Map(decryptedCluster)
+			}
+		}
+	}
+
 	mesheryK8sContextPage := MesheryK8sContextPage{
 		Page:       page,
 		PageSize:   pageSize,
@@ -67,6 +92,26 @@ func (mkcp *MesheryK8sContextPersister) SaveMesheryK8sContext(mkc K8sContext) (c
 		mkc.ID = id
 	}
 
+	// Encrypt only after K8sContextGenerateID has run. The ID is derived from
+	// Auth and Cluster, and each Seal uses a fresh nonce, so encrypting first
+	// would produce a different ID on every save and break identity deduplication.
+	if mkcp.EncSvc != nil {
+		if mkc.Auth != nil {
+			encryptedAuth, err := mkcp.EncSvc.EncryptMap(mkc.Auth)
+			if err != nil {
+				return conn, ErrEncryptK8sContext(err)
+			}
+			mkc.Auth = sql.Map(encryptedAuth)
+		}
+		if mkc.Cluster != nil {
+			encryptedCluster, err := mkcp.EncSvc.EncryptMap(mkc.Cluster)
+			if err != nil {
+				return conn, ErrEncryptK8sContext(err)
+			}
+			mkc.Cluster = sql.Map(encryptedCluster)
+		}
+	}
+
 	// Perform the operation in a transaction
 	err := mkcp.DB.Transaction(func(tx *gorm.DB) error {
 		var mesheryK8sContext K8sContext
@@ -86,5 +131,27 @@ func (mkcp *MesheryK8sContextPersister) GetMesheryK8sContext(id string) (K8sCont
 	var mesheryK8sContext K8sContext
 
 	err := mkcp.DB.First(&mesheryK8sContext, "id = ?", id).Error
-	return mesheryK8sContext, err
+	if err != nil {
+		return mesheryK8sContext, err
+	}
+
+	if mkcp.EncSvc != nil {
+		if mesheryK8sContext.Auth != nil {
+			decryptedAuth, err := mkcp.EncSvc.DecryptMap(mesheryK8sContext.Auth)
+			if err != nil {
+				return mesheryK8sContext, ErrDecryptK8sContext(err)
+			}
+			mesheryK8sContext.Auth = sql.Map(decryptedAuth)
+		}
+		if mesheryK8sContext.Cluster != nil {
+			decryptedCluster, err := mkcp.EncSvc.DecryptMap(mesheryK8sContext.Cluster)
+			if err != nil {
+				return mesheryK8sContext, ErrDecryptK8sContext(err)
+			}
+			mesheryK8sContext.Cluster = sql.Map(decryptedCluster)
+		}
+	}
+
+	return mesheryK8sContext, nil
 }
+

--- a/server/pkg/encryption/encryption.go
+++ b/server/pkg/encryption/encryption.go
@@ -1,0 +1,246 @@
+// Package encryption provides optional application-layer AES-256-GCM
+// at-rest encryption for Meshery's sensitive datastore columns (credential
+// secrets and kubeconfig auth/cluster sections).
+//
+// Activation
+//
+// Set one of the following environment variables before starting the server:
+//
+//	MESHERY_ENCRYPTION_KEY      – 64-char hex string (openssl rand -hex 32)
+//	                              or 44-char base64 string (openssl rand -base64 32)
+//	MESHERY_ENCRYPTION_KEY_FILE – path to a file whose first line is the
+//	                              hex or base64 key (useful with Kubernetes Secrets)
+//
+// If neither variable is set, NewFromEnv returns (nil, nil) and the feature
+// is disabled; all existing plaintext rows are read without modification.
+//
+// Wire format
+//
+// Encrypted maps are stored in the existing JSON column as:
+//
+//	{"__enc__":"enc:v1:<base64(nonce || ciphertext)>"}
+//
+// The 12-byte GCM nonce is prepended to the ciphertext so each value is
+// independently decryptable. A map that does not contain the "__enc__" key is
+// treated as plaintext and returned unchanged by DecryptMap.
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	// EncryptionKeyEnv is the environment variable for the hex/base64 key.
+	EncryptionKeyEnv = "MESHERY_ENCRYPTION_KEY"
+
+	// EncryptionKeyFileEnv is the environment variable pointing to a file
+	// that contains the hex/base64 key.
+	EncryptionKeyFileEnv = "MESHERY_ENCRYPTION_KEY_FILE"
+
+	// encSentinelKey is the JSON map key that marks an encrypted value.
+	encSentinelKey = "__enc__"
+
+	// encPrefix is a version tag prepended to every encrypted blob so future
+	// algorithm migrations can be detected and handled explicitly.
+	encPrefix = "enc:v1:"
+
+	// gcmNonceSize is the standard GCM nonce length in bytes.
+	gcmNonceSize = 12
+)
+
+// Service encrypts and decrypts map[string]interface{} values with AES-256-GCM.
+// A nil Service pointer is valid; all methods on a nil receiver are no-ops that
+// return the input unchanged, so callers can safely skip nil checks:
+//
+//	svc, _ := encryption.NewFromEnv()
+//	encrypted, err := svc.EncryptMap(secret)  // safe even when svc == nil
+type Service struct {
+	gcm cipher.AEAD // built once at construction; safe for concurrent use
+}
+
+// New creates a Service from the supplied raw 32-byte key.
+// Returns an error if the key length is wrong.
+func New(key []byte) (*Service, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("encryption key must be 32 bytes (AES-256); got %d bytes", len(key))
+	}
+	k := make([]byte, 32)
+	copy(k, key)
+	block, err := aes.NewCipher(k)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{gcm: gcm}, nil
+}
+
+// NewFromEnv reads the encryption key from environment variables.
+// It checks MESHERY_ENCRYPTION_KEY first, then MESHERY_ENCRYPTION_KEY_FILE.
+// Returns (nil, nil) when neither variable is set — encryption is disabled.
+// Returns a non-nil error when a variable is set but the value is invalid.
+func NewFromEnv() (*Service, error) {
+	source := EncryptionKeyEnv
+	raw := strings.TrimSpace(os.Getenv(EncryptionKeyEnv))
+	if raw == "" {
+		file := strings.TrimSpace(os.Getenv(EncryptionKeyFileEnv))
+		if file == "" {
+			// Neither variable set — feature disabled.
+			return nil, nil
+		}
+		source = EncryptionKeyFileEnv
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("encryption: cannot read key file %q: %w", file, err)
+		}
+		// Take only the first line, strip whitespace.
+		raw = strings.TrimSpace(strings.SplitN(string(data), "\n", 2)[0])
+	}
+	key, err := parseKey(raw)
+	if err != nil {
+		return nil, fmt.Errorf("encryption: invalid key in %s: %w", source, err)
+	}
+	return New(key)
+}
+
+// parseKey decodes a hex- or base64-encoded 32-byte key.
+func parseKey(s string) ([]byte, error) {
+	// 64 hex chars → 32 bytes
+	if len(s) == 64 {
+		b, err := hex.DecodeString(s)
+		if err == nil && len(b) == 32 {
+			return b, nil
+		}
+	}
+	// Standard base64 with optional padding (44 chars for 32 bytes, or 43 without =)
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		// Try without padding
+		b, err = base64.RawStdEncoding.DecodeString(s)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("value is neither 64-char hex nor valid base64: %w", err)
+	}
+	if len(b) != 32 {
+		return nil, fmt.Errorf("decoded key length is %d bytes; must be 32 bytes (AES-256)", len(b))
+	}
+	return b, nil
+}
+
+// EncryptMap JSON-marshals m, encrypts the result with AES-256-GCM, and
+// returns a sentinel map {"__enc__":"enc:v1:<base64>"}.
+//
+// If the receiver is nil (feature disabled), m is returned unchanged.
+// If m already contains the "__enc__" key it is returned unchanged to prevent
+// double-encryption.
+func (s *Service) EncryptMap(m map[string]interface{}) (map[string]interface{}, error) {
+	if s == nil {
+		return m, nil
+	}
+	if _, alreadyEncrypted := m[encSentinelKey]; alreadyEncrypted {
+		return m, nil
+	}
+
+	plaintext, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("encryption: marshal before encrypt: %w", err)
+	}
+
+	ciphertext, err := s.seal(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("encryption: seal: %w", err)
+	}
+
+	return map[string]interface{}{
+		encSentinelKey: encPrefix + base64.StdEncoding.EncodeToString(ciphertext),
+	}, nil
+}
+
+// DecryptMap detects a sentinel map and decrypts it back to the original
+// map[string]interface{}.
+//
+// If the receiver is nil or m does not contain the "__enc__" key the map is
+// returned unchanged (plaintext pass-through for backwards compatibility).
+func (s *Service) DecryptMap(m map[string]interface{}) (map[string]interface{}, error) {
+	if s == nil {
+		return m, nil
+	}
+
+	enc, ok := m[encSentinelKey]
+	if !ok {
+		// Plaintext row — return as-is for backwards compatibility.
+		return m, nil
+	}
+
+	encStr, ok := enc.(string)
+	if !ok {
+		return nil, fmt.Errorf("encryption: sentinel value is not a string")
+	}
+	if !strings.HasPrefix(encStr, encPrefix) {
+		return nil, fmt.Errorf("encryption: unrecognised encryption prefix in sentinel value")
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(encStr, encPrefix))
+	if err != nil {
+		return nil, fmt.Errorf("encryption: base64 decode: %w", err)
+	}
+
+	plaintext, err := s.open(ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("encryption: open: %w", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(plaintext, &result); err != nil {
+		return nil, fmt.Errorf("encryption: unmarshal after decrypt: %w", err)
+	}
+	return result, nil
+}
+
+// IsEncrypted reports whether m is a sentinel map produced by EncryptMap.
+func (s *Service) IsEncrypted(m map[string]interface{}) bool {
+	if m == nil {
+		return false
+	}
+	_, ok := m[encSentinelKey]
+	return ok
+}
+
+// seal encrypts plaintext with AES-256-GCM and returns nonce || ciphertext.
+func (s *Service) seal(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, gcmNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("nonce generation: %w", err)
+	}
+
+	// Append ciphertext after nonce so the combined blob is self-contained.
+	sealed := s.gcm.Seal(nonce, nonce, plaintext, nil)
+	return sealed, nil
+}
+
+// open decrypts a nonce || ciphertext blob produced by seal.
+func (s *Service) open(data []byte) ([]byte, error) {
+	if len(data) < gcmNonceSize {
+		return nil, fmt.Errorf("ciphertext too short: %d bytes", len(data))
+	}
+
+	nonce := data[:gcmNonceSize]
+	ciphertext := data[gcmNonceSize:]
+
+	plaintext, err := s.gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("AEAD open failed (wrong key or tampered data): %w", err)
+	}
+	return plaintext, nil
+}

--- a/server/pkg/encryption/encryption_test.go
+++ b/server/pkg/encryption/encryption_test.go
@@ -1,0 +1,329 @@
+package encryption_test
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/meshery/meshery/server/pkg/encryption"
+)
+
+// newTestKey returns a deterministic 32-byte key suitable for tests.
+func newTestKey() []byte {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	return key
+}
+
+func newTestService(t *testing.T) *encryption.Service {
+	t.Helper()
+	svc, err := encryption.New(newTestKey())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return svc
+}
+
+// ── New ──────────────────────────────────────────────────────────────────────
+
+func TestNew_ValidKey(t *testing.T) {
+	_, err := encryption.New(newTestKey())
+	if err != nil {
+		t.Fatalf("expected no error for 32-byte key, got: %v", err)
+	}
+}
+
+func TestNew_ShortKey(t *testing.T) {
+	_, err := encryption.New(make([]byte, 16))
+	if err == nil {
+		t.Fatal("expected error for 16-byte key, got nil")
+	}
+}
+
+func TestNew_LongKey(t *testing.T) {
+	_, err := encryption.New(make([]byte, 64))
+	if err == nil {
+		t.Fatal("expected error for 64-byte key, got nil")
+	}
+}
+
+func TestNew_EmptyKey(t *testing.T) {
+	_, err := encryption.New([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty key, got nil")
+	}
+}
+
+// ── NewFromEnv ───────────────────────────────────────────────────────────────
+
+func TestNewFromEnv_NoVarsReturnsNil(t *testing.T) {
+	t.Setenv(encryption.EncryptionKeyEnv, "")
+	t.Setenv(encryption.EncryptionKeyFileEnv, "")
+
+	svc, err := encryption.NewFromEnv()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if svc != nil {
+		t.Fatal("expected nil service when no env var is set")
+	}
+}
+
+func TestNewFromEnv_HexKey(t *testing.T) {
+	hexKey := hex.EncodeToString(newTestKey())
+	t.Setenv(encryption.EncryptionKeyEnv, hexKey)
+	t.Setenv(encryption.EncryptionKeyFileEnv, "")
+
+	svc, err := encryption.NewFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("expected non-nil service for valid hex key")
+	}
+}
+
+func TestNewFromEnv_Base64Key(t *testing.T) {
+	b64Key := base64.StdEncoding.EncodeToString(newTestKey())
+	t.Setenv(encryption.EncryptionKeyEnv, b64Key)
+	t.Setenv(encryption.EncryptionKeyFileEnv, "")
+
+	svc, err := encryption.NewFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("expected non-nil service for valid base64 key")
+	}
+}
+
+func TestNewFromEnv_KeyFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "meshery-key-*.txt")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	hexKey := hex.EncodeToString(newTestKey())
+	if _, err := fmt.Fprintln(f, hexKey); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close key file: %v", err)
+	}
+
+	t.Setenv(encryption.EncryptionKeyEnv, "")
+	t.Setenv(encryption.EncryptionKeyFileEnv, f.Name())
+
+	svc, err := encryption.NewFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("expected non-nil service when key file is valid")
+	}
+}
+
+func TestNewFromEnv_InvalidKeyReturnsError(t *testing.T) {
+	t.Setenv(encryption.EncryptionKeyEnv, "not-a-key")
+	t.Setenv(encryption.EncryptionKeyFileEnv, "")
+
+	_, err := encryption.NewFromEnv()
+	if err == nil {
+		t.Fatal("expected error for invalid key value, got nil")
+	}
+}
+
+// ── EncryptMap / DecryptMap round-trip ───────────────────────────────────────
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	svc := newTestService(t)
+
+	original := map[string]interface{}{
+		"auth":    map[string]interface{}{"token": "super-secret"},
+		"cluster": map[string]interface{}{"server": "https://k8s.example.com"},
+	}
+
+	encrypted, err := svc.EncryptMap(original)
+	if err != nil {
+		t.Fatalf("EncryptMap: %v", err)
+	}
+
+	decrypted, err := svc.DecryptMap(encrypted)
+	if err != nil {
+		t.Fatalf("DecryptMap: %v", err)
+	}
+
+	// Check that the round-trip preserved the auth token.
+	authMap, ok := decrypted["auth"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected auth to be map, got %T", decrypted["auth"])
+	}
+	if got := authMap["token"]; got != "super-secret" {
+		t.Errorf("auth.token = %v, want %q", got, "super-secret")
+	}
+}
+
+func TestEncryptedMapContainsSentinel(t *testing.T) {
+	svc := newTestService(t)
+	m := map[string]interface{}{"key": "value"}
+
+	enc, err := svc.EncryptMap(m)
+	if err != nil {
+		t.Fatalf("EncryptMap: %v", err)
+	}
+	if len(enc) != 1 {
+		t.Errorf("encrypted map should have exactly 1 key, got %d", len(enc))
+	}
+	blob, ok := enc["__enc__"].(string)
+	if !ok {
+		t.Fatal("sentinel key __enc__ missing or not a string")
+	}
+	if !strings.HasPrefix(blob, "enc:v1:") {
+		t.Errorf("sentinel value should start with enc:v1:, got %q", blob)
+	}
+}
+
+func TestPlaintextPassThrough(t *testing.T) {
+	svc := newTestService(t)
+
+	// A map without __enc__ key should be returned unchanged by DecryptMap.
+	plain := map[string]interface{}{"foo": "bar"}
+	result, err := svc.DecryptMap(plain)
+	if err != nil {
+		t.Fatalf("DecryptMap on plaintext: %v", err)
+	}
+	if result["foo"] != "bar" {
+		t.Errorf("expected plaintext pass-through, got %v", result)
+	}
+}
+
+func TestNonceUniqueness(t *testing.T) {
+	svc := newTestService(t)
+	m := map[string]interface{}{"secret": "same"}
+
+	enc1, _ := svc.EncryptMap(m)
+	enc2, _ := svc.EncryptMap(m)
+
+	blob1 := enc1["__enc__"].(string)
+	blob2 := enc2["__enc__"].(string)
+
+	if blob1 == blob2 {
+		t.Error("two encryptions of the same plaintext should produce different ciphertexts (nonce reuse)")
+	}
+}
+
+func TestDoubleEncryptIsNoop(t *testing.T) {
+	svc := newTestService(t)
+	m := map[string]interface{}{"k": "v"}
+
+	enc1, err := svc.EncryptMap(m)
+	if err != nil {
+		t.Fatalf("EncryptMap: %v", err)
+	}
+	// Encrypting an already-encrypted map must be a no-op.
+	enc2, err := svc.EncryptMap(enc1)
+	if err != nil {
+		t.Fatalf("EncryptMap (second): %v", err)
+	}
+	if enc1["__enc__"] != enc2["__enc__"] {
+		t.Error("double-encrypt changed the ciphertext blob")
+	}
+}
+
+func TestEmptyMapRoundTrip(t *testing.T) {
+	svc := newTestService(t)
+	m := map[string]interface{}{}
+
+	enc, err := svc.EncryptMap(m)
+	if err != nil {
+		t.Fatalf("EncryptMap: %v", err)
+	}
+	dec, err := svc.DecryptMap(enc)
+	if err != nil {
+		t.Fatalf("DecryptMap: %v", err)
+	}
+	if len(dec) != 0 {
+		t.Errorf("expected empty map after round-trip, got %v", dec)
+	}
+}
+
+func TestTamperedCiphertextReturnsError(t *testing.T) {
+	svc := newTestService(t)
+	m := map[string]interface{}{"s": "secret"}
+
+	enc, _ := svc.EncryptMap(m)
+
+	// Corrupt the ciphertext by flipping bits in the base64 blob.
+	blob := enc["__enc__"].(string)
+	corrupted := blob[:len(blob)-4] + "XXXX"
+	enc["__enc__"] = corrupted
+
+	_, err := svc.DecryptMap(enc)
+	if err == nil {
+		t.Fatal("expected error for tampered ciphertext, got nil")
+	}
+}
+
+func TestDecryptMap_NonStringSentinel(t *testing.T) {
+	svc := newTestService(t)
+	_, err := svc.DecryptMap(map[string]interface{}{"__enc__": 42})
+	if err == nil {
+		t.Fatal("expected error for non-string sentinel value, got nil")
+	}
+}
+
+func TestDecryptMap_UnknownPrefix(t *testing.T) {
+	svc := newTestService(t)
+	_, err := svc.DecryptMap(map[string]interface{}{"__enc__": "enc:v2:AAAA"})
+	if err == nil {
+		t.Fatal("expected error for unrecognised encryption prefix, got nil")
+	}
+}
+
+// ── Nil receiver (disabled feature) ─────────────────────────────────────────
+
+func TestNilServiceEncryptMapIsNoop(t *testing.T) {
+	var svc *encryption.Service
+	m := map[string]interface{}{"k": "v"}
+
+	result, err := svc.EncryptMap(m)
+	if err != nil {
+		t.Fatalf("expected no error from nil service, got: %v", err)
+	}
+	if result["k"] != "v" {
+		t.Error("nil service EncryptMap should return input unchanged")
+	}
+}
+
+func TestNilServiceDecryptMapIsNoop(t *testing.T) {
+	var svc *encryption.Service
+	m := map[string]interface{}{"k": "v"}
+
+	result, err := svc.DecryptMap(m)
+	if err != nil {
+		t.Fatalf("expected no error from nil service, got: %v", err)
+	}
+	if result["k"] != "v" {
+		t.Error("nil service DecryptMap should return input unchanged")
+	}
+}
+
+// ── IsEncrypted ──────────────────────────────────────────────────────────────
+
+func TestIsEncrypted(t *testing.T) {
+	svc := newTestService(t)
+
+	plain := map[string]interface{}{"k": "v"}
+	enc, _ := svc.EncryptMap(plain)
+
+	if svc.IsEncrypted(plain) {
+		t.Error("plaintext map should not be detected as encrypted")
+	}
+	if !svc.IsEncrypted(enc) {
+		t.Error("encrypted map should be detected as encrypted")
+	}
+}


### PR DESCRIPTION

- Fixes #21445
- [x] Yes, I signed my commits.

**Notes for Reviewers**

**This PR implements optional application-layer AES-256-GCM encryption at rest for sensitive data (credentials and kubeconfig auth/cluster sections) in Meshery's SQLite datastore.**

- Add AES-256-GCM encryption package under `server/internal/encryption` with key loading via environment variables (`MESHERY_ENCRYPTION_KEY` / `MESHERY_ENCRYPTION_KEY_FILE`) and transparent backwards-compatible plaintext fallback
- Wrap credential secret persistence in `DefaultLocalProvider` (`SaveUserCredential`, `GetCredentialByID`, `GetUserCredentials`, `UpdateUserCredential`)
- Wrap Kubernetes context auth and cluster persistence in `MesheryK8sContextPersister` (`SaveMesheryK8sContext`, `GetMesheryK8sContext`, `GetMesheryK8sContexts`)
- Add MeshKit error codes 1481–1484 in `server/models/error.go` and bump `next_error_code` in `server/helpers/component_info.json`
- Add `mesheryctl system encrypt-datastore` migration command supporting `--key`, `--key-file`, `--db-path`, `--dry-run`, and `--decrypt` for in-place migration of existing datastores
- Add documentation in `concepts/logical/credentials.md` and `installation/production/security-hardening.md`



### Testing / Verification

Comprehensive unit tests have been added covering encryption, decryption, migration, and persistence layers:

1. **`server/internal/encryption/encryption_test.go`** (19 unit tests):
   - Key validation (32-byte requirement, hex/base64 parsing)
   - Environment variable and key file loading
   - AES-256-GCM seal/open round-trip
   - Nonce uniqueness & tamper detection
   - Plaintext pass-through and double-encrypt idempotency
   - Safe nil-receiver fallback when disabled
  
2. **`mesheryctl/internal/cli/root/system/encrypt_datastore_test.go`**:
   - `TestMigrateCredentialsTable`: In-place encryption, decryption, idempotency, and dry-run verification
   - `TestMigrateK8sContextsTable`: In-place encryption, decryption, and dry-run verification for Kubernetes contexts
   - `TestEncryptDatastoreCmd_FlagDefaults`: CLI flag verification

3. **`server/models/default_local_provider_test.go`** & **`server/models/k8s_context_test.go`**:
   - `TestDefaultLocalProvider_CredentialEncryption`: Full CRUD lifecycle testing on credentials with encryption enabled
   - `TestMesheryK8sContextPersister_Encryption`: K8s context persistence and retrieval with encryption enabled

<details>
<summary>Test Output Log</summary>
=== RUN TestNew_ValidKey --- PASS: TestNew_ValidKey (0.00s) === RUN TestNew_ShortKey --- PASS: TestNew_ShortKey (0.00s) === RUN TestNew_LongKey --- PASS: TestNew_LongKey (0.00s) === RUN TestNew_EmptyKey --- PASS: TestNew_EmptyKey (0.00s) === RUN TestNewFromEnv_NoVarsReturnsNil --- PASS: TestNewFromEnv_NoVarsReturnsNil (0.00s) === RUN TestNewFromEnv_HexKey --- PASS: TestNewFromEnv_HexKey (0.00s) === RUN TestNewFromEnv_Base64Key --- PASS: TestNewFromEnv_Base64Key (0.00s) === RUN TestNewFromEnv_KeyFile --- PASS: TestNewFromEnv_KeyFile (0.00s) === RUN TestNewFromEnv_InvalidKeyReturnsError --- PASS: TestNewFromEnv_InvalidKeyReturnsError (0.00s) === RUN TestEncryptDecryptRoundTrip --- PASS: TestEncryptDecryptRoundTrip (0.00s) === RUN TestEncryptedMapContainsSentinel --- PASS: TestEncryptedMapContainsSentinel (0.00s) === RUN TestPlaintextPassThrough --- PASS: TestPlaintextPassThrough (0.00s) === RUN TestNonceUniqueness --- PASS: TestNonceUniqueness (0.00s) === RUN TestDoubleEncryptIsNoop --- PASS: TestDoubleEncryptIsNoop (0.00s) === RUN TestEmptyMapRoundTrip --- PASS: TestEmptyMapRoundTrip (0.00s) === RUN TestTamperedCiphertextReturnsError --- PASS: TestTamperedCiphertextReturnsError (0.00s) === RUN TestNilServiceEncryptMapIsNoop --- PASS: TestNilServiceEncryptMapIsNoop (0.00s) === RUN TestNilServiceDecryptMapIsNoop --- PASS: TestNilServiceDecryptMapIsNoop (0.00s) === RUN TestIsEncrypted --- PASS: TestIsEncrypted (0.00s) PASS ok github.com/meshery/meshery/server/internal/encryption 0.008s



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional AES-256-GCM encryption for sensitive credentials and Kubernetes context data stored in SQLite.
  * Supports environment-variable or key-file configuration, with plaintext compatibility when encryption is disabled.
  * Added `mesheryctl system encrypt-datastore` for encryption, decryption, previews, and custom datastore paths.

* **Documentation**
  * Added setup, key-management, migration, and security-hardening guidance.
  * Documented nonce protection, supported key formats, and datastore migration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->