### PR TITLE
[mesheryctl] Simplify CLI error output to human-readable format

### DIFF
--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/system"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/workspaces"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	mesherrs "github.com/meshery/meshkit/errors"
 	logrus "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
@@ -92,11 +93,46 @@ mesheryctl -v [or] --verbose
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the RootCmd.
 func Execute() error {
-	//log formatter for improved UX
-	// Removing printing command usage on error
 	RootCmd.SilenceUsage = true
+	RootCmd.SilenceErrors = true
 	err := RootCmd.Execute()
+	if err != nil {
+		displayError(err, verbose)
+	}
 	return err
+}
+
+// displayError prints a human-readable error to stderr.
+// In normal mode only the short description is shown; --verbose reveals all diagnostic fields.
+func displayError(err error, verbose bool) {
+	if verbose {
+		short := mesherrs.GetSDescription(err)
+		long := mesherrs.GetLDescription(err)
+		cause := mesherrs.GetCause(err)
+		remedy := mesherrs.GetRemedy(err)
+
+		if short == "None" || short == "" {
+			fmt.Fprintln(os.Stderr, "Error:", err.Error())
+			return
+		}
+		fmt.Fprintln(os.Stderr, "Error:", short)
+		if long != "None" && long != "" {
+			fmt.Fprintln(os.Stderr, "Details:", long)
+		}
+		if cause != "None" && cause != "" {
+			fmt.Fprintln(os.Stderr, "Probable Cause:", cause)
+		}
+		if remedy != "None" && remedy != "" {
+			fmt.Fprintln(os.Stderr, "Suggested Remediation:", remedy)
+		}
+	} else {
+		msg := mesherrs.GetSDescription(err)
+		if msg == "None" || msg == "" {
+			msg = err.Error()
+		}
+		fmt.Fprintln(os.Stderr, "Error:", msg)
+		fmt.Fprintln(os.Stderr, "Run with --verbose (-v) for more details")
+	}
 }
 
 func init() {


### PR DESCRIPTION
## Description

Fixes #21399

mesheryctl currently surfaces the full MeshKit pipe-delimited diagnostic string on every error:
Error: Failed to make a request | Short Description: ... | Probable Cause: ... | Suggested Remediation: ...

This PR gates the diagnostic detail behind --verbose / -v.
- Normal mode:
Error: Failed to make a request
Run with --verbose (-v) for more details

- Verbose mode (mesheryctl -v <command>):
Error: Failed to make a request
Details: Unable to connect to Meshery server
Probable Cause: Meshery server is not reachable
Suggested Remediation: Run mesheryctl system restart

## Changes

- root.go : set RootCmd.SilenceErrors = true, add displayError(err, verbose) that uses mesherrs.GetSDescription for the short path and expands all four MeshKit fields in verbose mode. 
Non-MeshKit errors fall back to err.Error().

## Checklist
- [x] go build ./mesheryctl/... passes
- [x] go vet passes
- [x] Existing tests pass
- [x] Commit signed off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error handling with clearer, more consistent error messages.
  * Added guidance to enable verbose mode for additional troubleshooting details.
  * Verbose mode now displays error details, probable causes, and remediation steps when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->