### PR TITLE
[server] Fix malformed doc comments in server/models (batch 8)

### DIFF
--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -264,8 +264,7 @@ func (cp *ConnectionPersister) UpdateConnectionByID(connection *connections.Conn
 	return connection, nil
 }
 
-// Get connection by ID
-// If kind is provided filter with kind too
+// GetConnection gets a connection by ID. If kind is provided, it also filters by kind.
 func (cp *ConnectionPersister) GetConnection(id core.Uuid, kind string) (*connections.Connection, error) {
 	connection := connections.Connection{}
 	query := cp.DB.Where("id = ?", id)

--- a/server/models/keys_helper.go
+++ b/server/models/keys_helper.go
@@ -35,7 +35,7 @@ func NewKeysRegistrationHelper(dbHandler *database.Handler, log logger.Handler) 
 	return krh, err
 }
 
-// returns the spreadsheet column index that captures whether the key should be registered.
+// GetIndexForRegisterCol returns the spreadsheet column index that captures whether the key should be registered.
 func (kh *KeysRegistrationHelper) GetIndexForRegisterCol(cols []string) int {
 	if shouldRegisterColIndex != -1 {
 		return shouldRegisterColIndex

--- a/server/models/meshery_filter.go
+++ b/server/models/meshery_filter.go
@@ -56,7 +56,7 @@ type MesheryCatalogFilterRequestBody struct {
 	CatalogData sql.Map   `json:"catalogData,omitempty"`
 }
 
-// MesheryCatalogFilterRequestBody refers to the type of request body
+// MesheryCloneFilterRequestBody refers to the type of request body
 // that CloneMesheryFilterHandler would receive
 type MesheryCloneFilterRequestBody struct {
 	Name string `json:"name,omitempty"`

--- a/server/models/meshsync_register_queue.go
+++ b/server/models/meshsync_register_queue.go
@@ -11,7 +11,7 @@ var (
 	registrationQueue *MeshSyncRegistrationQueue
 )
 
-// Configure MeshSync to additionally publish the resources that can be registered as connection to other broker topic/subject (meshsync.registerconnection.queue?).
+// MeshSyncRegistrationQueue configures MeshSync to additionally publish the resources that can be registered as connection to other broker topic/subject (meshsync.registerconnection.queue?).
 // Meshery Server subscribes to that topic/subject and performs the necessary action.
 type MeshSyncRegistrationQueue struct {
 	RegChan chan MeshSyncRegistrationData

--- a/server/models/preference.go
+++ b/server/models/preference.go
@@ -30,7 +30,7 @@ type LoadTestPreferences struct {
 	LoadGenerator      string `json:"gen,omitempty"`
 }
 
-// Parameters to updates Anonymous stats
+// PreferenceParams holds the parameters used to update anonymous usage stats.
 type PreferenceParams struct {
 	AnonymousUsageStats  bool `json:"anonymousUsageStats"`
 	AnonymousPerfResults bool `json:"anonymousPerfResults"`

--- a/server/models/preference_persister.go
+++ b/server/models/preference_persister.go
@@ -9,7 +9,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// PreferencePersister assists with persisting session in store
+// SessionPreferencePersister assists with persisting session in store.
 type SessionPreferencePersister struct {
 	DB *database.Handler
 }

--- a/server/models/seed_models_logs.go
+++ b/server/models/seed_models_logs.go
@@ -17,7 +17,7 @@ import (
 
 var TAB = "    "
 
-// representation of what could not be registered
+// RegistrationFailureLog represents what could not be registered.
 type RegistrationFailureLog struct {
 	// {'artifacthub':{'modelname': 'component' : {'jaegar': error}}}
 	// for models, the structure will be like this:


### PR DESCRIPTION
Continues the doc-comment cleanup from #21549, #21554, #21578, #21579, #21580, #21588, #21613 and #21614, back in `server/models` this time (batch 2 and batch 3 covered part of this package already; this covers 7 of the files that were left).

## What changed

`staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/` (the direct package, not its subpackages) reported 7 hits, one per file. All are comment-text-only changes, no behavior changes.

Two are wrong-name bugs rather than just missing names:

- `MesheryCloneFilterRequestBody` (meshery_filter.go) carried this comment:

  ```go
  // MesheryCatalogFilterRequestBody refers to the type of request body
  // that CloneMesheryFilterHandler would receive
  type MesheryCloneFilterRequestBody struct {
  ```

  `MesheryCatalogFilterRequestBody` is a real, different type declared a few lines above in the same file, with its own correct comment. The sentence itself was accurate (`CloneMesheryFilterHandler` really does receive a `*models.MesheryCloneFilterRequestBody`, confirmed in `server/handlers/meshery_filter_handler.go`), so only the leading name needed to change.

- `SessionPreferencePersister` (preference_persister.go) was documented as `PreferencePersister`, the name of the interface it implements (`PreferencePersister`, defined separately in `preference.go`), not its own name.

The rest (`RegistrationFailureLog`, `PreferenceParams`, `MeshSyncRegistrationQueue`, `GetIndexForRegisterCol`, `GetConnection`) just never named the symbol they were documenting; their descriptions were otherwise accurate and are kept as-is.

## Verification

- `staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/`: 7 hits before, 0 after (9 remain in subpackages under `server/models/...`, unrelated to this PR's files).
- `go build ./server/models/...` and `go build ./server/...`: clean.
- `go vet ./server/models/...`: clean.
- `go test ./server/models/`: 20 pre-existing failures on this machine, all with the identical root cause `Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work`, none touching the files or symbols this PR changes. Confirmed unrelated by stashing this PR's changes and re-running the same tests against unmodified master: identical failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and corrected internal developer documentation for connection lookups, registration queues, preferences, session persistence, key registration, filter requests, and failure logs.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->