### PR TITLE
Automate Test Case #9 (Homebrew installation)

### DIFF
--- a/mesheryctl/tests/e2e/010-installation/01-brew.bats
+++ b/mesheryctl/tests/e2e/010-installation/01-brew.bats
@@ -24,6 +24,5 @@ setup() {
 
     run "$brew_prefix/bin/mesheryctl" version
     assert_success
-    assert_output --partial "Client"
-    assert_output --partial "$brew_version"
+    assert_line --regexp "Client.*$brew_version"
 }

--- a/mesheryctl/tests/e2e/010-installation/01-brew.bats
+++ b/mesheryctl/tests/e2e/010-installation/01-brew.bats
@@ -24,5 +24,7 @@ setup() {
 
     run "$brew_prefix/bin/mesheryctl" version
     assert_success
-    assert_line --regexp "Client.*$brew_version"
+    local client_version
+    client_version=$(echo "$output" | awk '/^Client/ {print $2}')
+    assert_equal "$client_version" "v$brew_version"
 }

--- a/mesheryctl/tests/e2e/010-installation/01-brew.bats
+++ b/mesheryctl/tests/e2e/010-installation/01-brew.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+setup() {
+    load "$E2E_HELPERS_PATH/bats_libraries"
+    _load_bats_libraries
+}
+
+@test "[TC-9][tg=Installation] Install mesheryctl via Homebrew" {
+    if ! command -v brew &> /dev/null; then
+        skip "brew is not installed on this system"
+    fi
+
+    run brew install mesheryctl
+    assert_success
+
+    run brew --prefix mesheryctl
+    assert_success
+    local brew_prefix="$output"
+
+    run brew list --versions mesheryctl
+    assert_success
+    local brew_version
+    brew_version=$(echo "$output" | awk '{print $2}')
+
+    run "$brew_prefix/bin/mesheryctl" version
+    assert_success
+    assert_output --partial "Client"
+    assert_output --partial "$brew_version"
+}


### PR DESCRIPTION
### Summary

This PR fixes #21084 

This PR automates the Meshery Test Plan test case 9 (Homebrew installation).
It introduces a focused, standalone BATS test that executes `brew install mesheryctl` and natively validates the installation. To prevent false positives from pre-existing system binaries, the test explicitly queries Homebrew's internal path (`brew --prefix`), runs the newly installed binary, and strictly requires the binary's reported version to match the exact string Homebrew claims to have installed.
utilizes the standard `mesheryctl` BATS helper logic and strictly adheres to the QA Allure traceability contract by prefixing the test name with `[TC-9][tg=Installation]`.

### Testing
- Verified `mesheryctl` BATS convention conformity.
- The test natively guards itself (`if ! command -v brew`) to gracefully skip execution instead of failing when invoked on Windows or local environments where Homebrew is not installed. 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for installing `mesheryctl` through Homebrew.
  * Verifies the installation location, installed version, and `mesheryctl version` output.
  * Automatically skips when Homebrew is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->