### PR TITLE
[Docs] Fix VS Code sign-off screenshot alignment and mobile readability

### DIFF
--- a/docs/assets/scss/_elements.scss
+++ b/docs/assets/scss/_elements.scss
@@ -15,6 +15,15 @@ img.center {
   margin-left: auto;
   margin-right: auto;
 }
+// A centered screenshot sized to a fraction of the column (e.g. the DCO sign-off
+// IDE setting at width="50%") is too small to read on phones. Widen it to fill
+// the content column on small screens; normal and large screens keep the
+// authored width.
+img.mobile-full {
+  @media (max-width: 768px) {
+    width: 100%;
+  }
+}
 video.center {
   display: block;
   margin-left: auto;

--- a/docs/assets/scss/_elements.scss
+++ b/docs/assets/scss/_elements.scss
@@ -15,6 +15,7 @@ img.center {
   margin-left: auto;
   margin-right: auto;
 }
+
 // A centered screenshot sized to a fraction of the column (e.g. the DCO sign-off
 // IDE setting at width="50%") is too small to read on phones. Widen it to fill
 // the content column on small screens; normal and large screens keep the
@@ -74,7 +75,7 @@ h5,
   font-weight: 400;
 }
 h6 {
-  font-size: .9rem;
+  font-size: 0.9rem;
   font-weight: 300;
 }
 
@@ -125,11 +126,10 @@ ol {
 li:has(> a[href*="/installation/quick-start"]) {
   list-style-type: none;
   margin-left: -2rem;
-  
+
   @media (max-width: 1200px) {
     margin-left: 0rem;
   }
-  
 }
 
 li:has(> a[href*="/extensions"]) {
@@ -148,7 +148,14 @@ pre,
 code,
 kbd,
 samp {
-  font-family: SFMono-Regular, Menlo, Monaco, Consolas, liberation mono, courier new, monospace;
+  font-family:
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    liberation mono,
+    courier new,
+    monospace;
 }
 
 button {
@@ -158,4 +165,3 @@ button {
   border-radius: 5px;
   border: 1px solid var(--color-secondary-light);
 }
-

--- a/docs/content/en/project/contributing/_index.md
+++ b/docs/content/en/project/contributing/_index.md
@@ -54,7 +54,8 @@ To ensure all your commits are signed, you may choose to add this alias to your 
   commit = commit -s
 </code></pre>
 
-Or you may configure your IDE, for example, VSCode to automatically sign-off commits for you:<a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"/></a>
+Or you may configure your IDE, for example, VSCode to automatically sign-off commits for you:
+<a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img class="center mobile-full" src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"/></a>
 
 </li>
 

--- a/docs/content/en/project/contributing/_index.md
+++ b/docs/content/en/project/contributing/_index.md
@@ -5,7 +5,8 @@ categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to the Meshery project and any of its components.
 ---
-# Contributing 
+
+# Contributing
 
 Please do! Thanks for your help! 🎈 Meshery is community-built and welcomes collaboration. Contributors are expected to adhere to the [CNCF's Code of Conduct](https://github.com/meshery/meshery/blob/master/CODE_OF_CONDUCT.md).
 
@@ -55,7 +56,7 @@ To ensure all your commits are signed, you may choose to add this alias to your 
 </code></pre>
 
 Or you may configure your IDE, for example, VSCode to automatically sign-off commits for you:
-<a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img class="center mobile-full" src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"/></a>
+<a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img class="center mobile-full" src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" alt="VS Code setting for automatic commit sign-off" width="50%"/></a>
 
 </li>
 
@@ -92,6 +93,7 @@ $ git push --force-with-lease</code></pre>
 That rewrites the branch, so settle it first with anyone else working on it, and with any
 automation that is tracking the branch by commit hash - a force push moves the tip out from
 under both.
+
 </li>
 </ul>
 </details>
@@ -128,7 +130,7 @@ git checkout master
 
 This yields a working tree a fraction of the size of a full clone. `--filter=blob:none` makes it a [partial clone](https://git-scm.com/docs/partial-clone), so Git transparently fetches any excluded file on demand if you ever check one out - nothing is permanently lost, and `git log`/`git blame` keep working across the full history.
 
-The `!/models/*` pattern excludes the *contents* of `models/` (not the directory itself), which is what lets the two following lines re-include only the `meshery-core` and `kubernetes` models. For the docs, exclude the older archived snapshots under `docs/static/` and keep the newest (currently `docs/static/v0.9`); add another `!` line for each older version as new snapshots are archived.
+The `!/models/*` pattern excludes the _contents_ of `models/` (not the directory itself), which is what lets the two following lines re-include only the `meshery-core` and `kubernetes` models. For the docs, exclude the older archived snapshots under `docs/static/` and keep the newest (currently `docs/static/v0.9`); add another `!` line for each older version as new snapshots are archived.
 
 ### Re-including an excluded directory
 


### PR DESCRIPTION
The DCO sign-off section's VS Code screenshot rendered inline after the text and drifted right on wide screens with the sidebar hidden. Render it as a centered block via class="center".

At width="50%" that centered image was too small to read on phones, so add a scoped `mobile-full` utility that fills the content column at <=768px while normal and large screens keep the authored 50% width.

Fixes #21538

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved mobile display of designated documentation images by allowing them to fill the content width on smaller screens.
  * Preserved authored image sizing on standard and large screens.
  * Refined typography and formatting for a more consistent presentation.

* **Documentation**
  * Improved the contribution guide’s IDE sign-off instructions with descriptive screenshot text and clearer formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->