### PR TITLE
fix(mesheryctl): close kubernetes log stream promptly after consumption

### DIFF
--- a/mesheryctl/internal/cli/root/system/logs.go
+++ b/mesheryctl/internal/cli/root/system/logs.go
@@ -228,10 +228,12 @@ mesheryctl system logs meshery-istio
 					if err != nil {
 						return err
 					}
-					defer func() { _ = logs.Close() }()
 					var logBuf []byte
 					if !systemLogsFlags.Follow {
 						logBuf, err = io.ReadAll(logs)
+						// ponytail: close this container's stream as soon as it is consumed,
+						// not when the whole pod loop returns — scoped defer.
+						_ = logs.Close()
 						if err != nil {
 							return utils.ErrReadResponseBody(err)
 						}
@@ -240,6 +242,7 @@ mesheryctl system logs meshery-istio
 						wg.Add(1)
 						go func() {
 							defer wg.Done()
+							defer func() { _ = logs.Close() }()
 							for {
 								buf := make([]byte, BYTE_SIZE)
 								numBytes, err := logs.Read(buf)


### PR DESCRIPTION
## What
Close each Kubernetes log stream as soon as its consumer finishes instead of when the whole `mesheryctl system logs` command returns.

## Evidence
logs.go:231 `defer func(){ _ = logs.Close() }()` runs at function return, so streams for finished containers stay open across the pod loop.

## Fix
For non-follow: close after io.ReadAll. For --follow: close in the consumer goroutine on exit.

## Test plan
`go build ./...` passes; `mesheryctl system logs` opens and closes one stream per container; `--follow` closes on termination.

## Duplicate Scan
No open PR references #21474.

## Risk
Output identical; only stream lifecycle tightened.

Closes #21474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes log stream cleanup for non-following logs.
  * Ensured following log streams close properly when streaming ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->