### PR TITLE
Add Pacifique Mugisho attendance details

### DIFF
--- a/docs/meetings/2026/week-of-08-20-2026/pacifique_mugisho-attendance.md
+++ b/docs/meetings/2026/week-of-08-20-2026/pacifique_mugisho-attendance.md
@@ -1,0 +1,11 @@
+### Introduction
+
+My name is Pacifique Mugisho, I'm a ML Engineer and PyTorch ambassador. 
+ 
+This is my very first meeting, and I'm already excited to be part of Meshery, contributing and collaborating on open source projects.
+
+If you'd like to connect, you can check my: 
+
+- GitHub: [ganji759](https://github.com/ganji759)
+
+- LinkedIn: [Pacifique Mugisho](https://www.linkedin.com/in/pacifique-mugisho-a487801b7/)

--- a/docs/meetings/2026/week-of-08-20-2026/pacifique_mugisho-attendance.md
+++ b/docs/meetings/2026/week-of-08-20-2026/pacifique_mugisho-attendance.md
@@ -1,10 +1,10 @@
 ### Introduction
 
-My name is Pacifique Mugisho, I'm a ML Engineer and PyTorch ambassador. 
+My name is Pacifique Mugisho, I'm an ML engineer and PyTorch ambassador. 
  
-This is my very first meeting, and I'm already excited to be part of Meshery, contributing and collaborating on open source projects.
+This is my very first meeting, and I'm already excited to be part of Meshery, contributing and collaborating on open-source projects.
 
-If you'd like to connect, you can check my: 
+If you'd like to connect, you can check out my: 
 
 - GitHub: [ganji759](https://github.com/ganji759)
 


### PR DESCRIPTION
Added attendance information for Pacifique Mugisho, including introduction and links to GitHub and LinkedIn.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a meeting introduction for Pacifique Mugisho, including his professional background and social profile links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->