### PR TITLE
[server] Fix malformed doc comments in server/handlers (batch 4)

### DIFF
--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -44,6 +44,8 @@ import (
 )
 
 /**Meshmodel endpoints **/
+
+// DefaultPageSizeForMeshModelComponents is the default page size used when listing MeshModel components.
 const DefaultPageSizeForMeshModelComponents = 25
 
 func (h *Handler) GetMeshmodelModelsByCategories(rw http.ResponseWriter, r *http.Request) {
@@ -765,8 +767,7 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 	}
 }
 
-// request body should be json
-// request body should be of ComponentCapability format
+// RegisterMeshmodelComponents expects the request body to be JSON, decoded into a registry.MeshModelRegistrantData
 func (h *Handler) RegisterMeshmodelComponents(rw http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
 	var cc registry.MeshModelRegistrantData
@@ -850,8 +851,7 @@ func (h *Handler) GetMeshmodelRegistrants(rw http.ResponseWriter, r *http.Reques
 	}
 }
 
-// request body should be json
-// request body should be of struct containing ID and Status fields
+// UpdateEntityStatus expects the request body to be JSON, of a struct containing ID and Status fields
 func (h *Handler) UpdateEntityStatus(rw http.ResponseWriter, r *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
 	dec := json.NewDecoder(r.Body)
 	userID := user.ID

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -851,7 +851,7 @@ func (h *Handler) GetMeshmodelRegistrants(rw http.ResponseWriter, r *http.Reques
 	}
 }
 
-// UpdateEntityStatus expects the request body to be JSON, of a struct containing ID and Status fields
+// UpdateEntityStatus expects the request body to be a JSON object with id, status, displayName (and legacy displayname) fields
 func (h *Handler) UpdateEntityStatus(rw http.ResponseWriter, r *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
 	dec := json.NewDecoder(r.Body)
 	userID := user.ID

--- a/server/handlers/extensions.go
+++ b/server/handlers/extensions.go
@@ -19,7 +19,7 @@ var (
 	mx                sync.Mutex
 )
 
-// Defines the version metadata for the extension
+// ExtensionVersion defines the version metadata for the extension
 type ExtensionVersion struct {
 	Version string `json:"version,omitempty"`
 }
@@ -100,10 +100,8 @@ func (h *Handler) ExtensionsVersionHandler(w http.ResponseWriter, _ *http.Reques
 	}
 }
 
-/*
-* ExtensionsHandler is a handler function which works as a proxy to resolve the
-* request of any extension point to its remote provider
- */
+// ExtensionsHandler is a handler function which works as a proxy to resolve the
+// request of any extension point to its remote provider
 func (h *Handler) ExtensionsHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	resp, err := provider.ExtensionProxy(req)
 	if err != nil {

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -44,7 +44,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// MesheryPatternRequestBody refers to the type of request body that
+// MesheryPatternPOSTRequestBody refers to the type of request body that
 // SaveMesheryPattern would receive. Canonical wire form for the
 // wrapper is `patternData` (camelCase) per the identifier-naming
 // migration; the legacy snake_case `pattern_data` spelling is still
@@ -414,7 +414,7 @@ func (h *Handler) handlePatternPOST(
 
 }
 
-// Verifies and converts a pattern to design format if required.
+// VerifyAndConvertToDesign verifies and converts a pattern to design format if required.
 // A pattern is required to be converted to design format iff,
 // 1. pattern_file attribute is empty, and
 // 2. The "type" (sourcetype/original content) is not Design. [is one of compose/helmchart/manifests]
@@ -1844,8 +1844,8 @@ func (h *Handler) handlePatternUpdate(
 
 }
 
-// PatternFileRequestHandler will handle requests of both type GET and POST
-// on the route /api/pattern
+// DesignFileRequestHandlerWithSourceType will handle requests of both type POST and PUT
+// on the route /api/pattern/{sourcetype}
 func (h *Handler) DesignFileRequestHandlerWithSourceType(
 	rw http.ResponseWriter,
 	r *http.Request,
@@ -1885,7 +1885,7 @@ func (h *Handler) GetMesheryDesignTypesHandler(
 	}
 }
 
-// GetMesheryPatternHandler fetched the design using the given id and sourcetype
+// GetMesheryPatternSourceHandler fetched the design using the given id and sourcetype
 func (h *Handler) GetMesheryPatternSourceHandler(
 	rw http.ResponseWriter,
 	r *http.Request,

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -1885,7 +1885,7 @@ func (h *Handler) GetMesheryDesignTypesHandler(
 	}
 }
 
-// GetMesheryPatternSourceHandler fetched the design using the given id and sourcetype
+// GetMesheryPatternSourceHandler fetches the design using the given id and sourcetype
 func (h *Handler) GetMesheryPatternSourceHandler(
 	rw http.ResponseWriter,
 	r *http.Request,

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -263,7 +263,7 @@ func doesntNeedReeval(response pattern.EvaluationResponse) bool {
 	return true
 }
 
-// MAX_RE_EVALUATION_DEPTH is the max number of times to keep revaluating the design till there are no reval triggering actions in the response
+// MAX_RE_EVALUATION_DEPTH is the max number of times to keep reevaluating the design. Reevaluation also stops early once there are no more reevaluation-triggering actions in the response, but reaching this depth limit returns a partial result
 const MAX_RE_EVALUATION_DEPTH = 5
 
 // defaultPolicyEvalTimeout bounds a single evaluation. Override via POLICY_EVAL_TIMEOUT.

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -263,7 +263,7 @@ func doesntNeedReeval(response pattern.EvaluationResponse) bool {
 	return true
 }
 
-// max number of time to keep revaluating the design till there are no reval triggering actions in the response
+// MAX_RE_EVALUATION_DEPTH is the max number of times to keep revaluating the design till there are no reval triggering actions in the response
 const MAX_RE_EVALUATION_DEPTH = 5
 
 // defaultPolicyEvalTimeout bounds a single evaluation. Override via POLICY_EVAL_TIMEOUT.
@@ -294,7 +294,7 @@ func policyEvalTimeout() time.Duration {
 	return defaultPolicyEvalTimeout
 }
 
-// Helper method to make design evaluation based on the relationship policies.
+// EvaluateDesign evaluates the design based on the relationship policies.
 // evalIterations is num of passes the evaluator needs to go through to do complete evaluation
 func (h *Handler) EvaluateDesign(
 	relationshipPolicyEvalPayload pattern.EvaluationRequest,


### PR DESCRIPTION
## What this fixes

Continuing the sweep from `server/models` (#21549, #21554, #21578,
#21579), now into `server/handlers`. Running
`staticcheck -checks="ST1020,ST1021,ST1022" ./server/handlers/...` and
picking the top four files by violation count turns up 11:
`meshery_pattern_handler.go` (4), `component_handler.go` (3),
`policy_relationship_handler.go` (2), `extensions.go` (2). This PR
fixes all of them, comment text only, no behavior changes.

## One is a real behavior mismatch, not just a name

`DesignFileRequestHandlerWithSourceType`'s comment was copied verbatim
from the real `PatternFileRequestHandler` elsewhere in the same file:
"will handle requests of both type GET and POST on the route
/api/pattern". Checked both sides before touching anything:

| | Route (`server/router/server.go`) | Verbs in the body |
|---|---|---|
| `PatternFileRequestHandler` | `/api/pattern` | `GET`, `POST` |
| `DesignFileRequestHandlerWithSourceType` | `/api/pattern/{sourcetype}` | `POST`, `PUT` |

The first row is exactly what the copied comment claims, correctly,
for the function it was written for. The second row is what
`DesignFileRequestHandlerWithSourceType` actually does, which the
copied comment got completely wrong on both the route and the verbs.

Same file, a second copy-paste, name only this time:
`GetMesheryPatternSourceHandler`'s comment said
`GetMesheryPatternHandler`, copied from the real
`GetMesheryPatternHandler` a thousand lines up. Its trailing
description ("...and sourcetype") had already been correctly updated
for the new function, just not the leading name.

## Two are format bugs, not wording bugs

- `ExtensionsHandler`'s comment was a `/* */` block comment written in
  javadoc style with nothing after the opening `/*`. Once the comment
  delimiters are stripped, the text starts with a newline and an
  asterisk, not the symbol's name, so it read as malformed to
  staticcheck despite being fully accurate. Converted to the plain
  `//` line-comment style used everywhere else in this codebase,
  wording unchanged.
- `DefaultPageSizeForMeshModelComponents` sat directly under a
  `/**Meshmodel endpoints **/` section-header comment with no blank
  line, so that header was being read as its doc comment. Added a
  blank line to separate the header from a new one-line doc comment
  for the constant.

## The rest

- `VerifyAndConvertToDesign`, `ExtensionVersion`, `EvaluateDesign`:
  name merged into the existing, already-accurate first sentence
- `MesheryPatternPOSTRequestBody`: comment said the pre-`POST`-suffix
  name, the rest of this large, carefully written comment (including
  a `Deprecated:` note) left untouched
- `MAX_RE_EVALUATION_DEPTH`: name added, plus "time" to "times"
- `RegisterMeshmodelComponents` and `UpdateEntityStatus`: both had
  "request body should be json / request body should be of X format"
  split across two lines with no name at all, merged into one
  sentence each. `RegisterMeshmodelComponents` also named a decode
  target, "ComponentCapability", that does not exist anywhere in this
  codebase (checked); the function actually decodes into
  `registry.MeshModelRegistrantData`, read directly off the three
  lines below it, so the comment now names that instead

## Verification

```
$ staticcheck -checks="ST1020,ST1021,ST1022" ./server/handlers/...
# before: 11 hits across these four files
# after:  0 hits in these four files (grep confirmed; other files in
#         this package still have their own separate violations, out
#         of scope for this PR)
```

Also clean: `go build ./server/handlers/...`, `go build ./server/...`,
`go vet ./server/handlers/...`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved and corrected API documentation across component, extension, pattern, and policy handling.
  * Updated comments to accurately describe routes, methods, parameters, and evaluation behavior.
  * No user-visible functionality or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->