### PR TITLE
Fix Welcome First-Time Contributors workflow failure

### DIFF
--- a/.github/workflows/welcome-first-time-contributors.yml
+++ b/.github/workflows/welcome-first-time-contributors.yml
@@ -144,7 +144,6 @@ jobs:
       - name: 🚨 Alert on Failure
         if: failure()
         uses: slackapi/slack-github-action@v2.1.1
-        # Only run if the Slack bot token secret is configured; skip gracefully otherwise.
         continue-on-error: true
         with:
           method: chat.postMessage

--- a/.github/workflows/welcome-first-time-contributors.yml
+++ b/.github/workflows/welcome-first-time-contributors.yml
@@ -142,7 +142,7 @@ jobs:
       # is alerted to any automation breakage promptly.
       # -----------------------------------------------------------------------
       - name: 🚨 Alert on Failure
-        if: failure() && secrets.SLACK_BOT_TOKEN != ''
+        if: failure()
         uses: slackapi/slack-github-action@v2.1.1
         # Only run if the Slack bot token secret is configured; skip gracefully otherwise.
         continue-on-error: true


### PR DESCRIPTION
The Welcome First-Time Contributors workflow has been failing with the below error:
<img width="1542" height="150" alt="Screenshot 2026-08-21 at 7 32 05 AM" src="https://github.com/user-attachments/assets/c5c43099-23fe-45fc-8a8c-f1c480ec207b" />

The cause if the error is because the workflow is trying to use `secrets` in a context GitHub Actions does not allow.

**Notes for Reviewers**
Removing condition checking for `SLACK_BOT_TOKEN` in failure alert step as **this token is always present**.

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure notifications for the first-time contributor workflow by ensuring alerts are attempted whenever the workflow fails.
  * Notification errors continue to be handled without interrupting the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->