### PR TITLE
[ci]: improvement to the failure notification for the Model Generator workflow.

### DIFF
--- a/.github/workflows/model-generator.yml
+++ b/.github/workflows/model-generator.yml
@@ -30,9 +30,14 @@ jobs:
           make
 
       - name: Generate Models and Components
+        env:
+          CRED: ${{ secrets.INTEGRATION_SPREADSHEET_CRED }}
         run: |
           cd mesheryctl
-          ./mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "${{ secrets.INTEGRATION_SPREADSHEET_CRED }}"
+          ./mesheryctl registry generate \
+            --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" \
+            --spreadsheet-cred "$CRED" \
+            2>&1 | tee "$RUNNER_TEMP/generate.log"
 
       - name: Upload artifacts
         if: always()
@@ -67,21 +72,61 @@ jobs:
           commit_message: "Models generated and updated"
           branch: master
 
+      - name: Classify failure
+        if: failure()
+        id: classify-failure
+        run: |
+          LOG="$RUNNER_TEMP/generate.log"
+          [ -f "$LOG" ] || : > "$LOG"
+
+          DETAIL=$(sed 's/\x1b\[[0-9;]*m//g' "$LOG" \
+            | grep -a -m1 '^Error: ' \
+            | sed 's/^Error: //' \
+            | cut -c1-200 \
+            | tr -d '\r\n' || true)
+
+          if [ ! -s "$LOG" ]; then
+            REASON="Failed before model generation started"
+          elif grep -qa "Invalid JWT Token" "$LOG"; then
+            REASON="Spreadsheet credential rejected"
+          elif grep -qa "error parsing relationships" "$LOG"; then
+            REASON="Relationship data could not be parsed"
+          elif grep -qa "error parsing" "$LOG"; then
+            REASON="Spreadsheet tab could not be read"
+          elif grep -qa "error updating registry" "$LOG"; then
+            REASON="Spreadsheet could not be opened"
+          elif grep -qa "isn't specified" "$LOG" || grep -qa "is required" "$LOG"; then
+            REASON="Invalid command arguments"
+          else
+            REASON="Unrecognized failure"
+          fi
+
+          [ -n "$DETAIL" ] || DETAIL="No error message was captured."
+
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          echo "detail=$DETAIL" >> "$GITHUB_OUTPUT"
+          echo "### $REASON" >> "$GITHUB_STEP_SUMMARY"
+          echo "$DETAIL" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Send Email on Workflow Failure
         if: failure()
+        continue-on-error: true
         uses: dawidd6/action-send-mail@v7
         with:
           server_address: smtp.gmail.com
           server_port: 465
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
-          subject: GitHub Actions - Workflow Failure
+          subject: "${{ steps.classify-failure.outputs.reason }} (run #${{ github.run_number }})"
           from: |
             "Model Generator and Updater" <no-reply@meshery.io>
           to: developers@meshery.io
           body: |
-            The GitHub Actions workflow in ${{ github.repository }} has failed.
-            You can find more details in the GitHub Actions log ${{ github.workflow }}.
+            ${{ steps.classify-failure.outputs.detail }}
+
+            Trigger : ${{ github.event_name }}
+            Run     : ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          attachments: ${{ runner.temp }}/generate.log
 
       - name: Send Email on Registry Generate Error
         if: env.registry-generate-error == 'false' #Turn it back to true when we are good with all the errors.


### PR DESCRIPTION
## Summary

Previously, a failure produced an email with a fixed subject ("GitHub Actions - Workflow Failure") and a body naming only the repository and workflow. Nothing identified which run failed or why, so every failure required opening Actions, locating the run, and reading the logs before triage could start.

Three changes:

- The generate step's console output is captured with `tee`. `mesheryctl` prints the failure reason to the console, but that output was previously discarded when the runner was destroyed — so the actual reason never survived the run.
- A new `Classify failure` step maps the captured output to a short label and extracts the tool's own error message. `root.go` sets `SilenceUsage` but not `SilenceErrors`, so cobra prints `Error: <message>`, which is used verbatim for the body.
- The failure email leads with the label in the subject, the tool's error text in the body, a direct link to the failed run attempt, and the console output as an attachment. It's also marked `continue-on-error` so an SMTP problem can't replace the real failure in the run history.

Subjects now read like `Spreadsheet credential rejected (run #412)` instead of the fixed string, so failures are distinguishable and triageable from the inbox.

The credential was also moved from the command line into `env:` so it is no longer inlined into the script text.

## Notes

Labels cover the paths that actually produce a non-zero exit — `registry generate` only fails hard on setup errors (credential rejected, spreadsheet unreachable, sheet parse failure, invalid arguments), since per-model failures are logged and swallowed upstream. Anything unmatched falls through to `Unrecognized failure` with the raw message still shown in the body, so no failure loses information.

`Send Email on Registry Generate Error` is intentionally untouched — its condition is muted pending the registry error backlog, per the existing inline comment.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated generation failure reporting.
  * Failure notifications now include a clearer reason, diagnostic details, and run information.
  * Notifications continue processing even if email delivery encounters an error.

* **Chores**
  * Improved generation command logging and credential handling for more reliable workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->