### PR TITLE
fix(mesheryctl): make imgs-output-path optional in registry publish

### DIFF
--- a/mesheryctl/internal/cli/root/registry/publish.go
+++ b/mesheryctl/internal/cli/root/registry/publish.go
@@ -93,7 +93,9 @@ mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdw
 		googleSheetCredential = args[1]
 		sheetID = args[2]
 		modelsOutputPath = args[3]
-		imgsOutputPath = args[4]
+		if len(args) > 4 {
+			imgsOutputPath = args[4]
+		}
 
 		srv, err := meshkitUtils.NewSheetSRV(googleSheetCredential)
 		if err != nil {
@@ -192,6 +194,7 @@ func mesherySystem() error {
 // Create models definitions to remote provider path
 // and add models icons to image output path
 func remoteProviderSystem() error {
+	var err error
 	// Construct absolute path to store models
 	outputPath, _ := filepath.Abs(filepath.Join("../", modelsOutputPath))
 	modelDir := filepath.Join(outputPath)
@@ -203,10 +206,11 @@ func remoteProviderSystem() error {
 			comps = []meshkitRegistryUtils.ComponentCSV{}
 		}
 
-		err := utils.GenerateIcons(model, comps, imgsOutputPath)
-		if err != nil {
-			utils.Log.Debug(utils.ErrGeneratingIcons(err, imgsOutputPath))
-			utils.Log.Fatalf("Error generating icons for model %s: %v", model.Model, err.Error())
+		if imgsOutputPath != "" {
+			if err := utils.GenerateIcons(model, comps, imgsOutputPath); err != nil {
+				utils.Log.Debug(utils.ErrGeneratingIcons(err, imgsOutputPath))
+				utils.Log.Fatalf("Error generating icons for model %s: %v", model.Model, err.Error())
+			}
 		}
 
 		_, _, err = WriteModelDefToFileSystem(&model, "", modelDir)


### PR DESCRIPTION
## What
Make the images-output-path optional in `mesheryctl registry publish` so the documented 4-argument example works.

## Evidence
publish.go:84 hardcodes `len(args) != 5`; the help example uses 4 args. RunE read `args[4]` unconditionally (panic risk on 4 args).

## Fix
Guard `imgsOutputPath = args[4]` behind `len(args) > 4`; skip icon generation when empty.

## Test plan
`go build ./...` passes; `mesheryctl registry publish meshery <cred> <sheet> [repo]/models` no longer errors on arg count.

## Duplicate Scan
No open PR references #21558.

## Risk
Icon output only emitted when path provided; matches example.

Closes #21558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the publish command when no image output path is provided.
  - Publishing now completes without attempting unnecessary icon generation.
  - Model definitions continue to be written consistently in both publishing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->