### PR TITLE
[mesheryctl] Fix malformed doc comments in pkg/utils

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -85,8 +85,8 @@ func NewRequest(method string, url string, body io.Reader) (*http.Request, error
 	return req, nil
 }
 
-// Function returns a new http response given a http request
-// Function will test the response and return any errors associated with it
+// MakeRequest returns a new http response given a http request
+// It tests the response and returns any errors associated with it
 func MakeRequest(req *http.Request) (*http.Response, error) {
 	client := &http.Client{}
 
@@ -144,7 +144,7 @@ func MakeRequest(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-// Function checks the location of token and returns appropriate location of the token
+// GetTokenLocation checks the location of token and returns appropriate location of the token
 func GetTokenLocation(token config.Token) (string, error) {
 	// Find home directory.
 	home, err := os.UserHomeDir()

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -85,8 +85,7 @@ func NewRequest(method string, url string, body io.Reader) (*http.Request, error
 	return req, nil
 }
 
-// MakeRequest returns a new http response given a http request
-// It tests the response and returns any errors associated with it
+// MakeRequest sends an HTTP request, validates the response, and returns the response or an error.
 func MakeRequest(req *http.Request) (*http.Response, error) {
 	client := &http.Client{}
 

--- a/mesheryctl/pkg/utils/error.go
+++ b/mesheryctl/pkg/utils/error.go
@@ -173,7 +173,7 @@ func SystemProviderSubError(msg string, cmd string) string {
 	}
 }
 
-// SystemProviderSubError returns a formatted error message with a link to `provider` command usage page
+// SystemModelSubError returns a formatted error message with a link to `model` command usage page
 // in addition to the error message
 func SystemModelSubError(msg string, cmd string) string {
 	switch cmd {

--- a/mesheryctl/pkg/utils/formatter.go
+++ b/mesheryctl/pkg/utils/formatter.go
@@ -18,13 +18,13 @@ func (f *TerminalFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return append([]byte(entry.Message), '\n'), nil
 }
 
-// Call this function to setup logrus
+// SetupLogrusFormatter sets up logrus with the terminal formatter
 func SetupLogrusFormatter() {
 	//log formatter for improved UX
 	log.SetFormatter(new(TerminalFormatter))
 }
 
-// Initialize Meshkit Logger instance
+// SetupMeshkitLogger initializes a Meshkit logger instance
 func SetupMeshkitLogger(name string, debugLevel bool, output io.Writer) logger.Handler {
 	logLevel := viper.GetInt("LOG_LEVEL")
 	if !debugLevel {

--- a/mesheryctl/pkg/utils/healthcheck.go
+++ b/mesheryctl/pkg/utils/healthcheck.go
@@ -328,8 +328,8 @@ func pollForPodRunning(c *meshkitkube.Client, namespace, podName string, timeout
 	})
 }
 
-// WaitForPodRunning waits up to timeout seconds for pod in 'namespace' to enter running state.
-// It returns an error if no pods are found or not all discovered pods enter running state.
+// WaitForPodRunning waits up to timeout seconds for the pod matching desiredPod in namespace to enter running state.
+// It returns an error if namespace has no pods, if desiredPod is not found among them, or if it does not reach running state in time.
 func WaitForPodRunning(c *meshkitkube.Client, desiredPod, namespace string, timeout int) error {
 	podList, err := GetPodList(c, namespace)
 	if err != nil {

--- a/mesheryctl/pkg/utils/healthcheck.go
+++ b/mesheryctl/pkg/utils/healthcheck.go
@@ -328,8 +328,8 @@ func pollForPodRunning(c *meshkitkube.Client, namespace, podName string, timeout
 	})
 }
 
-// Wait up to timeout seconds for pod in 'namespace' to enter running state.
-// Returns an error if no pods are found or not all discovered pods enter running state.
+// WaitForPodRunning waits up to timeout seconds for pod in 'namespace' to enter running state.
+// It returns an error if no pods are found or not all discovered pods enter running state.
 func WaitForPodRunning(c *meshkitkube.Client, desiredPod, namespace string, timeout int) error {
 	podList, err := GetPodList(c, namespace)
 	if err != nil {
@@ -381,7 +381,7 @@ func pollForNamespaceDeleted(c *meshkitkube.Client, namespace string, timeout ti
 	})
 }
 
-// Wait up to timeout seconds for `namespace` to be deleted.
+// WaitForNamespaceDeleted waits up to timeout seconds for `namespace` to be deleted.
 func WaitForNamespaceDeleted(c *meshkitkube.Client, namespace string, timeout int) error {
 	return pollForNamespaceDeleted(c, namespace, time.Duration(timeout)*time.Second)
 }

--- a/mesheryctl/pkg/utils/helpers.go
+++ b/mesheryctl/pkg/utils/helpers.go
@@ -459,7 +459,7 @@ func SetFileLocation() error {
 	return nil
 }
 
-// NavigateToBroswer naviagtes to the endpoint displaying Meshery UI in the broswer.
+// NavigateToBrowser navigates to the endpoint displaying the Meshery UI in the browser.
 func NavigateToBrowser(endpoint string) error {
 	err := browser.OpenURL(endpoint)
 	return err
@@ -732,7 +732,7 @@ func GetName(mesheryServerUrl, configuration string) (map[string]string, error) 
 	return nameIdMap, nil
 }
 
-// Delete configuration from meshery server endpoint /api/{configurations}/{id}
+// DeleteConfiguration deletes configuration from meshery server endpoint /api/{configurations}/{id}
 func DeleteConfiguration(mesheryServerUrl, id, configuration string) error {
 	url := mesheryServerUrl + "/api/" + configuration + "/" + id
 	req, err := NewRequest("DELETE", url, nil)
@@ -767,7 +767,7 @@ func ValidId(mesheryServerUrl, args string, configuration string) (string, bool,
 	return args, isID, nil
 }
 
-// ValidId - Check if args is a valid name or a valid name prefix and returns the full name and ID
+// ValidName - Check if args is a valid name or a valid name prefix and returns the full name and ID
 func ValidName(mesheryServerUrl, args string, configuration string) (string, string, bool, error) {
 	isName := false
 	nameIdMap, err := GetName(mesheryServerUrl, configuration)
@@ -853,7 +853,7 @@ func ParseURLGithub(URL string) (string, string, error) {
 	return URL, "", ErrParsingUrl(errors.New("only github urls are supported"))
 }
 
-// Indicate an ongoing Process at a given time on CLI
+// CreateDefaultSpinner creates a spinner that indicates an ongoing process on the CLI
 func CreateDefaultSpinner(suffix string, finalMsg string) *spinner.Spinner {
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 
@@ -862,7 +862,7 @@ func CreateDefaultSpinner(suffix string, finalMsg string) *spinner.Spinner {
 	return s
 }
 
-// Get Meshery Session Data/Details (Adapters)
+// GetSessionData gets Meshery session data/details (adapters)
 func GetSessionData(mctlCfg *config.MesheryCtlConfig) (*models.Preference, error) {
 	path := mctlCfg.GetBaseMesheryURL() + "/api/system/sync"
 	method := "GET"
@@ -1373,7 +1373,7 @@ func IsValidUrl(path string) bool {
 	return u.Scheme != "" && u.Host != ""
 }
 
-// get current k8s context
+// GetCurrentK8sContext gets current k8s context
 func GetCurrentK8sContext(client *meshkitkube.Client) (string, error) {
 	if client == nil {
 		return "", fmt.Errorf("kubernetes client is nil")

--- a/mesheryctl/pkg/utils/platform.go
+++ b/mesheryctl/pkg/utils/platform.go
@@ -672,7 +672,7 @@ func GetPodList(client *meshkitkube.Client, namespace string) (*v1core.PodList, 
 	return podList, nil
 }
 
-// GetRequiredPods checks if the pods specified by the user is valid returns a map of the required pods
+// GetRequiredPods checks whether the pods specified by the user are valid and returns a map of the required pods.
 func GetRequiredPods(specifiedPods []string, availablePods []v1core.Pod) (map[string]string, error) {
 	requiredPodsMap := make(map[string]string)
 	var availablePodsName []string

--- a/mesheryctl/pkg/utils/platform.go
+++ b/mesheryctl/pkg/utils/platform.go
@@ -204,7 +204,7 @@ func DownloadOperatorManifest() error {
 	return nil
 }
 
-// returns the Channel and Version given a context
+// GetChannelAndVersion returns the Channel and Version given a context
 func GetChannelAndVersion(currCtx *(config.Context)) (string, string, error) {
 	var version, channel string
 	version = currCtx.GetVersion()
@@ -658,7 +658,7 @@ func CreateManifestsFolder() error {
 	return nil
 }
 
-// GetPods lists all the available pods in the MesheryNamespace
+// GetPodList lists all the available pods in the MesheryNamespace
 func GetPodList(client *meshkitkube.Client, namespace string) (*v1core.PodList, error) {
 	// Create a pod interface for the given namespace
 	podInterface := client.KubeClient.CoreV1().Pods(namespace)
@@ -672,7 +672,7 @@ func GetPodList(client *meshkitkube.Client, namespace string) (*v1core.PodList, 
 	return podList, nil
 }
 
-// GetRequiredPodsMap checks if the pods specified by the user is valid returns a map of the required pods
+// GetRequiredPods checks if the pods specified by the user is valid returns a map of the required pods
 func GetRequiredPods(specifiedPods []string, availablePods []v1core.Pod) (map[string]string, error) {
 	requiredPodsMap := make(map[string]string)
 	var availablePodsName []string
@@ -782,7 +782,7 @@ func InstallprereqDocker() error {
 	return nil
 }
 
-// Sets the path to user's kubeconfig file into global variables
+// SetKubeConfig sets the path to user's kubeconfig file into global variables
 func SetKubeConfig() {
 	// Define the path where the kubeconfig.yaml will be written to
 	usr, err := user.Current()

--- a/mesheryctl/pkg/utils/testing.go
+++ b/mesheryctl/pkg/utils/testing.go
@@ -228,7 +228,7 @@ func visible(s string) string {
 	return out
 }
 
-// Path to the current file
+// GetBasePath returns the directory containing this file
 func GetBasePath(t *testing.T) string {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -251,7 +251,7 @@ func (tf *GoldenFile) Load() string {
 	return normalizedContent
 }
 
-// Load a Golden file
+// LoadByte loads a golden file and returns its raw bytes
 func (tf *GoldenFile) LoadByte() []byte {
 	tf.t.Helper()
 	path := filepath.Join(tf.dir, tf.name)
@@ -263,7 +263,7 @@ func (tf *GoldenFile) LoadByte() []byte {
 	return content
 }
 
-// write a Golden file
+// Write writes content to the golden file, creating it if it does not already exist
 func (tf *GoldenFile) Write(content string) {
 	tf.t.Helper()
 	path := filepath.Join(tf.dir, tf.name)
@@ -286,7 +286,7 @@ func (tf *GoldenFile) Write(content string) {
 	}
 }
 
-// write a Golden file
+// WriteInByte writes raw bytes to the golden file
 func (tf *GoldenFile) WriteInByte(content []byte) {
 	tf.t.Helper()
 	path := filepath.Join(tf.dir, tf.name)
@@ -330,7 +330,7 @@ func CopyMeshconfigFixture(t *testing.T, src string) string {
 	return dst
 }
 
-// use default context /pkg/utils/TestConfig.yaml
+// SetupContextEnv sets up the test context using the default /pkg/utils/TestConfig.yaml configuration
 func SetupContextEnv(t *testing.T) {
 	configPath := CopyMeshconfigFixture(t, SharedTestConfigPath(t))
 	viper.Reset()
@@ -347,7 +347,7 @@ func SetupContextEnv(t *testing.T) {
 	}
 }
 
-// setup logrus formatter and return the buffer in which commands output is to be set.
+// SetupLogrusGrabTesting sets up the logrus formatter and returns the buffer that command output is written to.
 func SetupLogrusGrabTesting(_ *testing.T, _ bool) *bytes.Buffer {
 	b := bytes.NewBufferString("")
 	logrus.SetOutput(b)
@@ -355,7 +355,7 @@ func SetupLogrusGrabTesting(_ *testing.T, _ bool) *bytes.Buffer {
 	return b
 }
 
-// setup meshkit logger for testing and return the buffer in which commands output is to be set.
+// SetupMeshkitLoggerTesting sets up the Meshkit logger for testing and returns the buffer that command output is written to.
 func SetupMeshkitLoggerTesting(_ *testing.T, verbose bool) *bytes.Buffer {
 	b := bytes.NewBufferString("")
 	logLevel := logrus.InfoLevel
@@ -369,7 +369,7 @@ func SetupMeshkitLoggerTesting(_ *testing.T, verbose bool) *bytes.Buffer {
 	return b
 }
 
-// setup custom context with SetupCustomContextEnv
+// SetupCustomContextEnv sets up the test context using the configuration file at pathToContext
 func SetupCustomContextEnv(t *testing.T, pathToContext string) {
 	viper.Reset()
 	ViperCompose = viper.New()
@@ -389,18 +389,18 @@ func SetupCustomContextEnv(t *testing.T, pathToContext string) {
 	}
 }
 
-// Start mock HTTP client to mock requests
+// StartMockery starts the mock HTTP client used to mock requests
 func StartMockery(t *testing.T) {
 	// activate http mocking
 	httpmock.Activate()
 }
 
-// stop HTTP mock client
+// StopMockery stops the mock HTTP client and resets it
 func StopMockery(_ *testing.T) {
 	httpmock.DeactivateAndReset()
 }
 
-// Set file location for testing stuff
+// SetFileLocationTesting points MesheryFolder, DockerComposeFile, and AuthConfigFile at fixtures under dir, for use in tests
 func SetFileLocationTesting(dir string) {
 	MesheryFolder = filepath.Join(dir, "fixtures", MesheryFolder)
 	DockerComposeFile = filepath.Join(MesheryFolder, DockerComposeFile)
@@ -460,16 +460,15 @@ func StartMockMesheryServer(t *testing.T) error {
 	return nil
 }
 
-// The HandlePagination function add special characters that is not
-// handle properly in test. This function will remove undesired characters
-// and spaces to ensure excepted versus actual result match when using http.MockURL
+// CleanStringFromHandlePagination removes undesired characters and spaces added by the
+// HandlePagination function so that expected and actual results match in tests using http.MockURL
 func CleanStringFromHandlePagination(data string) string {
 	cleaned := StripAnsiEscapeCodes(data)
 	cleaned = formatToTabs(cleaned)
 	return cleaned
 }
 
-// removeANSICodes removes ANSI escape codes from a string.
+// StripAnsiEscapeCodes removes ANSI escape codes from a string.
 //
 // Parameters:
 //

--- a/mesheryctl/pkg/utils/testing.go
+++ b/mesheryctl/pkg/utils/testing.go
@@ -330,7 +330,7 @@ func CopyMeshconfigFixture(t *testing.T, src string) string {
 	return dst
 }
 
-// SetupContextEnv sets up the test context using the default /pkg/utils/TestConfig.yaml configuration
+// SetupContextEnv sets up the test context using the default pkg/utils/TestConfig.yaml configuration
 func SetupContextEnv(t *testing.T) {
 	configPath := CopyMeshconfigFixture(t, SharedTestConfigPath(t))
 	viper.Reset()
@@ -389,13 +389,13 @@ func SetupCustomContextEnv(t *testing.T, pathToContext string) {
 	}
 }
 
-// StartMockery starts the mock HTTP client used to mock requests
+// StartMockery activates HTTP mocking so requests made during the test are intercepted
 func StartMockery(t *testing.T) {
 	// activate http mocking
 	httpmock.Activate()
 }
 
-// StopMockery stops the mock HTTP client and resets it
+// StopMockery deactivates HTTP mocking and resets it
 func StopMockery(_ *testing.T) {
 	httpmock.DeactivateAndReset()
 }
@@ -461,7 +461,7 @@ func StartMockMesheryServer(t *testing.T) error {
 }
 
 // CleanStringFromHandlePagination removes undesired characters and spaces added by the
-// HandlePagination function so that expected and actual results match in tests using http.MockURL
+// HandlePagination function so that expected and actual results match in tests using MockURL
 func CleanStringFromHandlePagination(data string) string {
 	cleaned := StripAnsiEscapeCodes(data)
 	cleaned = formatToTabs(cleaned)


### PR DESCRIPTION
## What this fixes

`.github/.golangci.yml` has `ST1020`, `ST1021`, and `ST1022` listed as
"temporarily disabled" under staticcheck. These are the checks that
require an exported symbol's doc comment to start with the symbol's
own name (standard Go convention).

Running staticcheck with just those three checks enabled against
`mesheryctl/pkg/utils` turns up 30 violations. This PR fixes all of
them, comment text only, no behavior changes.

## Not just a style nit, a few were actually wrong

Most of the 30 just needed the symbol's name added to the front of an
otherwise accurate comment. But five of them still named a function
that no longer exists, left over from a rename or a copy-paste that
was never fully updated:

| Function | Comment used to say |
|---|---|
| `GetPodList` | "GetPods lists all the available pods..." |
| `GetRequiredPods` | "GetRequiredPodsMap checks if the pods..." |
| `ValidName` | "ValidId - Check if args is a valid name..." (copied from `ValidId` above it) |
| `SystemModelSubError` | "SystemProviderSubError returns..." and pointed at the `provider` command instead of `model` |
| `StripAnsiEscapeCodes` | "removeANSICodes removes ANSI escape codes..." |

`NavigateToBrowser`'s comment also had two typos ("NavigateToBroswer",
"broswer") fixed along the way.

## Verification

Built the exact tool this repo's lint config uses (`staticcheck`) and
ran it scoped to the checks in question, before and after:

```
$ staticcheck -checks="ST1020,ST1021,ST1022" ./mesheryctl/pkg/utils/...
# before: 30 violations listed
# after:  no output, exit 0
```

Also ran, all clean:
- `go build ./mesheryctl/...`
- `go vet ./mesheryctl/pkg/utils/...`
- `go test --short ./mesheryctl/pkg/utils/...` — one pre-existing
  failure, `TestPrereq`, unrelated to this change. It shells out to
  `uname`, which doesn't exist on the Windows machine I'm testing on;
  the function itself (`prereq()` in `helpers.go`) is untouched by
  this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved developer-facing documentation across command-line utilities.
  * Corrected descriptions for authentication, error handling, formatting, health checks, platform operations, helper functions, and testing utilities.
  * Standardized comments to clearly match the associated operations and improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->