### PR TITLE
Fix/dashboard tab icons

### DIFF
--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -6,6 +6,7 @@ import ResourcesTable from './resources/resources-table';
 import ResourcesSubMenu, { CRDsResourcesSubMenu } from './resources/resources-sub-menu';
 import KubernetesIcon from '../../assets/icons/technology/kubernetes';
 import MesheryIcon from './images/meshery-icon';
+import GetKubernetesNodeIcon from './utils';
 import { TabPanel } from './tabpanel';
 import { iconLarge } from '../../css/icons.styles';
 import { useWindowDimensions } from '@/utils/dimension';

--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -373,7 +373,7 @@ const Dashboard = () => {
                       resource === 'Overview' ? (
                         <MesheryIcon style={iconLarge} />
                       ) : (
-                        <KubernetesIcon style={iconLarge} />
+                        <GetKubernetesNodeIcon kind={resource} size={iconLarge} />
                       )
                     }
                     label={resource}

--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -383,7 +383,10 @@ const Dashboard = () => {
                       resource === 'Overview' ? (
                         <MesheryIcon style={iconLarge} />
                       ) : (
-                        <GetKubernetesNodeIcon kind={CATEGORY_ICON_KIND[resource] ?? resource} size={iconLarge} />
+                        <GetKubernetesNodeIcon
+                          kind={CATEGORY_ICON_KIND[resource] ?? resource}
+                          size={iconLarge}
+                        />
                       )
                     }
                     label={resource}

--- a/ui/components/dashboard/index.tsx
+++ b/ui/components/dashboard/index.tsx
@@ -4,7 +4,6 @@ import { useNotificationHandlers } from '../../utils/hooks/useNotification';
 import { ResourcesConfig } from './resources/config';
 import ResourcesTable from './resources/resources-table';
 import ResourcesSubMenu, { CRDsResourcesSubMenu } from './resources/resources-sub-menu';
-import KubernetesIcon from '../../assets/icons/technology/kubernetes';
 import MesheryIcon from './images/meshery-icon';
 import GetKubernetesNodeIcon from './utils';
 import { TabPanel } from './tabpanel';
@@ -85,6 +84,17 @@ const useDashboardRouter = () => {
 };
 
 const ResourceCategoryTabs = ['Overview', ...Object.keys(ResourcesConfig)];
+
+const CATEGORY_ICON_KIND: Record<string, string> = {
+  Node: 'Node',
+  Namespace: 'Namespace',
+  Workload: 'Deployment',
+  Configuration: 'ConfigMap',
+  Network: 'Service',
+  Security: 'ClusterRole',
+  Storage: 'PersistentVolume',
+  CRDS: 'CustomResourceDefinition',
+};
 
 const Dashboard = () => {
   const { data: userData, isLoading } = useGetUserPrefQuery();
@@ -373,7 +383,7 @@ const Dashboard = () => {
                       resource === 'Overview' ? (
                         <MesheryIcon style={iconLarge} />
                       ) : (
-                        <GetKubernetesNodeIcon kind={resource} size={iconLarge} />
+                        <GetKubernetesNodeIcon kind={CATEGORY_ICON_KIND[resource] ?? resource} size={iconLarge} />
                       )
                     }
                     label={resource}


### PR DESCRIPTION
## Description
Fixes #21049

On the Dashboard page, all resource category tabs (Node, Namespace, Workload, Configuration, Network, Security, Storage, CRDS) were rendering the same hardcoded Kubernetes wheel icon. This PR replaces the hardcoded `KubernetesIcon` with `GetKubernetesNodeIcon`, which dynamically resolves the correct icon for each resource category.

## Changes
- Imported `GetKubernetesNodeIcon` from `./utils` in `ui/components/dashboard/index.tsx`
- Replaced hardcoded `<KubernetesIcon />` with `<GetKubernetesNodeIcon kind={resource} size={iconLarge} />` for non-Overview tabs

## Verification
- `GetKubernetesNodeIcon` is already used successfully in `resources-sub-menu.tsx` for sub-tab icons, confirming it correctly resolves category-specific icons
- The `componentIcon()` helper from `@sistent/sistent` maps each resource kind to its distinct SVG icon


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Kubernetes resource tabs to display icons specific to each resource kind instead of using a generic Kubernetes icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1908" height="948" alt="image" src="https://github.com/user-attachments/assets/a4e4554f-05c6-4017-893b-40c107177f2e" />
