### PR TITLE
fix(server): stop fatal boot panic seeding models under a pinned PROVIDER

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,15 @@ make helm-docs      # Generate Helm chart docs
   own `helpers/component_info.json` **in the same commit**, and the tracked docs reference at
   `docs/data/errorref/` must be regenerated or the new codes are silently omitted. Full
   contract: [writing MeshKit errors](./docs/content/en/project/contributing/contributing-error.md).
+- **MUST NOT resolve a provider by name out of `HandlerConfig.Providers` in boot-time
+  code.** `PROVIDER` enforcement deletes every non-enforced registration, Local included,
+  so `Providers[LocalProviderName]` yields a nil `Provider` on a pinned deployment - the
+  unrecovered nil-deref that killed the server during model seeding (#21584). Persist an
+  event raised outside a user request through `HandlerConfig.SystemEventPersister`; index
+  `Providers` only with the comma-ok form, and only on the request path. Boot-time work
+  that can fault belongs inside `models.RunSeedStage` so it degrades the server rather
+  than terminating it. Detail:
+  [Extensibility: Providers](./docs/content/en/reference/extensibility/providers/index.md).
 - Only `utils.Log.Error(err)` renders a MeshKit error's code, cause and remediation; cobra's
   default print shows just the message. In `mesheryctl` commands, log the structured error
   for the user *and* return it for the exit path.
@@ -476,6 +485,7 @@ worked detail behind them — open the one that matches what you are working on.
 | Releases, CI secrets, the QA dashboard | [Build & Release (CI)](./docs/content/en/project/contributing/build-and-release.md) |
 | Connections and credential secrets | [Connections](./docs/content/en/project/contributing/models/connections.md) |
 | A permission-gated page, control or key | [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md) |
+| Providers, `PROVIDER` enforcement, boot-time seeding | [Extensibility: Providers](./docs/content/en/reference/extensibility/providers/index.md) |
 | UI extensions, Remote Components | [Contributing to Meshery UI](./docs/content/en/project/contributing/ui/ui.md) |
 | `mesheryctl`, golden files | [Contributing to Meshery CLI](./docs/content/en/project/contributing/cli/cli.md) |
 | A docs page, its assets or shortcodes | [Contributing to Meshery Docs](./docs/content/en/project/contributing/contributing-docs/docs.md) |

--- a/docs/content/en/project/contributing/contributing-error.md
+++ b/docs/content/en/project/contributing/contributing-error.md
@@ -88,7 +88,7 @@ how to choose the status code.
 There already exists an [interface for logger](https://github.com/meshery/meshkit/blob/master/logger/logger.go) in MeshKit.<br><br>
 
 {{% alert color="warning" title="WARNING" %}}
-To enforce the use of meshkit errors, meshkit logger was designed such that it only works with meshkit errors. If a non-meshkit error is logged through the logger, it would panic and kill the process. See: [meshkit#119](https://github.com/meshery/meshkit/pull/119) for more insight.
+To enforce the use of meshkit errors, the meshkit logger reads its structured fields - code, severity, probable cause, suggested remediation - straight off a meshkit error. A plain Go error still logs, but every one of those fields renders as `None`, leaving the operator a bare message with no code to look up and no remediation to follow. Wrap an error in a meshkit error before logging it. See: [meshkit#119](https://github.com/meshery/meshkit/pull/119) for more insight.
 {{% /alert %}}
 
 #### Defining a Logger

--- a/docs/content/en/project/contributing/contributing-server-events/index.md
+++ b/docs/content/en/project/contributing/contributing-server-events/index.md
@@ -62,6 +62,8 @@ Events in Meshery are persisted through two distinct mechanisms to ensure reliab
 
 The `provider.PersistEvent(*event,nil)` method stores all events in Meshery's local database. This method works identically for both Local and Remote providers, ensuring events are always accessible within your Meshery instance.
 
+An event raised outside any user request - the registrant summaries and registration failures emitted while models are seeded at boot - has no provider to route through, and on a deployment that pins `PROVIDER` the provider registration map may not even hold the one you would name. Persist those through `HandlerConfig.SystemEventPersister`, which writes to the same local database. See [Enforced Provider Flow]({{< ref "reference/extensibility/providers/index.md" >}}) for why a name lookup is not an option there.
+
 ### Remote Event Publishing
 
 The `provider.PublishEventToProvider(token, event)` method enables event synchronization with remote providers (like Meshery Cloud). For Local providers, this method is a no-op (does nothing), while Remote providers use it to send events to their remote services.

--- a/docs/content/en/reference/extensibility/providers/index.md
+++ b/docs/content/en/reference/extensibility/providers/index.md
@@ -176,6 +176,25 @@ When the `PROVIDER` environment variable is set (e.g., `PROVIDER=Local` or `PROV
 5. If `PROVIDER` is set but cannot be resolved to a registered provider, Meshery refuses to start (it does not fall back to the chooser).
 6. Changing `PROVIDER` on an existing deployment requires a restart. It is not a build-time flag. Re-login is required; data does not migrate between providers.
 
+Boot-time work is unaffected by the pin. Model seeding, connection seeding, and
+key seeding all run before any user request and are provider-independent, so a
+pinned deployment seeds exactly what an unpinned one does, and the system events
+raised while seeding (the `For registrant ... imported ...` summaries and any
+registration failures) are persisted to the same `events` table either way.
+
+{{% alert color="warning" title="Contributing: do not look a provider up by name at boot" %}}
+Because enforcement empties the registration map of everything but the pinned
+provider, server code that runs at boot must not resolve a provider by name from
+`HandlerConfig.Providers` - `Providers["Local"]` yields a nil `Provider` on a
+pinned deployment. Code needing to persist an event outside a user request takes
+`HandlerConfig.SystemEventPersister` instead, which is wired directly to the
+database and is independent of which providers are registered. Reaching into the
+registration map for a sink is what made a pinned deployment panic at boot in
+[#21584](https://github.com/meshery/meshery/issues/21584). Request-path code is
+unaffected: it receives its provider from the request context, which enforcement
+resolves consistently.
+{{% /alert %}}
+
 ### Deep-Link Preservation
 
 Meshery preserves the originally requested URL when authentication is required, enabling seamless navigation after login:

--- a/docs/data/errorref/meshery-server_errors_export.json
+++ b/docs/data/errorref/meshery-server_errors_export.json
@@ -4239,8 +4239,8 @@
         "severity": "Alert",
         "long_description": "",
         "short_description": "Meshery Server recovered from a fault while seeding its registry",
-        "probable_cause": "An unexpected condition was hit while seeding at startup",
-        "suggested_remediation": "Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose and restart Meshery Server to seed again"
+        "probable_cause": "An unexpected condition was hit while seeding, either at startup or while reseeding after a database reset",
+        "suggested_remediation": "Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose, then seed again - restart Meshery Server, or re-run the reset that triggered the seeding"
       }
     }
   }

--- a/docs/data/errorref/meshery-server_errors_export.json
+++ b/docs/data/errorref/meshery-server_errors_export.json
@@ -4223,6 +4223,24 @@
         "short_description": "A database reset is already in progress",
         "probable_cause": "A reset was requested while an earlier one was still seeding keys, catalog designs, or components",
         "suggested_remediation": "Wait for the in-flight reset to finish, then retry"
+      },
+      "1482": {
+        "name": "ErrNoSystemEventSinkCode",
+        "code": "1482",
+        "severity": "Alert",
+        "long_description": "HandlerConfig.SystemEventPersister is nil, so events raised outside a user request - registry seeding summaries and registration failures - cannot be persisted",
+        "short_description": "No sink is configured for Meshery's system events",
+        "probable_cause": "Meshery Server was built with a HandlerConfig that does not wire SystemEventPersister",
+        "suggested_remediation": "Set HandlerConfig.SystemEventPersister when constructing the handler configuration; on a released build this indicates a defect, so please report it at https://github.com/meshery/meshery/issues/new/choose"
+      },
+      "1483": {
+        "name": "ErrSeedingStagePanicCode",
+        "code": "1483",
+        "severity": "Alert",
+        "long_description": "",
+        "short_description": "Meshery Server recovered from a fault while seeding its registry",
+        "probable_cause": "An unexpected condition was hit while seeding at startup",
+        "suggested_remediation": "Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose and restart Meshery Server to seed again"
       }
     }
   }

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -292,6 +292,15 @@ func main() {
 
 		EventBroadcaster: models.NewBroadcaster("Events"),
 
+		// System events (registry seeding summaries, registration failures)
+		// are raised outside any user request, so they are persisted through
+		// their own sink rather than through Providers - which PROVIDER
+		// enforcement may reduce to a single remote with no Local entry.
+		// This is the same database handler every provider's own
+		// EventsPersister wraps, so the events land in the same table either
+		// way.
+		SystemEventPersister: &models.EventsPersister{DB: dbHandler},
+
 		K8scontextChannel: models.NewContextHelper(),
 		OperatorTracker:   models.NewOperatorTracker(viper.GetBool("DISABLE_OPERATOR")),
 	}
@@ -303,18 +312,29 @@ func main() {
 	//seed the local meshmodel components
 	rego := policies.Rego{}
 
+	// Seeding runs off the request path, in its own goroutine, so a fault in
+	// any stage must degrade the server rather than terminate it: an
+	// unrecovered panic here would take the HTTP listener down with it. Each
+	// stage is wrapped separately so one faulting stage still leaves the
+	// others to run.
 	go func() {
-		krh.SeedKeys(viper.GetString("KEYS_PATH"))
+		models.RunSeedStage(log, "user keys", func() {
+			krh.SeedKeys(viper.GetString("KEYS_PATH"))
+		})
 
 		// This is where models are seeded from meshmodel directory to registry
-		models.SeedComponents(log, hc, regManager, dbHandler)
+		models.RunSeedStage(log, "models", func() {
+			models.SeedComponents(log, hc, regManager, dbHandler)
+		})
 		// Rego is intialized for passing of policy if the policies are made to be per model base this needs to be removed.
-		r, err := policies.NewRegoInstance(models.PoliciesPath, regManager)
-		if err != nil {
-			log.Warn(handlers.ErrCreatingOPAInstance(err))
-		} else {
-			rego = *r
-		}
+		models.RunSeedStage(log, "policies", func() {
+			r, err := policies.NewRegoInstance(models.PoliciesPath, regManager)
+			if err != nil {
+				log.Warn(handlers.ErrCreatingOPAInstance(err))
+			} else {
+				rego = *r
+			}
+		})
 	}()
 
 	lProv.SeedContent(log)

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -337,7 +337,9 @@ func main() {
 		})
 	}()
 
-	lProv.SeedContent(log)
+	models.RunSeedStage(log, "content", func() {
+		lProv.SeedContent(log)
+	})
 	provs[lProv.Name()] = lProv
 
 	// Trim once here so a whitespace-only PROVIDER behaves exactly like unset

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -202,11 +202,17 @@ func (h *Handler) ResetSystemDatabase(w http.ResponseWriter, r *http.Request, _ 
 		seedingStarted = true
 		go func() {
 			defer models.ReleaseResetLock()
-			krh.SeedKeys(viper.GetString("KEYS_PATH"))
-			if lp, ok := provider.(*models.DefaultLocalProvider); ok {
-				lp.SeedContent(h.log)
-			}
-			models.SeedComponents(h.log, h.config, h.registryManager, dbHandler)
+			models.RunSeedStage(h.log, "user keys", func() {
+				krh.SeedKeys(viper.GetString("KEYS_PATH"))
+			})
+			models.RunSeedStage(h.log, "content", func() {
+				if lp, ok := provider.(*models.DefaultLocalProvider); ok {
+					lp.SeedContent(h.log)
+				}
+			})
+			models.RunSeedStage(h.log, "models", func() {
+				models.SeedComponents(h.log, h.config, h.registryManager, dbHandler)
+			})
 		}()
 		writeJSONMessage(w, system.SystemMessageResponse{Message: "Database reset successful"}, http.StatusOK)
 	}

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1482
+  "next_error_code": 1484
 }

--- a/server/internal/graphql/resolver/meshsync.go
+++ b/server/internal/graphql/resolver/meshsync.go
@@ -147,11 +147,17 @@ func (r *Resolver) resyncCluster(ctx context.Context, provider models.Provider, 
 			seedingStarted = true
 			go func() {
 				defer models.ReleaseResetLock()
-				krh.SeedKeys(viper.GetString("KEYS_PATH"))
-				if lp, ok := provider.(*models.DefaultLocalProvider); ok {
-					lp.SeedContent(r.Log)
-				}
-				models.SeedComponents(r.Log, r.Config, rm, dbHandler)
+				models.RunSeedStage(r.Log, "user keys", func() {
+					krh.SeedKeys(viper.GetString("KEYS_PATH"))
+				})
+				models.RunSeedStage(r.Log, "content", func() {
+					if lp, ok := provider.(*models.DefaultLocalProvider); ok {
+						lp.SeedContent(r.Log)
+					}
+				})
+				models.RunSeedStage(r.Log, "models", func() {
+					models.SeedComponents(r.Log, r.Config, rm, dbHandler)
+				})
 			}()
 			r.Log.Info("Hard reset complete.")
 		} else { //Delete meshsync objects coming from a particular cluster

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -731,8 +731,8 @@ func ErrSeedingStagePanic(stage string, cause interface{}, stack []byte) error {
 		errors.Alert,
 		[]string{"Meshery Server recovered from a fault while seeding its registry"},
 		[]string{fmt.Sprintf("faulting stage: %s", stage), fmt.Sprintf("%v\n%s", cause, stack)},
-		[]string{"An unexpected condition was hit while seeding at startup"},
-		[]string{"Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose and restart Meshery Server to seed again"},
+		[]string{"An unexpected condition was hit while seeding, either at startup or while reseeding after a database reset"},
+		[]string{"Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose, then seed again - restart Meshery Server, or re-run the reset that triggered the seeding"},
 	)
 }
 

--- a/server/models/error.go
+++ b/server/models/error.go
@@ -146,6 +146,8 @@ const (
 	ErrSeedingComponentsCode              = "meshery-server-1358"
 	ErrSeedingConnectionsCode             = "meshery-server-1462"
 	ErrSeedingConnectionKindCode          = "meshery-server-1463"
+	ErrNoSystemEventSinkCode              = "meshery-server-1482"
+	ErrSeedingStagePanicCode              = "meshery-server-1483"
 	ErrImportFailureCode                  = "meshery-server-1359"
 	ErrMarshallingDesignIntoYAMLCode      = "meshery-server-1135"
 	ErrStatusCodeCode                     = "meshery-server-1368"
@@ -704,6 +706,33 @@ func ErrSeedingConnectionKind(err error, kind string) error {
 		[]string{err.Error()},
 		[]string{fmt.Sprintf("The %s connection could not be written to Meshery's database", kind), "The connection definition for this kind may disagree with the connections table schema"},
 		[]string{fmt.Sprintf("Confirm the %s connection definition is valid; other connection kinds are unaffected and this one is seeded again on the next restart", kind)},
+	)
+}
+
+func ErrNoSystemEventSink() error {
+	return errors.New(
+		ErrNoSystemEventSinkCode,
+		errors.Alert,
+		[]string{"No sink is configured for Meshery's system events"},
+		[]string{"HandlerConfig.SystemEventPersister is nil, so events raised outside a user request - registry seeding summaries and registration failures - cannot be persisted"},
+		[]string{"Meshery Server was built with a HandlerConfig that does not wire SystemEventPersister"},
+		[]string{"Set HandlerConfig.SystemEventPersister when constructing the handler configuration; on a released build this indicates a defect, so please report it at https://github.com/meshery/meshery/issues/new/choose"},
+	)
+}
+
+// ErrSeedingStagePanic reports a fault that RunSeedStage recovered from. The
+// short description, probable cause and remediation are deliberately literal
+// rather than composed with the stage name: errorutil can only lift static
+// strings into docs/data/errorref, so an interpolated one publishes as an empty
+// entry (see ErrImportFailure). The stage and stack trace carry in the details.
+func ErrSeedingStagePanic(stage string, cause interface{}, stack []byte) error {
+	return errors.New(
+		ErrSeedingStagePanicCode,
+		errors.Alert,
+		[]string{"Meshery Server recovered from a fault while seeding its registry"},
+		[]string{fmt.Sprintf("faulting stage: %s", stage), fmt.Sprintf("%v\n%s", cause, stack)},
+		[]string{"An unexpected condition was hit while seeding at startup"},
+		[]string{"Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose and restart Meshery Server to seed again"},
 	)
 }
 

--- a/server/models/handlers.go
+++ b/server/models/handlers.go
@@ -292,6 +292,16 @@ type HandlerConfig struct {
 	ProviderCookieName     string
 	ProviderCookieDuration time.Duration
 
+	// SystemEventPersister is the sink for events raised outside any user
+	// request - registry seeding summaries, registration failures. It is
+	// deliberately NOT resolved from Providers: PROVIDER enforcement drops
+	// every non-enforced registration (Local included), so a lookup keyed on
+	// a provider name is only valid on an unpinned deployment. Wired in
+	// cmd/main.go to the same database handler every provider's
+	// EventsPersister uses, so the events land in the same `events` table
+	// whether or not a deployment pins PROVIDER.
+	SystemEventPersister SystemEventPersister
+
 	// to be removed
 	BrokerEndpointURL *string
 

--- a/server/models/providers.go
+++ b/server/models/providers.go
@@ -552,6 +552,27 @@ func VerifyMesheryProvider(provider string, supportedProviders map[string]Provid
 	return ok
 }
 
+// SystemEventPersister persists a system-initiated event - one raised outside
+// any user request, such as the registrant summaries and registration failures
+// emitted while models are seeded at boot.
+//
+// It exists so that boot-time code does not have to reach into
+// HandlerConfig.Providers for a sink. Providers are a request-routing table:
+// which one a request is served by depends on the meshery-provider cookie, and
+// since PROVIDER enforcement (RestrictToEnforcedProvider) the table may hold a
+// single remote and no Local entry at all. System events are not
+// request-scoped, so binding them to that table was always a category error -
+// it is what made a pinned deployment panic while seeding models
+// (meshery/meshery#21584).
+//
+// Every Provider satisfies this interface, and so does *EventsPersister; all of
+// them write to the same local `events` table, so nothing about where these
+// events land changes with the provider a deployment is pinned to.
+type SystemEventPersister interface {
+	// PersistSystemEvent persists a system-initiated event to the local database.
+	PersistSystemEvent(event events.Event) error
+}
+
 // Provider - interface for providers
 type Provider interface {
 	PreferencePersister

--- a/server/models/seed_models.go
+++ b/server/models/seed_models.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"time"
 
@@ -112,6 +113,28 @@ func getLatestModelDefDir(latestVersionDirPath string) (string, error) {
 	})
 
 	return modelDefs[0].dirPath, nil
+}
+
+// RunSeedStage runs one boot-time seeding stage, converting a panic inside it
+// into a logged, structured error.
+//
+// cmd/main.go runs the seeding stages in a bare goroutine, where Go gives a
+// panic no second chance: an unrecovered fault in any of them takes down the
+// whole process, HTTP listener included. That is not a proportionate response
+// to a seeding fault - a Meshery Server with an incomplete registry is still
+// useful, and the operator can read the error and restart, whereas a server
+// that exits at boot leaves them with a crash loop and no UI to read it in
+// (meshery/meshery#21584).
+//
+// Each stage is wrapped separately so one faulting stage does not skip the
+// others.
+func RunSeedStage(log logger.Handler, stage string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error(ErrSeedingStagePanic(stage, r, debug.Stack()))
+		}
+	}()
+	fn()
 }
 
 // SeedComponents registers the latest versions of models

--- a/server/models/seed_models.go
+++ b/server/models/seed_models.go
@@ -118,14 +118,16 @@ func getLatestModelDefDir(latestVersionDirPath string) (string, error) {
 // RunSeedStage runs one seeding stage, converting a panic inside it into a
 // logged, structured error.
 //
-// Every caller - boot in cmd/main.go, and the two paths that reseed after a
-// reset (handlers.ResetSystemDatabase and the GraphQL resyncCluster hard
-// reset) - runs the stages in a bare goroutine, where Go gives a panic no
-// second chance: an unrecovered fault in any of them takes down the whole
-// process, HTTP listener included. That is not a proportionate response to a
-// seeding fault - a Meshery Server with an incomplete registry is still
-// useful, and the operator can read the error and restart, whereas a server
-// that exits at boot leaves them with a crash loop and no UI to read it in
+// Nine of the ten stages run in a bare goroutine - the boot goroutine in
+// cmd/main.go and the two paths that reseed after a reset
+// (handlers.ResetSystemDatabase and the GraphQL resyncCluster hard reset) -
+// where Go gives a panic no second chance. The tenth, boot's "content" stage,
+// runs synchronously on main's own goroutine, where a panic unwinds main and
+// exits just as surely. Either shape takes down the whole process, HTTP
+// listener included, which is not a proportionate response to a seeding fault
+// - a Meshery Server with an incomplete registry is still useful, and the
+// operator can read the error and act on it, whereas a server that exits at
+// boot leaves them with a crash loop and no UI to read it in
 // (meshery/meshery#21584).
 //
 // Each stage is wrapped separately so one faulting stage does not skip the

--- a/server/models/seed_models.go
+++ b/server/models/seed_models.go
@@ -128,6 +128,12 @@ func getLatestModelDefDir(latestVersionDirPath string) (string, error) {
 //
 // Each stage is wrapped separately so one faulting stage does not skip the
 // others.
+//
+// The cover is bounded by what recover can reach: only panics on the wrapped
+// stage's own goroutine. A stage that itself spawns a goroutine - SeedKeys
+// does, in keys_helper.go - leaves that goroutine outside this recover, and a
+// panic there still terminates the process. Recovering it belongs where it is
+// spawned, not here.
 func RunSeedStage(log logger.Handler, stage string, fn func()) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/server/models/seed_models.go
+++ b/server/models/seed_models.go
@@ -115,13 +115,15 @@ func getLatestModelDefDir(latestVersionDirPath string) (string, error) {
 	return modelDefs[0].dirPath, nil
 }
 
-// RunSeedStage runs one boot-time seeding stage, converting a panic inside it
-// into a logged, structured error.
+// RunSeedStage runs one seeding stage, converting a panic inside it into a
+// logged, structured error.
 //
-// cmd/main.go runs the seeding stages in a bare goroutine, where Go gives a
-// panic no second chance: an unrecovered fault in any of them takes down the
-// whole process, HTTP listener included. That is not a proportionate response
-// to a seeding fault - a Meshery Server with an incomplete registry is still
+// Every caller - boot in cmd/main.go, and the two paths that reseed after a
+// reset (handlers.ResetSystemDatabase and the GraphQL resyncCluster hard
+// reset) - runs the stages in a bare goroutine, where Go gives a panic no
+// second chance: an unrecovered fault in any of them takes down the whole
+// process, HTTP listener included. That is not a proportionate response to a
+// seeding fault - a Meshery Server with an incomplete registry is still
 // useful, and the operator can read the error and restart, whereas a server
 // that exits at boot leaves them with a crash loop and no UI to read it in
 // (meshery/meshery#21584).

--- a/server/models/seed_models_logs.go
+++ b/server/models/seed_models_logs.go
@@ -106,11 +106,16 @@ func failedMsgCompute(failedMsg string, hostName string, regLog *RegistrationFai
 // than a Provider because the failure event is raised outside any user request:
 // the caller may be boot-time seeding, which has no provider to route through
 // once PROVIDER enforcement has emptied the registration map.
+//
+// A failure to persist that event is returned, not swallowed, alongside the
+// failure summary: both return values are independent, so the caller must
+// report the error and still act on a non-empty summary.
 func FailedEventCompute(hostname string, mesheryInstanceID core.Uuid, persister SystemEventPersister, userID string, ec *Broadcast, regErrorStore *RegistrationFailureLog) (string, error) {
 	failedMsg, err := failedMsgCompute("", hostname, regErrorStore)
 	if err != nil {
 		return "", err
 	}
+	var persistErr error
 	if failedMsg != "" {
 		filePath := viper.GetString("REGISTRY_LOG_FILE")
 		errorEventBuilder := events.NewEvent().FromOwner(mesheryInstanceID).FromSystem(mesheryInstanceID).WithCategory("registration").WithAction("get_summary")
@@ -121,14 +126,14 @@ func FailedEventCompute(hostname string, mesheryInstanceID core.Uuid, persister 
 			"ViewLink":     filePath,
 			"error":        ErrImportFailure(hostname, failedMsg),
 		})
-		_ = persister.PersistSystemEvent(*errorEvent)
+		persistErr = persister.PersistSystemEvent(*errorEvent)
 		if userID != "" {
 			userUUID := gofrs.FromStringOrNil(userID)
 			ec.Publish(userUUID, errorEvent)
 
 		}
 	}
-	return failedMsg, nil
+	return failedMsg, persistErr
 }
 
 func writeLogsToFiles(regLog *RegistrationFailureLog) error {
@@ -269,7 +274,9 @@ func RegistryLog(log logger.Handler, handlerConfig *HandlerConfig, regManager *m
 		})
 		eventBuilder.WithSeverity(events.Informational).WithDescription(successMessage)
 		successEvent := eventBuilder.Build()
-		_ = persister.PersistSystemEvent(*successEvent)
+		if err := persister.PersistSystemEvent(*successEvent); err != nil {
+			log.Error(err)
+		}
 
 		failLog, err := FailedEventCompute(kind, sysID, persister, "", handlerConfig.EventBroadcaster, regErrorStore)
 		if err != nil {

--- a/server/models/seed_models_logs.go
+++ b/server/models/seed_models_logs.go
@@ -99,7 +99,14 @@ func failedMsgCompute(failedMsg string, hostName string, regLog *RegistrationFai
 	return failedMsg, nil
 }
 
-func FailedEventCompute(hostname string, mesheryInstanceID core.Uuid, provider *Provider, userID string, ec *Broadcast, regErrorStore *RegistrationFailureLog) (string, error) {
+// FailedEventCompute reports the registration failures recorded for hostname
+// and, when there are any, persists an error event describing them.
+//
+// persister is the sink for that event. It is a SystemEventPersister rather
+// than a Provider because the failure event is raised outside any user request:
+// the caller may be boot-time seeding, which has no provider to route through
+// once PROVIDER enforcement has emptied the registration map.
+func FailedEventCompute(hostname string, mesheryInstanceID core.Uuid, persister SystemEventPersister, userID string, ec *Broadcast, regErrorStore *RegistrationFailureLog) (string, error) {
 	failedMsg, err := failedMsgCompute("", hostname, regErrorStore)
 	if err != nil {
 		return "", err
@@ -114,7 +121,7 @@ func FailedEventCompute(hostname string, mesheryInstanceID core.Uuid, provider *
 			"ViewLink":     filePath,
 			"error":        ErrImportFailure(hostname, failedMsg),
 		})
-		_ = (*provider).PersistSystemEvent(*errorEvent)
+		_ = persister.PersistSystemEvent(*errorEvent)
 		if userID != "" {
 			userUUID := gofrs.FromStringOrNil(userID)
 			ec.Publish(userUUID, errorEvent)
@@ -221,7 +228,22 @@ func formatRegistrantSummary(kind string, summary v1beta1.EntitySummary) string 
 }
 
 func RegistryLog(log logger.Handler, handlerConfig *HandlerConfig, regManager *meshmodel.RegistryManager, regErrorStore *RegistrationFailureLog) {
-	provider := handlerConfig.Providers[LocalProviderName]
+	// Seeding runs before any user request, so there is no provider to route
+	// these events through - and, since PROVIDER enforcement, no guarantee
+	// that any particular provider is even registered. This used to read
+	// handlerConfig.Providers[LocalProviderName], which RestrictToEnforcedProvider
+	// deletes on a pinned deployment; the zero Provider it returned then
+	// panicked the seeding goroutine and, with it, the whole server
+	// (meshery/meshery#21584).
+	persister := handlerConfig.SystemEventPersister
+	if persister == nil {
+		// Reachable only if a caller built a HandlerConfig without wiring the
+		// persister. Report it rather than dropping the events silently, then
+		// keep going: the startup summaries below are still worth logging, and
+		// a missing sink must not cost the operator the boot log too.
+		log.Error(ErrNoSystemEventSink())
+		persister = discardSystemEvents{}
+	}
 
 	systemID := viper.GetString("INSTANCE_ID")
 
@@ -247,9 +269,9 @@ func RegistryLog(log logger.Handler, handlerConfig *HandlerConfig, regManager *m
 		})
 		eventBuilder.WithSeverity(events.Informational).WithDescription(successMessage)
 		successEvent := eventBuilder.Build()
-		_ = provider.PersistSystemEvent(*successEvent)
+		_ = persister.PersistSystemEvent(*successEvent)
 
-		failLog, err := FailedEventCompute(kind, sysID, &provider, "", handlerConfig.EventBroadcaster, regErrorStore)
+		failLog, err := FailedEventCompute(kind, sysID, persister, "", handlerConfig.EventBroadcaster, regErrorStore)
 		if err != nil {
 			log.Error(err)
 		}
@@ -284,3 +306,11 @@ func (rfl *RegistrationFailureLog) GetEntityRegErrors() []EntityRegError {
 	}
 	return errors
 }
+
+// discardSystemEvents is the fallback sink used when a HandlerConfig reaches
+// RegistryLog without a SystemEventPersister. It drops events, which is only
+// ever correct because the omission has already been reported as an error - it
+// is not a silent skip.
+type discardSystemEvents struct{}
+
+func (discardSystemEvents) PersistSystemEvent(events.Event) error { return nil }

--- a/server/models/seed_models_logs_enforced_provider_test.go
+++ b/server/models/seed_models_logs_enforced_provider_test.go
@@ -1,0 +1,161 @@
+package models
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/meshery/meshkit/database"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/meshkit/models/events"
+	"github.com/spf13/viper"
+)
+
+// stubProvider is a Provider that panics on every call it is not given an
+// implementation for. Embedding the interface is deliberate: the tests below
+// must fail loudly if RegistryLog ever reaches back into the provider
+// registration map for a system-event sink.
+type stubProvider struct {
+	Provider
+}
+
+// enforcedProviderKey is the registration key a pinned deployment keeps. It is
+// spelled like a real remote's key (cmd/main.go registers remotes under the
+// name from /capabilities, falling back to the URL host) so the fixture matches
+// what issue #21584 was reported against: PROVIDER pinned to cloud.meshery.io.
+const enforcedProviderKey = "cloud.meshery.io"
+
+// newRegistryLogTestConfig builds the HandlerConfig boot-time seeding runs with,
+// plus the database its system events land in.
+func newRegistryLogTestConfig(t *testing.T, db *database.Handler) *HandlerConfig {
+	t.Helper()
+
+	if err := db.AutoMigrate(events.Event{}); err != nil {
+		t.Fatalf("migrate events: %v", err)
+	}
+	return &HandlerConfig{
+		Providers: map[string]Provider{
+			LocalProviderName:   stubProvider{},
+			enforcedProviderKey: stubProvider{},
+		},
+		EventBroadcaster:     NewBroadcaster("Events"),
+		SystemEventPersister: &EventsPersister{DB: db},
+	}
+}
+
+// persistedSystemEvents reads back every event RegistryLog persisted.
+func persistedSystemEvents(t *testing.T, db *database.Handler) []events.Event {
+	t.Helper()
+
+	var persisted []events.Event
+	if err := db.Find(&persisted).Error; err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+	return persisted
+}
+
+// registryLogTestLogger keeps RegistryLog's output out of the test log while
+// still satisfying its logger.Handler argument.
+func registryLogTestLogger(t *testing.T) logger.Handler {
+	t.Helper()
+	return newSeedTestLogger(t)
+}
+
+// TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking is the regression
+// test for meshery/meshery#21584.
+//
+// A deployment that pins PROVIDER has every other registration - the Local
+// Provider included - deleted from HandlerConfig.Providers by
+// RestrictToEnforcedProvider. RegistryLog used to index that map by
+// LocalProviderName and call PersistSystemEvent on the zero Provider it got
+// back, which panicked in the unrecovered seeding goroutine and killed the
+// server at boot before a single model was seeded.
+//
+// The assertion is deliberately not just "did not panic": the summary events
+// must still be persisted, because dropping them would trade a crash for
+// silently missing notifications on exactly the deployments that pin a
+// provider.
+func TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking(t *testing.T) {
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t))
+	hc := newRegistryLogTestConfig(t, db)
+
+	RestrictToEnforcedProvider(hc.Providers, enforcedProviderKey)
+	if _, ok := hc.Providers[LocalProviderName]; ok {
+		t.Fatalf("fixture is not exercising the reported condition: Local is still registered after enforcement")
+	}
+
+	viper.Set("REGISTRY_LOG_FILE", t.TempDir()+"/registry-errors.log")
+	t.Cleanup(func() { viper.Set("REGISTRY_LOG_FILE", "") })
+
+	RegistryLog(registryLogTestLogger(t), hc, regm, NewRegistrationFailureLogHandler())
+
+	persisted := persistedSystemEvents(t, db)
+	if len(persisted) == 0 {
+		t.Fatal("no system event was persisted; the registrant summaries raised while seeding were dropped")
+	}
+	var summaries int
+	for _, e := range persisted {
+		if strings.HasPrefix(e.Description, "For registrant ") {
+			summaries++
+		}
+	}
+	if summaries == 0 {
+		t.Fatalf("no registrant summary event persisted; got %d event(s): %+v", len(persisted), persisted)
+	}
+}
+
+// TestRegistryLogDoesNotReadTheProviderRegistry pins the invariant the fix
+// establishes: system events raised while seeding are not routed through
+// HandlerConfig.Providers at all, so no future change to which providers a
+// deployment registers can reintroduce #21584. An empty map is the strongest
+// form of "no provider is registered", and it must still seed and persist.
+func TestRegistryLogDoesNotReadTheProviderRegistry(t *testing.T) {
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t))
+	hc := newRegistryLogTestConfig(t, db)
+	hc.Providers = map[string]Provider{}
+
+	viper.Set("REGISTRY_LOG_FILE", t.TempDir()+"/registry-errors.log")
+	t.Cleanup(func() { viper.Set("REGISTRY_LOG_FILE", "") })
+
+	RegistryLog(registryLogTestLogger(t), hc, regm, NewRegistrationFailureLogHandler())
+
+	if len(persistedSystemEvents(t, db)) == 0 {
+		t.Fatal("no system event was persisted with an empty provider registry")
+	}
+}
+
+// TestRegistryLogWithoutASystemEventSinkStillLogs covers the one path that
+// legitimately drops events: a HandlerConfig built without a
+// SystemEventPersister. It must report the omission and keep going rather than
+// panic - the boot summaries are still worth logging.
+func TestRegistryLogWithoutASystemEventSinkStillLogs(t *testing.T) {
+	db, regm := seedTestRegistry(t, mesheryCoreModelDir(t))
+	hc := newRegistryLogTestConfig(t, db)
+	hc.SystemEventPersister = nil
+
+	viper.Set("REGISTRY_LOG_FILE", t.TempDir()+"/registry-errors.log")
+	t.Cleanup(func() { viper.Set("REGISTRY_LOG_FILE", "") })
+
+	RegistryLog(registryLogTestLogger(t), hc, regm, NewRegistrationFailureLogHandler())
+
+	if got := len(persistedSystemEvents(t, db)); got != 0 {
+		t.Fatalf("expected no persisted events without a sink, got %d", got)
+	}
+}
+
+// TestRunSeedStageRecoversPanic pins the resiliency half of #21584: a fault
+// while seeding must be reported and contained, never allowed to terminate the
+// server. cmd/main.go runs each seeding stage through this helper.
+func TestRunSeedStageRecoversPanic(t *testing.T) {
+	ran := false
+
+	RunSeedStage(registryLogTestLogger(t), "models", func() {
+		panic("boom")
+	})
+	RunSeedStage(registryLogTestLogger(t), "policies", func() {
+		ran = true
+	})
+
+	if !ran {
+		t.Fatal("a stage that panicked prevented a later stage from running")
+	}
+}

--- a/server/models/seed_models_logs_enforced_provider_test.go
+++ b/server/models/seed_models_logs_enforced_provider_test.go
@@ -1,7 +1,11 @@
 package models
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/meshery/meshkit/database"
@@ -58,6 +62,74 @@ func persistedSystemEvents(t *testing.T, db *database.Handler) []events.Event {
 func registryLogTestLogger(t *testing.T) logger.Handler {
 	t.Helper()
 	return newSeedTestLogger(t)
+}
+
+// loggedError is one record of the JSON stream logger.Handler writes to its
+// error output. That stream is the operator-facing diagnostic contract: Error
+// emits the MeshKit error's code alongside the message, and the code is what an
+// operator greps for and what docs/data/errorref is keyed on.
+type loggedError struct {
+	Code    string `json:"code"`
+	Message string `json:"msg"`
+}
+
+// errorLogSink captures that stream. logrus serializes its own writes; the
+// mutex covers reads, which happen on the test goroutine.
+type errorLogSink struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *errorLogSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+// records decodes every error the logger emitted.
+func (s *errorLogSink) records(t *testing.T) []loggedError {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var records []loggedError
+	dec := json.NewDecoder(bytes.NewReader(s.buf.Bytes()))
+	for {
+		var rec loggedError
+		err := dec.Decode(&rec)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode captured error log stream: %v", err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+// reports says whether the given MeshKit error code was emitted.
+func (s *errorLogSink) reports(t *testing.T, code string) bool {
+	t.Helper()
+
+	for _, rec := range s.records(t) {
+		if rec.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// capturingTestLogger returns a logger.Handler whose error output is captured
+// rather than written to stderr, so a test can assert on what was reported.
+func capturingTestLogger(t *testing.T) (logger.Handler, *errorLogSink) {
+	t.Helper()
+
+	log := newSeedTestLogger(t)
+	sink := &errorLogSink{}
+	log.UpdateErrorLogOutput(sink)
+	return log, sink
 }
 
 // TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking is the regression
@@ -135,10 +207,14 @@ func TestRegistryLogWithoutASystemEventSinkStillLogs(t *testing.T) {
 	viper.Set("REGISTRY_LOG_FILE", t.TempDir()+"/registry-errors.log")
 	t.Cleanup(func() { viper.Set("REGISTRY_LOG_FILE", "") })
 
-	RegistryLog(registryLogTestLogger(t), hc, regm, NewRegistrationFailureLogHandler())
+	log, sink := capturingTestLogger(t)
+	RegistryLog(log, hc, regm, NewRegistrationFailureLogHandler())
 
 	if got := len(persistedSystemEvents(t, db)); got != 0 {
 		t.Fatalf("expected no persisted events without a sink, got %d", got)
+	}
+	if !sink.reports(t, ErrNoSystemEventSinkCode) {
+		t.Fatalf("dropping the events was not reported as %s, making it a silent skip; emitted: %+v", ErrNoSystemEventSinkCode, sink.records(t))
 	}
 }
 
@@ -148,14 +224,18 @@ func TestRegistryLogWithoutASystemEventSinkStillLogs(t *testing.T) {
 func TestRunSeedStageRecoversPanic(t *testing.T) {
 	ran := false
 
-	RunSeedStage(registryLogTestLogger(t), "models", func() {
+	log, sink := capturingTestLogger(t)
+	RunSeedStage(log, "models", func() {
 		panic("boom")
 	})
-	RunSeedStage(registryLogTestLogger(t), "policies", func() {
+	RunSeedStage(log, "policies", func() {
 		ran = true
 	})
 
 	if !ran {
 		t.Fatal("a stage that panicked prevented a later stage from running")
+	}
+	if !sink.reports(t, ErrSeedingStagePanicCode) {
+		t.Fatalf("the recovered fault was not reported as %s, so containing it swallowed it; emitted: %+v", ErrSeedingStagePanicCode, sink.records(t))
 	}
 }


### PR DESCRIPTION
## Intent

Fix the fatal boot-time panic that kills Meshery Server during model seeding when PROVIDER is pinned to a remote provider (issue https://github.com/meshery/meshery/issues/21584). Reported against a live cluster running PROVIDER=cloud.meshery.io: the server dies at boot and seeds no models, so this is a release-blocking defect, not a degraded path.

ROOT CAUSE (all five links independently confirmed by reproduction, not assumed):
1. Commit 29fd37ba79b9 "[Server] Hard-enforce PROVIDER so Local cannot be selected" added models.RestrictToEnforcedProvider (server/models/providers.go), called from server/cmd/main.go. It deletes every non-enforced key from the provider registration map - including LocalProviderName.
2. hc.Providers (server/models/handlers.go, map[string]Provider) is that same map instance.
3. server/models/seed_models_logs.go did an unguarded lookup: provider := handlerConfig.Providers[LocalProviderName]. With Local deleted this yields the zero-value Provider (a nil interface).
4. RegistryLog then called provider.PersistSystemEvent(*successEvent) on that nil interface and panicked; the same assumption fed &provider into FailedEventCompute. The reproduced crash address (addr=0x2d0) is the itab method-slot offset of a nil interface, which independently confirms link 3.
5. SeedComponents runs in an UNRECOVERED goroutine (main.main.func4, server/cmd/main.go), so the panic took down the entire server process instead of failing only the seeding step.
Masking condition: default deployments leave Local registered, so the lookup returns a live provider and seeding works. Only a pinned deployment reaches the nil - which is why CI stayed green and the defect shipped.

REQUIREMENTS THE USER SET:
- Reproduce first at the real user path (boot the server with PROVIDER pinned to a remote), then run the counterfactual (same boot, PROVIDER unset) so flipping only the pin flips the outcome.
- Fix at the CORRECT LAYER, not automatically the call site. The real defect is that RegistryLog hard-codes an assumption - "the Local provider is always registered" - that RestrictToEnforcedProvider deliberately invalidated.
- A nil-guard that silently skips persistence is acceptable ONLY if dropping those events is shown to be intended behavior; if it merely hides a missing initialization it is NOT a fix.
- Investigate the behavior question rather than guessing: under a pinned remote, should boot-time registrant-summary and registration-failure system events route to the enforced provider, or is not persisting them acceptable? Escalate only if it is a genuine product-contract call.
- Scan for siblings: other code assuming Local is present in the registration map, or indexing Providers without the comma-ok result; and check the seeding path's neighbours SeedConnections, krh.SeedKeys and lProv.SeedContent under a pinned provider. Fix what is genuinely broken; record in the PR anything found and deliberately left.
- Address the resiliency defect too: a failure while seeding models must not be able to kill the server. Harden the unrecovered goroutine so a seeding fault degrades the server, with the failure surfaced through the existing structured error and logging machinery rather than swallowed. Keep it proportionate and in the same PR.
- Do NOT restructure provider enforcement beyond what the fix requires. RestrictToEnforcedProvider is intended behavior; the bug is that a consumer was never taught about it.
- Report which links of the root-cause chain the reproduction confirmed and which it did not, plus any disconfirming evidence, without quietly dropping a link that failed to hold.

ACCEPTANCE CRITERIA:
- A pinned-PROVIDER boot completes model seeding without panicking, verified by running it.
- An unpinned boot still seeds identically (no regression on the default path).
- The reproduction becomes a regression test that fails without the fix and passes with it, covering the pinned-provider seeding path specifically. Required, not optional.
- Any sibling occurrence is fixed or explicitly recorded in the PR description with a reason.
- A seeding failure no longer terminates the server process.
- Docs updated if this changes documented PROVIDER behavior (the pinning change touched docs/ and the Helm README).

DECISIONS AND TRADEOFFS MADE WHILE DOING THE WORK (deliberate - please do not flag these as oversights):
- The behavior question turned out NOT to be a product-contract call, settled by evidence rather than opinion: RemoteProvider.PersistSystemEvent and DefaultLocalProvider's (via its embedded *EventsPersister) are the SAME implementation over the SAME dbHandler, both documented as persisting to the local database. So "route to the enforced provider" and "route to Local" produce identical rows in the identical table; the choice is vacuous at runtime, and the only option evidence ruled out was dropping the events. Confirmed empirically by reading the rows back: pre-fix pinned boot = 0 summary events, post-fix pinned = 3, unpinned = the same 3 with identical text. No escalation was warranted.
- Chosen fix layer: HandlerConfig.Providers is a REQUEST-ROUTING table; boot-time seeding has no request and, since enforcement, no guarantee any named provider is registered. So HandlerConfig now carries a new SystemEventPersister field (new narrow interface in server/models/providers.go with just PersistSystemEvent), wired in cmd/main.go to &models.EventsPersister{DB: dbHandler} - the same handler every provider's own EventsPersister wraps. RegistryLog and FailedEventCompute persist through it and no longer touch the provider map at all. This was chosen deliberately over a nil-guard at the call site and over "fall back to any registered provider".
- models.FailedEventCompute's third parameter changed from *Provider to SystemEventPersister. This is deliberate and safe: it has exactly one caller (RegistryLog). The separate helpers.FailedEventCompute in server/helpers/common_registry_logs.go still takes *models.Provider and was intentionally left alone - its caller (server/models/meshmodel/core/register.go) receives a request-scoped provider from the session, which enforcement resolves consistently, so it is not affected by this defect.
- The nil-persister branch in RegistryLog is deliberately loud, not a silent skip: it logs a new structured MeshKit error (meshery-server-1482 ErrNoSystemEventSink) and then substitutes an explicit discardSystemEvents sink so the boot summaries are still logged. It is reachable only if a caller builds a HandlerConfig without wiring the field - a programmer error, never the reported condition.
- Resiliency: added models.RunSeedStage(log, stage, fn) in server/models/seed_models.go, which recovers and reports via a new structured error (meshery-server-1483 ErrSeedingStagePanic) carrying the stage name and stack trace. cmd/main.go wraps each of the three seeding stages ("user keys", "models", "policies") SEPARATELY rather than the whole goroutine once, so one faulting stage does not skip the others.
- ErrSeedingStagePanic's short description, probable cause and remediation are deliberately literal strings rather than fmt.Sprintf-composed with the stage name, because errorutil can only lift static strings into docs/data/errorref (an interpolated one publishes as an empty entry - see ErrImportFailure/1359). The stage name carries in the error details instead.
- Error codes 1482 and 1483 were allocated from server/helpers/component_info.json, which is bumped to next_error_code 1484 in the same commit, and docs/data/errorref/meshery-server_errors_export.json was regenerated to include both (a minimal +18-line diff; that file was otherwise current with master).

SIBLING SCAN RESULT (deliberate, already verified - not gaps):
- Providers[...] has exactly two other indexing sites, both already comma-ok guarded: handlers/middlewares.go and handlers/ui_handler.go.
- AuthMiddleware's providerI.(models.Provider) type assertion fails safely on a nil interface stored in the request context, so it redirects rather than dereferencing.
- SeedConnections, krh.SeedKeys and lProv.SeedContent are all provider-independent (they take the db handler / registry directly), so none is affected by enforcement.
- ONE issue found and DELIBERATELY LEFT, to be recorded in the PR description: server/cmd/main.go has a pre-existing data race - `rego` is written inside the seeding goroutine while &rego is handed to handlers.NewHandlerInstance. It predates this change and fixing it correctly means changing that constructor's contract, which would enlarge this PR well past the fix. Please do not treat it as introduced here.

VERIFICATION ALREADY PERFORMED (real binary, real network probe to https://cloud.meshery.io, not a mock):
- Pre-fix pinned boot: panics at seed_models_logs.go:250 with the issue's exact stack and 0 models seeded.
- Post-fix pinned boot: seeds all three registrants (artifacthub/github/meshery) plus 2 system-owned connections, persists 3 summary events, no panic, server still listening.
- Unpinned boot before and after the fix: identical seeding, no regression.
- Regression tests added in server/models/seed_models_logs_enforced_provider_test.go; verified they FAIL with the exact nil-deref panic when RegistryLog is reverted to the old Providers[LocalProviderName] lookup, and pass with the fix. They assert events are actually persisted, not merely that nothing panicked. Also -race clean.
- Resiliency verified end-to-end with a purpose-built binary carrying an injected panic in SeedComponents: the server logged code=meshery-server-1483 with the full stack and kept serving (HTTP 200).
- go test ./server/models/... ./server/handlers/... all green. make golangci is red on 8 PRE-EXISTING issues in files this change does not touch (provider-ui/node_modules, server/integration-tests); CI is only-new-issues so they do not gate.

DOCS: docs/content/en/reference/extensibility/providers/index.md gained a note that boot-time seeding is provider-independent and a contributor warning not to look a provider up by name at boot; AGENTS.md gained the matching MANDATORY rule and a Further Reading row. Nothing previously documented about PROVIDER pinning changed meaning, so no other doc or the Helm README needed edits.

## What Changed

- **Boot-time system events no longer route through the provider registration map.** `RegistryLog` read `handlerConfig.Providers[LocalProviderName]`, which `RestrictToEnforcedProvider` deletes on a `PROVIDER`-pinned deployment, so `PersistSystemEvent` was called on a nil interface and panicked (#21584). `HandlerConfig` now carries a `SystemEventPersister` field (new narrow interface in `server/models/providers.go`), wired in `cmd/main.go` to `&models.EventsPersister{DB: dbHandler}` - the same handler every provider's own persister wraps, so the events land in the same `events` table pinned or not. `models.FailedEventCompute` takes that sink instead of `*Provider` (single caller), and persist failures are now returned/logged rather than discarded. A nil sink is not a silent skip: it logs new error `meshery-server-1482` and falls back to an explicit discard sink.
- **A seeding fault can no longer kill the server.** New `models.RunSeedStage(log, stage, fn)` recovers a panic and reports it as `meshery-server-1483` with the stage name and stack trace. Applied per stage - `user keys`, `models`, `policies`, `content` - in `cmd/main.go`, and to both reset-triggered reseed goroutines (`handlers.ResetSystemDatabase`, the GraphQL `resyncCluster` hard reset), so one faulting stage does not skip the others or take the HTTP listener down.
- **Regression coverage, error codes and docs.** `server/models/seed_models_logs_enforced_provider_test.go` pins the pinned-provider seeding path (events actually persisted, provider registry never read, nil-sink path still logs, `RunSeedStage` recovers). `next_error_code` bumped to 1484 with `docs/data/errorref` regenerated; the providers reference gains a boot-time-seeding note and a contributor warning against name-based provider lookup at boot, the server-events guide points at the new sink, and `AGENTS.md` gains the matching MANDATORY rule. A stale claim that the meshkit logger panics on a non-meshkit error was corrected in the error-contributing guide.

Deliberately left: `server/cmd/main.go` has a pre-existing data race where `rego` is written inside the seeding goroutine while `&rego` is handed to `handlers.NewHandlerInstance`. It predates this branch and fixing it correctly means changing that constructor's contract, which would enlarge this PR well past the fix.

## Risk Assessment

✅ Low: The fix is at the correct layer (system events no longer resolve through the request-routing provider map), no path to the reported nil-deref remains reachable, the regression tests assert persisted rows and emitted error codes rather than absence of a panic, and the pipeline-authored reset-path changes are mechanical wrappings that preserve stage order and the existing reset-lock defer.

## Testing

I reproduced the defect first and then verified the fix at the real user path rather than only in unit tests. A server binary built from the base commit and booted with PROVIDER=cloud.meshery.io against the live provider host died exactly as reported - SIGSEGV addr=0x2d0 at seed_models_logs.go:250, stack ending in the unrecovered main.main.func4 goroutine, zero summary events persisted and the port refusing connections. The same boot with the fixed binary seeded all three registrants and 292 models, persisted three summary events readable back out of SQLite, and kept answering /api/system/version with HTTP 200; the unpinned boot produced byte-identical events, so the default path is unchanged. For the resiliency criterion I built a binary with a fault injected into SeedComponents (reverted right after the build) and confirmed the server logged code=meshery-server-1483 with the stage name and stack and carried on serving. The new regression test is a real one: reverting RegistryLog to the old Providers[LocalProviderName] lookup makes it fail with the same nil deref, and it passes with the fix under -race, along with all tests in the touched packages. The first test run hit the documented stale-GOROOT build failure, which I fixed by running under env -u GOROOT as the build-environment doc prescribes. No screenshot or rendered-UI artifact applies: this is server boot behavior with no UI surface changed, and the closest end-user surface (the notification centre showing these system events) would require an authenticated session against the pinned remote provider, so I captured the persisted event rows and live HTTP responses instead. Test servers were killed and all build/run temp directories removed; the worktree is clean.

<details>
<summary>Evidence: Evidence summary (before/after table, root-cause links confirmed)</summary>

```text
# meshery#21584 - boot panic seeding models under a pinned PROVIDER

All four runs below are the **real server binary** (`go build ./server/cmd`), booted against
`PROVIDER_BASE_URLS=https://cloud.meshery.io` with an isolated `HOME`/`USER_DATA_FOLDER`, and
seeding the repository's real 478 model directories. `cloud.meshery.io` was reachable
(`/api/provider/capabilities` -> HTTP 401, i.e. a live host rejecting an unauthenticated probe).

| # | binary | `PROVIDER` | outcome | summary events in `events` | HTTP `/api/system/version` |
|---|--------|-----------|---------|---------------------------|----------------------------|
| 02 | base `24d664f81e7` (pre-fix) | `cloud.meshery.io` | **process killed** by `SIGSEGV addr=0x2d0` at `seed_models_logs.go:250` in `main.main.func4` | **0** | connection refused |
| 03 | `feca984f60c` (fixed) | `cloud.meshery.io` | seeds 3 registrants, no panic, still serving | **3** | **200** |
| 04 | `feca984f60c` (fixed) | *unset* | identical seeding | **3**, byte-identical descriptions to 03 | **200** |
| 05 | `feca984f60c` + injected fault in `SeedComponents` | `cloud.meshery.io` | fault **recovered**, logged `code=meshery-server-1483` with the stage name and stack, boot continued | n/a | **200** |

`03` vs `04`: `diff` of the persisted event descriptions is empty - a pinned boot and an unpinned
boot seed and persist exactly the same thing. 292 models registered in both.

## Root-cause links confirmed by reproduction

- **Links 1-3** (enforcement deletes `Local` -> `Providers[LocalProviderName]` yields a nil
  `Provider`): confirmed. Run 02 logs `PROVIDER is pinned to "cloud.meshery.io"; unregistering
  every other provider (including Local)` and then faults inside `RegistryLog`.
- **Link 4** (nil-interface method call; `addr=0x2d0` is the itab slot offset): confirmed - the
  live boot and the unit-level counterfactual both fault at `addr=0x2d0`, `seed_models_logs.go:250`.
- **Link 5** (unrecovered goroutine kills the process): confirmed - the stack ends at
  `main.main.func4 ... created by main.main`, and the process is gone; `:9481` refuses connections
  even though the server had already logged `Meshery Server listening on: 9481` 18s earlier.
- **Masking condition** (unpinned deployments never reach the nil): confirmed by run 04.

Nothing disconfirming surfaced. One nuance the runs add to the report: the pre-fix boot dies
*after* the first registrant summary is logged, so its `models` seeding stage is left half-done
(292 model rows written, 0 events, `SeedConnections` never reached) rather than "seeds no models".

## Files

- `01-regression-test-fails-without-fix.txt` - the new regression test run against a tree whose
  `seed_models_logs.go` is reverted to base: fails with the same `addr=0x2d0` nil deref.
- `02-boot-prefix-pinned-PANICS.log` - pre-fix pinned boot (the reported defect).
- `03-boot-fixed-pinned-OK.log` - fixed pinned boot + events read back out of SQLite.
- `04-boot-fixed-unpinned-OK.log` - fixed unpinned boot (no regression on the default path).
- `05-boot-seeding-fault-degrades-not-kills.log` - injected seeding fault, server keeps serving.
- `06-regression-tests-pass-with-fix.txt` - the four new tests, `-race`, against the fixed tree.
```
</details>
<details>
<summary>Evidence: Pre-fix pinned boot - the reported crash, real binary</summary>

<code>PROVIDER is pinned to &#34;cloud.meshery.io&#34;; unregistering every other provider (including Local)&#10;Meshery Server listening on: 9481&#10;For registrant artifacthub imported 152 models, 1350 components, 26 relationships.&#10;panic: runtime error: invalid memory address or nil pointer dereference&#10;[signal SIGSEGV: segmentation violation code=0x1 addr=0x2d0 pc=0x10e8689b3]&#10;&#10;goroutine 52 [running]:&#10;github.com/meshery/meshery/server/models.RegistryLog(...)&#10;server/models/seed_models_logs.go:250 +0x8f3&#10;github.com/meshery/meshery/server/models.SeedComponents(...)&#10;server/models/seed_models.go:131 +0x20f&#10;main.main.func4()&#10;server/cmd/main.go:310 +0x97&#10;created by main.main in goroutine 1&#10;server/cmd/main.go:306 +0x1f9c&#10;&#10;--- process state ---&#10;process is DEAD&#10;HTTP probe on :9481 -&gt; 000 connection refused&#10;registrant summary events persisted: 0</code>

```text
########################################################################
# BEFORE THE FIX - real server binary built from base 24d664f81e7
# $ PROVIDER=cloud.meshery.io PROVIDER_BASE_URLS=https://cloud.meshery.io ./meshery-server
########################################################################
time="2026-08-23T17:01:27-05:00" level=info msg="OpenTelemetry config not set; tracing disabled" app=meshery
time="2026-08-23T17:01:27-05:00" level=info msg="Local Provider capabilities are: Not Set" app=meshery
time="2026-08-23T17:01:27-05:00" level=info msg="Meshery Server release channel is: Not Set" app=meshery
time="2026-08-23T17:01:27-05:00" level=info msg="MESHSYNC_DEFAULT_DEPLOYMENT_MODE is embedded" app=meshery
time="2026-08-23T17:01:27-05:00" level=info msg="Meshery Database is at: /tmp/meshery-seed-e2e/data-prefix-pinned" app=meshery
time="2026-08-23T17:01:27-05:00" level=info msg="Using kubeconfig at: /tmp/meshery-seed-e2e/home-prefix-pinned/.kube" app=meshery
time="2026-08-23T17:01:27-05:00" level=info msg="Log level: info" app=meshery
time="2026-08-23T17:01:36-05:00" level=info msg="PROVIDER is pinned to \"cloud.meshery.io\"; unregistering every other provider (including Local)" app=meshery
time="2026-08-23T17:01:36-05:00" level=info msg="Meshery Server listening on: 9481" app=meshery
time="2026-08-23T17:01:54-05:00" level=info msg="For registrant artifacthub imported 152 models, 1350 components, 26 relationships." app=meshery
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2d0 pc=0x10e8689b3]

goroutine 52 [running]:
github.com/meshery/meshery/server/models.RegistryLog({0x112d4e5f8, 0x3dfd8a4726c0}, 0x3dfd89d20100, 0x3dfd8a1b2238, 0x3dfd8a5afac0)
	/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/models/seed_models_logs.go:250 +0x8f3
github.com/meshery/meshery/server/models.SeedComponents({0x112d4e5f8, 0x3dfd8a4726c0}, 0x3dfd89d20100, 0x3dfd8a1b2238, 0x113058610)
	/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/models/seed_models.go:131 +0x20f
main.main.func4()
	/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/cmd/main.go:310 +0x97
created by main.main in goroutine 1
	/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/cmd/main.go:306 +0x1f9c

--- process state ---
process is DEAD: the panic above was unrecovered in main.main.func4, so it took the whole server down
HTTP probe on :9481 -> 000connection refused

--- what landed in the database (sqlite mesherydb.sql) ---
registrant summary events persisted: 0
system-owned connections seeded:     4
```
</details>
<details>
<summary>Evidence: Fixed binary, PROVIDER pinned - seeds and stays up</summary>

<code>PROVIDER is pinned to &#34;cloud.meshery.io&#34;; unregistering every other provider (including Local)&#10;Meshery Server listening on: 9482&#10;For registrant artifacthub imported 152 models, 1350 components, 26 relationships.&#10;For registrant github imported 131 models, 1465 components, 570 relationships.&#10;For registrant meshery imported 9 models, 1156 components, 4 relationships.&#10;&#10;--- process state ---&#10;process is ALIVE (pid 38933) - no panic, seeding completed&#10;GET /api/system/version on :9482 -&gt; HTTP 200&#10;{&#34;build&#34;:&#34;Not Set&#34;,&#34;commitsha&#34;:&#34;Not Set&#34;,&#34;latest&#34;:&#34;v1.0.67&#34;,&#34;outdated&#34;:true,&#34;releaseChannel&#34;:&#34;Not Set&#34;}&#10;&#10;--- registrant summary events read back out of the database ---&#10;severity category action description&#10;------------- -------- ----------- ----------------------------------------------------------------------------------&#10;informational entity get_summary For registrant artifacthub imported 152 models, 1350 components, 26 relationships.&#10;informational entity get_summary For registrant github imported 131 models, 1465 components, 570 relationships.&#10;informational entity get_summary For registrant meshery imported 9 models, 1156 components, 4 relationships.&#10;&#10;models registered: 292</code>

```text
########################################################################
# AFTER THE FIX - real server binary built from feca984f60c
# $ PROVIDER=cloud.meshery.io PROVIDER_BASE_URLS=https://cloud.meshery.io ./meshery-server
########################################################################
time="2026-08-23T17:02:25-05:00" level=info msg="OpenTelemetry config not set; tracing disabled" app=meshery
time="2026-08-23T17:02:25-05:00" level=info msg="Local Provider capabilities are: Not Set" app=meshery
time="2026-08-23T17:02:25-05:00" level=info msg="Meshery Server release channel is: Not Set" app=meshery
time="2026-08-23T17:02:25-05:00" level=info msg="MESHSYNC_DEFAULT_DEPLOYMENT_MODE is embedded" app=meshery
time="2026-08-23T17:02:25-05:00" level=info msg="Meshery Database is at: /tmp/meshery-seed-e2e/data-fixed-pinned" app=meshery
time="2026-08-23T17:02:25-05:00" level=info msg="Using kubeconfig at: /tmp/meshery-seed-e2e/home-fixed-pinned/.kube" app=meshery
time="2026-08-23T17:02:25-05:00" level=info msg="Log level: info" app=meshery
time="2026-08-23T17:02:33-05:00" level=info msg="PROVIDER is pinned to \"cloud.meshery.io\"; unregistering every other provider (including Local)" app=meshery
time="2026-08-23T17:02:33-05:00" level=info msg="Meshery Server listening on: 9482" app=meshery
time="2026-08-23T17:02:49-05:00" level=info msg="For registrant artifacthub imported 152 models, 1350 components, 26 relationships." app=meshery
time="2026-08-23T17:02:49-05:00" level=info msg="For registrant github imported 131 models, 1465 components, 570 relationships." app=meshery
time="2026-08-23T17:02:49-05:00" level=info msg="For registrant meshery imported 9 models, 1156 components, 4 relationships." app=meshery
time="2026-08-23T17:02:49-05:00" level=info msg="Seeded 2 system-owned connection(s) from registered connection definitions" app=meshery

--- process state ---
process is ALIVE (pid 38933) - no panic, seeding completed
GET /api/system/version on :9482 -> HTTP 200
GET /api/system/version body: {"build":"Not Set","commitsha":"Not Set","latest":"v1.0.67","outdated":true,"releaseChannel":"Not Set"}

--- registrant summary events read back out of the database ---
severity       category  action       description                                                                       
-------------  --------  -----------  ----------------------------------------------------------------------------------
informational  entity    get_summary  For registrant artifacthub imported 152 models, 1350 components, 26 relationships.
informational  entity    get_summary  For registrant github imported 131 models, 1465 components, 570 relationships.    
informational  entity    get_summary  For registrant meshery imported 9 models, 1156 components, 4 relationships.       

--- registrant connections + models seeded ---
kind         name          status      rows
-----------  ------------  ----------  ----
artifacthub  Artifact Hub  registered  2   
github       GitHub        registered  1   
meshery      meshery       registered  1   
models registered: 292
```
</details>
<details>
<summary>Evidence: Fixed binary, PROVIDER unset - no regression on the default path</summary>

<code>--- process state ---&#10;process is ALIVE (pid 47398)&#10;GET /api/system/version on :9483 -&gt; HTTP 200&#10;&#10;registrant summary events: the same 3 rows, 292 models registered&#10;&#10;$ diff &lt;(pinned: select description from events order by description) \&#10;&lt;(unpinned: select description from events order by description)&#10;IDENTICAL</code>

```text
########################################################################
# COUNTERFACTUAL - same fixed binary, PROVIDER unset (default deployment)
# $ PROVIDER= PROVIDER_BASE_URLS=https://cloud.meshery.io ./meshery-server
########################################################################
time="2026-08-23T17:03:20-05:00" level=info msg="OpenTelemetry config not set; tracing disabled" app=meshery
time="2026-08-23T17:03:20-05:00" level=info msg="Local Provider capabilities are: Not Set" app=meshery
time="2026-08-23T17:03:20-05:00" level=info msg="Meshery Server release channel is: Not Set" app=meshery
time="2026-08-23T17:03:20-05:00" level=info msg="MESHSYNC_DEFAULT_DEPLOYMENT_MODE is embedded" app=meshery
time="2026-08-23T17:03:20-05:00" level=info msg="Meshery Database is at: /tmp/meshery-seed-e2e/data-fixed-unpinned" app=meshery
time="2026-08-23T17:03:20-05:00" level=info msg="Using kubeconfig at: /tmp/meshery-seed-e2e/home-fixed-unpinned/.kube" app=meshery
time="2026-08-23T17:03:20-05:00" level=info msg="Log level: info" app=meshery
time="2026-08-23T17:03:29-05:00" level=info msg="Meshery Server listening on: 9483" app=meshery
time="2026-08-23T17:03:44-05:00" level=info msg="For registrant artifacthub imported 152 models, 1350 components, 26 relationships." app=meshery
time="2026-08-23T17:03:44-05:00" level=info msg="For registrant github imported 131 models, 1465 components, 570 relationships." app=meshery
time="2026-08-23T17:03:44-05:00" level=info msg="For registrant meshery imported 9 models, 1156 components, 4 relationships." app=meshery
time="2026-08-23T17:03:44-05:00" level=info msg="Seeded 2 system-owned connection(s) from registered connection definitions" app=meshery

--- process state ---
process is ALIVE (pid 47398)
GET /api/system/version on :9483 -> HTTP 200

--- registrant summary events read back out of the database ---
severity       category  action       description                                                                       
-------------  --------  -----------  ----------------------------------------------------------------------------------
informational  entity    get_summary  For registrant artifacthub imported 152 models, 1350 components, 26 relationships.
informational  entity    get_summary  For registrant github imported 131 models, 1465 components, 570 relationships.    
informational  entity    get_summary  For registrant meshery imported 9 models, 1156 components, 4 relationships.       

--- registrant connections + models seeded ---
kind         name          status      rows
-----------  ------------  ----------  ----
artifacthub  Artifact Hub  registered  2   
github       GitHub        registered  1   
meshery      meshery       registered  1   
models registered: 292
```
</details>
<details>
<summary>Evidence: Seeding fault degrades the server instead of killing it (meshery-server-1483)</summary>

<code>level=error msg=&#34;faulting stage: models.injected seeding fault for resiliency verification&#10;goroutine 24 [running]: ... models.RunSeedStage.func1() seed_models.go:140&#10;panic(...) ... models.SeedComponents(...) seed_models.go:149&#10;main.main.func4.2() cmd/main.go:327 ...&#34;&#10;code=meshery-server-1483 severity=2&#10;short-description=&#34;Meshery Server recovered from a fault while seeding its registry&#34;&#10;suggested-remediation=&#34;Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete...&#34;&#10;level=info msg=&#34;PROVIDER is pinned to \&#34;cloud.meshery.io\&#34;&#34;&#10;level=info msg=&#34;Meshery Server listening on: 9484&#34;&#10;&#10;--- process state ---&#10;process is ALIVE (pid 87670) - the seeding fault degraded the server instead of terminating it&#10;GET /api/system/version on :9484 -&gt; HTTP 200</code>

```text
########################################################################
# RESILIENCY - fixed binary, a fault injected into SeedComponents
# (temporary 'panic(...) if MESHERY_TEST_SEED_PANIC' in SeedComponents; source restored after build)
# $ MESHERY_TEST_SEED_PANIC=1 PROVIDER=cloud.meshery.io ./meshery-server
# Before this change the same fault was unrecovered in main.main.func4 and killed the process.
########################################################################
time="2026-08-23T17:05:24-05:00" level=info msg="OpenTelemetry config not set; tracing disabled" app=meshery
time="2026-08-23T17:05:24-05:00" level=info msg="Local Provider capabilities are: Not Set" app=meshery
time="2026-08-23T17:05:24-05:00" level=info msg="Meshery Server release channel is: Not Set" app=meshery
time="2026-08-23T17:05:24-05:00" level=info msg="MESHSYNC_DEFAULT_DEPLOYMENT_MODE is embedded" app=meshery
time="2026-08-23T17:05:24-05:00" level=info msg="Meshery Database is at: /tmp/meshery-seed-e2e/data-fixed-panicinject" app=meshery
time="2026-08-23T17:05:24-05:00" level=info msg="Using kubeconfig at: /tmp/meshery-seed-e2e/home-fixed-panicinject/.kube" app=meshery
time="2026-08-23T17:05:24-05:00" level=info msg="Log level: info" app=meshery
time="2026-08-23T17:05:24-05:00" level=error msg="faulting stage: models.injected seeding fault for resiliency verification\ngoroutine 24 [running]:\nruntime/debug.Stack()\n\t/usr/local/Cellar/go/1.26.5/libexec/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/meshery/meshery/server/models.RunSeedStage.func1()\n\t/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/models/seed_models.go:140 +0x54\npanic({0x110ec5800?, 0x111843e30?})\n\t/usr/local/Cellar/go/1.26.5/libexec/src/runtime/panic.go:860 +0x13a\ngithub.com/meshery/meshery/server/models.SeedComponents({0x1118bf858, 0x23b4faa2aee0}, 0x23b4fac91680, 0x23b4fab84c18, 0x111bc9610)\n\t/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/models/seed_models.go:149 +0x266\nmain.main.func4.2()\n\t/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/cmd/main.go:327 +0x27\ngithub.com/meshery/meshery/server/models.RunSeedStage({0x1118bf858?, 0x23b4faa2aee0?}, {0x10dc8905f?, 0x0?}, 0x0?)\n\t/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/models/seed_models.go:143 +0x62\nmain.main.func4()\n\t/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/cmd/main.go:326 +0xea\ncreated by main.main in goroutine 1\n\t/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/cmd/main.go:320 +0x1fe6\n | Short Description: Meshery Server recovered from a fault while seeding its registry | Probable Cause: An unexpected condition was hit while seeding at startup | Suggested Remediation: Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose and restart Meshery Server to seed again" app=meshery code=meshery-server-1483 probable-cause="An unexpected condition was hit while seeding at startup" severity=2 short-description="Meshery Server recovered from a fault while seeding its registry" suggested-remediation="Meshery Server is still serving, but whatever the faulting stage contributes may be missing or incomplete. Report the stack trace above at https://github.com/meshery/meshery/issues/new/choose and restart Meshery Server to seed again"
time="2026-08-23T17:05:33-05:00" level=info msg="PROVIDER is pinned to \"cloud.meshery.io\"; unregistering every other provider (including Local)" app=meshery
time="2026-08-23T17:05:33-05:00" level=info msg="Meshery Server listening on: 9484" app=meshery

--- process state ---
process is ALIVE (pid 87670) - the seeding fault degraded the server instead of terminating it
GET /api/system/version on :9484 -> HTTP 200
```
</details>
<details>
<summary>Evidence: Regression test fails without the fix (seed_models_logs.go reverted to base)</summary>

<code>--- FAIL: TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking (0.05s)&#10;panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]&#10;[signal SIGSEGV: segmentation violation code=0x1 addr=0x2d0 pc=0x108eba2d3]&#10;github.com/meshery/meshery/server/models.RegistryLog(...)&#10;server/models/seed_models_logs.go:250 +0x8f3&#10;...TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking(...)&#10;server/models/seed_models_logs_enforced_provider_test.go:161 +0x34a&#10;FAIL github.com/meshery/meshery/server/models 1.268s</code>

```text
### Counterfactual: regression test run against the PRE-FIX RegistryLog
### (server/models/seed_models_logs.go restored to base 24d664f81e7, which reads
###  provider := handlerConfig.Providers[LocalProviderName])




--- FAIL: TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking (0.05s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2d0 pc=0x11206c2d3]
goroutine 50 [running]:
testing.tRunner.func1.2({0x114945b60, 0x1150bd0e0})
	/usr/local/Cellar/go/1.26.5/libexec/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
	/usr/local/Cellar/go/1.26.5/libexec/src/testing/testing.go:1977 +0x349
panic({0x114945b60?, 0x1150bd0e0?})
	/usr/local/Cellar/go/1.26.5/libexec/src/runtime/panic.go:860 +0x13a
github.com/meshery/meshery/server/models.RegistryLog({0x114f3ef20, 0x1ab749039aa0}, 0x1ab749096120, 0x1ab748883678, 0x1ab748dedc78)
	/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/models/seed_models_logs.go:250 +0x8f3
github.com/meshery/meshery/server/models.TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking(0x1ab748d50488)
	/Users/l/.no-mistakes/worktrees/8e90410cb9af/01M0R7AEVVDVKXTCRDA09HYJ82/server/models/seed_models_logs_enforced_provider_test.go:161 +0x34a
testing.tRunner(0x1ab748d50488, 0x114ece670)
	/usr/local/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 1
	/usr/local/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x4c5
FAIL	github.com/meshery/meshery/server/models	1.276s
FAIL
```
</details>
<details>
<summary>Evidence: New tests pass with the fix, under -race</summary>

<code>--- PASS: TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking (0.32s)&#10;--- PASS: TestRegistryLogDoesNotReadTheProviderRegistry (0.32s)&#10;--- PASS: TestRegistryLogWithoutASystemEventSinkStillLogs (0.31s)&#10;--- PASS: TestRunSeedStageRecoversPanic (0.00s)&#10;ok github.com/meshery/meshery/server/models 3.758s</code>

```text
=== RUN   TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking
--- PASS: TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking (0.32s)
=== RUN   TestRegistryLogDoesNotReadTheProviderRegistry
--- PASS: TestRegistryLogDoesNotReadTheProviderRegistry (0.32s)
=== RUN   TestRegistryLogWithoutASystemEventSinkStillLogs
--- PASS: TestRegistryLogWithoutASystemEventSinkStillLogs (0.31s)
=== RUN   TestRunSeedStageRecoversPanic
--- PASS: TestRunSeedStageRecoversPanic (0.00s)
ok  	github.com/meshery/meshery/server/models	3.758s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"496a26080c43289e82f9be8d854e5ae50e564fd7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `server/handlers/database_handlers.go:209` - The database-reset handler runs `krh.SeedKeys`, `lp.SeedContent` and `models.SeedComponents` inside a bare `go func()` (line 203) with no `recover`, so a panic in any of them still terminates the whole server process. This is the same resiliency defect the change fixes at `server/cmd/main.go:317-337`, and it is not listed among the deliberately-left items in the sibling scan. It is arguably worse than the boot case: this path is reachable at runtime by an authenticated user on a serving instance, so a fault takes down a live server rather than one that has not started. `defer models.ReleaseResetLock()` runs during unwinding but does not stop the process from dying. Fix: wrap each stage in `models.RunSeedStage(h.log, &#34;&lt;stage&gt;&#34;, func(){ ... })`, exactly as `cmd/main.go` now does.
- ⚠️ `server/internal/graphql/resolver/meshsync.go:154` - Same defect as the database-reset handler: the GraphQL hard-reset path runs `krh.SeedKeys`, `lp.SeedContent` and `models.SeedComponents` in an unrecovered `go func()` (line 148), so a seeding fault terminates the server process. The intent&#39;s acceptance criterion is &#34;A seeding failure no longer terminates the server process&#34;, which this path does not yet satisfy, and it is not among the recorded deliberately-left items. Fix: wrap each stage in `models.RunSeedStage(r.Log, &#34;&lt;stage&gt;&#34;, func(){ ... })`.
- ⚠️ `server/models/seed_models_logs.go:272` - `_ = persister.PersistSystemEvent(*successEvent)` discards the error, and so does `_ = persister.PersistSystemEvent(*errorEvent)` in `FailedEventCompute` (line 124). The whole point of the fix is that these boot summaries reach the `events` table; if `EventsPersister.PersistEvent` fails (it returns a structured `ErrPersistEvent`), the operator gets no signal at all and the guarantee the regression test pins silently regresses in production. Siblings in this same package already handle it - `server/models/k8s_context.go:572` and `:624` check the returned error. Fix: `if err := persister.PersistSystemEvent(*successEvent); err != nil { log.Error(err) }` at line 272; `FailedEventCompute` has no logger, so either return the error or take the same `log` its caller already holds.
- ℹ️ `server/models/seed_models.go:131` - `RunSeedStage`&#39;s `recover` only covers panics on its own goroutine, and one wrapped stage spawns a nested one: `krh.SeedKeys` starts `go func(){ csvReader.Parse(...) }` at `server/models/keys_helper.go:71`. A panic there would still terminate the process despite the wrapper. This is a residual qualification of the doc comment&#39;s claim rather than a blocker - the #21584 path itself is fully covered, since meshkit&#39;s `models/registration` package spawns no goroutines and `SeedComponents` runs entirely on the wrapped stack. Noting it so the invariant is not read as broader than it is.

🔧 Fix: Recover seeding panics on reset paths; log persist errors
2 issues (1 warning, 1 info) still open:
- ⚠️ `server/cmd/main.go:340` - `lProv.SeedContent(log)` is the only seeding stage still outside `models.RunSeedStage`. It runs synchronously on the main goroutine before `ListenAndServe`, so a panic inside it terminates the process at boot - the exact outcome the intent&#39;s acceptance criterion forbids (&#34;A seeding failure no longer terminates the server process&#34;) and the exact rationale `RunSeedStage`&#39;s own doc comment gives (&#34;a server that exits at boot leaves them with a crash loop and no UI to read it in&#34;). The asymmetry is concrete: this change wrapped the identical `lp.SeedContent(...)` call as the `&#34;content&#34;` stage on both runtime reset paths (server/handlers/database_handlers.go:209, server/internal/graphql/resolver/meshsync.go:154), so content seeding is now protected on a serving instance but not at boot. Those reset paths did not strictly need it either - net/http and gqlgen both recover handler panics, and only the spawned goroutines were exposed - whereas the main boot goroutine has no such recover. Fix: `models.RunSeedStage(log, &#34;content&#34;, func() { lProv.SeedContent(log) })`, keeping it synchronous and in place before `provs[lProv.Name()] = lProv` on line 341.
- ℹ️ `server/models/seed_models_logs_enforced_provider_test.go:130` - `TestRegistryLogWithoutASystemEventSinkStillLogs` asserts only `len(persistedSystemEvents(t, db)) == 0`. It never asserts that `ErrNoSystemEventSink` (meshery-server-1482) was reported, so the deliberate design decision the test is named for - that the nil-persister branch is loud rather than a silent skip, which is the only thing that makes `discardSystemEvents` defensible - is unpinned. The test passes unchanged if `RegistryLog` were to return early without logging anything, or if the `log.Error(ErrNoSystemEventSink())` call at server/models/seed_models_logs.go:246 were deleted. `logger.Handler` exposes `UpdateErrorLogOutput(io.Writer)`, so pointing the test logger&#39;s error output at a `bytes.Buffer` and asserting the emitted JSON carries `meshery-server-1482` is a semantic assertion on emitted diagnostic output, not on source text.

🔧 Fix: Wrap boot content seeding; pin error reporting in tests
2 infos still open:
- ℹ️ `server/models/seed_models.go:118` - `RunSeedStage`&#39;s doc comment describes it as running &#34;one boot-time seeding stage&#34; and attributes the bare goroutine to cmd/main.go, but the fix rounds extended it to the two runtime reset paths (server/handlers/database_handlers.go:205-215 and server/internal/graphql/resolver/meshsync.go:150-160), which execute on a live serving instance rather than at boot. `ErrSeedingStagePanic` inherits the same narrowing in operator-facing text: server/models/error.go:734 publishes the probable cause as &#34;An unexpected condition was hit while seeding at startup&#34;, so an operator who triggers a panic through `POST /api/system/database` or the GraphQL hard reset reads &#34;at startup&#34; for a fault that happened minutes into serving, and reads a remediation that only mentions restarting. Nothing misbehaves - this is diagnostic accuracy. The literal-string constraint (errorutil cannot lift interpolated text) does not prevent it: dropping &#34;at startup&#34; and generalising the remediation to &#34;restart Meshery Server or re-run the reset&#34; keeps the strings static, and the doc comment can simply name all three callers.
- ℹ️ `server/models/seed_models_logs_enforced_provider_test.go:202` - `TestRegistryLogWithoutASystemEventSinkStillLogs` now pins the loudness half (0 events persisted, meshery-server-1482 reported) but still does not pin the half its name claims: that RegistryLog keeps going and emits the registrant summaries. It passes unchanged if RegistryLog were to `log.Error(ErrNoSystemEventSink())` and return immediately, which is precisely the degeneration `discardSystemEvents` exists to prevent - the fallback is only defensible because the boot log survives the missing sink. Closing it needs a logger built at info level (newSeedTestLogger pins logrus.ErrorLevel, so log.Info is filtered) with `UpdateLogOutput` pointed at a second sink, then asserting at least one record whose message carries the &#34;For registrant &#34; prefix - the same observable the enforced-provider test already asserts on the persisted rows.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test ./server/models/ -run &#39;TestRegistryLog|TestRunSeedStage&#39; -v -count=1` (4 new tests, all pass)</code>
- <code>`go test -race ./server/models/ -run &#39;TestRegistryLog|TestRunSeedStage&#39; -count=1` (race-clean)</code>
- <code>Counterfactual: reverted `server/models/seed_models_logs.go` to base `24d664f81e7`, re-ran `TestRegistryLogUnderEnforcedProviderSeedsWithoutPanicking` -&gt; FAIL with `SIGSEGV addr=0x2d0` at `seed_models_logs.go:250`; file restored</code>
- <code>Built the real server binary from base: `git checkout 24d664f81e7 -- server &amp;&amp; cd server/cmd &amp;&amp; go build -o meshery-server-prefix .`</code>
- <code>Booted pre-fix binary: `PROVIDER=cloud.meshery.io PROVIDER_BASE_URLS=https://cloud.meshery.io USER_DATA_FOLDER=&lt;tmp&gt; PORT=9481 ./meshery-server-prefix` -&gt; process killed by the reported panic; `curl :9481/api/system/version` refused; `sqlite3 mesherydb.sql &#39;select count(*) from events&#39;` = 0</code>
- <code>Booted fixed binary pinned: same env on `:9482` -&gt; 3 `For registrant ... imported ...` summaries, no panic, `curl /api/system/version` HTTP 200, `select count(*) from events` = 3, 292 models registered</code>
- <code>Booted fixed binary unpinned: `PROVIDER=` on `:9483` -&gt; HTTP 200, 3 events, 292 models; `diff` of persisted event descriptions vs the pinned run is empty</code>
- <code>Resiliency: rebuilt with a temporary `panic()` behind `MESHERY_TEST_SEED_PANIC` in `SeedComponents` (source restored immediately after build), booted pinned on `:9484` -&gt; `code=meshery-server-1483` logged with stage name + stack, boot continued, `curl /api/system/version` HTTP 200</code>
- <code>`go test ./server/models/... ./server/handlers/... ./server/internal/graphql/resolver/... -count=1` (all touched packages green)</code>
- <code>Network precondition check: `curl https://cloud.meshery.io/api/provider/capabilities` -&gt; HTTP 401 (live host, unauthenticated probe rejected)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:218` - Judgment call, left as authored: the new AGENTS.md rule (line 218) carries a one-clause incident reference (&#34;the unrecovered nil-deref that killed the server during model seeding (#21584)&#34;). The placement policy discourages incident narrative in AGENTS.md, but the clause here is a causal pointer attached to an operative MUST NOT invariant, matching the register of neighbouring rules in the same file (&#34;the sink behind every Meshery CVE&#34;, &#34;what hid a secret which existed nowhere for three months&#34;), and the detail lives in the linked providers reference. Rewriting it would churn deliberate wording for no gain, so I kept it; flagging in case the reviewer wants it trimmed to the invariant alone.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable persistence for system-generated events during startup and database resets.
  - Added recovery handling so failures in one seeding stage do not stop subsequent stages.
  - Added structured alerts for missing event persistence and seeding failures.

- **Bug Fixes**
  - Prevented startup event logging from depending on unavailable provider configuration.
  - Plain Go errors now log safely without causing a panic.

- **Documentation**
  - Expanded guidance for provider enforcement, boot-time seeding, system events, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->