### PR TITLE
[mesheryctl] Fix malformed doc comments across cli/root and cli/pkg/api

### DIFF
--- a/mesheryctl/internal/cli/pkg/api/meshery.go
+++ b/mesheryctl/internal/cli/pkg/api/meshery.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Generic function to fetch data from Mesehry server needs to be type of meshery data ApiResponse
+// Fetch sends a GET request to the given URL and unmarshals the JSON response body into T.
 func Fetch[T any](url string) (*T, error) {
 	resp, err := makeRequest(url, http.MethodGet, nil, nil)
 	if err != nil {

--- a/mesheryctl/internal/cli/root/adapter/error.go
+++ b/mesheryctl/internal/cli/root/adapter/error.go
@@ -68,7 +68,7 @@ var (
 	ErrSMIConformanceTestsFailed = errors.New(ErrSMIConformanceTestsFailedCode, errors.Fatal, []string{"SMI conformance tests failed"}, []string{"SMI conformance tests failed"}, []string{}, []string{"Join https://mesheryio.slack.com/archives/C010H0HE2E6"})
 )
 
-// When unable to get release data
+// ErrGettingSessionData is returned when the CLI is unable to fetch session data from the Meshery server.
 func ErrGettingSessionData(err error) error {
 	return errors.New(ErrGettingSessionDataCode, errors.Fatal,
 		[]string{"Unable to fetch session data"},

--- a/mesheryctl/internal/cli/root/config/config.go
+++ b/mesheryctl/internal/cli/root/config/config.go
@@ -140,7 +140,7 @@ func (mc *MesheryCtlConfig) GetCurrentContext() (*Context, error) {
 	return currentContext, err
 }
 
-// Get any context
+// GetContext returns contents of the context with the given name.
 func (mc *MesheryCtlConfig) GetContext(name string) (*Context, error) {
 	context, err := mc.CheckIfGivenContextIsValid(name)
 	if err != nil {

--- a/mesheryctl/internal/cli/root/registry/registry.go
+++ b/mesheryctl/internal/cli/root/registry/registry.go
@@ -36,7 +36,7 @@ var (
 	csvDirectory            string
 )
 
-// PublishCmd represents the publish command to publish Meshery Models to Websites, Remote Provider, Meshery
+// RegistryCmd represents the registry command, which manages the state and contents of Meshery's internal registry of capabilities.
 var RegistryCmd = &cobra.Command{
 	Use:   "registry",
 	Short: "Manage the capability registry",

--- a/mesheryctl/internal/cli/root/system/check.go
+++ b/mesheryctl/internal/cli/root/system/check.go
@@ -266,7 +266,7 @@ func (hc *HealthChecker) Run() error {
 	return nil
 }
 
-// Run preflight healthchecks to verify environment health
+// RunPreflightHealthChecks runs preflight healthchecks to verify environment health.
 func (hc *HealthChecker) RunPreflightHealthChecks() error {
 	// Docker healthchecks are only invoked when it's not a PreRunExecution
 	// or it's a PreRunExecution and current platform is docker

--- a/mesheryctl/internal/cli/root/system/error.go
+++ b/mesheryctl/internal/cli/root/system/error.go
@@ -85,7 +85,7 @@ var (
 	contextDir            = "See that you have a correct context in your  meshconfig at `$HOME/.meshery/config.yaml`."
 )
 
-// A Format reference that returns Mesheryctl's URL docs for system command and sub commands
+// FormatErrorReference returns a mesheryctl system docs URL for cmdType, or the general system docs URL if cmdType is not set.
 func FormatErrorReference() string {
 	baseURL := "https://docs.meshery.io/reference/references/mesheryctl/system"
 	switch cmdType {

--- a/mesheryctl/internal/cli/root/system/error.go
+++ b/mesheryctl/internal/cli/root/system/error.go
@@ -85,7 +85,7 @@ var (
 	contextDir            = "See that you have a correct context in your  meshconfig at `$HOME/.meshery/config.yaml`."
 )
 
-// FormatErrorReference returns a mesheryctl system docs URL for cmdType, or the general system docs URL if cmdType is not set.
+// FormatErrorReference returns a mesheryctl system docs URL for cmdType, or the general system docs URL if cmdType is unset or unrecognized.
 func FormatErrorReference() string {
 	baseURL := "https://docs.meshery.io/reference/references/mesheryctl/system"
 	switch cmdType {


### PR DESCRIPTION
Continues the doc-comment cleanup from #21549, #21554, #21578, #21579, #21580, #21588 and #21613, this time in mesheryctl's CLI packages.

## What changed

`staticcheck -checks="ST1020,ST1021,ST1022" ./mesheryctl/...` reported 6 hits, one per file, spread across `cli/pkg/api` and four packages under `cli/root`. All are comment-text-only changes, no behavior changes.

Two are copy-paste leftovers rather than just missing names:

- `RegistryCmd` (registry.go) carried this comment, word for word:

  ```go
  // PublishCmd represents the publish command to publish Meshery Models to Websites, Remote Provider, Meshery
  var RegistryCmd = &cobra.Command{
  ```

  That is the real doc comment for `publishCmd`, which exists a few files over in the same package's `publish.go` with the exact same wording (just lowercase `p`). Replaced it with a description grounded in `RegistryCmd`'s own `Short`/`Long` fields instead of guessing.

- `ErrGettingSessionData` (adapter/error.go) was documented as "When unable to get release data", but its own error messages ("Unable to fetch session data") and the real `GetSessionData` helper it wraps (`mesheryctl/pkg/utils/helpers.go`) are both about session data, not release data.

The other four (`Fetch`, `GetContext`, `RunPreflightHealthChecks`, `FormatErrorReference`) just never named the symbol they were documenting.

One more thing I noticed but did **not** touch, since it is a behavior question rather than a doc-comment one: inside `FormatErrorReference`, the `cmdType` package variable that the switch dispatches on is declared but never assigned anywhere in the `system` package, so the switch always falls through to the generic URL, and separately its `"config"` case returns the `/context` docs URL instead of `/config` (every other case matches its own name, e.g. `"login"` to `/login`). Happy to open a follow-up for that if it's still relevant, or to fold a fix into this PR if you'd rather have it here.

## Verification

- `staticcheck -checks="ST1020,ST1021,ST1022" ./mesheryctl/...`: 6 hits before, 0 after.
- `go build ./mesheryctl/...`: clean.
- `go vet ./mesheryctl/...`: clean.
- `go test --short ./mesheryctl/internal/cli/pkg/api/... ./mesheryctl/internal/cli/root/adapter/... ./mesheryctl/internal/cli/root/config/... ./mesheryctl/internal/cli/root/registry/... ./mesheryctl/internal/cli/root/system/...`: all passing except two pre-existing failures in `cli/root/registry` (`TestPlanModelVersionsIgnoresSymlinks`, `TestPurgeCmdRunE_PropagatesRemovalFailures`) that I confirmed also fail on unmodified master on this machine, caused by Windows requiring elevated privileges to create symlinks. Unrelated to this change (registry.go's only edit here is the `RegistryCmd` comment).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI documentation for API fetching, session-data errors, context retrieval, registry management, health checks, and error-reference URLs.
  * Improved descriptions of command behavior and fallback documentation links.
  * No user-facing functionality or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->