### PR TITLE
[Server] Add REST endpoint for changeAdapterStatus, fix error swallowing (#19221)

### DIFF
--- a/server/handlers/adapter_status_handler.go
+++ b/server/handlers/adapter_status_handler.go
@@ -62,8 +62,8 @@ func (h *Handler) ChangeAdapterStatusHandler(w http.ResponseWriter, req *http.Re
 		targetPort = selectedAdapter.Location
 	}
 
-	// reject malformed target ports before they reach the adapter tracker
-	if _, err := strconv.Atoi(targetPort); err != nil {
+	// reject malformed or out-of-range target ports before they reach the adapter tracker
+	if port, err := strconv.Atoi(targetPort); err != nil || port < 1 || port > 65535 {
 		h.log.Error(ErrValidAdapter)
 		writeMeshkitError(w, ErrValidAdapter, http.StatusBadRequest)
 		return

--- a/server/handlers/adapter_status_handler.go
+++ b/server/handlers/adapter_status_handler.go
@@ -10,9 +10,9 @@ import (
 // changeAdapterStatusRequest is the REST request body for deploying or
 // undeploying an adapter.
 type changeAdapterStatusRequest struct {
-	AdapterName  string `json:"adapter_name"`
-	TargetPort   string `json:"target_port,omitempty"`
-	TargetStatus string `json:"target_status"` // "enabled" (deploy) or "disabled" (undeploy)
+	AdapterName  string `json:"adapterName"`
+	TargetPort   string `json:"targetPort,omitempty"`
+	TargetStatus string `json:"targetStatus"` // "enabled" (deploy) or "disabled" (undeploy)
 }
 
 // changeAdapterStatusResponse is the REST response body.
@@ -21,9 +21,12 @@ type changeAdapterStatusResponse struct {
 }
 
 // ChangeAdapterStatusHandler deploys or undeploys an adapter over REST.
-// This mirrors the behavior of the GraphQL changeAdapterStatus mutation,
-// including validation, default port resolution, and proper error
-// propagation (see #19221).
+// POST /api/system/adapter/status (auth required via ProviderMiddleware/AuthMiddleware).
+// Request body: {adapterName, targetPort?, targetStatus: "enabled"|"disabled"}.
+// Returns 400 for invalid or missing input, 401 if unauthenticated, 500 on
+// deploy/undeploy failure. This mirrors the behavior of the GraphQL
+// changeAdapterStatus mutation, including validation, default port
+// resolution, and proper error propagation (see #19221).
 func (h *Handler) ChangeAdapterStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
 	if req.Method != http.MethodPost {
 		writeMeshkitError(w, ErrMethodNotAllowed(req.Method), http.StatusMethodNotAllowed)
@@ -58,7 +61,18 @@ func (h *Handler) ChangeAdapterStatusHandler(w http.ResponseWriter, req *http.Re
 		targetPort = selectedAdapter.Location
 	}
 
-	deploy := body.TargetStatus == "enabled"
+	// reject any targetStatus value that isn't exactly "enabled" or "disabled"
+	var deploy bool
+	switch body.TargetStatus {
+	case "enabled":
+		deploy = true
+	case "disabled":
+		deploy = false
+	default:
+		h.log.Error(ErrValidAdapter)
+		writeMeshkitError(w, ErrValidAdapter, http.StatusBadRequest)
+		return
+	}
 
 	var operation string
 	var err error

--- a/server/handlers/adapter_status_handler.go
+++ b/server/handlers/adapter_status_handler.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/meshery/meshery/server/models"
+)
+
+// changeAdapterStatusRequest is the REST request body for deploying or
+// undeploying an adapter.
+type changeAdapterStatusRequest struct {
+	AdapterName  string `json:"adapter_name"`
+	TargetPort   string `json:"target_port,omitempty"`
+	TargetStatus string `json:"target_status"` // "enabled" (deploy) or "disabled" (undeploy)
+}
+
+// changeAdapterStatusResponse is the REST response body.
+type changeAdapterStatusResponse struct {
+	Status string `json:"status"`
+}
+
+// ChangeAdapterStatusHandler deploys or undeploys an adapter over REST.
+// This mirrors the behavior of the GraphQL changeAdapterStatus mutation,
+// including validation, default port resolution, and proper error
+// propagation (see #19221).
+func (h *Handler) ChangeAdapterStatusHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, _ models.Provider) {
+	if req.Method != http.MethodPost {
+		writeMeshkitError(w, ErrMethodNotAllowed(req.Method), http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body changeAdapterStatusRequest
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		h.log.Error(ErrRetrieveData(err))
+		writeMeshkitError(w, ErrRetrieveData(err), http.StatusBadRequest)
+		return
+	}
+
+	// not able to perform any operation when the name is not there
+	if body.AdapterName == "" && body.TargetPort == "" {
+		h.log.Error(ErrValidAdapter)
+		writeMeshkitError(w, ErrValidAdapter, http.StatusBadRequest)
+		return
+	}
+
+	targetPort := body.TargetPort
+
+	// in case of empty target, prefer the default ports
+	if targetPort == "" {
+		h.log.Debug("target port is not provided, looking for default ports")
+		selectedAdapter := getAdapterInformationByNameREST(body.AdapterName)
+		if selectedAdapter == nil {
+			h.log.Error(ErrValidAdapter)
+			writeMeshkitError(w, ErrValidAdapter, http.StatusBadRequest)
+			return
+		}
+		targetPort = selectedAdapter.Location
+	}
+
+	deploy := body.TargetStatus == "enabled"
+
+	var operation string
+	var err error
+	adapter := models.Adapter{Name: body.AdapterName, Location: body.AdapterName + ":" + targetPort}
+	if deploy {
+		operation = "Deploy"
+		h.log.Info("Deploying Adapter")
+		err = h.config.AdapterTracker.DeployAdapter(req.Context(), adapter)
+	} else {
+		operation = "Undeploy"
+		h.log.Info("Undeploying Adapter")
+		err = h.config.AdapterTracker.UndeployAdapter(req.Context(), adapter)
+	}
+
+	if err != nil {
+		h.log.Info("Failed to " + operation + " adapter")
+		h.log.Error(err)
+		writeMeshkitError(w, ErrRetrieveData(err), http.StatusInternalServerError)
+		return
+	}
+
+	h.log.Info(operation + "ed adapter")
+
+	err = json.NewEncoder(w).Encode(changeAdapterStatusResponse{Status: "processing"})
+	if err != nil {
+		obj := "data"
+		if isClientDisconnect(err) {
+			h.log.Debug(models.ErrMarshal(err, obj))
+		} else {
+			h.log.Error(models.ErrMarshal(err, obj))
+		}
+		return
+	}
+}
+
+// getAdapterInformationByNameREST mirrors resolver.getAdapterInformationByName
+// so the REST handler can resolve default ports without importing the
+// resolver package.
+func getAdapterInformationByNameREST(adapterName string) *models.Adapter {
+	var adapter *models.Adapter
+	for _, v := range models.ListAvailableAdapters {
+		if adapterName == v.Name {
+			adapter = &v
+		}
+	}
+	return adapter
+}

--- a/server/handlers/adapter_status_handler.go
+++ b/server/handlers/adapter_status_handler.go
@@ -40,8 +40,8 @@ func (h *Handler) ChangeAdapterStatusHandler(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	// not able to perform any operation when the name is not there
-	if body.AdapterName == "" && body.TargetPort == "" {
+	// adapterName is always required
+	if body.AdapterName == "" {
 		h.log.Error(ErrValidAdapter)
 		writeMeshkitError(w, ErrValidAdapter, http.StatusBadRequest)
 		return

--- a/server/handlers/adapter_status_handler.go
+++ b/server/handlers/adapter_status_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/meshery/meshery/server/models"
 )
@@ -59,6 +60,13 @@ func (h *Handler) ChangeAdapterStatusHandler(w http.ResponseWriter, req *http.Re
 			return
 		}
 		targetPort = selectedAdapter.Location
+	}
+
+	// reject malformed target ports before they reach the adapter tracker
+	if _, err := strconv.Atoi(targetPort); err != nil {
+		h.log.Error(ErrValidAdapter)
+		writeMeshkitError(w, ErrValidAdapter, http.StatusBadRequest)
+		return
 	}
 
 	// reject any targetStatus value that isn't exactly "enabled" or "disabled"

--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -57,12 +57,13 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 		operation = "Deploy"
 		err = r.Config.AdapterTracker.DeployAdapter(ctx, adapter)
 	}
+
 	if err != nil {
 		r.Log.Info("Failed to " + operation + " adapter")
 		r.Log.Error(err)
-	} else {
-		r.Log.Info(operation + "ed adapter")
+		return model.StatusUnknown, err
 	}
 
+	r.Log.Info(operation + "ed adapter")
 	return model.StatusProcessing, nil
 }

--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -46,7 +46,7 @@ func PerformAdapterStatusChange(ctx context.Context, r *Resolver, targetStatus m
 		r.Log.Info("Undeploying Adapter")
 	}
 
-	r.Log.Debug(fmt.Sprintf("changing adapter status for %s on port %s to %s \n", adapterName, targetPort, targetStatus))
+	r.Log.Debugf("changing adapter status for %s on port %s to %s", adapterName, targetPort, targetStatus)
 
 	var err error
 	adapter := models.Adapter{Name: adapterName, Location: fmt.Sprintf("%s:%s", adapterName, targetPort)}

--- a/server/internal/graphql/resolver/adapter.go
+++ b/server/internal/graphql/resolver/adapter.go
@@ -20,10 +20,10 @@ func getAdapterInformationByName(adapterName string) *models.Adapter {
 	return adapter
 }
 
-func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, targetStatus model.Status, adapterName, targetPort string) (model.Status, error) {
-	// not able to perform any operation when the name is not there
-	if adapterName == "" && targetPort == "" {
-		return model.StatusUnknown, ErrAdapterInsufficientInformation(fmt.Errorf("adapter name or targetport or both are missing"))
+func PerformAdapterStatusChange(ctx context.Context, r *Resolver, targetStatus model.Status, adapterName, targetPort string) (model.Status, error) {
+	// adapterName is always required
+	if adapterName == "" {
+		return model.StatusUnknown, ErrAdapterInsufficientInformation(fmt.Errorf("adapter name is required"))
 	}
 
 	// in case of empty target, prefer the default ports
@@ -46,7 +46,8 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 		r.Log.Info("Undeploying Adapter")
 	}
 
-	r.Log.Debug(fmt.Printf("changing adapter status for %s on port %s to %s \n", adapterName, targetPort, targetStatus))
+	r.Log.Debug(fmt.Sprintf("changing adapter status for %s on port %s to %s \n", adapterName, targetPort, targetStatus))
+
 	var err error
 	adapter := models.Adapter{Name: adapterName, Location: fmt.Sprintf("%s:%s", adapterName, targetPort)}
 	var operation string
@@ -66,4 +67,8 @@ func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, t
 
 	r.Log.Info(operation + "ed adapter")
 	return model.StatusProcessing, nil
+}
+
+func (r *Resolver) changeAdapterStatus(ctx context.Context, _ models.Provider, targetStatus model.Status, adapterName, targetPort string) (model.Status, error) {
+	return PerformAdapterStatusChange(ctx, r, targetStatus, adapterName, targetPort)
 }

--- a/server/models/handlers.go
+++ b/server/models/handlers.go
@@ -70,6 +70,7 @@ type HandlerInterface interface {
 	MeshOpsHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	AdaptersHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	AvailableAdaptersHandler(w http.ResponseWriter, req *http.Request)
+	ChangeAdapterStatusHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	EventStreamHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	SubscribeEventsHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)
 	SubscribeMesheryControllersStatusHandler(w http.ResponseWriter, req *http.Request, prefObj *Preference, user *User, provider Provider)

--- a/server/router/server.go
+++ b/server/router/server.go
@@ -136,6 +136,8 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 	gMux.Handle("/api/system/adapter/manage", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.MeshAdapterConfigHandler)), models.ProviderAuth)))
 	gMux.Handle("/api/system/adapter/operation", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.MeshOpsHandler)), models.ProviderAuth))).
 		Methods("POST")
+	gMux.Handle("/api/system/adapter/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.KubernetesMiddleware(h.ChangeAdapterStatusHandler)), models.ProviderAuth))).
+		Methods("POST")
 	gMux.Handle("/api/system/adapters", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.AdaptersHandler), models.ProviderAuth)))
 	gMux.Handle("/api/system/availableAdapters", http.HandlerFunc(h.AvailableAdaptersHandler)).
 		Methods("GET")
@@ -255,7 +257,7 @@ func NewRouter(_ context.Context, h models.HandlerInterface, port int, g http.Ha
 
 	handleRegistry("/validate", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.ValidationHandler), models.NoAuth)), "POST")
 	handleRegistry("/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.RegisterMeshmodelComponents), models.NoAuth)), "POST") //This should also be left with NoAuth
-	gMux.Handle("/api/meshmodel/components/register", h.ProviderMiddleware((http.HandlerFunc(h.RegisterMeshmodelComponents)))).Methods("POST") //For backwards compatibility with previous registrants
+	gMux.Handle("/api/meshmodel/components/register", h.ProviderMiddleware((http.HandlerFunc(h.RegisterMeshmodelComponents)))).Methods("POST")    //For backwards compatibility with previous registrants
 	handleRegistry("/{entityType}/status", h.ProviderMiddleware(h.AuthMiddleware(h.SessionInjectorMiddleware(h.UpdateEntityStatus), models.NoAuth)), "POST")
 	handleRegistry("/components", h.ProviderMiddleware(h.AuthMiddleware(http.HandlerFunc(h.GetAllMeshmodelComponents), models.NoAuth)), "GET")
 


### PR DESCRIPTION
Adds a REST equivalent of the GraphQL `changeAdapterStatus` mutation and fixes the error-swallowing bug it shared.

**What this PR does**
- Fixes #19221: `changeAdapterStatus` (via a newly extracted `PerformAdapterStatusChange`) now returns the real error from `AdapterTracker.DeployAdapter`/`UndeployAdapter` instead of always returning `(StatusProcessing, nil)`.
- Adds `ChangeAdapterStatusHandler`, a new `POST /api/system/adapter/status` REST endpoint mirroring the same validation, default-port resolution, and deploy/undeploy behavior as the GraphQL mutation, with errors now properly propagated as HTTP error responses.
- Registers the route in `router/server.go` and the handler interface in `models/handlers.go`, following the same middleware chain as the existing `/api/system/adapter/operation` route.

**Part of #21559**

This PR delivers the backend/REST portion of the GraphQL-to-REST migration. UI migration (Relay → RTK Query) and removal of the old GraphQL mutation are tracked as follow-up work, pending merge and publish of the companion schema contract in meshery/schemas#1171.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to deploy or undeploy adapters.
  * Supports enabled or disabled target states, default ports, and processing-status responses.
* **Bug Fixes**
  * Improved validation for request methods, adapter names, ports, and target states.
  * Deployment or undeployment failures now return an unknown status with the corresponding error.
* **Refactor**
  * Integrated adapter status changes into standard server routing and request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->