### PR TITLE
[server] Fix malformed doc comments in server/machines (batch 6)

### DIFF
--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -17,6 +17,7 @@ import (
 
 type ConnectAction struct{}
 
+// ExecuteOnEntry is a no-op; ConnectAction performs all of its work in Execute.
 // Execute On Entry and Exit should not return next eventtype i suppose, look again.
 func (ca *ConnectAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
 	return machines.NoOp, nil, nil

--- a/server/machines/kubernetes/discover.go
+++ b/server/machines/kubernetes/discover.go
@@ -13,6 +13,7 @@ import (
 
 type DiscoverAction struct{}
 
+// ExecuteOnEntry is a no-op; DiscoverAction performs all of its work in Execute.
 // Execute On Entry and Exit should not return next eventtype i suppose, look again.
 func (da *DiscoverAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
 	return machines.NoOp, nil, nil

--- a/server/machines/kubernetes/register.go
+++ b/server/machines/kubernetes/register.go
@@ -15,6 +15,7 @@ import (
 
 type RegisterAction struct{}
 
+// ExecuteOnEntry is a no-op; RegisterAction performs all of its work in Execute.
 // Execute On Entry and Exit should not return next eventtype i suppose, look again.
 func (ra *RegisterAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
 	return machines.NoOp, nil, nil

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -45,10 +45,10 @@ type Payload struct {
 	Credential models.Credential
 }
 
-// Represents an event in the system/machine
+// EventType represents an event in the system/machine.
 type EventType string
 
-// Represents the mapping between event and the next state in the event's response
+// Events represents the mapping between an event and the next state in the event's response.
 type Events map[EventType]StateType
 
 type StateMachine struct {
@@ -125,9 +125,9 @@ func (sm *StateMachine) getNextState(event EventType) (StateType, error) {
 	return DefaultState, ErrInvalidTransitionEvent(sm.CurrentState, event)
 }
 
-// Returns events.Event and error. The func invoking the SendEvent should handle the error and publish the event.
-// wherever possible use the userID and systemID from context as the events can be created from other comps or actors and not only user actors.
-// In cases when the event is received as part of some other event and not explicitly created by an actor, use the useID and systemID of the actor who initially invoked the machine.
+// SendEvent returns events.Event and error. The func invoking SendEvent should handle the error and publish the event.
+// Wherever possible use the userID and systemID from context as the events can be created from other comps or actors and not only user actors.
+// In cases when the event is received as part of some other event and not explicitly created by an actor, use the userID and systemID of the actor who initially invoked the machine.
 func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payload interface{}) (*events.Event, error) {
 	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
 	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)

--- a/server/machines/state.go
+++ b/server/machines/state.go
@@ -1,6 +1,6 @@
 package machines
 
-// Represents an state in the system/machine
+// StateType represents a state in the system/machine.
 type StateType string
 
 type State struct {
@@ -8,7 +8,7 @@ type State struct {
 	Action Action
 }
 
-// Represents mapping between state name and the state
+// States represents the mapping between a state's name and the state itself.
 type States map[StateType]State
 
 func (s *State) RegisterEvent(eventType EventType, stateType StateType) *State {


### PR DESCRIPTION
Continues the doc-comment cleanup from #21549, #21554, #21578, #21579, #21580 and #21588, this time in `server/machines` (the connection state machine and its kubernetes actions).

## What changed

`staticcheck -checks="ST1020,ST1021,ST1022" ./server/machines/...` reported 8 hits across 5 files. All are comment-text-only changes, no behavior changes.

- `EventType`, `Events` (models.go), `StateType`, `States` (state.go): each comment described the type but never named it, so it read like a random sentence rather than documentation. Reworded to start with the type name.
- `SendEvent` (models.go): the existing comment was accurate and useful (explains when to use which context values) but never named the method. Reworded the first line to start with `SendEvent`, and fixed a `useID` typo in the same sentence while I was already rewording it.
- `ExecuteOnEntry` on `ConnectAction`, `DiscoverAction` and `RegisterAction` (server/machines/kubernetes/): all three carried the exact same leftover note, copy-pasted across the three files:

  ```go
  // Execute On Entry and Exit should not return next eventtype i suppose, look again.
  ```

  That note is a design question about the `Action` interface's return signature, not a description of what any specific `ExecuteOnEntry` does, so it never satisfied the lint rule. Checked each implementation's body: all three unconditionally `return machines.NoOp, nil, nil`, and their real logic lives entirely in `Execute`. Added a first line that says exactly that, and kept the original note as a second line rather than deleting it, since it may still be a question worth someone answering.

## Verification

- `staticcheck -checks="ST1020,ST1021,ST1022" ./server/machines/...`: 8 hits before, 0 after.
- `go build ./server/machines/...` and `go build ./server/...`: clean.
- `go vet ./server/machines/...` and `go vet ./server/...`: clean.
- `go test ./server/machines/...`: all passing (`machines`, `machines/helpers`, `machines/kubernetes`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Kubernetes connection, discovery, and registration actions are executed.
  * Improved documentation for machine events, event publication, and identifier selection.
  * Clarified the roles of machine state types and state collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->