### PR TITLE
fix(mesheryctl): resolve home dir only when --save is passed in view

### DIFF
--- a/mesheryctl/internal/cli/root/connections/view.go
+++ b/mesheryctl/internal/cli/root/connections/view.go
@@ -89,12 +89,6 @@ mesheryctl connection view [connection-name|connection-id] --output-format json 
 			selectedConnection = fetchedConnection
 		}
 
-		// Get the home directory of the user to save the output file
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return utils.ErrRetrieveHomeDir(errors.Wrap(err, "failed to determine user home directory"))
-		}
-
 		outputFormatterFactory := display.OutputFormatterFactory[connection.Connection]{}
 		outputFormatter, err := outputFormatterFactory.New(connectionViewFlagsProvided.outputFormat, *selectedConnection)
 		if err != nil {
@@ -107,6 +101,12 @@ mesheryctl connection view [connection-name|connection-id] --output-format json 
 		}
 
 		if connectionViewFlagsProvided.save {
+			// Get the home directory of the user to save the output file
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return utils.ErrRetrieveHomeDir(errors.Wrap(err, "failed to determine user home directory"))
+			}
+
 			// Prepare the connection string for file naming since connection from local provider
 			// can be created without a name.
 			connectionString := func(c connection.Connection) string {

--- a/mesheryctl/internal/cli/root/environments/view.go
+++ b/mesheryctl/internal/cli/root/environments/view.go
@@ -92,14 +92,15 @@ mesheryctl environment view --orgId [orgId]
 			return err
 		}
 
-		// Get the home directory of the user to save the output file
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return utils.ErrRetrieveHomeDir(errors.Wrap(err, "failed to determine user home directory"))
-		}
 		environmentString := strings.ReplaceAll(fmt.Sprintf("%v", selectedEnvironment.Name), " ", "_")
 
 		if environmentViewFlagsProvided.save {
+			// Get the home directory of the user to save the output file
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return utils.ErrRetrieveHomeDir(errors.Wrap(err, "failed to determine user home directory"))
+			}
+
 			fileName := fmt.Sprintf("environment_%s.%s", environmentString, strings.ToLower(environmentViewFlagsProvided.outputFormat))
 			file := filepath.Join(homeDir, ".meshery", fileName)
 			outputFormatterSaverFactory := display.OutputFormatterSaverFactory[environment.Environment]{}


### PR DESCRIPTION
## What
Only resolve the user home directory when `--save` is passed in `connection view` and `environment view`.

## Evidence
connections/view.go:93 and environments/view.go:96 call os.UserHomeDir() before the `if save` check, so non-save runs error in containerized environments without a home dir.

## Fix
Move the os.UserHomeDir() call inside the `if save` block.

## Test plan
`go build ./...` passes; `mesheryctl connection view <name>` (no --save) succeeds without a home dir; `--save` still writes the file.

## Duplicate Scan
No open PR references #21322.

## Risk
Display path unchanged; only save path deferred.

Closes #21322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Viewing connections or environments without saving output no longer requires resolving the home directory.
  * Improved reliability for standard view operations by limiting save-related checks to commands using the `--save` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->