### PR TITLE
Update ROADMAP.md with detailed version links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,6 +100,8 @@ Milestones on Meshery's high-level roadmap:
 
 - [CLI] kubectl Snapshot
 
+_See [(detailed v0.9.0 roadmap)](https://discuss.meshery.io/t/meshery-v0-9-roadmap/6296)_
+
 ### [v0.8.0](./docs/_releases/roadmap-v0.8.md)
 
 **Lifecycle Management**
@@ -130,8 +132,9 @@ Code coverage goal: 25%
 - [CLI] Deprecate: Full migration from Apps to Designs
 - [CLI] Mesheryctl Code coverage goal: 50%
 
-### [v0.7.0](./docs/_releases/roadmap-v0.7.md)
+_See [(detailed v0.8.0 roadmap)](https://discuss.meshery.io/t/meshery-v0-8-0-roadmap/4336)_
 
+### [v0.7.0](./docs/_releases/roadmap-v0.7.md)
 
 **Sustainability**
 
@@ -156,6 +159,8 @@ Code coverage goal: 25%
 **Extensibility**
 
 - [Provider] GitOps Snapshots
+
+_See [(detailed v0.7.0 roadmap)](https://discuss.meshery.io/t/meshery-v0-7-0-roadmap/232)_
 
 ### [v0.6.0](../../milestone/3)
 
@@ -205,6 +210,3 @@ Code coverage goal: 25%
 **Lifecycle Management**
 
 - [UI] Connection Wizard
-
-
-Refer to [Meshery Roadmap](https://docs.google.com/document/d/1kvcz8jdvFwXmYBBaY2-3fHHUUoy1GJLpZZXuoxZQoOk/edit#) document for detailed info.


### PR DESCRIPTION
Added links to detailed roadmaps for versions v0.9.0, v0.8.0, and v0.7.0. Removed reference to Google Docs for roadmap details.



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to detailed roadmap documents for versions v0.9.0, v0.8.0, and v0.7.0.
  * Removed the general roadmap reference in favor of version-specific documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->