### PR TITLE
[server] Fix malformed doc comments in server/models (batch 3)

### DIFF
--- a/server/models/capabilities_persister.go
+++ b/server/models/capabilities_persister.go
@@ -13,7 +13,7 @@ type UserCapabilities struct {
 	Capabilities ProviderProperties `json:"capabilities" gorm:"type:bytes;serializer:json" db:"capabilities"`
 }
 
-// ReadFromPersister - reads the capabilities for the given userID
+// ReadCapabilitiesForUser - reads the capabilities for the given userID
 func (u *UserCapabilitiesPersister) ReadCapabilitiesForUser(userID string) (*ProviderProperties, error) {
 	if u.DB == nil {
 		return nil, ErrDBConnection
@@ -32,7 +32,7 @@ func (u *UserCapabilitiesPersister) ReadCapabilitiesForUser(userID string) (*Pro
 	return &capabilities.Capabilities, nil
 }
 
-// WriteToPersister persists the capabilities for the user
+// WriteCapabilitiesForUser persists the capabilities for the user
 func (u *UserCapabilitiesPersister) WriteCapabilitiesForUser(userID string, data *ProviderProperties) error {
 	if u.DB == nil {
 		return ErrDBConnection
@@ -55,7 +55,7 @@ func (u *UserCapabilitiesPersister) WriteCapabilitiesForUser(userID string, data
 	return nil
 }
 
-// DeleteFromPersister removes the capabilities for the user
+// DeleteCapabilitiesForUser removes the capabilities for the user
 func (u *UserCapabilitiesPersister) DeleteCapabilitiesForUser(userID string) error {
 	if u.DB == nil {
 		return ErrDBConnection

--- a/server/models/environment_persister.go
+++ b/server/models/environment_persister.go
@@ -155,7 +155,7 @@ func (ep *EnvironmentPersister) UpdateEnvironmentByID(env *environment.Environme
 	return env, nil
 }
 
-// Get environment by ID
+// GetEnvironment returns an environment by ID
 func (ep *EnvironmentPersister) GetEnvironment(id core.Uuid) (*environment.Environment, error) {
 	environment := environment.Environment{}
 	query := ep.DB.Where("id = ?", id)
@@ -178,7 +178,7 @@ func (ep *EnvironmentPersister) GetEnvironmentByID(environmentID core.Uuid) ([]b
 	return envJSON, nil
 }
 
-// UpdateEnvironmentByID updates a single environment by ID
+// UpdateEnvironment updates an environment's fields from the given payload and persists the change
 func (ep *EnvironmentPersister) UpdateEnvironment(environmentID core.Uuid, payload *environment.EnvironmentPayload) (*environment.Environment, error) {
 	env, err := ep.GetEnvironment(environmentID)
 	if err != nil {

--- a/server/models/k8s_components_registration.go
+++ b/server/models/k8s_components_registration.go
@@ -39,7 +39,7 @@ type ModelTemplate struct {
 
 var K8sMeshModelMetadata = ModelTemplate{}
 
-// INstead define a set of actions
+// String converts a RegistrationStatus into its string representation
 func (rs RegistrationStatus) String() string {
 	switch rs {
 	case RegistrationComplete:
@@ -69,7 +69,7 @@ func NewComponentsRegistrationHelper(logger logger.Handler) *ComponentsRegistrat
 	}
 }
 
-// update the map with the given list of contexts
+// UpdateContexts updates the map with the given list of contexts
 func (cg *ComponentsRegistrationHelper) UpdateContexts(ctxs []*K8sContext) *ComponentsRegistrationHelper {
 	for _, ctx := range ctxs {
 		ctxID := ctx.ID
@@ -84,7 +84,7 @@ func (cg *ComponentsRegistrationHelper) UpdateContexts(ctxs []*K8sContext) *Comp
 
 type K8sRegistrationFunction func(provider *Provider, ctxt context.Context, config []byte, ctxID string, connectionID string, userID string, MesheryInstanceID core.Uuid, reg *meshmodel.RegistryManager, eb *Broadcast, log logger.Handler, ctxName string) error
 
-// start registration of components for the contexts
+// RegisterComponents starts registration of components for the contexts
 func (cg *ComponentsRegistrationHelper) RegisterComponents(ctxs []*K8sContext, regFunc []K8sRegistrationFunction, reg *meshmodel.RegistryManager, eventsBrodcaster *Broadcast, provider Provider, userID string, skip bool) {
 	/* If flag "SKIP_COMP_GEN" is set but the registration is invoked in form of API request explicitly,
 	then flag should not be respected and to control this behaviour skip is introduced.

--- a/server/models/meshery_pattern.go
+++ b/server/models/meshery_pattern.go
@@ -49,7 +49,7 @@ const (
 	Design        DesignType = "Design"
 )
 
-// reason for adding this constucts is because these has been removed in latest client-go
+// ListMetaApplyConfiguration exists because this construct was removed in the latest client-go
 // https://github.com/kubernetes/client-go/commit/0f17f43973be78f6dcaf6d9a8614fcb35be40d5c#diff-b49fe30cb74d2c3c9c0ca1438056432985f3cad978fd6440f91b695e16195ded
 type ListMetaApplyConfiguration struct {
 	SelfLink           *string `json:"selfLink,omitempty"`
@@ -203,7 +203,7 @@ type MesheryCatalogPatternRequestBody struct {
 	CatalogData isql.Map  `json:"catalogData,omitempty"`
 }
 
-// MesheryCatalogPatternRequestBody refers to the type of request body
+// MesheryClonePatternRequestBody refers to the type of request body
 // that CloneMesheryPatternHandler would receive
 type MesheryClonePatternRequestBody struct {
 	Name string `json:"name,omitempty"`

--- a/server/models/organization_persistor.go
+++ b/server/models/organization_persistor.go
@@ -11,13 +11,13 @@ import (
 	"github.com/meshery/schemas/models/v1beta2/organization"
 )
 
-// MesheryApplicationPersister is the persister for persisting
-// applications on the database
+// OrganizationPersister is the persister for persisting
+// organizations on the database
 type OrganizationPersister struct {
 	DB *database.Handler
 }
 
-// GetMesheryApplications returns all of the applications
+// GetOrganizations returns all of the organizations
 func (op *OrganizationPersister) GetOrganizations(search, order string, page, pageSize uint64, updatedAfter string) ([]byte, error) {
 	order = SanitizeOrderInput(order, []string{"created_at", "updated_at", "name"})
 

--- a/server/models/smiresults_persister.go
+++ b/server/models/smiresults_persister.go
@@ -7,7 +7,7 @@ import (
 	"github.com/meshery/schemas/models/core"
 )
 
-// SMIResultsPersister assists with persisting session in store
+// SMIResultsPersister assists with persisting SMI results in store
 type SMIResultsPersister struct {
 	DB *database.Handler
 }

--- a/server/models/smiresults_persister.go
+++ b/server/models/smiresults_persister.go
@@ -7,7 +7,7 @@ import (
 	"github.com/meshery/schemas/models/core"
 )
 
-// SmiResultsPersister assists with persisting session in store
+// SMIResultsPersister assists with persisting session in store
 type SMIResultsPersister struct {
 	DB *database.Handler
 }
@@ -25,7 +25,7 @@ type SmiResultPage struct {
 	Results    []*SmiResultWithID `json:"results"`
 }
 
-// GetSmiResults - gets result for the page and pageSize
+// GetResults - gets result for the page and pageSize
 func (s *SMIResultsPersister) GetResults(page, pageSize uint64) ([]byte, error) {
 	if s.DB == nil {
 		return nil, ErrDBConnection
@@ -52,7 +52,7 @@ func (s *SMIResultsPersister) GetResults(page, pageSize uint64) ([]byte, error) 
 	return bd, nil
 }
 
-// WriteSmiResult persists the result
+// WriteResult persists the result
 func (s *SMIResultsPersister) WriteResult(key core.Uuid, result []byte) error {
 	if s.DB == nil {
 		return ErrDBConnection

--- a/server/models/workspace_persister.go
+++ b/server/models/workspace_persister.go
@@ -190,7 +190,7 @@ func (wp *WorkspacePersister) UpdateWorkspaceByID(selectedWorkspace *workspace.W
 	return selectedWorkspace, nil
 }
 
-// Get workspace by ID
+// GetWorkspace returns a workspace by ID
 func (wp *WorkspacePersister) GetWorkspace(id core.Uuid) (*workspace.Workspace, error) {
 	workspace := workspace.Workspace{}
 	query := wp.DB.Where("id = ?", id)
@@ -213,7 +213,7 @@ func (wp *WorkspacePersister) GetWorkspaceByID(workspaceID core.Uuid) ([]byte, e
 	return wsJSON, nil
 }
 
-// UpdateWorkspaceByID updates a single workspace by ID
+// UpdateWorkspace updates a workspace's fields from the given payload and persists the change
 func (wp *WorkspacePersister) UpdateWorkspace(workspaceID core.Uuid, payload *workspace.WorkspaceUpdatePayload) (*workspace.Workspace, error) {
 	ws, err := wp.GetWorkspace(workspaceID)
 	if err != nil {


### PR DESCRIPTION
## What this fixes

Continuing the sweep from #21549, #21554, and #21578. Running
`staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/...` fresh
against the current tree and picking the next seven files by violation
count turns up 17 more: `smiresults_persister.go` (3),
`k8s_components_registration.go` (3), `capabilities_persister.go` (3),
`workspace_persister.go` (2), `organization_persistor.go` (2),
`meshery_pattern.go` (2), `environment_persister.go` (2). This PR fixes
all of them, comment text only, no behavior changes.

## Two files were copied from a real sibling elsewhere in the package

| File | Symbol | Comment used to say | Copied from |
|---|---|---|---|
| organization_persistor.go | `OrganizationPersister` (type) | `MesheryApplicationPersister is the persister for persisting applications on the database` | `meshery_application_persister.go`, word for word |
| organization_persistor.go | `GetOrganizations` | `GetMesheryApplications returns all of the applications` | same file |
| capabilities_persister.go | `ReadCapabilitiesForUser` | `ReadFromPersister` | the `PreferencePersister` interface pattern |
| capabilities_persister.go | `WriteCapabilitiesForUser` | `WriteToPersister` | same pattern |
| capabilities_persister.go | `DeleteCapabilitiesForUser` | `DeleteFromPersister` | same pattern |

`capabilities_persister.go` is worth a note: `ReadFromPersister` /
`WriteToPersister` / `DeleteFromPersister` are real method names, just
not on this type. They're the `PreferencePersister` interface,
implemented by `SessionPreferencePersister` and `MapPreferencePersister`
elsewhere in this package with correctly matching comments. Checked
both before touching anything, this type's own methods are named
differently and never had those names.

## Two are a same-file mix-up between a wrapper and its helper

- `workspace_persister.go`'s `UpdateWorkspace` comment said
  `UpdateWorkspaceByID updates a single workspace by ID`, that's the
  name of the sibling method it calls on its last line
  (`return wp.UpdateWorkspaceByID(ws)`) to persist the change, not its
  own name
- `environment_persister.go`'s `UpdateEnvironment` has the identical
  shape (fetch by ID, apply payload fields, delegate to
  `UpdateEnvironmentByID`) and the identical bug

## The rest

- `smiresults_persister.go`: `SMIResultsPersister`'s comment said
  `SmiResultsPersister` (wrong case), and both `GetResults` and
  `WriteResult` had comments still saying the old names
  `GetSmiResults` and `WriteSmiResult`
- `k8s_components_registration.go`: `String`'s comment was an
  unrelated leftover sentence, `INstead define a set of actions`,
  that doesn't describe what the method does. Rewritten from reading
  the actual switch statement. `UpdateContexts` and
  `RegisterComponents` just needed their names added to descriptions
  that were already accurate
- `meshery_pattern.go`: `ListMetaApplyConfiguration`'s comment
  explained why the type exists (a struct removed from client-go,
  with a link to the removal commit) but never named the type, fixed
  while leaving the link untouched. `MesheryClonePatternRequestBody`'s
  comment was copied from `MesheryCatalogPatternRequestBody` right
  above it, only the second line was updated for the new type

## Verification

```
$ staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/...
# before: 17 hits across these seven files
# after:  0 hits in these seven files (grep confirmed; other files in
#         this package still have their own separate violations, out
#         of scope for this PR)
```

Also clean: `go build ./server/models/...`, `go vet ./server/models/...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated technical documentation for environment, workspace, organization, capability, registration, pattern, and SMI operations.
  * Corrected outdated terminology and standardized method descriptions.
  * Improved descriptions for registration status formatting and component context updates.
  * No functional behavior or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->