### PR TITLE
fix(docs): standardize openapi schema URL in rest-apis single layout (#21409)

### DIFF
--- a/docs/layouts/rest-apis/single.html
+++ b/docs/layouts/rest-apis/single.html
@@ -9,7 +9,7 @@
 {{ $components := index $spec "components" | default dict }}
 {{ $securitySchemes := index $components "securitySchemes" | default dict }}
 {{ $tagGroups := index $spec "x-tagGroups" | default (slice) }}
-{{ $schemaURL := "https://raw.githubusercontent.com/meshery/meshery/refs/heads/master/docs/data/openapi.yml" }}
+{{ $schemaURL := "https://raw.githubusercontent.com/meshery/meshery/master/docs/data/openapi.yml" }}
 {{ $defaultOssServer := dict
   "url" "http://localhost:9081"
   "description" "Meshery Server default URL"

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -88,7 +88,7 @@ func (h *Handler) ProviderMiddleware(next http.Handler) http.Handler {
 				provider = h.config.Providers[providerKey]
 			}
 			if provider == nil && h.Provider != "" && providerName == models.NormalizeProviderName(h.Provider) {
-				h.log.Errorf("enforced provider %q is not registered in h.config.Providers; ProviderUIHandler will degrade to serving the provider-selection UI instead of auto-login. Register %q in PROVIDERS or unset PROVIDER on this deployment.", h.Provider, h.Provider)
+				h.log.Errorf("enforced provider %q is not registered in h.config.Providers; ProviderUIHandler will degrade to serving the provider-selection UI instead of auto-login. Add provider base URL to PROVIDER_BASE_URLS or unset PROVIDER on this deployment.", h.Provider)
 			}
 		}
 		ctx := context.WithValue(req.Context(), models.ProviderCtxKey, provider) // nolint

--- a/server/handlers/provider_handler.go
+++ b/server/handlers/provider_handler.go
@@ -216,8 +216,8 @@ func (h *Handler) ProviderUIHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.log.Errorf(
-			"enforced provider %q is not registered in h.config.Providers; serving the provider-selection UI instead of looping. Register %q in PROVIDERS or unset PROVIDER on this deployment.",
-			h.Provider, h.Provider,
+			"enforced provider %q is not registered in h.config.Providers; serving the provider-selection UI instead of looping. Add provider base URL to PROVIDER_BASE_URLS or unset PROVIDER on this deployment.",
+			h.Provider,
 		)
 	} else if h.config.PlaygroundBuild {
 		h.log.Errorf(


### PR DESCRIPTION
### Description
Standardized the raw GitHub URL for `openapi.yml` in `docs/layouts/rest-apis/single.html` to align with the standard raw GitHub URL format used across the documentation site.

Fixes #21409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated provider configuration error messages to reference the correct `PROVIDER_BASE_URLS` setting.
  * Improved provider registration guidance and removed redundant logging information.
  * Corrected the OpenAPI schema link to use the repository’s canonical URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->