### PR TITLE
[server] Fix malformed doc comments in server/handlers (batch 5)

### DIFF
--- a/server/handlers/common_handlers.go
+++ b/server/handlers/common_handlers.go
@@ -118,7 +118,7 @@ func (h *Handler) serveFile(responseWriter http.ResponseWriter, request *http.Re
 	}
 }
 
-// Deep-link and redirect support to land user on their originally requested page post authentication instead of dropping user on the root (home) page.
+// GetRefURL provides deep-link and redirect support to land the user on their originally requested page post authentication instead of dropping them on the root (home) page.
 func GetRefURL(req *http.Request) string {
 	return core.EncodeRefUrl(*req.URL)
 }

--- a/server/handlers/component_generation.go
+++ b/server/handlers/component_generation.go
@@ -32,7 +32,7 @@ type componentGenerationResponseDataItem struct {
 	Errors     []string                        `json:"errors"`
 }
 
-// MeshModelGenerationHandler expects the request body to be json
+// MeshModelGenerationHandler expects the request body to be JSON.
 // request body should be of format - {data: [{name: string, register: boolean}]}
 // response format - {data: [{name: string, components: [component], errors: [string] }]}
 func (h *Handler) MeshModelGenerationHandler(rw http.ResponseWriter, r *http.Request) {

--- a/server/handlers/component_generation.go
+++ b/server/handlers/component_generation.go
@@ -32,7 +32,7 @@ type componentGenerationResponseDataItem struct {
 	Errors     []string                        `json:"errors"`
 }
 
-// request body should be json
+// MeshModelGenerationHandler expects the request body to be json
 // request body should be of format - {data: [{name: string, register: boolean}]}
 // response format - {data: [{name: string, components: [component], errors: [string] }]}
 func (h *Handler) MeshModelGenerationHandler(rw http.ResponseWriter, r *http.Request) {

--- a/server/handlers/content_modifier.go
+++ b/server/handlers/content_modifier.go
@@ -30,8 +30,8 @@ func NewContentModifier(token string,
 	}
 }
 
-// TODO: Similar mechanisms for filters and applications
 // AddMetadataForPatterns takes in response bytes, and add metadata to it based on some checks
+// TODO: Similar mechanisms for filters and applications
 func (mc *ContentModifier) AddMetadataForPatterns(ctx context.Context, contentBytes *[]byte) error {
 	var patternsPage models.MesheryPatternPage
 	err := json.Unmarshal(*contentBytes, &patternsPage)

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -73,7 +73,7 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 	}
 }
 
-// Reset the system database to its initial state.
+// ResetSystemDatabase resets the system database to its initial state.
 func (h *Handler) ResetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 
 	mesherydbPath := path.Join(utils.GetHome(), ".meshery/config")

--- a/server/handlers/design_import.go
+++ b/server/handlers/design_import.go
@@ -169,7 +169,7 @@ func ConvertFileToManifest(identifiedFile files.IdentifiedFile, rawFile FileToIm
 	}
 }
 
-// returns the design file , the type of file that was identified during converion , and any error
+// ConvertFileToDesign returns the design file, the type of file that was identified during conversion, and any error
 func ConvertFileToDesign(fileToImport FileToImport, registry *registry.RegistryManager, logger logger.Handler) (pattern.PatternFile, core.IaCFileTypes, error) {
 
 	defer utils.TrackTime(logger, time.Now(), "ConvertFileToDesign")

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -753,7 +753,7 @@ func ErrUnsupportedEventStatus(err error, status string) error {
 	return errors.New(ErrUnsupportedEventStatusCode, errors.Alert, []string{fmt.Sprintf("Event status '%s' is not a supported status.", status)}, []string{err.Error()}, []string{"Unsupported event status for your current version of Meshery Server."}, []string{"Confirm that the status you are using is valid and a supported event status. Refer to Meshery Docs for a list of event statuses.", "Check for availability of a new version of Meshery Server. Try upgrading to the latest version."})
 }
 
-// ErrFetchMeshSyncResources
+// ErrFetchMeshSyncResources reports a failure to fetch MeshSync resources
 func ErrFetchMeshSyncResources(err error) error {
 	return errors.New(ErrFetchMeshSyncResourcesCode, errors.Alert, []string{"Error fetching MeshSync resources", "DB might be corrupted"}, []string{err.Error()}, []string{"MeshSync might not be reachable from Meshery"}, []string{"Make sure Meshery has connectivity to MeshSync", "Try restarting Meshery server"})
 }

--- a/server/handlers/mesh_ops_handlers.go
+++ b/server/handlers/mesh_ops_handlers.go
@@ -18,7 +18,7 @@ func init() {
 	gob.Register([]*models.Adapter{})
 }
 
-// AdaptersHandler is used to fetch all the adapters
+// AvailableAdaptersHandler returns the list of available adapters
 func (h *Handler) AvailableAdaptersHandler(w http.ResponseWriter, _ *http.Request) {
 	err := json.NewEncoder(w).Encode(models.ListAvailableAdapters)
 	if err != nil {

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -289,7 +289,7 @@ func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http
 	})
 }
 
-// GraphqlSessionInjectorMiddleware - is a middleware which injects user and session object
+// GraphqlMiddleware adapts next to the handler-chain signature and forwards the request to it, without injecting anything
 func (h *Handler) GraphqlMiddleware(next http.Handler) func(http.ResponseWriter, *http.Request, *models.Preference, *models.User, models.Provider) {
 	return func(w http.ResponseWriter, req *http.Request, pref *models.Preference, user *models.User, prov models.Provider) {
 		next.ServeHTTP(w, req)

--- a/server/handlers/validate.go
+++ b/server/handlers/validate.go
@@ -40,7 +40,7 @@ type jsonSchemaValidationType struct {
 	Schema string `json:"$schema,omitempty"`
 }
 
-// request body should be json
+// ValidationHandler expects the request body to be json
 // request body should be of format - {validationItems: {[id]:{schema: string, value: string, valueType: "JSON"|"YAML"|"CUE"}}}
 // response format - {[id]: {isValid: bool, error: string}}
 func (h *Handler) ValidationHandler(rw http.ResponseWriter, r *http.Request) {

--- a/server/handlers/validate.go
+++ b/server/handlers/validate.go
@@ -40,7 +40,7 @@ type jsonSchemaValidationType struct {
 	Schema string `json:"$schema,omitempty"`
 }
 
-// ValidationHandler expects the request body to be json
+// ValidationHandler expects the request body to be JSON.
 // request body should be of format - {validationItems: {[id]:{schema: string, value: string, valueType: "JSON"|"YAML"|"CUE"}}}
 // response format - {[id]: {isValid: bool, error: string}}
 func (h *Handler) ValidationHandler(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What this fixes

This finishes the `server/handlers` sweep started in #21580 (that PR
covered the top four files by violation count; these are the
remaining nine, one violation each): `common_handlers.go`,
`component_generation.go`, `content_modifier.go`,
`database_handlers.go`, `design_import.go`, `error.go`,
`mesh_ops_handlers.go`, `middlewares.go`, `validate.go`. 9 fixes,
comment text only, no behavior changes.

## Two are verbatim copies from a real sibling in the same file

Same pattern as `DesignFileRequestHandlerWithSourceType` in #21580.

- `AvailableAdaptersHandler`'s comment was copied word for word from
  `AdaptersHandler`'s real, correctly named comment a few lines below
  ("is used to fetch all the adapters"). `AvailableAdaptersHandler`
  does something simpler and different: it JSON-encodes and returns
  `models.ListAvailableAdapters` directly, no method check, no query
  handling. Rewritten to describe that.
- `GraphqlMiddleware`'s comment was copied from
  `SessionInjectorMiddleware`'s real comment ("is a middleware which
  injects user and session object"), accurate for
  `SessionInjectorMiddleware` itself but not for `GraphqlMiddleware`,
  whose entire body is `next.ServeHTTP(w, req)`. It ignores the
  `pref`/`user`/`provider` arguments it receives and injects nothing.
  Rewritten to describe what it actually does: adapts `next` to the
  handler-chain signature and forwards the request unchanged.

## The rest

- `GetRefURL`, `ResetSystemDatabase`, `ConvertFileToDesign` (also
  fixed a "converion" typo and stray spacing),
  `MeshModelGenerationHandler`, `ValidationHandler`: name merged into
  the existing, already-accurate first sentence
- `ErrFetchMeshSyncResources`: comment was the bare name with nothing
  after it, description added
- `AddMetadataForPatterns`: comment was already correctly named, but
  a `TODO` line sat before it, so the doc text staticcheck sees
  started with "TODO" instead of the symbol name. Swapped the two
  lines' order, no wording changed in either.

## Verification

```
$ staticcheck -checks="ST1020,ST1021,ST1022" ./server/handlers/...
# before: 9 hits across these nine files
# after:  0 hits in these nine files (grep confirmed; the four files
#         from #21580 still show as violations here since this
#         branch is off master, not off that unmerged branch, so
#         they're correctly out of scope for this PR)
```

Also clean: `go build ./server/handlers/...`, `go build ./server/...`,
`go vet ./server/handlers/...`.

This completes `server/handlers`: 0 violations left in the package
once both this PR and #21580 are in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified JSON request format expectations for applicable endpoints.
  * Improved descriptions of authentication redirects and deep-link navigation.
  * Corrected and refined documentation for design conversion, database reset, validation, middleware, adapter availability, resource-fetching errors, and content processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->