### PR TITLE
[Docs] Fix code block alignment on command reference pages

### DIFF
--- a/docs/assets/scss/_clipboard.scss
+++ b/docs/assets/scss/_clipboard.scss
@@ -24,6 +24,9 @@ pre.codeblock-pre {
   margin: 0px;
   padding: 0px;
 }
+.codeblock:not(:has(.clipboardjs)) {
+  padding: 0.5rem 0.75rem;
+}
 .clipboardjs {
   width: 100%;
   overflow: auto;


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21496 

.codeblock` gets its padding from the `.clipboardjs` child. Generated `mesheryctl` reference pages don't have this child, causing their code blocks to render flush left.

This is a regression from 4d5ff95a342b, which added padding to `.clipboardjs`. This PR adds the same padding to `.codeblock` only when `.clipboardjs` is absent,  leaving existing three-level blocks unchanged.

### Resolved

| | Count |
|---|---:|
| Rendered pages fixed | 101 |
| Code blocks fixed | 589 |
| Pages already correct | 140 |

Verified with a local `hugo -e dev -DFE --cleanDestinationDir` build: 2,876 pages generated with no errors.

### Before / After

| Before | 
|---|
|  
<img width="1915" height="977" alt="Screenshot From 2026-08-25 16-39-36_BEFORE" src="https://github.com/user-attachments/assets/3d30e29a-ee5f-444e-90d4-2470009d46ab" />
| 
|After|
|---|
<img width="1915" height="977" alt="Screenshot From 2026-08-25 17-37-47_AFTER" src="https://github.com/user-attachments/assets/637582d5-cae4-4f58-a30d-1e01c2268c21" />
|

### Not in this PR

The affected pages also lack a copy button because `main.js` binds it to `.clipboardjs`. Fixing that belongs in `mesheryctl/doc/doc.go` and would require regenerating about 100 pages, so it should be handled separately.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code block spacing by adding padding to code blocks without clipboard controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->