### PR TITLE
fix(mesheryctl): close file descriptor leaked in BackupConfigFile

### DIFF
--- a/mesheryctl/pkg/utils/helpers.go
+++ b/mesheryctl/pkg/utils/helpers.go
@@ -399,10 +399,11 @@ func BackupConfigFile(cfgFile string) {
 	if err != nil {
 		Log.Fatal(err)
 	}
-	_, err = os.Create(cfgFile)
+	f, err := os.Create(cfgFile)
 	if err != nil {
 		Log.Fatal(err)
 	}
+	_ = f.Close()
 }
 
 const (


### PR DESCRIPTION
## What
Close the file descriptor opened by `os.Create` in BackupConfigFile.

## Evidence
mesheryctl/pkg/utils/helpers.go:402 discards the *os.File from os.Create, leaking an fd on every backup.

## Fix
Capture the file and call Close() after creation.

## Test plan
`go build ./...` passes; existing config-backup path unaffected.

## Duplicate Scan
No open PR references #20045.

## Risk
Nil; local to helper.

Closes #20045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup file handling to ensure newly created files are properly closed.
  * Preserved existing error handling when backup file creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->