### PR TITLE
fix(policies): resolve path wildcards and subscripts in relationship …

### DIFF
--- a/server/policies/eval_rules.go
+++ b/server/policies/eval_rules.go
@@ -182,9 +182,14 @@ func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *patte
 			count = len(mutatedRefs)
 		}
 
+		mutatorMap, _ := toGenericMap(mutatorComp)
+		mutatedMap, _ := toGenericMap(mutatedComp)
+
 		for i := 0; i < count; i++ {
-			mutatorValue := configurationForComponentAtPath(mutatorRefs[i], mutatorComp, design)
-			oldValue := configurationForComponentAtPath(mutatedRefs[i], mutatedComp, design)
+			resolvedMutator := resolvePath(mutatorRefs[i], mutatorMap)
+			resolvedMutated := resolvePath(mutatedRefs[i], mutatedMap)
+			mutatorValue := configurationForComponentAtPath(resolvedMutator, mutatorComp, design)
+			oldValue := configurationForComponentAtPath(resolvedMutated, mutatedComp, design)
 			if mutatorValue == nil {
 				continue
 			}
@@ -192,13 +197,13 @@ func patchMutatorsAction(rel *relationship.RelationshipDefinition, design *patte
 				if !deepEqual(mutatorValue, oldValue) {
 					continue
 				}
-				actions = append(actions, cleanupActionForPath(mutatedID, mutatedRefs[i], mutatedComp))
+				actions = append(actions, cleanupActionForPath(mutatedID, resolvedMutated, mutatedComp))
 				continue
 			}
 			if deepEqual(mutatorValue, oldValue) {
 				continue
 			}
-			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(mutatedRefs[i]), mutatedID, mutatedRefs[i], mutatorValue))
+			actions = append(actions, newComponentUpdateAction(getComponentUpdateOp(resolvedMutated), mutatedID, resolvedMutated, mutatorValue))
 		}
 	}
 	return actions
@@ -491,10 +496,14 @@ func matchingMutators(
 	}
 
 	strategies := getMatchStrategyForSelector(fromClause)
+	mutatorMap, _ := toGenericMap(mutatorComp)
+	mutatedMap, _ := toGenericMap(mutatedComp)
 
 	for i := 0; i < count; i++ {
-		mutatorValue := configurationForComponentAtPath(mutatorRefs[i], mutatorComp, design)
-		mutatedValue := configurationForComponentAtPath(mutatedRefs[i], mutatedComp, design)
+		resolvedMutator := resolvePath(mutatorRefs[i], mutatorMap)
+		resolvedMutated := resolvePath(mutatedRefs[i], mutatedMap)
+		mutatorValue := configurationForComponentAtPath(resolvedMutator, mutatorComp, design)
+		mutatedValue := configurationForComponentAtPath(resolvedMutated, mutatedComp, design)
 		strategy := getStrategyForValueAt(strategies, i)
 		if !matchValuesWithStrategies(mutatorValue, mutatedValue, strategy) {
 			return false

--- a/server/policies/utils_test.go
+++ b/server/policies/utils_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meshery/schemas/models/v1beta1/component"
+	"github.com/meshery/schemas/models/v1beta1/pattern"
 	"github.com/meshery/schemas/models/v1beta2/relationship"
 )
 
@@ -277,4 +279,77 @@ func TestCanonicalSeedTypedStructIsAddressIndependent(t *testing.T) {
 		t.Fatalf("canonicalSeed leaked pointer addresses for typed struct:\n  a=%s\n  b=%s", a, b)
 	}
 }
+
+func TestMatchingMutators_ArrayPaths(t *testing.T) {
+	compFrom := &component.ComponentDefinition{
+		Component: component.Component{
+			Kind: "SecurityGroup",
+		},
+		Configuration: map[string]interface{}{
+			"name": "my-sg",
+		},
+	}
+
+	compTo := &component.ComponentDefinition{
+		Component: component.Component{
+			Kind: "EC2Instance",
+		},
+		Configuration: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"securityGroupRefs": []interface{}{
+					map[string]interface{}{
+						"name": "my-sg",
+					},
+				},
+			},
+		},
+	}
+
+	design := &pattern.PatternFile{
+		Components: []*component.ComponentDefinition{compFrom, compTo},
+	}
+
+	mutatorRefWildcard := [][]string{{"configuration", "name"}}
+	mutatedRefWildcard := [][]string{{"configuration", "spec", "securityGroupRefs", "_", "name"}}
+
+	mutatorRefIndex := [][]string{{"configuration", "name"}}
+	mutatedRefIndex := [][]string{{"configuration", "spec", "securityGroupRefs", "0", "name"}}
+
+	fromClauseWildcard := relationship.SelectorItem{
+		RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+			MutatorRef: &mutatorRefWildcard,
+		},
+	}
+	toClauseWildcard := relationship.SelectorItem{
+		RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+			MutatedRef: &mutatedRefWildcard,
+		},
+	}
+
+	fromClauseIndex := relationship.SelectorItem{
+		RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+			MutatorRef: &mutatorRefIndex,
+		},
+	}
+	toClauseIndex := relationship.SelectorItem{
+		RelationshipDefinitionSelectorsPatch: &relationship.RelationshipDefinitionSelectorsPatch{
+			MutatedRef: &mutatedRefIndex,
+		},
+	}
+
+	t.Run("wildcard path matches", func(t *testing.T) {
+		matched := matchingMutators(compFrom, compTo, fromClauseWildcard, toClauseWildcard, design)
+		if !matched {
+			t.Error("Expected matchingMutators to resolve path wildcard '_' and return true")
+		}
+	})
+
+	t.Run("index path matches", func(t *testing.T) {
+		matched := matchingMutators(compFrom, compTo, fromClauseIndex, toClauseIndex, design)
+		if !matched {
+			t.Error("Expected matchingMutators to resolve path index '0' and return true")
+		}
+	})
+}
+
 


### PR DESCRIPTION


#### Description
This PR resolves an issue in the relationship evaluation engine where selectors utilizing nested array subscripts (e.g., securityGroupRefs[0]) or path wildcards (e.g., securityGroupRefs[_]) failed to match/evaluate.

#### Root Cause
In matchingMutators and patchMutatorsAction (within server/policies/eval_rules.go), the engine retrieved component configuration values using raw selector paths directly, without invoking resolvePath. This caused:
1. Wildcard paths (_) to be checked as static string keys against Go slices, returning nil and failing.
2. Concrete index subscripts (like 0) to compare incorrectly when targeting empty or uninitialized array fields, preventing cross-model relationship identification.

#### Changes
* Updated matchingMutators and patchMutatorsAction inside server/policies/eval_rules.go to call resolvePath on mutator and mutated refs before invoking configurationForComponentAtPath.
* Added a dedicated unit test TestMatchingMutators_ArrayPaths inside server/policies/utils_test.go to verify and prevent regressions for both wildcard path resolution (_) and concrete subscript index resolution (0).

#### Verification & Testing
Ran the entire policies unit test suite locally to verify parity and ensure no regressions:
```bash
go test -v ./server/policies/...
```
All tests passed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resolution of nested and aliased component fields when generating patches and matching relationships.
  - Added support for array paths using wildcard and explicit index selectors.

- **Tests**
  - Added coverage to verify mutator matching across supported array path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->