### PR TITLE
[server] Fix malformed doc comments in server/models/pattern (batch 9)

### DIFF
--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -124,7 +124,7 @@ func isSpecialKey(k string) bool {
 	return false
 }
 
-// In case of any breaking change or bug caused by this, set this to false and the whitespace addition in schema generated/consumed would be removed(will go back to default behavior)
+// Format controls whitespace addition in schema generation/consumption. In case of any breaking change or bug caused by this, set this to false and the whitespace addition in schema generated/consumed would be removed(will go back to default behavior)
 const Format prettifier = true
 
 type DryRunResponseWrapper struct {

--- a/server/models/pattern/jsonschema/json.go
+++ b/server/models/pattern/jsonschema/json.go
@@ -9,6 +9,7 @@ import (
 
 var JSONSchema = &Schema{}
 
+// GlobalJSONSchema returns the package's shared Schema instance.
 // This approach is bad, and we are not the ones implementing this. The qri-io/jsonschema internally is creating a global instance of Schema.
 // Hence for concurrent operations, we have to make sure that the package qri-io/jsonschema is accessed in a thread-safe way.
 // So use this Global instance for now.
@@ -21,6 +22,7 @@ type Schema struct {
 	Lock sync.Mutex
 }
 
+// ValidateBytes validates data against the schema while holding the package-wide lock.
 // JsonSchema package creates a global instance(without any locks) of Schema struct which panics when concurrent routines try to call ValidateBytes.
 // So this package creates a thin shim to avoid internal concurrent map writes
 func (s *Schema) ValidateBytes(ctx context.Context, data []byte) ([]jsonschema.KeyError, error) {

--- a/server/models/pattern/jsonschema/json.go
+++ b/server/models/pattern/jsonschema/json.go
@@ -22,7 +22,7 @@ type Schema struct {
 	Lock sync.Mutex
 }
 
-// ValidateBytes validates data against the schema while holding the package-wide lock.
+// ValidateBytes validates data against the schema while holding the schema instance's lock.
 // JsonSchema package creates a global instance(without any locks) of Schema struct which panics when concurrent routines try to call ValidateBytes.
 // So this package creates a thin shim to avoid internal concurrent map writes
 func (s *Schema) ValidateBytes(ctx context.Context, data []byte) ([]jsonschema.KeyError, error) {

--- a/server/models/pattern/patterns/application/argo/v1alpha1/analysis_types.go
+++ b/server/models/pattern/patterns/application/argo/v1alpha1/analysis_types.go
@@ -17,7 +17,7 @@ type ClusterAnalysisTemplate struct {
 	Spec AnalysisTemplateSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
-// AnalysisTemplateList is a list of AnalysisTemplate resources
+// ClusterAnalysisTemplateList is a list of ClusterAnalysisTemplate resources
 type ClusterAnalysisTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`

--- a/server/models/pattern/stages/dry_run.go
+++ b/server/models/pattern/stages/dry_run.go
@@ -4,6 +4,7 @@ package stages
 
 const DryRunResponseKey = "dryRunResponse"
 
+// DryRun returns the ChainStageFunction that performs the dry-run stage in the pattern processing chain.
 // There are two types of errors here:
 // 1. Error while performing the Dry Run (when the DryRun request could not be sent)
 // 2. Errors in Dry Run (when the Dry Run request was performed successfully but there are errors in the Object sent for DryRun)

--- a/server/models/pattern/utils/k8s.go
+++ b/server/models/pattern/utils/k8s.go
@@ -141,7 +141,7 @@ func CreateK8sResource(
 	return nil
 }
 
-// DeleteK8sResouce deletes the given kubernetes resource
+// DeleteK8sResource deletes the given kubernetes resource
 func DeleteK8sResource(
 	client dynamic.Interface,
 	group,


### PR DESCRIPTION
Continues the doc-comment cleanup from #21549, #21554, #21578, #21579, #21580, #21588, #21613, #21614 and #21615, this time in the pattern engine subtree (`server/models/pattern/...`).

## What changed

`staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/pattern/...` reported 6 hits across 5 files. All are comment-text-only changes, no behavior changes.

One is a wrong-name bug and one is a plain typo:

- `ClusterAnalysisTemplateList` (`patterns/application/argo/v1alpha1/analysis_types.go`, the Argo Rollouts analysis types) was documented as:

  ```go
  // AnalysisTemplateList is a list of AnalysisTemplate resources
  type ClusterAnalysisTemplateList struct {
  ```

  `AnalysisTemplateList` is a real, different, non-cluster-scoped type declared further down the same file (line 36) with its own correct comment. Fixed the cluster-scoped one to name itself and its own element type.

- `DeleteK8sResource` (`utils/k8s.go`) already had a comment naming itself, just misspelled: `DeleteK8sResouce` (missing the second `r`), which is why staticcheck still flagged it.

The other three (`GlobalJSONSchema`, `ValidateBytes` in `jsonschema/json.go`, `Format` in `core/pattern.go`, `DryRun` in `stages/dry_run.go`) had accurate, useful explanations for why the code is shaped the way it is, just never led with the symbol's own name. Kept the existing wording intact in every case and only added or reworded the leading sentence.

## Verification

- `staticcheck -checks="ST1020,ST1021,ST1022" ./server/models/pattern/...`: 6 hits before, 0 after.
- `go build ./server/models/pattern/...` and `go build ./server/...`: clean.
- `go vet ./server/models/pattern/...`: clean.
- `go test ./server/models/pattern/core/... ./server/models/pattern/stages/... ./server/models/pattern/utils/...`: `core` and `utils` pass fully; `stages` has pre-existing failures on this machine, all with the identical root cause `Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work`, unrelated to `dry_run.go`'s comment change. Confirmed by stashing this PR's changes and re-running the same failing test against unmodified master: identical failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved technical documentation for schema formatting, validation behavior, dry-run processing, and Kubernetes resource deletion.
  - Clarified how shared schema access and validation are handled.
  - Corrected resource type references in deployment template documentation.
  - Added clearer descriptions for pattern-processing stages and configuration options.
  - Fixed a documentation typo related to Kubernetes resource deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->