### PR TITLE
[Models] Add ElastiCache SecurityGroup relationships

### DIFF
--- a/models/aws-elasticache-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-firewall-securitygroup.json
+++ b/models/aws-elasticache-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-firewall-securitygroup.json
@@ -1,0 +1,240 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "Firewall relationship between ElastiCache resources and SecurityGroup",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.8.0"
+    },
+    "name": "aws-elasticache-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "CacheCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ReplicationGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    },
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ServerlessCache",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "securityGroupRefs",
+                  "0",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticache-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-firewall-securitygroup.json
+++ b/models/aws-elasticache-controller/v1.8.0/v1.0.0/relationships/edge-non-binding-firewall-securitygroup.json
@@ -79,7 +79,7 @@
                   "configuration",
                   "spec",
                   "securityGroupRefs",
-                  "0",
+                  "-",
                   "from",
                   "name"
                 ]
@@ -148,7 +148,7 @@
                   "configuration",
                   "spec",
                   "securityGroupRefs",
-                  "0",
+                  "-",
                   "from",
                   "name"
                 ]
@@ -217,7 +217,7 @@
                   "configuration",
                   "spec",
                   "securityGroupRefs",
-                  "0",
+                  "-",
                   "from",
                   "name"
                 ]
@@ -233,7 +233,7 @@
       }
     }
   ],
-  "subType": "reference",
+  "subType": "firewall",
   "status": "enabled",
   "type": "non-binding",
   "version": "v1.0.0"


### PR DESCRIPTION
## Notes for Reviewers

This PR fixes #21307.

### Description

Adds the missing non-binding reference relationships from `SecurityGroup` to the following ElastiCache resources in `aws-elasticache-controller` v1.8.0:

- `SecurityGroup → CacheCluster`
- `SecurityGroup → ReplicationGroup`
- `SecurityGroup → ServerlessCache`

The relationships use the existing ACK `spec.securityGroupRefs` field.

### Testing

- JSON validation passed.
- `mesheryctl model build aws-elasticache-controller/v1.8.0 --path ./models` passed.
- Local model import recognizes all three relationships.
- Policy conformance tests passed:
  `go test -v ./server/policies/...`
- Updated the array path to use evaluator-supported array path syntax.
- Local design evaluation successfully identifies and applies all three cross-model SecurityGroup relationships.

### Kanvas Verification

The relationships were verified in Kanvas using the following test design:

[Kanvas test design](https://playground.meshery.io/extension/meshmap?mode=design&design=adaa9813-a4d4-44a6-a4f2-e06011dbaded)

The resulting SecurityGroup relationships are visible in the Kanvas design.

[Video demonstration](https://github.com/user-attachments/assets/c435defc-7371-4977-ace9-949f4f8fb387)


### Signed commits

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relationship visibility between EC2 security groups and ElastiCache cache clusters, replication groups, and serverless caches.
  * Enabled security group references to be reflected across supported ElastiCache resources.
  * Security group associations now appear consistently across supported cache configurations, improving visibility and configuration management.
  * These relationships are informational and do not automatically bind or modify firewall security groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->