### PR TITLE
[Docs] Fix pagination button hover contrast in light mode

### DIFF
--- a/docs/assets/scss/_pagination.scss
+++ b/docs/assets/scss/_pagination.scss
@@ -38,10 +38,13 @@
     color: var(--brand-color-secondary);
     font-size: 1rem;
   }
-  &:hover {
-    .fa-chevron-right::before, .fa-chevron-left::before {
-        color: var(--color-white);
-    }
+}
+
+.dark-mode .toc-title:hover {
+  color: var(--color-white);
+
+  .fa-chevron-right::before,
+  .fa-chevron-left::before {
     color: var(--color-white);
   }
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes: In light mode, Previous/Next pagination titles (.toc-title) turned white on hover while the card background stayed white, so the links became invisible. Hover-to-white now applies only under .dark-mode; light mode keeps the teal title color.

- BEFORE
<img width="1912" height="1031" alt="Screenshot 2026-08-25 093148" src="https://github.com/user-attachments/assets/a0b2434b-3739-4b22-be02-45ee32a1310e" />

- AFTER
<img width="1918" height="1020" alt="Screenshot 2026-08-25 092742" src="https://github.com/user-attachments/assets/a2bff334-9ea8-407d-8e3f-fa78ddd64fcf" />

Summary
Scope the pagination title/chevron hover color change to dark mode only in docs/assets/scss/_pagination.scss.

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved pagination hover styling in dark mode.
  * Pagination titles and chevron icons now display with improved contrast when hovered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->