### PR TITLE
[CI] Add raw error and run link to model-generator failure email

### DIFF
--- a/.github/workflows/model-generator.yml
+++ b/.github/workflows/model-generator.yml
@@ -67,95 +67,21 @@ jobs:
           commit_message: "Models generated and updated"
           branch: master
 
-      - name: Gather Failure Details
-        id: gather-failure-details
+      - name: Capture Failure Log
         if: failure()
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const outFile = '${{ runner.temp }}/failure-details.md';
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            let jobUrl = runUrl;
-            let failedStepName = null;
-            let logExcerpt = null;
-            let diagnosticNote = null;
-
-            try {
-              const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: context.runId,
-              });
-              // This workflow has a single job, so the run's latest job is always ours.
-              const job = jobsResp.jobs[0];
-
-              if (job) {
-                jobUrl = `${runUrl}/job/${job.id}`;
-                const failedStep = job.steps.find((s) => s.conclusion === 'failure');
-
-                if (failedStep) {
-                  failedStepName = failedStep.name;
-
-                  const { data: rawLog } = await github.rest.actions.downloadJobLogsForWorkflowRun({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    job_id: job.id,
-                  });
-
-                  const start = new Date(failedStep.started_at).getTime();
-                  const end = failedStep.completed_at ? new Date(failedStep.completed_at).getTime() : Date.now();
-                  const stepLines = [];
-                  for (const line of String(rawLog).split('\n')) {
-                    const m = line.match(/^(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\s?(.*)$/);
-                    if (!m) continue;
-                    const ts = new Date(m[1]).getTime();
-                    if (ts >= start && ts <= end) stepLines.push(m[2]);
-                  }
-
-                  if (stepLines.length) {
-                    // GitHub's per-step log view numbers lines starting at 1 within that
-                    // step; anchoring on the ##[error] line (or the last line) jumps the
-                    // reader straight to where the failure was reported.
-                    let errorLine = stepLines.findIndex((l) => l.includes('##[error]'));
-                    if (errorLine === -1) errorLine = stepLines.length - 1;
-                    jobUrl += `#step:${failedStep.number}:${errorLine + 1}`;
-
-                    const MAX_LINES = 150;
-                    const MAX_CHARS = 8000;
-                    const full = stepLines.join('\n');
-                    let excerpt = stepLines.slice(-MAX_LINES).join('\n');
-                    if (excerpt.length > MAX_CHARS) excerpt = excerpt.slice(-MAX_CHARS);
-                    if (excerpt.length < full.length) excerpt = `... (truncated) ...\n${excerpt}`;
-                    logExcerpt = excerpt;
-                  }
-                }
-              }
-            } catch (err) {
-              diagnosticNote = `Could not fetch full diagnostics from the Actions API: ${err.message}`;
-            }
-
-            const lines = [
-              `The **${context.workflow}** workflow in \`${context.repo.owner}/${context.repo.repo}\` failed` +
-                (failedStepName ? ` at step **"${failedStepName}"**.` : '.'),
-              '',
-              `Failing step: ${jobUrl}`,
-              `Full run: ${runUrl}`,
-            ];
-
-            if (logExcerpt) {
-              lines.push('', '**Raw error output:**', '````', logExcerpt, '````');
-            } else {
-              lines.push('', '_Raw step output was not available._');
-            }
-
-            if (diagnosticNote) {
-              lines.push('', `_${diagnosticNote}_`);
-            }
-
-            fs.writeFileSync(outFile, lines.join('\n'));
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          {
+            echo "The **${{ github.workflow }}** workflow failed."
+            echo ""
+            echo "Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            echo "**Raw error output:**"
+            echo '```'
+            gh run view "${{ github.run_id }}" --log-failed | tail -n 300
+            echo '```'
+          } > "${{ runner.temp }}/failure-details.md"
 
       - name: Send Email on Workflow Failure
         if: failure()

--- a/.github/workflows/model-generator.yml
+++ b/.github/workflows/model-generator.yml
@@ -67,6 +67,96 @@ jobs:
           commit_message: "Models generated and updated"
           branch: master
 
+      - name: Gather Failure Details
+        id: gather-failure-details
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const outFile = '${{ runner.temp }}/failure-details.md';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            let jobUrl = runUrl;
+            let failedStepName = null;
+            let logExcerpt = null;
+            let diagnosticNote = null;
+
+            try {
+              const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+              });
+              // This workflow has a single job, so the run's latest job is always ours.
+              const job = jobsResp.jobs[0];
+
+              if (job) {
+                jobUrl = `${runUrl}/job/${job.id}`;
+                const failedStep = job.steps.find((s) => s.conclusion === 'failure');
+
+                if (failedStep) {
+                  failedStepName = failedStep.name;
+
+                  const { data: rawLog } = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    job_id: job.id,
+                  });
+
+                  const start = new Date(failedStep.started_at).getTime();
+                  const end = failedStep.completed_at ? new Date(failedStep.completed_at).getTime() : Date.now();
+                  const stepLines = [];
+                  for (const line of String(rawLog).split('\n')) {
+                    const m = line.match(/^(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\s?(.*)$/);
+                    if (!m) continue;
+                    const ts = new Date(m[1]).getTime();
+                    if (ts >= start && ts <= end) stepLines.push(m[2]);
+                  }
+
+                  if (stepLines.length) {
+                    // GitHub's per-step log view numbers lines starting at 1 within that
+                    // step; anchoring on the ##[error] line (or the last line) jumps the
+                    // reader straight to where the failure was reported.
+                    let errorLine = stepLines.findIndex((l) => l.includes('##[error]'));
+                    if (errorLine === -1) errorLine = stepLines.length - 1;
+                    jobUrl += `#step:${failedStep.number}:${errorLine + 1}`;
+
+                    const MAX_LINES = 150;
+                    const MAX_CHARS = 8000;
+                    const full = stepLines.join('\n');
+                    let excerpt = stepLines.slice(-MAX_LINES).join('\n');
+                    if (excerpt.length > MAX_CHARS) excerpt = excerpt.slice(-MAX_CHARS);
+                    if (excerpt.length < full.length) excerpt = `... (truncated) ...\n${excerpt}`;
+                    logExcerpt = excerpt;
+                  }
+                }
+              }
+            } catch (err) {
+              diagnosticNote = `Could not fetch full diagnostics from the Actions API: ${err.message}`;
+            }
+
+            const lines = [
+              `The **${context.workflow}** workflow in \`${context.repo.owner}/${context.repo.repo}\` failed` +
+                (failedStepName ? ` at step **"${failedStepName}"**.` : '.'),
+              '',
+              `Failing step: ${jobUrl}`,
+              `Full run: ${runUrl}`,
+            ];
+
+            if (logExcerpt) {
+              lines.push('', '**Raw error output:**', '````', logExcerpt, '````');
+            } else {
+              lines.push('', '_Raw step output was not available._');
+            }
+
+            if (diagnosticNote) {
+              lines.push('', `_${diagnosticNote}_`);
+            }
+
+            fs.writeFileSync(outFile, lines.join('\n'));
+
       - name: Send Email on Workflow Failure
         if: failure()
         uses: dawidd6/action-send-mail@v7
@@ -75,13 +165,12 @@ jobs:
           server_port: 465
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
-          subject: GitHub Actions - Workflow Failure
+          subject: GitHub Actions - Workflow Failure - ${{ github.repository }} (run #${{ github.run_number }})
           from: |
             "Model Generator and Updater" <no-reply@meshery.io>
           to: developers@meshery.io
-          body: |
-            The GitHub Actions workflow in ${{ github.repository }} has failed.
-            You can find more details in the GitHub Actions log ${{ github.workflow }}.
+          convert_markdown: true
+          body: file://${{ runner.temp }}/failure-details.md
 
       - name: Send Email on Registry Generate Error
         if: env.registry-generate-error == 'false' #Turn it back to true when we are good with all the errors.


### PR DESCRIPTION
## Summary

The `model-generator.yml` "Send Email on Workflow Failure" step only ever said the run had failed - no error text, and its "link" was just the plain workflow name (`${{ github.workflow }}`), not a URL. That made the overnight failure email nearly useless for triage.

- **New `Capture Failure Log` step** (`if: failure()`): a single `run:` block that calls `gh run view "$RUN_ID" --log-failed`, the gh CLI's built-in flag for printing only the failed step(s)' raw log output. Writes that (tail-capped at 300 lines as a safety net) plus the run URL into a markdown file.
- **Send Email step**: reads that file via `body: file://...` with `convert_markdown: true`, so the run link renders clickable and the raw output renders as a code block.

Went through an Octokit-based version first (list jobs, download the full job log, slice by timestamp window, compute a step-relative line anchor) - that was overkill for what `gh run view --log-failed` already does in one call, so it's gone in favor of this much smaller diff.

Left the second email ("Send Email on Registry Generate Error") alone - it already links to the run and attaches the registry error log, which was working correctly.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/model-generator.yml'))"` - YAML parses.
- [x] `actionlint .github/workflows/model-generator.yml` - no new findings (pre-existing shellcheck SC2086 note on an untouched step only).
- [x] `gh run view --help` - confirmed `--log-failed` is a real, supported flag.
- [ ] Next real failure of this workflow (or a manual `workflow_dispatch` forced to fail) - confirm the email arrives with the raw log excerpt and a working run link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow failure notifications with detailed logs from the failed run.
  * Email alerts now include the repository name and run number for easier identification.
  * Failure details are formatted in markdown for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->