### PR TITLE
[server] Fix malformed doc comments in server/models (batch 2)

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -275,7 +275,7 @@ func (l *DefaultLocalProvider) GetProviderType() ProviderType {
 func (l *DefaultLocalProvider) DownloadProviderExtensionPackage() {
 }
 
-// downloadProviderExtensionPackage will download the remote provider extensions
+// DownloadProviderExtensionPackageFromURL will download the remote provider extensions
 // package
 func (l *DefaultLocalProvider) DownloadProviderExtensionPackageFromURL(packageUrl string, log logger.Handler) error {
 	// Skip download if the SKIP_DOWNLOAD_EXTENSIONS flag is set
@@ -640,7 +640,7 @@ func (l *DefaultLocalProvider) FetchResults(_, page, pageSize, _, _, profileID s
 	return l.ResultPersister.GetResults(pg, pgs, profileID, l.Log)
 }
 
-// FetchResults - fetches results from provider backend
+// FetchAllResults - fetches results from provider backend
 func (l *DefaultLocalProvider) FetchAllResults(_, page, pageSize, _, _, _, _ string) ([]byte, error) {
 	if page == "" {
 		page = "0"
@@ -720,7 +720,7 @@ func (l *DefaultLocalProvider) FetchSmiResults(_ *http.Request, page, pageSize, 
 	return l.SmiResultPersister.GetResults(pg, pgs)
 }
 
-// FetchSmiResults - fetches results from provider backend
+// FetchSmiResult - fetches results from provider backend
 func (l *DefaultLocalProvider) FetchSmiResult(_ *http.Request, _, _, _, _ string, resultID core.Uuid) ([]byte, error) {
 	return l.SmiResultPersister.GetResult(resultID)
 }
@@ -1005,7 +1005,7 @@ func (l *DefaultLocalProvider) DeleteMesheryPattern(_ *http.Request, patternID s
 	return l.MesheryPatternPersister.DeleteMesheryPattern(id)
 }
 
-// DeleteMesheryPattern deletes a meshery pattern with the given id
+// DeleteMesheryPatterns deletes the meshery patterns specified in the given request body
 func (l *DefaultLocalProvider) DeleteMesheryPatterns(_ *http.Request, patterns MesheryPatternDeleteRequestBody) ([]byte, error) {
 	return l.MesheryPatternPersister.DeleteMesheryPatterns(patterns)
 }
@@ -1717,7 +1717,7 @@ func (l *DefaultLocalProvider) GetOrganizations(_, page, pageSize, search, order
 	return l.OrganizationPersister.GetOrganizations(search, order, pg, pgs, updatedAfter)
 }
 
-// GetKeys returns the list of keys
+// GetUsersKeys returns the list of keys
 func (l *DefaultLocalProvider) GetUsersKeys(_, _, _, search, order, updatedAfter string, _ string) ([]byte, error) {
 	keys, err := l.KeyPersister.GetUsersKeys(search, order, updatedAfter)
 	if err != nil {
@@ -1726,7 +1726,7 @@ func (l *DefaultLocalProvider) GetUsersKeys(_, _, _, search, order, updatedAfter
 	return keys, nil
 }
 
-// GetKey returns the key for the given keyID
+// GetUsersKey returns the key for the given keyID
 func (l *DefaultLocalProvider) GetUsersKey(_ *http.Request, keyID string) ([]byte, error) {
 	id := uuid.FromStringOrNil(keyID)
 	return l.KeyPersister.GetUsersKey(id)

--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -310,7 +310,7 @@ func (mch *MesheryControllersHelper) ResolveControllersConfigForConnection(metad
 	return merged, effective, nil
 }
 
-// initializes Meshsync data handler for the contexts for whom it has not been
+// AddMeshsyncDataHandlers initializes Meshsync data handler for the contexts for whom it has not been
 // initialized yet. Apart from updating the map, it also runs the handler after
 // updating the map. The presence of a handler for a context in a map indicate that
 // the meshsync data for that context is properly being handled
@@ -746,7 +746,7 @@ func (mch *MesheryControllersHelper) ResyncMeshsync(ctx context.Context) error {
 	return nil
 }
 
-// attach a MesheryController for each context if
+// AddCtxControllerHandlers attaches a MesheryController for each context if
 // 1. the config is valid
 // 2. if it is not already attached
 func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *MesheryControllersHelper {
@@ -1008,7 +1008,7 @@ func (mch *MesheryControllersHelper) RemoveCtxControllerHandler(ctx context.Cont
 	mch.ctxControllerHandlers = nil
 }
 
-// update the status of MesheryOperator in all the contexts
+// UpdateOperatorsStatusMap updates the status of MesheryOperator in all the contexts
 // for whom MesheryControllers are attached
 // should be called after AddCtxControllerHandlers
 func (mch *MesheryControllersHelper) UpdateOperatorsStatusMap(ot *OperatorTracker) *MesheryControllersHelper {
@@ -1187,7 +1187,7 @@ func (mch *MesheryControllersHelper) SetOperatorDeployment(k8sctx K8sContext, de
 	return nil
 }
 
-// looks at the status of Meshery Operator for each cluster and takes necessary action.
+// DeployUndeployedOperators looks at the status of Meshery Operator for each cluster and takes necessary action.
 // it will deploy the operator only when it is in NotDeployed state
 func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTracker, contextID string) *MesheryControllersHelper {
 	if ot.DisableOperator { //Return true everytime so that operators stay in undeployed state across all contexts
@@ -1297,7 +1297,7 @@ func NewOperatorDeploymentConfig(adapterTracker AdaptersTrackerInterface) contro
 	}
 }
 
-// checkLatestVersion takes in the current server version compares it with the target
+// CheckLatestVersion takes in the current server version compares it with the target
 // and returns the (isOutdated, latestVersion, error)
 func CheckLatestVersion(serverVersion string) (*bool, string, error) {
 	// Inform user of the latest release version
@@ -1389,8 +1389,8 @@ func setOverrideValues(delete bool, adapterTracker AdaptersTrackerInterface) map
 	return overrideValues
 }
 
-// setOverrideValues detects the currently insalled adapters and sets appropriate
-// overrides so as to not uninstall them.
+// SetOverrideValuesForMesheryDeploy detects the currently installed adapters and sets appropriate
+// overrides so as to not uninstall them, then sets the override for the given adapter based on install.
 func SetOverrideValuesForMesheryDeploy(adapters []Adapter, adapter Adapter, install bool) map[string]interface{} {
 	installedAdapters := make([]string, 0)
 	for _, adapter := range adapters {

--- a/server/models/providers.go
+++ b/server/models/providers.go
@@ -31,7 +31,7 @@ type ExtensionInput struct {
 	BrokerConn      broker.Handler
 }
 
-// Router
+// Router describes the HTTP handler and path used to serve a plugin's endpoint.
 type Router struct {
 	HTTPHandler http.Handler
 	Path        string
@@ -123,10 +123,10 @@ type UserPrefsExtensions []UserPrefsExtension
 // GraphQLExtensions is a collection of GraphQLExtension endpoints
 type GraphQLExtensions []GraphQLExtension
 
-// NavigatorExtensions is a collection of AccountExtension
+// AccountExtensions is a collection of AccountExtension
 type AccountExtensions []AccountExtension
 
-// CollaboratorExtension describes the Collaborator extension point in the UI
+// CollaboratorExtensions is a collection of CollaboratorExtension
 type CollaboratorExtensions []CollaboratorExtension
 
 // GraphQLExtension describes the graphql server extension point in the backend
@@ -186,7 +186,7 @@ type UserPrefsExtension struct {
 	Type      string `json:"type,omitempty"`
 }
 
-// CollaboratorsExtension is the struct for collaborators extension
+// CollaboratorExtension is the struct for collaborators extension
 type CollaboratorExtension struct {
 	Component string `json:"component,omitempty"`
 	Type      string `json:"type,omitempty"`
@@ -207,7 +207,7 @@ type Capability struct {
 	Endpoint string  `json:"endpoint,omitempty"`
 }
 
-// K8sContextResponse - struct of response sent by provider when requested to persist k8s config
+// K8sContextPersistResponse - struct of response sent by provider when requested to persist k8s config
 type K8sContextPersistResponse struct {
 	K8sContext K8sContext `json:"k8sContext,omitempty"`
 	Inserted   bool       `json:"inserted,omitempty"`


### PR DESCRIPTION
## What this fixes

Continuing the sweep from #21549 and #21554. `.github/.golangci.yml` has
`ST1020`, `ST1021`, and `ST1022` marked "temporarily disabled" under
staticcheck, the checks that require an exported symbol's doc comment to
start with the symbol's own name.

Running `staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/...`
and picking the next three files by violation count turns up 17 more:
`default_local_provider.go` (6), `meshery_controllers.go` (6),
`providers.go` (5). This PR fixes all of them, comment text only, no
behavior changes.

## Most are stale names, not just style

| File | Symbol | Comment used to say | Note |
|---|---|---|---|
| default_local_provider.go | `DownloadProviderExtensionPackageFromURL` | `downloadProviderExtensionPackage` | old name, before `FromURL` was added |
| default_local_provider.go | `FetchAllResults` | `FetchResults` | |
| default_local_provider.go | `FetchSmiResult` | `FetchSmiResults` | plural, function is singular |
| default_local_provider.go | `DeleteMesheryPatterns` | copy of `DeleteMesheryPattern`'s comment above it | described deleting one pattern by id; this function takes a request body listing multiple patterns |
| default_local_provider.go | `GetUsersKeys` | `GetKeys` | |
| default_local_provider.go | `GetUsersKey` | `GetKey` | |
| providers.go | `AccountExtensions` | `NavigatorExtensions` | copied from the sibling collection type above it, only the element type name was updated |
| providers.go | `CollaboratorExtensions` | description written for the singular `CollaboratorExtension` type | misplaced onto the plural collection type |
| providers.go | `CollaboratorExtension` | `CollaboratorsExtension` | extra "s" |
| providers.go | `K8sContextPersistResponse` | `K8sContextResponse` | missing "Persist" |
| meshery_controllers.go | `SetOverrideValuesForMesheryDeploy` | truncated copy of the unexported `setOverrideValues`'s comment just above it | missing this function's actual distinguishing behavior (setting the override for one given adapter based on `install`); also fixed a pre-existing "insalled" typo on that line |

`SetOverrideValuesForMesheryDeploy` is the one worth double-checking: it
sits right below a different, unexported function `setOverrideValues`
with a similar but longer comment. Confirmed against the body that
`SetOverrideValuesForMesheryDeploy` really does have its own distinct
last step, setting one specific adapter's override based on the
`install bool` argument, which the copied comment never mentioned.

The rest just needed the name added to the front, description already
accurate:

- `AddMeshsyncDataHandlers`
- `AddCtxControllerHandlers` (also fixed "attach" to "attaches" for
  subject-verb agreement)
- `UpdateOperatorsStatusMap`
- `DeployUndeployedOperators`
- `CheckLatestVersion` (lowercase `checkLatestVersion` to match the
  exported name)
- `Router`, whose comment was just the bare word "Router" with no
  description at all

## Verification

```
$ staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/...
# before: 17 hits across these three files
# after:  0 hits in these three files (grep confirmed; other files in
#         this package still have their own separate violations, out
#         of scope for this PR)
```

Also clean: `go build ./server/models/...`, `go vet ./server/models/...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified API documentation for provider downloads, result retrieval, pattern deletion, user key access, controller operations, and Kubernetes context handling.
  - Improved descriptions for routing, account extensions, collaborator extensions, and related responses.

- **Refactor**
  - Renamed a public Kubernetes context response type for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->