### PR TITLE
Add relationship: MetricStream to Role in aws-cloudwatch-controller

### DIFF
--- a/models/aws-cloudwatch-controller/v1.8.1/v1.0.0/relationships/edge-non-binding-reference-role.json
+++ b/models/aws-cloudwatch-controller/v1.8.1/v1.0.0/relationships/edge-non-binding-reference-role.json
@@ -1,0 +1,85 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Non-binding reference relationship between MetricStream and Role, established via the roleRef field.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.8.1"
+    },
+    "name": "aws-cloudwatch-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "MetricStream",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": { "version": "" },
+              "name": "aws-cloudwatch-controller",
+              "registrant": { "kind": "github" },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                ["configuration", "spec", "roleRef", "from", "name"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": { "version": "" },
+              "name": "aws-iam-controller",
+              "registrant": { "kind": "github" },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                ["displayName"]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
Fixes #21279

Adds a non-binding reference relationship between `MetricStream` and `Role`
in `aws-cloudwatch-controller` (v1.8.1), linking via the `roleRef.from.name` field,
per ACK best practice of prioritizing spec reference fields.

## Validation done
- `mesheryctl model build aws-cloudwatch-controller/v1.8.1` — builds successfully
- `mesheryctl model import` — model imports cleanly and the relationship
  registers correctly (confirmed `MetricStream → Role` appears in the
  imported model's relationship list, alongside the existing 5 relationships)

## Still to do
- [ ] Demo video/screenshots of the components connecting in Kanvas
- [ ] Screenshot of successful evaluation result
- [ ] Screenshot of mutation/patching in action

Will update this PR with the Kanvas demo shortly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing CloudWatch `MetricStream` references to IAM roles.
  - Displays the referenced role name in the relationship details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->