### PR TITLE
[server][mesheryctl] Fix malformed doc comments across the repo (consolidated)

### DIFF
--- a/mesheryctl/internal/cli/pkg/api/meshery.go
+++ b/mesheryctl/internal/cli/pkg/api/meshery.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Generic function to fetch data from Mesehry server needs to be type of meshery data ApiResponse
+// Fetch sends a GET request to the given URL and unmarshals the JSON response body into T.
 func Fetch[T any](url string) (*T, error) {
 	resp, err := makeRequest(url, http.MethodGet, nil, nil)
 	if err != nil {

--- a/mesheryctl/internal/cli/root/adapter/error.go
+++ b/mesheryctl/internal/cli/root/adapter/error.go
@@ -68,7 +68,7 @@ var (
 	ErrSMIConformanceTestsFailed = errors.New(ErrSMIConformanceTestsFailedCode, errors.Fatal, []string{"SMI conformance tests failed"}, []string{"SMI conformance tests failed"}, []string{}, []string{"Join https://mesheryio.slack.com/archives/C010H0HE2E6"})
 )
 
-// When unable to get release data
+// ErrGettingSessionData is returned when the CLI is unable to fetch session data from the Meshery server.
 func ErrGettingSessionData(err error) error {
 	return errors.New(ErrGettingSessionDataCode, errors.Fatal,
 		[]string{"Unable to fetch session data"},

--- a/mesheryctl/internal/cli/root/config/config.go
+++ b/mesheryctl/internal/cli/root/config/config.go
@@ -140,7 +140,7 @@ func (mc *MesheryCtlConfig) GetCurrentContext() (*Context, error) {
 	return currentContext, err
 }
 
-// Get any context
+// GetContext validates and returns a pointer to the named context.
 func (mc *MesheryCtlConfig) GetContext(name string) (*Context, error) {
 	context, err := mc.CheckIfGivenContextIsValid(name)
 	if err != nil {

--- a/mesheryctl/internal/cli/root/registry/registry.go
+++ b/mesheryctl/internal/cli/root/registry/registry.go
@@ -36,7 +36,7 @@ var (
 	csvDirectory            string
 )
 
-// PublishCmd represents the publish command to publish Meshery Models to Websites, Remote Provider, Meshery
+// RegistryCmd represents the registry command, which manages the state and contents of Meshery's internal registry of capabilities.
 var RegistryCmd = &cobra.Command{
 	Use:   "registry",
 	Short: "Manage the capability registry",

--- a/mesheryctl/internal/cli/root/system/check.go
+++ b/mesheryctl/internal/cli/root/system/check.go
@@ -266,7 +266,7 @@ func (hc *HealthChecker) Run() error {
 	return nil
 }
 
-// Run preflight healthchecks to verify environment health
+// RunPreflightHealthChecks runs preflight healthchecks to verify environment health.
 func (hc *HealthChecker) RunPreflightHealthChecks() error {
 	// Docker healthchecks are only invoked when it's not a PreRunExecution
 	// or it's a PreRunExecution and current platform is docker

--- a/mesheryctl/internal/cli/root/system/error.go
+++ b/mesheryctl/internal/cli/root/system/error.go
@@ -85,7 +85,7 @@ var (
 	contextDir            = "See that you have a correct context in your  meshconfig at `$HOME/.meshery/config.yaml`."
 )
 
-// A Format reference that returns Mesheryctl's URL docs for system command and sub commands
+// FormatErrorReference returns a mesheryctl system docs URL for cmdType, or the general system docs URL if cmdType is unset or unrecognized.
 func FormatErrorReference() string {
 	baseURL := "https://docs.meshery.io/reference/references/mesheryctl/system"
 	switch cmdType {

--- a/server/extensions/output.go
+++ b/server/extensions/output.go
@@ -2,7 +2,7 @@ package extensions
 
 import "net/http"
 
-// Router
+// Router pairs an HTTP handler with the URL path it should be served at, for extension endpoints registered into a shared routing table.
 type Router struct {
 	HTTPHandler http.Handler
 	Path        string

--- a/server/handlers/common_handlers.go
+++ b/server/handlers/common_handlers.go
@@ -118,7 +118,7 @@ func (h *Handler) serveFile(responseWriter http.ResponseWriter, request *http.Re
 	}
 }
 
-// Deep-link and redirect support to land user on their originally requested page post authentication instead of dropping user on the root (home) page.
+// GetRefURL provides deep-link and redirect support to land the user on their originally requested page post-authentication instead of dropping them on the root (home) page.
 func GetRefURL(req *http.Request) string {
 	return core.EncodeRefUrl(*req.URL)
 }

--- a/server/handlers/component_generation.go
+++ b/server/handlers/component_generation.go
@@ -32,7 +32,7 @@ type componentGenerationResponseDataItem struct {
 	Errors     []string                        `json:"errors"`
 }
 
-// request body should be json
+// MeshModelGenerationHandler expects the request body to be JSON.
 // request body should be of format - {data: [{name: string, register: boolean}]}
 // response format - {data: [{name: string, components: [component], errors: [string] }]}
 func (h *Handler) MeshModelGenerationHandler(rw http.ResponseWriter, r *http.Request) {

--- a/server/handlers/component_handler.go
+++ b/server/handlers/component_handler.go
@@ -44,6 +44,8 @@ import (
 )
 
 /**Meshmodel endpoints **/
+
+// DefaultPageSizeForMeshModelComponents is the default page size used when listing Meshmodel components.
 const DefaultPageSizeForMeshModelComponents = 25
 
 func (h *Handler) GetMeshmodelModelsByCategories(rw http.ResponseWriter, r *http.Request) {
@@ -765,8 +767,7 @@ func (h *Handler) GetAllMeshmodelComponents(rw http.ResponseWriter, r *http.Requ
 	}
 }
 
-// request body should be json
-// request body should be of ComponentCapability format
+// RegisterMeshmodelComponents expects the request body to be JSON, decoded into a registry.MeshModelRegistrantData.
 func (h *Handler) RegisterMeshmodelComponents(rw http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
 	var cc registry.MeshModelRegistrantData
@@ -850,8 +851,7 @@ func (h *Handler) GetMeshmodelRegistrants(rw http.ResponseWriter, r *http.Reques
 	}
 }
 
-// request body should be json
-// request body should be of struct containing ID and Status fields
+// UpdateEntityStatus expects the request body to be a JSON object with id, status, displayName (and legacy displayname) fields.
 func (h *Handler) UpdateEntityStatus(rw http.ResponseWriter, r *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
 	dec := json.NewDecoder(r.Body)
 	userID := user.ID

--- a/server/handlers/content_modifier.go
+++ b/server/handlers/content_modifier.go
@@ -30,8 +30,8 @@ func NewContentModifier(token string,
 	}
 }
 
-// TODO: Similar mechanisms for filters and applications
 // AddMetadataForPatterns takes in response bytes, and add metadata to it based on some checks
+// TODO: Similar mechanisms for filters and applications
 func (mc *ContentModifier) AddMetadataForPatterns(ctx context.Context, contentBytes *[]byte) error {
 	var patternsPage models.MesheryPatternPage
 	err := json.Unmarshal(*contentBytes, &patternsPage)

--- a/server/handlers/database_handlers.go
+++ b/server/handlers/database_handlers.go
@@ -73,7 +73,7 @@ func (h *Handler) GetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *m
 	}
 }
 
-// Reset the system database to its initial state.
+// ResetSystemDatabase resets the system database to its initial state.
 func (h *Handler) ResetSystemDatabase(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 
 	mesherydbPath := path.Join(utils.GetHome(), ".meshery/config")

--- a/server/handlers/design_import.go
+++ b/server/handlers/design_import.go
@@ -169,7 +169,7 @@ func ConvertFileToManifest(identifiedFile files.IdentifiedFile, rawFile FileToIm
 	}
 }
 
-// returns the design file , the type of file that was identified during converion , and any error
+// ConvertFileToDesign returns the design file, the type of file that was identified during conversion, and any error
 func ConvertFileToDesign(fileToImport FileToImport, registry *registry.RegistryManager, logger logger.Handler) (pattern.PatternFile, core.IaCFileTypes, error) {
 
 	defer utils.TrackTime(logger, time.Now(), "ConvertFileToDesign")

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -753,7 +753,7 @@ func ErrUnsupportedEventStatus(err error, status string) error {
 	return errors.New(ErrUnsupportedEventStatusCode, errors.Alert, []string{fmt.Sprintf("Event status '%s' is not a supported status.", status)}, []string{err.Error()}, []string{"Unsupported event status for your current version of Meshery Server."}, []string{"Confirm that the status you are using is valid and a supported event status. Refer to Meshery Docs for a list of event statuses.", "Check for availability of a new version of Meshery Server. Try upgrading to the latest version."})
 }
 
-// ErrFetchMeshSyncResources
+// ErrFetchMeshSyncResources reports a failure to fetch MeshSync resources
 func ErrFetchMeshSyncResources(err error) error {
 	return errors.New(ErrFetchMeshSyncResourcesCode, errors.Alert, []string{"Error fetching MeshSync resources", "DB might be corrupted"}, []string{err.Error()}, []string{"MeshSync might not be reachable from Meshery"}, []string{"Make sure Meshery has connectivity to MeshSync", "Try restarting Meshery server"})
 }

--- a/server/handlers/extensions.go
+++ b/server/handlers/extensions.go
@@ -19,7 +19,7 @@ var (
 	mx                sync.Mutex
 )
 
-// Defines the version metadata for the extension
+// ExtensionVersion defines the version metadata for the extension
 type ExtensionVersion struct {
 	Version string `json:"version,omitempty"`
 }
@@ -100,10 +100,8 @@ func (h *Handler) ExtensionsVersionHandler(w http.ResponseWriter, _ *http.Reques
 	}
 }
 
-/*
-* ExtensionsHandler is a handler function which works as a proxy to resolve the
-* request of any extension point to its remote provider
- */
+// ExtensionsHandler is a handler function which works as a proxy to resolve the
+// request of any extension point to its remote provider
 func (h *Handler) ExtensionsHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	resp, err := provider.ExtensionProxy(req)
 	if err != nil {

--- a/server/handlers/mesh_ops_handlers.go
+++ b/server/handlers/mesh_ops_handlers.go
@@ -18,7 +18,7 @@ func init() {
 	gob.Register([]*models.Adapter{})
 }
 
-// AdaptersHandler is used to fetch all the adapters
+// AvailableAdaptersHandler returns the list of available adapters
 func (h *Handler) AvailableAdaptersHandler(w http.ResponseWriter, _ *http.Request) {
 	err := json.NewEncoder(w).Encode(models.ListAvailableAdapters)
 	if err != nil {

--- a/server/handlers/meshery_pattern_handler.go
+++ b/server/handlers/meshery_pattern_handler.go
@@ -44,7 +44,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// MesheryPatternRequestBody refers to the type of request body that
+// MesheryPatternPOSTRequestBody refers to the type of request body that
 // SaveMesheryPattern would receive. Canonical wire form for the
 // wrapper is `patternData` (camelCase) per the identifier-naming
 // migration; the legacy snake_case `pattern_data` spelling is still
@@ -414,7 +414,7 @@ func (h *Handler) handlePatternPOST(
 
 }
 
-// Verifies and converts a pattern to design format if required.
+// VerifyAndConvertToDesign verifies and converts a pattern to design format if required.
 // A pattern is required to be converted to design format iff,
 // 1. pattern_file attribute is empty, and
 // 2. The "type" (sourcetype/original content) is not Design. [is one of compose/helmchart/manifests]
@@ -1844,8 +1844,8 @@ func (h *Handler) handlePatternUpdate(
 
 }
 
-// PatternFileRequestHandler will handle requests of both type GET and POST
-// on the route /api/pattern
+// DesignFileRequestHandlerWithSourceType will handle requests of both type POST and PUT
+// on the route /api/pattern/{sourcetype}
 func (h *Handler) DesignFileRequestHandlerWithSourceType(
 	rw http.ResponseWriter,
 	r *http.Request,
@@ -1885,7 +1885,7 @@ func (h *Handler) GetMesheryDesignTypesHandler(
 	}
 }
 
-// GetMesheryPatternHandler fetched the design using the given id and sourcetype
+// GetMesheryPatternSourceHandler fetches the design using the given id and sourcetype
 func (h *Handler) GetMesheryPatternSourceHandler(
 	rw http.ResponseWriter,
 	r *http.Request,

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -289,7 +289,7 @@ func (h *Handler) SessionInjectorMiddleware(next func(http.ResponseWriter, *http
 	})
 }
 
-// GraphqlSessionInjectorMiddleware - is a middleware which injects user and session object
+// GraphqlMiddleware adapts next to the handler-chain signature and forwards the request to it, without injecting anything
 func (h *Handler) GraphqlMiddleware(next http.Handler) func(http.ResponseWriter, *http.Request, *models.Preference, *models.User, models.Provider) {
 	return func(w http.ResponseWriter, req *http.Request, pref *models.Preference, user *models.User, prov models.Provider) {
 		next.ServeHTTP(w, req)

--- a/server/handlers/policy_relationship_handler.go
+++ b/server/handlers/policy_relationship_handler.go
@@ -263,7 +263,10 @@ func doesntNeedReeval(response pattern.EvaluationResponse) bool {
 	return true
 }
 
-// max number of time to keep revaluating the design till there are no reval triggering actions in the response
+// MAX_RE_EVALUATION_DEPTH is the maximum number of re-evaluation passes. The loop also
+// stops early when the caller's evalIterations limit is reached, or when the response
+// contains no further re-evaluation-triggering actions. Reaching this depth limit logs a
+// warning and returns a partial result.
 const MAX_RE_EVALUATION_DEPTH = 5
 
 // defaultPolicyEvalTimeout bounds a single evaluation. Override via POLICY_EVAL_TIMEOUT.
@@ -294,8 +297,9 @@ func policyEvalTimeout() time.Duration {
 	return defaultPolicyEvalTimeout
 }
 
-// Helper method to make design evaluation based on the relationship policies.
-// evalIterations is num of passes the evaluator needs to go through to do complete evaluation
+// EvaluateDesign evaluates the design based on the relationship policies.
+// evalIterations is an upper bound on evaluation passes; the loop may stop earlier if no
+// re-evaluation-triggering actions remain.
 func (h *Handler) EvaluateDesign(
 	relationshipPolicyEvalPayload pattern.EvaluationRequest,
 	evalIterations int,

--- a/server/handlers/validate.go
+++ b/server/handlers/validate.go
@@ -40,7 +40,7 @@ type jsonSchemaValidationType struct {
 	Schema string `json:"$schema,omitempty"`
 }
 
-// request body should be json
+// ValidationHandler expects the request body to be JSON.
 // request body should be of format - {validationItems: {[id]:{schema: string, value: string, valueType: "JSON"|"YAML"|"CUE"}}}
 // response format - {[id]: {isValid: bool, error: string}}
 func (h *Handler) ValidationHandler(rw http.ResponseWriter, r *http.Request) {

--- a/server/helpers/adapters_tracker.go
+++ b/server/helpers/adapters_tracker.go
@@ -68,7 +68,7 @@ func (a *AdaptersTracker) GetAdapters(_ context.Context) []models.Adapter {
 	return ad
 }
 
-// AddAdapter is used to add new adapters to the collection
+// DeployAdapter deploys the adapter on the current platform (Docker or Kubernetes) and then adds it to the collection.
 func (a *AdaptersTracker) DeployAdapter(ctx context.Context, adapter models.Adapter) (err error) {
 	platform := utils.GetPlatform()
 
@@ -221,7 +221,7 @@ func (a *AdaptersTracker) DeployAdapter(ctx context.Context, adapter models.Adap
 	return nil
 }
 
-// RemoveAdapter is used to remove existing adapters from the collection
+// UndeployAdapter undeploys the adapter from the current platform (Docker or Kubernetes) and then removes it from the collection.
 func (a *AdaptersTracker) UndeployAdapter(ctx context.Context, adapter models.Adapter) (err error) {
 	platform := utils.GetPlatform()
 

--- a/server/helpers/utils/utils.go
+++ b/server/helpers/utils/utils.go
@@ -326,7 +326,7 @@ func GetComponentFieldPathFromK8sFieldPath(path string) (newpath string) {
 	return fmt.Sprintf("%s.%s", "settings", path)
 }
 
-// Prunes the diff part present in the k8s response message.
+// FormatK8sMessage prunes the diff part present in the k8s response message.
 // Diff corresponds to the previous change and applied change, and doesn't contain any info which can be helpful to the user.
 // If we want we can show this in a CodeEditor component.
 func FormatK8sMessage(message string) string {

--- a/server/internal/graphql/model/helpers.go
+++ b/server/internal/graphql/model/helpers.go
@@ -42,11 +42,11 @@ var (
 	}
 )
 
-// SetOverrideValues detects the currently insalled adapters and sets appropriate
+// SetOverrideValues detects the currently installed adapters and sets appropriate
 // overrides so as to not uninstall them. It also sets override values for
-// operator so that it can be enabled or disabled depending on the need
-
-// to be depricated
+// operator so that it can be enabled or disabled depending on the need.
+//
+// TODO: to be deprecated
 func SetOverrideValues(delete bool, adapterTracker models.AdaptersTrackerInterface) map[string]interface{} {
 	installedAdapters := make([]string, 0)
 	adapters := adapterTracker.GetAdapters(context.TODO())
@@ -128,7 +128,7 @@ func (k *K8sConnectionTracker) Set(id string, url string) {
 	k.contextToBroker[id] = url
 }
 
-// Takes a set of endpoints and discard the current endpoint if its not present in the set
+// ResetEndpoints takes a set of endpoints and discards any tracked endpoint that is not present in the set.
 func (k *K8sConnectionTracker) ResetEndpoints(available map[string]bool) {
 	k.mx.Lock()
 	defer k.mx.Unlock()
@@ -155,7 +155,7 @@ func (k *K8sConnectionTracker) Get(id string) (url string) {
 	return
 }
 
-// Takes the meshkit Logger and logs a comma separated list of currently tracked Broker Endpoints
+// Log takes the meshkit Logger and logs a comma-separated list of currently tracked broker endpoints.
 func (k *K8sConnectionTracker) Log(l logger.Handler) {
 	var e = "Connected broker endpoints : "
 	k.mx.Lock()

--- a/server/machines/kubernetes/connect.go
+++ b/server/machines/kubernetes/connect.go
@@ -17,7 +17,9 @@ import (
 
 type ConnectAction struct{}
 
-// Execute On Entry and Exit should not return next eventtype i suppose, look again.
+// ExecuteOnEntry is a no-op; ConnectAction performs all of its work in Execute.
+//
+// TODO: Execute On Entry and Exit should not return next eventtype i suppose, look again.
 func (ca *ConnectAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
 	return machines.NoOp, nil, nil
 }

--- a/server/machines/kubernetes/discover.go
+++ b/server/machines/kubernetes/discover.go
@@ -13,7 +13,9 @@ import (
 
 type DiscoverAction struct{}
 
-// Execute On Entry and Exit should not return next eventtype i suppose, look again.
+// ExecuteOnEntry is a no-op; DiscoverAction performs all of its work in Execute.
+//
+// TODO: Execute On Entry and Exit should not return next eventtype i suppose, look again.
 func (da *DiscoverAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
 	return machines.NoOp, nil, nil
 }

--- a/server/machines/kubernetes/register.go
+++ b/server/machines/kubernetes/register.go
@@ -15,7 +15,9 @@ import (
 
 type RegisterAction struct{}
 
-// Execute On Entry and Exit should not return next eventtype i suppose, look again.
+// ExecuteOnEntry is a no-op; RegisterAction performs all of its work in Execute.
+//
+// TODO: Execute On Entry and Exit should not return next eventtype i suppose, look again.
 func (ra *RegisterAction) ExecuteOnEntry(ctx context.Context, machineCtx interface{}, data interface{}) (machines.EventType, *events.Event, error) {
 	return machines.NoOp, nil, nil
 }

--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -45,10 +45,10 @@ type Payload struct {
 	Credential models.Credential
 }
 
-// Represents an event in the system/machine
+// EventType represents an event in the system/machine.
 type EventType string
 
-// Represents the mapping between event and the next state in the event's response
+// Events represents the mapping between an event and the next state in the event's response.
 type Events map[EventType]StateType
 
 type StateMachine struct {
@@ -125,9 +125,9 @@ func (sm *StateMachine) getNextState(event EventType) (StateType, error) {
 	return DefaultState, ErrInvalidTransitionEvent(sm.CurrentState, event)
 }
 
-// Returns events.Event and error. The func invoking the SendEvent should handle the error and publish the event.
-// wherever possible use the userID and systemID from context as the events can be created from other comps or actors and not only user actors.
-// In cases when the event is received as part of some other event and not explicitly created by an actor, use the useID and systemID of the actor who initially invoked the machine.
+// SendEvent returns events.Event and error. The func invoking SendEvent should handle the error and publish the event.
+// Wherever possible use the userID and systemID from context as the events can be created from other comps or actors and not only user actors.
+// In cases when the event is received as part of some other event and not explicitly created by an actor, use the userID and systemID of the actor who initially invoked the machine.
 func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payload interface{}) (*events.Event, error) {
 	user, _ := ctx.Value(models.UserCtxKey).(*models.User)
 	sysID, _ := ctx.Value(models.SystemIDKey).(*core.Uuid)

--- a/server/machines/state.go
+++ b/server/machines/state.go
@@ -1,6 +1,6 @@
 package machines
 
-// Represents an state in the system/machine
+// StateType represents a state in the system/machine.
 type StateType string
 
 type State struct {
@@ -8,7 +8,7 @@ type State struct {
 	Action Action
 }
 
-// Represents mapping between state name and the state
+// States represents the mapping between a state's name and the state itself.
 type States map[StateType]State
 
 func (s *State) RegisterEvent(eventType EventType, stateType StateType) *State {

--- a/server/models/connection_persister.go
+++ b/server/models/connection_persister.go
@@ -264,8 +264,7 @@ func (cp *ConnectionPersister) UpdateConnectionByID(connection *connections.Conn
 	return connection, nil
 }
 
-// Get connection by ID
-// If kind is provided filter with kind too
+// GetConnection gets a connection by ID. If kind is provided, it also filters by kind.
 func (cp *ConnectionPersister) GetConnection(id core.Uuid, kind string) (*connections.Connection, error) {
 	connection := connections.Connection{}
 	query := cp.DB.Where("id = ?", id)

--- a/server/models/connections/connections.go
+++ b/server/models/connections/connections.go
@@ -72,9 +72,9 @@ var validConnectionStatusToManage = []ConnectionStatus{
 	NOTFOUND,
 }
 
-// Check whether the Connection should be managed.
-// Connections with status as Discovered, Registered, Connected should only be managed.
-// Eg: If the status is set as Maintenance or Ignore do not try to mange it, not even during greedy import of K8sConnection from KubeConfig.
+// ShouldConnectionBeManaged checks whether the Connection should be managed.
+// Connections with status as Discovered, Registered, Connected, or NotFound should only be managed.
+// Eg: If the status is set as Maintenance or Ignore do not try to manage it, not even during greedy import of K8sConnection from KubeConfig.
 func ShouldConnectionBeManaged(c Connection) bool {
 	for _, validStatus := range validConnectionStatusToManage {
 		if validStatus == c.Status {
@@ -122,11 +122,12 @@ func MergePayloadOntoExisting(payload *ConnectionPayload, existing *Connection) 
 	}
 }
 
-// The status-per-kind response wrapper surfaced on a few integrations
-// endpoints, and its element type. Both are the canonical v1beta3 connection
-// constructs rather than local stubs: the local copy of the page had dropped
-// `page`, `pageSize` and `totalCount`, so the swagger definition generated from
-// it (server/handlers/doc.go) under-described the response it documents.
+// ConnectionStatusInfo is the element type of the status-per-kind response
+// wrapper (ConnectionsStatusPage) surfaced on a few integrations endpoints.
+// Both are the canonical v1beta3 connection constructs rather than local stubs:
+// the local copy of the page had dropped `page`, `pageSize` and `totalCount`,
+// so the swagger definition generated from it (server/handlers/doc.go)
+// under-described the response it documents.
 type ConnectionStatusInfo = schemasConnection.ConnectionStatusInfo
 
 type ConnectionsStatusPage = schemasConnection.ConnectionsStatusPage

--- a/server/models/keys_helper.go
+++ b/server/models/keys_helper.go
@@ -35,7 +35,8 @@ func NewKeysRegistrationHelper(dbHandler *database.Handler, log logger.Handler) 
 	return krh, err
 }
 
-// returns the spreadsheet column index that captures whether the key should be registered.
+// GetIndexForRegisterCol returns the spreadsheet column index that captures whether the
+// key should be registered, or -1 if the column is absent.
 func (kh *KeysRegistrationHelper) GetIndexForRegisterCol(cols []string) int {
 	if shouldRegisterColIndex != -1 {
 		return shouldRegisterColIndex

--- a/server/models/meshery_filter.go
+++ b/server/models/meshery_filter.go
@@ -56,7 +56,7 @@ type MesheryCatalogFilterRequestBody struct {
 	CatalogData sql.Map   `json:"catalogData,omitempty"`
 }
 
-// MesheryCatalogFilterRequestBody refers to the type of request body
+// MesheryCloneFilterRequestBody refers to the type of request body
 // that CloneMesheryFilterHandler would receive
 type MesheryCloneFilterRequestBody struct {
 	Name string `json:"name,omitempty"`

--- a/server/models/meshmodel/core/register.go
+++ b/server/models/meshmodel/core/register.go
@@ -151,7 +151,9 @@ func mergeAllAPIResults(content []byte, cli *kubernetes.Client) [][]byte {
 	return m
 }
 
-// move to meshmodel
+// GetK8sMeshModelComponents fetches Kubernetes CRDs and OpenAPI definitions using the given kubeconfig and converts them into MeshModel component definitions.
+//
+// TODO: move to meshmodel
 func GetK8sMeshModelComponents(kubeconfig []byte) ([]component.ComponentDefinition, error) {
 	cli, err := kubernetes.New(kubeconfig)
 	if err != nil {

--- a/server/models/meshsync_register_queue.go
+++ b/server/models/meshsync_register_queue.go
@@ -11,8 +11,12 @@ var (
 	registrationQueue *MeshSyncRegistrationQueue
 )
 
-// Configure MeshSync to additionally publish the resources that can be registered as connection to other broker topic/subject (meshsync.registerconnection.queue?).
-// Meshery Server subscribes to that topic/subject and performs the necessary action.
+// MeshSyncRegistrationQueue holds a channel for queuing Kubernetes resources that are
+// eligible to be registered as Meshery connections.
+//
+// TODO: MeshSync additionally publishes these resources to a broker topic/subject
+// (meshsync.registerconnection.queue?); Meshery Server subscribes and performs the
+// necessary action.
 type MeshSyncRegistrationQueue struct {
 	RegChan chan MeshSyncRegistrationData
 }

--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -124,8 +124,7 @@ func isSpecialKey(k string) bool {
 	return false
 }
 
-// Format is passed to the deprecated Prettify and DePrettify methods; both currently
-// return their input unchanged. In case of any breaking change or bug caused by this,
+// In case of any breaking change or bug caused by this,
 // set this to false and the whitespace addition in schema generated/consumed would be
 // removed (will go back to default behavior).
 const Format prettifier = true

--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -124,7 +124,10 @@ func isSpecialKey(k string) bool {
 	return false
 }
 
-// In case of any breaking change or bug caused by this, set this to false and the whitespace addition in schema generated/consumed would be removed(will go back to default behavior)
+// Format is passed to the deprecated Prettify and DePrettify methods; both currently
+// return their input unchanged. In case of any breaking change or bug caused by this,
+// set this to false and the whitespace addition in schema generated/consumed would be
+// removed (will go back to default behavior).
 const Format prettifier = true
 
 type DryRunResponseWrapper struct {

--- a/server/models/pattern/jsonschema/json.go
+++ b/server/models/pattern/jsonschema/json.go
@@ -9,6 +9,7 @@ import (
 
 var JSONSchema = &Schema{}
 
+// GlobalJSONSchema returns the package's shared Schema instance.
 // This approach is bad, and we are not the ones implementing this. The qri-io/jsonschema internally is creating a global instance of Schema.
 // Hence for concurrent operations, we have to make sure that the package qri-io/jsonschema is accessed in a thread-safe way.
 // So use this Global instance for now.
@@ -21,6 +22,7 @@ type Schema struct {
 	Lock sync.Mutex
 }
 
+// ValidateBytes validates data against the schema while holding the schema instance's lock.
 // JsonSchema package creates a global instance(without any locks) of Schema struct which panics when concurrent routines try to call ValidateBytes.
 // So this package creates a thin shim to avoid internal concurrent map writes
 func (s *Schema) ValidateBytes(ctx context.Context, data []byte) ([]jsonschema.KeyError, error) {

--- a/server/models/pattern/patterns/application/argo/v1alpha1/analysis_types.go
+++ b/server/models/pattern/patterns/application/argo/v1alpha1/analysis_types.go
@@ -17,7 +17,7 @@ type ClusterAnalysisTemplate struct {
 	Spec AnalysisTemplateSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 }
 
-// AnalysisTemplateList is a list of AnalysisTemplate resources
+// ClusterAnalysisTemplateList is a list of ClusterAnalysisTemplate resources
 type ClusterAnalysisTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`

--- a/server/models/pattern/stages/dry_run.go
+++ b/server/models/pattern/stages/dry_run.go
@@ -4,6 +4,7 @@ package stages
 
 const DryRunResponseKey = "dryRunResponse"
 
+// DryRun returns the ChainStageFunction that performs the dry-run stage in the pattern processing chain.
 // There are two types of errors here:
 // 1. Error while performing the Dry Run (when the DryRun request could not be sent)
 // 2. Errors in Dry Run (when the Dry Run request was performed successfully but there are errors in the Object sent for DryRun)

--- a/server/models/pattern/utils/k8s.go
+++ b/server/models/pattern/utils/k8s.go
@@ -141,7 +141,7 @@ func CreateK8sResource(
 	return nil
 }
 
-// DeleteK8sResouce deletes the given kubernetes resource
+// DeleteK8sResource deletes the given kubernetes resource
 func DeleteK8sResource(
 	client dynamic.Interface,
 	group,

--- a/server/models/preference.go
+++ b/server/models/preference.go
@@ -30,7 +30,7 @@ type LoadTestPreferences struct {
 	LoadGenerator      string `json:"gen,omitempty"`
 }
 
-// Parameters to updates Anonymous stats
+// PreferenceParams holds the parameters used to update anonymous usage stats.
 type PreferenceParams struct {
 	AnonymousUsageStats  bool `json:"anonymousUsageStats"`
 	AnonymousPerfResults bool `json:"anonymousPerfResults"`

--- a/server/models/preference_persister.go
+++ b/server/models/preference_persister.go
@@ -9,7 +9,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// PreferencePersister assists with persisting session in store
+// SessionPreferencePersister assists with persisting session in store.
 type SessionPreferencePersister struct {
 	DB *database.Handler
 }

--- a/server/models/seed_models_logs.go
+++ b/server/models/seed_models_logs.go
@@ -17,7 +17,7 @@ import (
 
 var TAB = "    "
 
-// representation of what could not be registered
+// RegistrationFailureLog represents what could not be registered.
 type RegistrationFailureLog struct {
 	// {'artifacthub':{'modelname': 'component' : {'jaegar': error}}}
 	// for models, the structure will be like this:


### PR DESCRIPTION
Consolidates #21580, #21588, #21613, #21614, #21615, #21616 and #21617 into one PR via cherry-pick, per feedback on #21615 that seven separate batch PRs for one kind of fix was too much noise. Sorry about that, and thanks for the nudge. Those seven PRs are now closed in favor of this one; nothing else changed about their content.

Together with #21549 and #21554 (already merged), this closes out every `staticcheck -checks="ST1020,ST1021,ST1022" ./...` hit in the repo (91 when this cleanup started). All 42 file changes here are comment-text-only, no behavior changes.

## What changed, by package

- **server/handlers** (13 files): two comments were copy-pasted from a real, different, more complex sibling function and described the wrong behavior entirely (`DesignFileRequestHandlerWithSourceType` had `PatternFileRequestHandler`'s route/verbs; `AvailableAdaptersHandler` had `AdaptersHandler`'s query-parsing description). One `ExtensionsHandler` comment was a javadoc-style `/* */` block whose first real line was blank, so Go's doc-comment parser never associated it with the function. One constant sat directly under a section-header comment with no blank line, so the header was read as its doc comment instead. The rest just never named the symbol they documented.
- **server/machines** (5 files, `machines/` and `machines/kubernetes/`): `ConnectAction`, `DiscoverAction` and `RegisterAction` all carried the exact same leftover design note on `ExecuteOnEntry` ("Execute On Entry and Exit should not return next eventtype i suppose, look again"), which is a design question, not a description. Read each implementation: all three are unconditional no-ops, with the real work in `Execute`. Added a real first line to each describing that, kept the original note as a second line rather than deleting it.
- **mesheryctl** (6 files across `cli/pkg/api` and `cli/root/{adapter,config,registry,system}`): `RegistryCmd` carried `publishCmd`'s comment verbatim (a different, real command a few lines over in the same package). `ErrGettingSessionData` was documented as being about "release data" when its own error messages and the helper it wraps are both about session data.
- **server/models** (7 files, direct package): `MesheryCloneFilterRequestBody` carried `MesheryCatalogFilterRequestBody`'s comment (a different, real type a few lines above it), though the sentence itself was already accurate for the type it now documents. `SessionPreferencePersister` was documented under the name of the `PreferencePersister` interface it implements, not its own name.
- **server/models/pattern** (5 files across `core`, `jsonschema`, `patterns/application/argo/v1alpha1`, `stages`, `utils`): `ClusterAnalysisTemplateList` (Argo Rollouts analysis types) carried its non-cluster-scoped sibling `AnalysisTemplateList`'s comment verbatim. `DeleteK8sResource` already tried to name itself but misspelled it (`DeleteK8sResouce`).
- **6 more files** (`server/extensions`, `server/helpers`, `server/helpers/utils`, `server/internal/graphql/model`, `server/models/connections`, `server/models/meshmodel/core`): `DeployAdapter`/`UndeployAdapter` each carried their simpler sibling's comment (`AddAdapter`/`RemoveAdapter`, "adds/removes from the collection") when both actually talk to Docker or Kubernetes and only touch the collection as a last step. `SetOverrideValues` had an accurate description separated from the function by a blank line, so only a trailing "to be depricated" fragment counted as its doc comment; removed the blank line and fixed two typos already in the text. `Router` had no description at all; traced its one real usage to write one.

Two things flagged rather than decided unilaterally, both still open as of this PR:
- `FormatErrorReference` (mesheryctl) branches on a `cmdType` variable that is declared but never assigned anywhere in its package, so the switch always falls through to the general URL; separately, its `"config"` case returns the `"/context"` URL instead of `"/config"` (every other case matches its own name). Documented the current fallback behavior accurately; did not touch the dead code or the mismatched case, since reviving or removing that is a design call.
- `GetK8sMeshModelComponents`'s only comment was `// move to meshmodel`, but the file already lives at `server/models/meshmodel/core/register.go`, so the TODO may already be satisfied. Kept it rather than deleting information that might still be relevant.

## Addressed in revision (2026-08-31)

Per review feedback, the following were corrected in the squashed commit:

- **Accuracy**: `MeshSyncRegistrationQueue` comment said "configures MeshSync" when the type is a channel wrapper; rewritten to describe what it holds and moved the design note to `TODO:`.
- **Accuracy**: `ResetEndpoints` said "discards the current endpoint" when it discards every tracked endpoint absent from the set; corrected.
- **Accuracy**: `Format` constant said "controls whitespace addition" but `Prettify` returns its input unchanged (deprecated); rewritten to reflect the current no-op behavior.
- **Accuracy**: `GetIndexForRegisterCol` did not mention the -1 return when the column is absent; added.
- **Accuracy**: `GetContext` said "returns contents of" when it validates and returns a pointer; corrected.
- **Accuracy**: `MAX_RE_EVALUATION_DEPTH` comment omitted the `evalIterations == i+1` stop condition and was a 243-char single line; rewritten and wrapped. `EvaluateDesign`'s `evalIterations` note said "num of passes the evaluator needs to go through" when it is an upper bound; corrected.
- **Consistency**: Design note on `ExecuteOnEntry` in `connect.go`, `discover.go`, `register.go` was appended as a bare second line; moved to a `TODO:` under a blank comment line to match the pattern already established in `helpers.go` and `meshmodel/core/register.go`.
- **Consistency**: `DefaultPageSizeForMeshModelComponents` comment used `MeshModel` in prose where the rest of the file uses `Meshmodel`; corrected. Terminal periods made consistent across the three new comments in `component_handler.go`.
- **Consistency**: `GetRefURL` comment used "post authentication" (unhyphenated); corrected to "post-authentication".

## Verification

- `staticcheck -checks="ST1020,ST1021,ST1022" ./...`: 0 hits left in the repo.
- `go build ./...`: clean.
- `go vet ./...`: clean.
- `go test --short` across every touched package: all passing except two packages (`server/handlers`, `server/models/pattern/stages`) with pre-existing failures on this machine, all sharing the identical root cause `Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work`, an environment limitation unrelated to any of these changes (every file touched here has comment-only diffs, confirmed above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error responses when registry log flushing fails, returning a structured server error instead of an incorrect client error.

- **Documentation**
  - Clarified API behavior, JSON request formats, error handling, connection filtering, pagination, design evaluation, and adapter lifecycle operations.
  - Improved terminology across command-line, server, Kubernetes, MeshModel, pattern, and preference documentation.
  - Corrected outdated references, typos, and descriptions for greater accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->