### PR TITLE
[UI] Fix empty state for CRDs when no cluster is connected

### DIFF
--- a/ui/components/dashboard/resources/resources-sub-menu.test.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.test.tsx
@@ -65,6 +65,12 @@ vi.mock('../utils', () => ({
   default: ({ kind }: { kind: string }) => <svg data-testid={`icon-${kind}`} />,
 }));
 
+vi.mock('@/components/shared/EmptyState/K8sContextEmptyState', () => ({
+  K8sEmptyState: ({ message }: { message: string }) => (
+    <div data-testid="crds-empty-state">{message}</div>
+  ),
+}));
+
 vi.mock('css/icons.styles', () => ({ iconMedium: {} }));
 
 vi.mock('@sistent/sistent', () => ({
@@ -188,7 +194,7 @@ describe('CRDsResourcesSubMenu', () => {
     expect(crdsArgs[0]).toEqual([null, null, { id: 'cluster-1' }, null, 'CRDS', ['ctx-1']]);
   });
 
-  it('renders the fallback ResourcesTable when no CRDs are available or when no cluster is connected', () => {
+  it('suggests connecting a cluster when no Kubernetes connection exists', () => {
     const crdsResource = {
       submenu: true,
       useTableConfig: (...args: unknown[]) => {
@@ -206,10 +212,45 @@ describe('CRDsResourcesSubMenu', () => {
     );
 
     expect(screen.queryByTestId('tab-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('crds-empty-state')).toHaveTextContent(
+      'Connect a Kubernetes cluster to discover and view its custom resources.',
+    );
+    expect(screen.queryByTestId('resources-table')).not.toBeInTheDocument();
+  });
 
-    // This is a fallback component that will automatically display either
-    // "No data available" or "Sorry, no matching records found".
-    // However, in this test file, the ResourcesTable component is mocked.
-    expect(screen.queryByTestId('resources-table')).toBeInTheDocument();
+  it('suggests selecting a connected cluster when none is selected', () => {
+    const crdsResource = { submenu: true, useTableConfig: () => ({}) };
+    render(
+      <ResourcesSubMenu
+        k8sConfig={[{ id: 'cluster-1', kubernetesServerId: 'server-1' }]}
+        resource={crdsResource}
+        selectedK8sContexts={[]}
+        selectedResource=""
+        handleChangeSelectedResource={vi.fn()}
+        isCRDS={true}
+      />,
+    );
+
+    expect(screen.getByTestId('crds-empty-state')).toHaveTextContent(
+      'Select a connected Kubernetes cluster to discover and view its custom resources.',
+    );
+  });
+
+  it('suggests checking connection health when the selection is unavailable', () => {
+    const crdsResource = { submenu: true, useTableConfig: () => ({}) };
+    render(
+      <ResourcesSubMenu
+        k8sConfig={[{ id: 'cluster-1' }]}
+        resource={crdsResource}
+        selectedK8sContexts={['cluster-1']}
+        selectedResource=""
+        handleChangeSelectedResource={vi.fn()}
+        isCRDS={true}
+      />,
+    );
+
+    expect(screen.getByTestId('crds-empty-state')).toHaveTextContent(
+      'The selected Kubernetes connection is unavailable. Check its health in Connections, then select it again.',
+    );
   });
 });

--- a/ui/components/dashboard/resources/resources-sub-menu.test.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.test.tsx
@@ -253,4 +253,22 @@ describe('CRDsResourcesSubMenu', () => {
       'The selected Kubernetes connection is unavailable. Check its health in Connections, then select it again.',
     );
   });
+
+  it('explains when the selected Kubernetes cluster has no custom resources', () => {
+    const crdsResource = { submenu: true, useTableConfig: () => ({}) };
+    render(
+      <ResourcesSubMenu
+        k8sConfig={[{ id: 'cluster-1', kubernetesServerId: 'server-1' }]}
+        resource={crdsResource}
+        selectedK8sContexts={['cluster-1']}
+        selectedResource=""
+        handleChangeSelectedResource={vi.fn()}
+        isCRDS={true}
+      />,
+    );
+
+    expect(screen.getByTestId('crds-empty-state')).toHaveTextContent(
+      'No custom resources are available for the selected Kubernetes cluster.',
+    );
+  });
 });

--- a/ui/components/dashboard/resources/resources-sub-menu.test.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.test.tsx
@@ -187,4 +187,27 @@ describe('CRDsResourcesSubMenu', () => {
     // The hook is called with the cluster args needed to fetch CRD kinds.
     expect(crdsArgs[0]).toEqual([null, null, { id: 'cluster-1' }, null, 'CRDS', ['ctx-1']]);
   });
+
+  it('renders no CRDs tabs when the CRDs hook resolves no cluster-backed resource', () => {
+    const crdsArgs: unknown[][] = [];
+    const crdsResource = {
+      submenu: true,
+      useTableConfig: (...args: unknown[]) => {
+        crdsArgs.push(args);
+        return {};
+      },
+    };
+    render(
+      <CRDsResourcesSubMenu
+        k8sConfig={null}
+        resource={crdsResource}
+        selectedK8sContexts={[]}
+        selectedResource="Foo"
+        handleChangeSelectedResource={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('tab-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pannel-Foo')).not.toBeInTheDocument();
+    expect(crdsArgs[0]).toEqual([null, null, null, null, 'CRDS', []]);
+  });
 });

--- a/ui/components/dashboard/resources/resources-sub-menu.test.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.test.tsx
@@ -188,26 +188,28 @@ describe('CRDsResourcesSubMenu', () => {
     expect(crdsArgs[0]).toEqual([null, null, { id: 'cluster-1' }, null, 'CRDS', ['ctx-1']]);
   });
 
-  it('renders no CRDs tabs when the CRDs hook resolves no cluster-backed resource', () => {
-    const crdsArgs: unknown[][] = [];
+  it('renders the fallback ResourcesTable when no CRDs are available or when no cluster is connected', () => {
     const crdsResource = {
       submenu: true,
       useTableConfig: (...args: unknown[]) => {
-        crdsArgs.push(args);
         return {};
       },
     };
     render(
       <CRDsResourcesSubMenu
-        k8sConfig={null}
+        k8sConfig={''}
         resource={crdsResource}
         selectedK8sContexts={[]}
-        selectedResource="Foo"
+        selectedResource=""
         handleChangeSelectedResource={vi.fn()}
       />,
     );
+
     expect(screen.queryByTestId('tab-0')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('pannel-Foo')).not.toBeInTheDocument();
-    expect(crdsArgs[0]).toEqual([null, null, null, null, 'CRDS', []]);
+
+    // This is a fallback component that will automatically display either
+    // "No data available" or "Sorry, no matching records found".
+    // However, in this test file, the ResourcesTable component is mocked.
+    expect(screen.queryByTestId('resources-table')).toBeInTheDocument();
   });
 });

--- a/ui/components/dashboard/resources/resources-sub-menu.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.tsx
@@ -51,10 +51,13 @@ const ResourcesSubMenu = ({
     () => (isCRDS ? CRDsKeys.map((key) => key.model) : []),
     [CRDsKeys, isCRDS],
   );
-  const crdsKind = useMemo(
-    () => (isCRDS ? CRDsKeys.map((key) => key.name) : []),
-    [CRDsKeys, isCRDS],
-  );
+  const crdsKind = useMemo(() => {
+    if (isCRDS) {
+      const kinds = CRDsKeys.map((key) => key.name);
+      return kinds.length ? kinds : [''];
+    }
+    return [];
+  }, [CRDsKeys, isCRDS]);
 
   // useTableConfig is a custom hook, so it is called unconditionally at the top
   // level to keep hook order stable across renders.
@@ -125,30 +128,18 @@ const ResourcesSubMenu = ({
         </WrapperPaper>
       )}
 
-      {isCRDS && !CRDsKeys.length ? (
-        <TabPanel value={selectedResource || 'CRDS'} index={selectedResource || 'CRDS'}>
+      {tabs.map((key, index) => (
+        <TabPanel value={selectedResource || ''} index={key} key={`${key}-${index}`}>
           <ResourcesTable
-            workloadType="CRDS"
+            key={index}
+            workloadType={key}
             k8sConfig={k8sConfig}
             useResourceConfig={resource.useTableConfig}
             submenu={resource.submenu}
             selectedK8sContexts={selectedK8sContexts}
           />
         </TabPanel>
-      ) : (
-        tabs.map((key, index) => (
-          <TabPanel value={selectedResource || ''} index={key} key={`${key}-${index}`}>
-            <ResourcesTable
-              key={index}
-              workloadType={key}
-              k8sConfig={k8sConfig}
-              useResourceConfig={resource.useTableConfig}
-              submenu={resource.submenu}
-              selectedK8sContexts={selectedK8sContexts}
-            />
-          </TabPanel>
-        ))
-      )}
+      ))}
     </>
   );
 };

--- a/ui/components/dashboard/resources/resources-sub-menu.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.tsx
@@ -129,7 +129,7 @@ const ResourcesSubMenu = ({
       )}
 
       {tabs.map((key, index) => (
-        <TabPanel value={selectedResource || ''} index={key} key={`${key}-${index}`}>
+        <TabPanel value={selectedResource} index={key} key={`${key}-${index}`}>
           <ResourcesTable
             key={index}
             workloadType={key}

--- a/ui/components/dashboard/resources/resources-sub-menu.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.tsx
@@ -7,6 +7,8 @@ import { SecondaryTab, SecondaryTabs, WrapperPaper } from '../style';
 import GetKubernetesNodeIcon from '../utils';
 import { iconMedium } from 'css/icons.styles';
 import { styled } from '@sistent/sistent';
+import { K8sEmptyState } from '@/components/shared/EmptyState/K8sContextEmptyState';
+import { getK8sClusterIdsFromCtxId } from '@/utils/multi-ctx';
 
 const DashboardIconText = styled('div')({
   display: 'flex',
@@ -51,13 +53,10 @@ const ResourcesSubMenu = ({
     () => (isCRDS ? CRDsKeys.map((key) => key.model) : []),
     [CRDsKeys, isCRDS],
   );
-  const crdsKind = useMemo(() => {
-    if (isCRDS) {
-      const kinds = CRDsKeys.map((key) => key.name);
-      return kinds.length ? kinds : [''];
-    }
-    return [];
-  }, [CRDsKeys, isCRDS]);
+  const crdsKind = useMemo(
+    () => (isCRDS ? CRDsKeys.map((key) => key.name) : []),
+    [CRDsKeys, isCRDS],
+  );
 
   // useTableConfig is a custom hook, so it is called unconditionally at the top
   // level to keep hook order stable across renders.
@@ -81,11 +80,23 @@ const ResourcesSubMenu = ({
     () => tabs.findIndex((resourceName) => resourceName === selectedResource),
     [selectedResource, tabs],
   );
+  const clusterIds =
+    isCRDS && !CRDsKeys.length && Array.isArray(k8sConfig)
+      ? getK8sClusterIdsFromCtxId(selectedK8sContexts, k8sConfig)
+      : [];
+  const emptyStateMessage =
+    !Array.isArray(k8sConfig) || k8sConfig.length === 0
+      ? 'Connect a Kubernetes cluster to discover and view its custom resources.'
+      : !Array.isArray(selectedK8sContexts) || selectedK8sContexts.length === 0
+        ? 'Select a connected Kubernetes cluster to discover and view its custom resources.'
+        : clusterIds.length === 0
+          ? 'The selected Kubernetes connection is unavailable. Check its health in Connections, then select it again.'
+          : 'No custom resources are available for the selected Kubernetes cluster.';
 
   return (
     <>
       {isCRDS && !CRDsKeys.length ? (
-        <></>
+        <K8sEmptyState message={emptyStateMessage} />
       ) : (
         <WrapperPaper>
           <SecondaryTabs

--- a/ui/components/dashboard/resources/resources-sub-menu.tsx
+++ b/ui/components/dashboard/resources/resources-sub-menu.tsx
@@ -81,57 +81,74 @@ const ResourcesSubMenu = ({
 
   return (
     <>
-      <WrapperPaper>
-        <SecondaryTabs
-          sx={{
-            [`& .${TABS_SCROLL_BUTTONS_CLASS}`]: {
-              '&.Mui-disabled': { display: 'none' },
-            },
-            '& .MuiTabs-scroller': {
-              flexGrow: '0',
-            },
-            justifyContent: 'center',
-          }}
-          value={selectedTabIndex}
-          onChange={(_e, value) => handleChangeSelectedResource(tabs[value])}
-          variant={'scrollable'}
-          allowScrollButtonsMobile
-          scrollButtons="auto"
-          centered
-        >
-          {tabs.map((key, index) => {
-            const title = isCRDS ? key : tableConfigResult[key].name;
-            return (
-              <SecondaryTab
-                key={index}
-                value={index}
-                label={
-                  <DashboardIconText>
-                    <GetKubernetesNodeIcon
-                      kind={key}
-                      model={crdsModelName[index]}
-                      size={iconMedium}
-                    />
-                    {title}
-                  </DashboardIconText>
-                }
-              />
-            );
-          })}
-        </SecondaryTabs>
-      </WrapperPaper>
-      {tabs.map((key, index) => (
-        <TabPanel value={selectedResource} index={key} key={`${key}-${index}`}>
+      {isCRDS && !CRDsKeys.length ? (
+        <></>
+      ) : (
+        <WrapperPaper>
+          <SecondaryTabs
+            sx={{
+              [`& .${TABS_SCROLL_BUTTONS_CLASS}`]: {
+                '&.Mui-disabled': { display: 'none' },
+              },
+              '& .MuiTabs-scroller': {
+                flexGrow: '0',
+              },
+              justifyContent: 'center',
+            }}
+            value={selectedTabIndex}
+            onChange={(_e, value) => handleChangeSelectedResource(tabs[value])}
+            variant={'scrollable'}
+            allowScrollButtonsMobile
+            scrollButtons="auto"
+            centered
+          >
+            {tabs.map((key, index) => {
+              const title = isCRDS ? key : tableConfigResult[key].name;
+              return (
+                <SecondaryTab
+                  key={index}
+                  value={index}
+                  label={
+                    <DashboardIconText>
+                      <GetKubernetesNodeIcon
+                        kind={key}
+                        model={crdsModelName[index]}
+                        size={iconMedium}
+                      />
+                      {title}
+                    </DashboardIconText>
+                  }
+                />
+              );
+            })}
+          </SecondaryTabs>
+        </WrapperPaper>
+      )}
+
+      {isCRDS && !CRDsKeys.length ? (
+        <TabPanel value={selectedResource || 'CRDS'} index={selectedResource || 'CRDS'}>
           <ResourcesTable
-            key={index}
-            workloadType={key}
+            workloadType="CRDS"
             k8sConfig={k8sConfig}
             useResourceConfig={resource.useTableConfig}
             submenu={resource.submenu}
             selectedK8sContexts={selectedK8sContexts}
           />
         </TabPanel>
-      ))}
+      ) : (
+        tabs.map((key, index) => (
+          <TabPanel value={selectedResource || ''} index={key} key={`${key}-${index}`}>
+            <ResourcesTable
+              key={index}
+              workloadType={key}
+              k8sConfig={k8sConfig}
+              useResourceConfig={resource.useTableConfig}
+              submenu={resource.submenu}
+              selectedK8sContexts={selectedK8sContexts}
+            />
+          </TabPanel>
+        ))
+      )}
     </>
   );
 };

--- a/ui/components/dashboard/resources/resources-table.tsx
+++ b/ui/components/dashboard/resources/resources-table.tsx
@@ -116,11 +116,7 @@ const ResourcesTableInner = (props: ResourcesTableProps) => {
     workloadType,
     selectedK8sContexts,
   );
-  const tableConfig = (submenu ? resolvedConfig[workloadType] : resolvedConfig) ?? {
-    name: workloadType,
-    colViews: [],
-    columns: [],
-  };
+  const tableConfig = submenu ? resolvedConfig[workloadType] : resolvedConfig;
 
   const encodedClusterIds = useMemo(() => JSON.stringify(clusterIds), [clusterIds]);
 

--- a/ui/components/dashboard/resources/resources-table.tsx
+++ b/ui/components/dashboard/resources/resources-table.tsx
@@ -48,22 +48,6 @@ const ResourcesTable = (props: ResourcesTableProps) => {
     return null;
   }
 
-  // if (!props.selectedK8sContexts?.length) {
-  //   return (
-  //     <ResponsiveDataTable
-  //       data={[]}
-  //       columns={[]}
-  //       options={{
-  //         textLabels: {
-  //           body: {
-  //             noMatch: 'No values found',
-  //           },
-  //         },
-  //       }}
-  //     />
-  //   );
-  // }
-
   return <ResourcesTableInner {...props} />;
 };
 

--- a/ui/components/dashboard/resources/resources-table.tsx
+++ b/ui/components/dashboard/resources/resources-table.tsx
@@ -48,6 +48,22 @@ const ResourcesTable = (props: ResourcesTableProps) => {
     return null;
   }
 
+  // if (!props.selectedK8sContexts?.length) {
+  //   return (
+  //     <ResponsiveDataTable
+  //       data={[]}
+  //       columns={[]}
+  //       options={{
+  //         textLabels: {
+  //           body: {
+  //             noMatch: 'No values found',
+  //           },
+  //         },
+  //       }}
+  //     />
+  //   );
+  // }
+
   return <ResourcesTableInner {...props} />;
 };
 
@@ -116,7 +132,11 @@ const ResourcesTableInner = (props: ResourcesTableProps) => {
     workloadType,
     selectedK8sContexts,
   );
-  const tableConfig = submenu ? resolvedConfig[workloadType] : resolvedConfig;
+  const tableConfig = (submenu ? resolvedConfig[workloadType] : resolvedConfig) ?? {
+    name: workloadType,
+    colViews: [],
+    columns: [],
+  };
 
   const encodedClusterIds = useMemo(() => JSON.stringify(clusterIds), [clusterIds]);
 


### PR DESCRIPTION
### Summary
Enhance the CRDs dashboard empty state with contextual guidance based on Kubernetes connection status:

- Prompt users to connect a Kubernetes cluster when none exists.
- Prompt users to select a connected cluster when no cluster is selected.
- Suggest checking connection health when the selected connection is unavailable.
- Clarify when a connected cluster has no custom resources.
- Preserve normal CRD tab rendering and avoid resolving cluster IDs unnecessarily.
Added test coverage for all empty-state scenarios and the existing CRD tab behavior.

#### Before

<img width="1424" height="814" alt="Screenshot 2026-08-26 at 16 38 25" src="https://github.com/user-attachments/assets/cc2f243e-bdf0-431f-8574-ea8a905f9190" />

#### After

<img width="1607" height="589" alt="Screenshot 2026-09-03 at 10 36 21" src="https://github.com/user-attachments/assets/7a16ae4a-3fdb-4268-950f-4ca12c3f2f75" />


- This PR fixes #21624

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved the Kubernetes resources view when no custom resources are available.
- Displays a relevant empty-state message when no cluster is connected, no cluster is selected, or the selected cluster is unavailable.
- Prevents an empty resources submenu from appearing when there are no available resources.
- Existing resource navigation and rendering remain unchanged when resources are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->