### PR TITLE
[server] Fix malformed doc comments in models/remote_provider.go

### DIFF
--- a/server/models/remote_provider.go
+++ b/server/models/remote_provider.go
@@ -353,7 +353,7 @@ func (l *RemoteProvider) fetchCapabilities(ctx context.Context, token string, ve
 	return providerProperties, nil
 }
 
-// downloadProviderExtensionPackage will download the remote provider extensions
+// DownloadProviderExtensionPackage will download the remote provider extensions
 // package
 func (l *ProviderProperties) DownloadProviderExtensionPackage(log logger.Handler) {
 	// Skip download if the SKIP_DOWNLOAD_EXTENSIONS flag is set
@@ -853,7 +853,7 @@ func (l *RemoteProvider) GetUsers(token, page, pageSize, search, order, filter s
 	return nil, err
 }
 
-// Returns Keys from a user /api/identity/users/keys
+// GetUsersKeys returns keys from a user via /api/identity/users/keys
 func (l *RemoteProvider) GetUsersKeys(token, page, pageSize, search, order, filter string, orgID string) ([]byte, error) {
 	if !l.Capabilities.IsSupported(UsersKeys) {
 		l.Log.Warn(ErrOperationNotAvailable)
@@ -1042,9 +1042,7 @@ func (l *RemoteProvider) Logout(w http.ResponseWriter, req *http.Request) error 
 	return errors.New(string(bd))
 }
 
-// HandleUnAuthenticated
-//
-// Redirects to alert user of expired session.
+// HandleUnAuthenticated redirects to alert user of expired session.
 // Includes redirect loop detection — if the user has been redirected more than
 // MaxAuthRetries times within a short window, an error page is served instead
 // of continuing the redirect chain.
@@ -2705,7 +2703,7 @@ func (l *RemoteProvider) CloneMesheryPattern(req *http.Request, patternID string
 	return nil, err
 }
 
-// PublishMesheryPattern publishes a meshery pattern with the given id to catalog
+// PublishCatalogPattern publishes a meshery pattern with the given id to catalog
 func (l *RemoteProvider) PublishCatalogPattern(req *http.Request, publishPatternRequest *MesheryCatalogPatternRequestBody) ([]byte, error) {
 	if !l.Capabilities.IsSupported(MesheryPatternsCatalog) {
 		l.Log.Error(ErrOperationNotAvailable)
@@ -2760,7 +2758,7 @@ func (l *RemoteProvider) PublishCatalogPattern(req *http.Request, publishPattern
 	return nil, err
 }
 
-// UnPublishMesheryPattern unpublishes a meshery pattern with the given id to catalog
+// UnPublishCatalogPattern unpublishes a meshery pattern with the given id to catalog
 func (l *RemoteProvider) UnPublishCatalogPattern(req *http.Request, publishPatternRequest *MesheryCatalogPatternRequestBody) ([]byte, error) {
 	if !l.Capabilities.IsSupported(MesheryPatternsCatalog) {
 		l.Log.Error(ErrOperationNotAvailable)
@@ -3284,7 +3282,7 @@ func (l *RemoteProvider) CloneMesheryFilter(req *http.Request, filterID string, 
 	return nil, err
 }
 
-// CloneMesheryFilter publishes a meshery filter with the given id to catalog
+// PublishCatalogFilter publishes a meshery filter with the given id to catalog
 func (l *RemoteProvider) PublishCatalogFilter(req *http.Request, publishFilterRequest *MesheryCatalogFilterRequestBody) ([]byte, error) {
 	if !l.Capabilities.IsSupported(MesheryFiltersCatalog) {
 		l.Log.Error(ErrOperationNotAvailable)
@@ -3339,7 +3337,7 @@ func (l *RemoteProvider) PublishCatalogFilter(req *http.Request, publishFilterRe
 	return nil, err
 }
 
-// UnPublishMesheryFilter publishes a meshery filter with the given id to catalog
+// UnPublishCatalogFilter unpublishes a meshery filter with the given id from catalog
 func (l *RemoteProvider) UnPublishCatalogFilter(req *http.Request, publishFilterRequest *MesheryCatalogFilterRequestBody) ([]byte, error) {
 	if !l.Capabilities.IsSupported(MesheryFiltersCatalog) {
 		l.Log.Error(ErrOperationNotAvailable)
@@ -5062,7 +5060,7 @@ func (l *RemoteProvider) GetKubeClient() *mesherykube.Client {
 	return l.KubeClient
 }
 
-// SaveCredential - to save a creadential for an integration
+// SaveUserCredential - to save a credential for an integration
 func (l *RemoteProvider) SaveUserCredential(token string, credential *Credential) (*Credential, error) {
 	var createdCredential Credential
 	if !l.Capabilities.IsSupported(PersistCredentials) {
@@ -5105,7 +5103,7 @@ func (l *RemoteProvider) SaveUserCredential(token string, credential *Credential
 	return nil, ErrFetch(fmt.Errorf("failed to save the credential"), string(bdr), resp.StatusCode)
 }
 
-// GetCredentials - to get saved credentials
+// GetUserCredentials - to get saved credentials
 func (l *RemoteProvider) GetUserCredentials(req *http.Request, _ string, page, pageSize int, search, order string) (*CredentialsPage, error) {
 	if !l.Capabilities.IsSupported(PersistCredentials) {
 		l.Log.Error(ErrOperationNotAvailable)


### PR DESCRIPTION
## What this fixes

Same issue as #21549, but in `server/models` this time.
`.github/.golangci.yml` has `ST1020`, `ST1021`, and `ST1022` marked
"temporarily disabled" under staticcheck, the checks that require an
exported symbol's doc comment to start with the symbol's own name.

Running staticcheck with just those three checks against
`server/models/remote_provider.go` turns up 9 violations. This PR
fixes all of them, comment text only, no behavior changes.

## Six of the nine are stale names, not just style

| Function | Comment used to say | Note |
|---|---|---|
| `DownloadProviderExtensionPackage` | lowercase `downloadProviderExtensionPackage` | old unexported name |
| `PublishCatalogPattern` | `PublishMesheryPattern` | |
| `UnPublishCatalogPattern` | `UnPublishMesheryPattern` | |
| `PublishCatalogFilter` | `CloneMesheryFilter` | |
| `UnPublishCatalogFilter` | `UnPublishMesheryFilter publishes...` | described as publishing, not unpublishing |
| `SaveUserCredential` | `SaveCredential` | also fixed a "creadential" typo |
| `GetUserCredentials` | `GetCredentials` | |

`UnPublishCatalogFilter` is the one worth double-checking: its old
comment said it "publishes" a filter to catalog. Confirmed against the
function body that it's genuinely the unpublish path, it sends an
HTTP DELETE (its sibling `PublishCatalogFilter` sends POST), and its
own log line reads `"attempting to unpubish filter"`.

The other two, `GetUsersKeys` and `HandleUnAuthenticated`, just needed
the name added. `HandleUnAuthenticated`'s comment was literally just
the bare name on its own line with nothing after it, merged into a
proper first sentence instead.

## Verification

```
$ staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/...
# before: 9 hits in remote_provider.go
# after:  0 hits in remote_provider.go (grep confirmed, other files
#         in this package still have their own separate violations,
#         out of scope for this PR)
```

Also clean: `go build ./server/...`, `go vet ./server/models/...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal API comments to accurately describe provider downloads, authentication, catalog filtering, and credential handling.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->