### PR TITLE
fix(mesheryctl): add 10s timeout to http.Client in system check

### DIFF
--- a/mesheryctl/internal/cli/root/system/check.go
+++ b/mesheryctl/internal/cli/root/system/check.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -501,7 +502,7 @@ func (hc *HealthChecker) runMesheryVersionHealthChecks() error {
 		return err
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	// failed to fetch response for server version
 	if err != nil || resp.StatusCode != 200 {
@@ -712,7 +713,7 @@ func (hc *HealthChecker) runOperatorHealthChecks() error {
 // If no adapter is specified all the adapters are checked
 func (hc *HealthChecker) runAdapterHealthChecks(adapterName string) error {
 	url := hc.mctlCfg.GetBaseMesheryURL()
-	client := &http.Client{}
+	client := &http.Client{Timeout: 10 * time.Second}
 	var adapters []*models.Adapter
 	prefs, err := utils.GetSessionData(hc.mctlCfg)
 	if err != nil {


### PR DESCRIPTION
## What
Add a 10s timeout to the HTTP clients in `runServerChecks` and `runAdapterHealthChecks` so `mesheryctl system check` fails fast instead of hanging forever against an unresponsive server.

## Evidence
mesheryctl/internal/cli/root/system/check.go:504 and :715 create `&http.Client{}` with no timeout.

## Fix
`client := &http.Client{Timeout: 10 * time.Second}` at both sites.

## Test plan
`go build ./...` passes. Health check against a non-listening endpoint returns an error within 10s rather than blocking.

## Duplicate Scan
No open PR references #19994.

## Risk
Only changes request timeout; no behavior change when the server responds.

Closes #19994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added 10-second timeouts to server version and adapter health checks.
  * Prevented checks from hanging indefinitely when a service is unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->