### PR TITLE
Update playground cleanup workflow to point to new infra (OCI)

### DIFF
--- a/.github/workflows/cncf-playground-reset.yaml
+++ b/.github/workflows/cncf-playground-reset.yaml
@@ -20,6 +20,7 @@ jobs:
           key: ${{ secrets.OCI_BASTION_KEY }}
           envs: MANIFEST_REF
           script: |
+            set -euo pipefail
             SCRIPT_URL="https://raw.githubusercontent.com/meshery/meshery/${MANIFEST_REF}/install/playground/playground-cleanup.sh"
             SCRIPT_FILE="$(mktemp)"
             trap 'rm -f "$SCRIPT_FILE"' EXIT

--- a/.github/workflows/cncf-playground-reset.yaml
+++ b/.github/workflows/cncf-playground-reset.yaml
@@ -12,12 +12,20 @@ jobs:
     steps:
     - name: Cluster cleanup by running the cleanup script inside VM
       uses: appleboy/ssh-action@master
+      env:
+          MANIFEST_REF: ${{ github.sha }}
       with:
-          host: ${{ secrets.METAL_SERVER6 }}
-          username: root
-          key: ${{ secrets.METAL_SSH_KEY }}
+          host: ${{ secrets.OCI_BASTION_HOST }}
+          username: ${{ secrets.OCI_BASTION_USERNAME }}
+          key: ${{ secrets.OCI_BASTION_KEY }}
+          envs: MANIFEST_REF
           script: |
-            cd meshery/install/playground; ./playground-cleanup.sh
+            SCRIPT_URL="https://raw.githubusercontent.com/meshery/meshery/${MANIFEST_REF}/install/playground/playground-cleanup.sh"
+            SCRIPT_FILE="$(mktemp)"
+            trap 'rm -f "$SCRIPT_FILE"' EXIT
+            curl -fsSL "$SCRIPT_URL" -o "$SCRIPT_FILE"
+            kubectl config use-context staging
+            bash "$SCRIPT_FILE"
 
 # reboot:
 #   name: Reboot Metal servers

--- a/install/playground/playground-cleanup.sh
+++ b/install/playground/playground-cleanup.sh
@@ -2,7 +2,7 @@
 #TODO: Make the cleanup smarter than basic namespace deletion
 #Script is placed in /root directory in VM.
 
-valid_namespaces=("kube-system" "default" "monitoring" "kube-flannel" "kube-node-lease" "kube-public" "meshery" "metallb-system" "projectcontour" "ingress-nginx" "cloud" "postgres" "staging-fullstack" "cnpg" "cnpg-system" "cnpg-postgres" "cloud" "local-path-storage")
+valid_namespaces=("kube-system" "default" "monitoring" "kube-flannel" "kube-node-lease" "kube-public" "meshery" "metallb-system" "projectcontour" "ingress-nginx" "cloud" "postgres" "staging-fullstack" "cnpg" "cnpg-system" "cnpg-postgres" "cloud" "local-path-storage" "cert-manager" "dev" "discourse" "kube-system" "layer5-cloud" "meshery" "playground-sandbox" "staging")
 
 for ns in $(kubectl get ns -o jsonpath="{.items[*].metadata.name}"); 
 do

--- a/install/playground/playground-cleanup.sh
+++ b/install/playground/playground-cleanup.sh
@@ -2,7 +2,7 @@
 #TODO: Make the cleanup smarter than basic namespace deletion
 #Script is placed in /root directory in VM.
 
-valid_namespaces=("kube-system" "default" "monitoring" "kube-flannel" "kube-node-lease" "kube-public" "meshery" "metallb-system" "projectcontour" "ingress-nginx" "cloud" "postgres" "staging-fullstack" "cnpg" "cnpg-system" "cnpg-postgres" "cloud" "local-path-storage" "cert-manager" "dev" "discourse" "kube-system" "layer5-cloud" "meshery" "playground-sandbox" "staging")
+valid_namespaces=("kube-system" "default" "monitoring" "kube-flannel" "kube-node-lease" "kube-public" "meshery" "metallb-system" "projectcontour" "ingress-nginx" "cloud" "postgres" "staging-fullstack" "cnpg" "cnpg-system" "cnpg-postgres" "local-path-storage" "cert-manager" "dev" "discourse" "kube-system" "meshery" "playground-sandbox" "staging")
 
 for ns in $(kubectl get ns -o jsonpath="{.items[*].metadata.name}"); 
 do


### PR DESCRIPTION
**Notes for Reviewers**
The staging OKE on OCI runs the production playground workloads inside a specific namespace called `playground-sandbox`. A future roadmap will be to include cleanup within the namespace too to empty it. This will release resources.

- This PR fixes #21150 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playground reset reliability by running cleanup through the designated infrastructure.
  * Ensured cleanup runs against the workflow’s exact revision and removes temporary files afterward.
  * Updated reset cleanup behavior to preserve supported namespaces while excluding obsolete or duplicate entries.
  * Applied stricter error handling and the correct staging environment during cleanup to help prevent incomplete resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->