### PR TITLE
test(mesheryctl): add automated BATS test for install without deploying

### DIFF
--- a/mesheryctl/tests/e2e/000-prerequisites/00-install.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-install.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+# [Test Plan] Test #4: Install mesheryctl but do not deploy Meshery
+
+setup() {
+    load "$E2E_HELPERS_PATH/bats_libraries"
+    _load_bats_libraries
+
+    # Create an isolated temporary directory for test artifacts
+    TEST_TMP_DIR=$(mktemp -d)
+}
+
+teardown() {
+    if [ -d "$TEST_TMP_DIR" ]; then
+        rm -rf "$TEST_TMP_DIR"
+    fi
+}
+
+@test "[TC-0004][cut=Installer][tg=Installation] given DEPLOY_MESHERY=false when running install script then mesheryctl is installed without deploying Meshery" {
+    # Execute the installer script with DEPLOY_MESHERY=false
+    run bash -c "DEPLOY_MESHERY=false bash -c \"\$(curl -sL https://meshery.io/install)\""
+    assert_success
+
+    # Assert that the installer prints the expected instruction to start Meshery
+    assert_output --partial 'Run "mesheryctl system start" to start Meshery.'
+
+    # Verify that mesheryctl was installed and can execute client version
+    if [ -f "$HOME/.meshery/bin/mesheryctl" ]; then
+        run "$HOME/.meshery/bin/mesheryctl" version --client
+        assert_success
+    elif [ -f "/usr/local/bin/mesheryctl" ]; then
+        run /usr/local/bin/mesheryctl version --client
+        assert_success
+    elif [ -n "$MESHERYCTL_BIN" ] && [ -f "$MESHERYCTL_BIN" ]; then
+        run "$MESHERYCTL_BIN" version --client
+        assert_success
+    fi
+}

--- a/mesheryctl/tests/e2e/000-prerequisites/00-install.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-install.bats
@@ -6,8 +6,9 @@ setup() {
     load "$E2E_HELPERS_PATH/bats_libraries"
     _load_bats_libraries
 
-    # Create an isolated temporary directory for test artifacts
+    # Create isolated temporary directory and pre-create bin dir to target isolated install
     TEST_TMP_DIR=$(mktemp -d)
+    mkdir -p "$TEST_TMP_DIR/.meshery/bin"
 }
 
 teardown() {
@@ -17,22 +18,24 @@ teardown() {
 }
 
 @test "[TC-0004][cut=Installer][tg=Installation] given DEPLOY_MESHERY=false when running install script then mesheryctl is installed without deploying Meshery" {
-    # Execute the installer script with DEPLOY_MESHERY=false
-    run bash -c "DEPLOY_MESHERY=false bash -c \"\$(curl -sL https://meshery.io/install)\""
+    # Execute the installer script with DEPLOY_MESHERY=false targeting isolated HOME
+    run bash -c "HOME='$TEST_TMP_DIR' DEPLOY_MESHERY=false bash -c \"\$(curl --proto '=https' --tlsv1.2 -sSfL --max-time 30 https://meshery.io/install)\""
     assert_success
 
     # Assert that the installer prints the expected instruction to start Meshery
     assert_output --partial 'Run "mesheryctl system start" to start Meshery.'
 
-    # Verify that mesheryctl was installed and can execute client version
-    if [ -f "$HOME/.meshery/bin/mesheryctl" ]; then
-        run "$HOME/.meshery/bin/mesheryctl" version --client
+    # Assert that mesheryctl binary was created in the isolated install directory
+    assert_file_exists "$TEST_TMP_DIR/.meshery/bin/mesheryctl"
+
+    # Verify that the installed binary is executable and returns client version
+    run "$TEST_TMP_DIR/.meshery/bin/mesheryctl" version --client
+    assert_success
+
+    # Assert that Meshery was not deployed or started (no running meshery containers)
+    if command -v docker >/dev/null 2>&1; then
+        run docker ps --filter "name=meshery" --format "{{.Names}}"
         assert_success
-    elif [ -f "/usr/local/bin/mesheryctl" ]; then
-        run /usr/local/bin/mesheryctl version --client
-        assert_success
-    elif [ -n "$MESHERYCTL_BIN" ] && [ -f "$MESHERYCTL_BIN" ]; then
-        run "$MESHERYCTL_BIN" version --client
-        assert_success
+        refute_output --partial "meshery"
     fi
 }

--- a/mesheryctl/tests/e2e/000-prerequisites/00-install.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-install.bats
@@ -9,6 +9,7 @@ setup() {
     # Create isolated temporary directory and pre-create bin dir to target isolated install
     TEST_TMP_DIR=$(mktemp -d)
     mkdir -p "$TEST_TMP_DIR/.meshery/bin"
+    INSTALL_SCRIPT="$TEST_TMP_DIR/install.sh"
 }
 
 teardown() {
@@ -18,8 +19,13 @@ teardown() {
 }
 
 @test "[TC-0004][cut=Installer][tg=Installation] given DEPLOY_MESHERY=false when running install script then mesheryctl is installed without deploying Meshery" {
+    # Download the installer script first to preserve curl exit status
+    run curl --proto '=https' --tlsv1.2 -sSfL --max-time 30 https://meshery.io/install -o "$INSTALL_SCRIPT"
+    assert_success
+    assert_file_exists "$INSTALL_SCRIPT"
+
     # Execute the installer script with DEPLOY_MESHERY=false targeting isolated HOME
-    run bash -c "HOME='$TEST_TMP_DIR' DEPLOY_MESHERY=false bash -c \"\$(curl --proto '=https' --tlsv1.2 -sSfL --max-time 30 https://meshery.io/install)\""
+    run env HOME="$TEST_TMP_DIR" DEPLOY_MESHERY=false bash "$INSTALL_SCRIPT"
     assert_success
 
     # Assert that the installer prints the expected instruction to start Meshery
@@ -28,8 +34,8 @@ teardown() {
     # Assert that mesheryctl binary was created in the isolated install directory
     assert_file_exists "$TEST_TMP_DIR/.meshery/bin/mesheryctl"
 
-    # Verify that the installed binary is executable and returns client version
-    run "$TEST_TMP_DIR/.meshery/bin/mesheryctl" version --client
+    # Verify that the installed binary is executable and returns client version using the isolated HOME
+    run env HOME="$TEST_TMP_DIR" "$TEST_TMP_DIR/.meshery/bin/mesheryctl" version --client
     assert_success
 
     # Assert that Meshery was not deployed or started (no running meshery containers)


### PR DESCRIPTION
#### Description
Fixes #21079
Automates and verifies Test Case **#4** from the Meshery Test Plan: *"Install mesheryctl without deploying Meshery"*.
This PR adds a new BATS test in `mesheryctl/tests/e2e/000-prerequisites/00-install.bats` that:
1. Executes the installation script using `DEPLOY_MESHERY=false`.
2. Verifies that the installer completes with exit code `0`.
3. Asserts that the installer prints the expected instruction: `Run "mesheryctl system start" to start Meshery.`
4. Verifies that the `mesheryctl` binary is available and can execute `mesheryctl version --client`.
5. Cleans up isolated temporary directories after test completion.
---
#### How Has This Been Tested?
- Verified test assertions against the installer script behavior (`DEPLOY_MESHERY=false`).
- Followed test metadata and library conventions in `mesheryctl/tests/e2e/`.
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end installation coverage using an isolated environment.
  * Verified the command-line tool installs to the expected location and reports its client version.
  * Confirmed installation does not automatically start Meshery containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->