### PR TITLE
[Docs] Add copy button to mesheryctl command reference code blocks

### DIFF
--- a/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
@@ -14,8 +14,7 @@ Deploy infrastructure to the Kubernetes cluster
 Deploy infrastructure to the connected Kubernetes cluster
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter deploy [flags]
-
+<code class='clipboardjs'>mesheryctl adapter deploy [flags]</code>
 </div>
 </pre> 
 
@@ -24,39 +23,28 @@ mesheryctl adapter deploy [flags]
 Deploy a infrastructure from an interactive on the default namespace
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter deploy
-
+<code class='clipboardjs'>mesheryctl adapter deploy</code>
 </div>
 </pre> 
 
 Deploy infrastructure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter deploy linkerd
-
+<code class='clipboardjs'>mesheryctl adapter deploy linkerd</code>
 </div>
 </pre> 
 
 Deploy Linkerd mesh on a specific namespace
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter deploy linkerd --namespace linkerd-ns
-
+<code class='clipboardjs'>mesheryctl adapter deploy linkerd --namespace linkerd-ns</code>
 </div>
 </pre> 
 
 Deploy Linkerd mesh and wait for it to be deployed
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter deploy linkerd --watch
-
-</div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-		
-
+<code class='clipboardjs'>mesheryctl adapter deploy linkerd --watch</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/adapter/remove.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/remove.md
@@ -14,8 +14,7 @@ remove cloud and cloud native infrastructure
 remove cloud and cloud native infrastructure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter remove [flags]
-
+<code class='clipboardjs'>mesheryctl adapter remove [flags]</code>
 </div>
 </pre> 
 
@@ -24,23 +23,14 @@ mesheryctl adapter remove [flags]
 Remove Linkerd deployment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter remove linkerd
-
+<code class='clipboardjs'>mesheryctl adapter remove linkerd</code>
 </div>
 </pre> 
 
 Remove a Linkerd control plane found under a specific namespace (linkerd-ns)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter remove linkerd --namespace linkerd-ns
-
-</div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-		
-
+<code class='clipboardjs'>mesheryctl adapter remove linkerd --namespace linkerd-ns</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/adapter/validate.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/validate.md
@@ -14,8 +14,7 @@ Validate conformance to predefined standards
 Validate predefined conformance to different standard specifications
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter validate [flags]
-
+<code class='clipboardjs'>mesheryctl adapter validate [flags]</code>
 </div>
 </pre> 
 
@@ -24,16 +23,14 @@ mesheryctl adapter validate [flags]
 Validate conformance to predefined standards
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter validate [mesh name] --adapter [name of the adapter] --tokenPath [path to token for authentication] --spec [specification to be used for conformance test] --namespace [namespace to be used]
-
+<code class='clipboardjs'>mesheryctl adapter validate [mesh name] --adapter [name of the adapter] --tokenPath [path to token for authentication] --spec [specification to be used for conformance test] --namespace [namespace to be used]</code>
 </div>
 </pre> 
 
 Validate Istio to predefined standards
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl adapter validate istio --adapter meshery-istio --spec smi
-
+<code class='clipboardjs'>mesheryctl adapter validate istio --adapter meshery-istio --spec smi</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/completion.md
+++ b/docs/content/en/reference/references/mesheryctl/completion.md
@@ -14,8 +14,7 @@ Generate shell completion scripts
 Output shell completion code
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion [bash|zsh|fish]
-
+<code class='clipboardjs'>mesheryctl completion [bash|zsh|fish]</code>
 </div>
 </pre> 
 
@@ -24,8 +23,7 @@ mesheryctl completion [bash|zsh|fish]
 ### bash <= 3.2
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-source /dev/stdin <<< "$(mesheryctl completion bash)"
-
+<code class='clipboardjs'>source /dev/stdin &lt;&lt;&lt; "$(mesheryctl completion bash)"</code>
 </div>
 </pre> 
 
@@ -33,38 +31,33 @@ bash <= 3.2 on osx
 ensure you have bash-completion 1.3+
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-brew install bash-completion 
-
+<code class='clipboardjs'>brew install bash-completion </code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion bash > $(brew --prefix)/etc/bash_completion.d/mesheryctl
-
+<code class='clipboardjs'>mesheryctl completion bash &gt; $(brew --prefix)/etc/bash_completion.d/mesheryctl</code>
 </div>
 </pre> 
 
 ### bash >= 4.0
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-source <(mesheryctl completion bash)
-
+<code class='clipboardjs'>source &lt;(mesheryctl completion bash)</code>
 </div>
 </pre> 
 
 bash >= 4.0 on osx
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-brew install bash-completion@2
-
+<code class='clipboardjs'>brew install bash-completion@2</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion bash > $(brew --prefix)/etc/bash_completion.d/mesheryctl
-
+<code class='clipboardjs'>mesheryctl completion bash &gt; $(brew --prefix)/etc/bash_completion.d/mesheryctl</code>
 </div>
 </pre> 
 
@@ -74,39 +67,34 @@ to enable it.  You can execute the following once:
 Might need to start a new shell for this setup to take effect.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-$ echo "autoload -U compinit; compinit" >> ~/.zshrc
-
+<code class='clipboardjs'>$ echo "autoload -U compinit; compinit" &gt;&gt; ~/.zshrc</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-source <(mesheryctl completion zsh)
-
+<code class='clipboardjs'>source &lt;(mesheryctl completion zsh)</code>
 </div>
 </pre> 
 
 zsh on osx / oh-my-zsh
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-COMPLETION_DIR=$(echo $fpath | grep -o '[^ ]*completions' | grep -v cache) && mkdir -p $COMPLETION_DIR && mesheryctl completion zsh > "${COMPLETION_DIR}/_mesheryctl"
-
+<code class='clipboardjs'>COMPLETION_DIR=$(echo $fpath | grep -o '[^ ]*completions' | grep -v cache) &amp;&amp; mkdir -p $COMPLETION_DIR &amp;&amp; mesheryctl completion zsh &gt; "${COMPLETION_DIR}/_mesheryctl"</code>
 </div>
 </pre> 
 
 ### fish:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion fish | source
-
+<code class='clipboardjs'>mesheryctl completion fish | source</code>
 </div>
 </pre> 
 
 To load fish shell completions for each session, execute once:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion fish > ~/.config/fish/completions/mesheryctl.fish
-
+<code class='clipboardjs'>mesheryctl completion fish &gt; ~/.config/fish/completions/mesheryctl.fish</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/component/_index.md
@@ -15,8 +15,7 @@ List, search and view component(s) and detailed informations
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component [flags]
-
+<code class='clipboardjs'>mesheryctl component [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl component [flags]
 Display number of available components in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component --count
-
+<code class='clipboardjs'>mesheryctl component --count</code>
 </div>
 </pre> 
 
 List available component(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component list
-
+<code class='clipboardjs'>mesheryctl component list</code>
 </div>
 </pre> 
 
 Search for component(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component search [component-name]
-
+<code class='clipboardjs'>mesheryctl component search [component-name]</code>
 </div>
 </pre> 
 
 View a specific component
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component view [component-name | component-id]
-
+<code class='clipboardjs'>mesheryctl component view [component-name | component-id]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/list.md
+++ b/docs/content/en/reference/references/mesheryctl/component/list.md
@@ -15,8 +15,7 @@ List all components registered in Meshery Server
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component list [flags]
-
+<code class='clipboardjs'>mesheryctl component list [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl component list [flags]
 View list of components
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component list
-
+<code class='clipboardjs'>mesheryctl component list</code>
 </div>
 </pre> 
 
 View list of components with specified page number (10 components per page)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component list --page [page-number]
-
+<code class='clipboardjs'>mesheryctl component list --page [page-number]</code>
 </div>
 </pre> 
 
 View list of components with specified page number with specified number of components per page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component list --page [page-number] --pagesize [page-size]
-
+<code class='clipboardjs'>mesheryctl component list --page [page-number] --pagesize [page-size]</code>
 </div>
 </pre> 
 
 Display the number of components present in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component list --count
-
+<code class='clipboardjs'>mesheryctl component list --count</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/search.md
+++ b/docs/content/en/reference/references/mesheryctl/component/search.md
@@ -15,8 +15,7 @@ Search components registered in Meshery Server based on kind
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component search [flags]
-
+<code class='clipboardjs'>mesheryctl component search [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl component search [flags]
 Search for components using a query
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component search [query-text]
-
+<code class='clipboardjs'>mesheryctl component search [query-text]</code>
 </div>
 </pre> 
 
 Search for multi-word component names (must be quoted)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component search "Component name"
-
+<code class='clipboardjs'>mesheryctl component search "Component name"</code>
 </div>
 </pre> 
 
 Search list of components of specified page [int]
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component search [query-text] [--page 1]
-
+<code class='clipboardjs'>mesheryctl component search [query-text] [--page 1]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/view.md
+++ b/docs/content/en/reference/references/mesheryctl/component/view.md
@@ -15,8 +15,7 @@ View a component registered in Meshery Server
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component view [flags]
-
+<code class='clipboardjs'>mesheryctl component view [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl component view [flags]
 View details of a specific component
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component view [component-name | component-id]
-
+<code class='clipboardjs'>mesheryctl component view [component-name | component-id]</code>
 </div>
 </pre> 
 
 View details of a specific component in specified format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component view [component-name | component-id] -o [json|yaml]
-
+<code class='clipboardjs'>mesheryctl component view [component-name | component-id] -o [json|yaml]</code>
 </div>
 </pre> 
 
 View details of a specific component in specified format and save it as a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl component view [component-name | component-id] -o [json|yaml] --save
-
+<code class='clipboardjs'>mesheryctl component view [component-name | component-id] -o [json|yaml] --save</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/_index.md
@@ -15,8 +15,7 @@ View and manage your Meshery connection.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection [flags]
-
+<code class='clipboardjs'>mesheryctl connection [flags]</code>
 </div>
 </pre> 
 
@@ -25,60 +24,52 @@ mesheryctl connection [flags]
 Display total count of all available connections
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection --count
-
+<code class='clipboardjs'>mesheryctl connection --count</code>
 </div>
 </pre> 
 
 Create a new Kubernetes connection using a specific type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type aks
-
+<code class='clipboardjs'>mesheryctl connection create --type aks</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type eks
-
+<code class='clipboardjs'>mesheryctl connection create --type eks</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type gke
-
+<code class='clipboardjs'>mesheryctl connection create --type gke</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type minikube
-
+<code class='clipboardjs'>mesheryctl connection create --type minikube</code>
 </div>
 </pre> 
 
 List all the connection
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list
-
+<code class='clipboardjs'>mesheryctl connection list</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list --count
-
+<code class='clipboardjs'>mesheryctl connection list --count</code>
 </div>
 </pre> 
 
 Delete a connection
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection delete [connection_id]
-
+<code class='clipboardjs'>mesheryctl connection delete [connection_id]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/create.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/create.md
@@ -15,8 +15,7 @@ Create a new connection to a Kubernetes cluster or other supported platform.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create [flags]
-
+<code class='clipboardjs'>mesheryctl connection create [flags]</code>
 </div>
 </pre> 
 
@@ -25,37 +24,32 @@ mesheryctl connection create [flags]
 Create a new Kubernetes connection using a specific type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type aks
-
+<code class='clipboardjs'>mesheryctl connection create --type aks</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type eks
-
+<code class='clipboardjs'>mesheryctl connection create --type eks</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type gke
-
+<code class='clipboardjs'>mesheryctl connection create --type gke</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type minikube
-
+<code class='clipboardjs'>mesheryctl connection create --type minikube</code>
 </div>
 </pre> 
 
 Create a connection with a token
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection create --type gke --token auth.json
-
+<code class='clipboardjs'>mesheryctl connection create --type gke --token auth.json</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/delete.md
@@ -15,8 +15,7 @@ Delete a connection.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection delete [flags]
-
+<code class='clipboardjs'>mesheryctl connection delete [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl connection delete [flags]
 Delete a connection
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection delete [connection_id]
-
+<code class='clipboardjs'>mesheryctl connection delete [connection_id]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/list.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/list.md
@@ -15,8 +15,7 @@ List all available connections.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list [flags]
-
+<code class='clipboardjs'>mesheryctl connection list [flags]</code>
 </div>
 </pre> 
 
@@ -25,40 +24,35 @@ mesheryctl connection list [flags]
 List all the connections
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list
-
+<code class='clipboardjs'>mesheryctl connection list</code>
 </div>
 </pre> 
 
 List all the connections with page number
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list --page [page-number]
-
+<code class='clipboardjs'>mesheryctl connection list --page [page-number]</code>
 </div>
 </pre> 
 
 List all the connections matching a specific kind and status
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list --kind [kind] --status [status]
-
+<code class='clipboardjs'>mesheryctl connection list --kind [kind] --status [status]</code>
 </div>
 </pre> 
 
 List all the connections matching a set of kinds and statuses
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list --kind [kind] --kind [kind] --status [status] --status [status]
-
+<code class='clipboardjs'>mesheryctl connection list --kind [kind] --kind [kind] --status [status] --status [status]</code>
 </div>
 </pre> 
 
 Display total count of all available connections
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection list --count
-
+<code class='clipboardjs'>mesheryctl connection list --count</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/view.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/view.md
@@ -15,8 +15,7 @@ View a connection by its ID or name.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection view [flags]
-
+<code class='clipboardjs'>mesheryctl connection view [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl connection view [flags]
 View details of a specific connection in default format (yaml)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection view [connection-name|connection-id]
-
+<code class='clipboardjs'>mesheryctl connection view [connection-name|connection-id]</code>
 </div>
 </pre> 
 
 View details of a specific connection in JSON format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection view [connection-name|connection-id] --output-format json
-
+<code class='clipboardjs'>mesheryctl connection view [connection-name|connection-id] --output-format json</code>
 </div>
 </pre> 
 
 View details of a specific connection in json format and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl connection view [connection-name|connection-id] --output-format json --save
-
+<code class='clipboardjs'>mesheryctl connection view [connection-name|connection-id] --output-format json --save</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/design/_index.md
@@ -15,8 +15,7 @@ Manage cloud and cloud native infrastructure using predefined designs.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design [flags]
-
+<code class='clipboardjs'>mesheryctl design [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl design [flags]
 Apply design file:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design apply --file [path to design file | URL of the file]
-
+<code class='clipboardjs'>mesheryctl design apply --file [path to design file | URL of the file]</code>
 </div>
 </pre> 
 
 Delete design file:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design delete --file [path to design file]
-
+<code class='clipboardjs'>mesheryctl design delete --file [path to design file]</code>
 </div>
 </pre> 
 
 View design file:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design view [design name | ID]
-
+<code class='clipboardjs'>mesheryctl design view [design name | ID]</code>
 </div>
 </pre> 
 
 List all designs:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design list
-
+<code class='clipboardjs'>mesheryctl design list</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/design/apply.md
@@ -15,8 +15,7 @@ Apply design will trigger deploy of the design file.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design apply [flags]
-
+<code class='clipboardjs'>mesheryctl design apply [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl design apply [flags]
 apply a design file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design apply -f [file | URL]
-
+<code class='clipboardjs'>mesheryctl design apply -f [file | URL]</code>
 </div>
 </pre> 
 
 deploy a saved design
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design apply [design-name]
-
+<code class='clipboardjs'>mesheryctl design apply [design-name]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/design/delete.md
@@ -15,8 +15,7 @@ delete design file will trigger deletion of the design file.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design delete [flags]
-
+<code class='clipboardjs'>mesheryctl design delete [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl design delete [flags]
 delete a design file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design delete [file | URL]
-
+<code class='clipboardjs'>mesheryctl design delete [file | URL]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/deploy.md
@@ -15,8 +15,7 @@ Command will trigger deploy of design.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design deploy [flags]
-
+<code class='clipboardjs'>mesheryctl design deploy [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl design deploy [flags]
 Deploy design by providing file path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design deploy -f [filepath] -s [source type]
-
+<code class='clipboardjs'>mesheryctl design deploy -f [filepath] -s [source type]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/evaluate.md
+++ b/docs/content/en/reference/references/mesheryctl/design/evaluate.md
@@ -16,8 +16,7 @@ The evaluated design is saved to the specified output file while an overview
 of evaluation actions is printed to the terminal.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design evaluate [ID] [flags]
-
+<code class='clipboardjs'>mesheryctl design evaluate [ID] [flags]</code>
 </div>
 </pre> 
 
@@ -26,24 +25,21 @@ mesheryctl design evaluate [ID] [flags]
 Evaluate a design from a file and save the result
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design evaluate -f design.yaml -o evaluated-design.yaml
-
+<code class='clipboardjs'>mesheryctl design evaluate -f design.yaml -o evaluated-design.yaml</code>
 </div>
 </pre> 
 
 Evaluate a design by ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design evaluate 12345678-abcd-efgh-ijkl-123456789012 -o result.yaml
-
+<code class='clipboardjs'>mesheryctl design evaluate 12345678-abcd-efgh-ijkl-123456789012 -o result.yaml</code>
 </div>
 </pre> 
 
 Evaluate and save as JSON
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design evaluate -f design.yaml --output-format json -o evaluated-design.json
-
+<code class='clipboardjs'>mesheryctl design evaluate -f design.yaml --output-format json -o evaluated-design.json</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/export.md
+++ b/docs/content/en/reference/references/mesheryctl/design/export.md
@@ -18,8 +18,7 @@ By default, the exported design will be saved in the current directory. The diff
 type allowed are oci, original, and current. The default design type is current.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design export [pattern-name | ID] [flags]
-
+<code class='clipboardjs'>mesheryctl design export [pattern-name | ID] [flags]</code>
 </div>
 </pre> 
 
@@ -28,32 +27,28 @@ mesheryctl design export [pattern-name | ID] [flags]
 Export a design with a specific ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design export [pattern-name | ID]
-
+<code class='clipboardjs'>mesheryctl design export [pattern-name | ID]</code>
 </div>
 </pre> 
 
 Export a design with a specific ID and type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design export [pattern-name | ID] --type [design-type]
-
+<code class='clipboardjs'>mesheryctl design export [pattern-name | ID] --type [design-type]</code>
 </div>
 </pre> 
 
 Export a design and save it to a specific directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design export [pattern-name | ID] --output ./designs
-
+<code class='clipboardjs'>mesheryctl design export [pattern-name | ID] --output ./designs</code>
 </div>
 </pre> 
 
 Export a design with a specific type and save it to a directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design export [pattern-name | ID] --type [design-type] --output ./exports
-
+<code class='clipboardjs'>mesheryctl design export [pattern-name | ID] --type [design-type] --output ./exports</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/import.md
+++ b/docs/content/en/reference/references/mesheryctl/design/import.md
@@ -22,8 +22,7 @@ Import a Meshery design
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design import [flags]
-
+<code class='clipboardjs'>mesheryctl design import [flags]</code>
 </div>
 </pre> 
 
@@ -32,29 +31,25 @@ mesheryctl design import [flags]
 Import design manifest
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design import -f [file/URL] -s [source-type] -n [name]
-
+<code class='clipboardjs'>mesheryctl design import -f [file/URL] -s [source-type] -n [name]</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design import -f design.tar
-
+<code class='clipboardjs'>mesheryctl design import -f design.tar</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design import -f design.yml -n design-name
-
+<code class='clipboardjs'>mesheryctl design import -f design.yml -n design-name</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name
-
+<code class='clipboardjs'>mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/list.md
+++ b/docs/content/en/reference/references/mesheryctl/design/list.md
@@ -15,8 +15,7 @@ Display list of all available designs.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design list [flags]
-
+<code class='clipboardjs'>mesheryctl design list [flags]</code>
 </div>
 </pre> 
 
@@ -25,40 +24,35 @@ mesheryctl design list [flags]
 Display a list of all available designs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design list
-
+<code class='clipboardjs'>mesheryctl design list</code>
 </div>
 </pre> 
 
 Display a list of all available designs with verbose output
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design list --verbose
-
+<code class='clipboardjs'>mesheryctl design list --verbose</code>
 </div>
 </pre> 
 
 Display a list of all available designs with specified page number (10 designs per page by default)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design list --page [pange-number]
-
+<code class='clipboardjs'>mesheryctl design list --page [pange-number]</code>
 </div>
 </pre> 
 
 Display a list of all available designs with custom page size (10 designs per page by default)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design list --pagesize [page-size]
-
+<code class='clipboardjs'>mesheryctl design list --pagesize [page-size]</code>
 </div>
 </pre> 
 
 Display only the count of all available designs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design list --count
-
+<code class='clipboardjs'>mesheryctl design list --count</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/undeploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/undeploy.md
@@ -15,8 +15,7 @@ Undeploy design will trigger undeploy of design.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design undeploy [flags]
-
+<code class='clipboardjs'>mesheryctl design undeploy [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl design undeploy [flags]
 Undeploy design by providing file path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design undeploy -f [filepath]
-
+<code class='clipboardjs'>mesheryctl design undeploy -f [filepath]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/view.md
+++ b/docs/content/en/reference/references/mesheryctl/design/view.md
@@ -15,8 +15,7 @@ Display the content of a specific design based on name or id.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design view design name [flags]
-
+<code class='clipboardjs'>mesheryctl design view design name [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl design view design name [flags]
 view a design
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl design view [design-name | ID]
-
+<code class='clipboardjs'>mesheryctl design view [design-name | ID]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/_index.md
@@ -15,8 +15,7 @@ Create, delete, list of view details of environment(s) of a specific organizatio
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment [flags]
-
+<code class='clipboardjs'>mesheryctl environment [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl environment [flags]
 Create an environment in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment create --orgId [orgId] --name [name] --description [description]
-
+<code class='clipboardjs'>mesheryctl environment create --orgId [orgId] --name [name] --description [description]</code>
 </div>
 </pre> 
 
 Delete an environment in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment delete environment-id
-
+<code class='clipboardjs'>mesheryctl environment delete environment-id</code>
 </div>
 </pre> 
 
 List of registered environments in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment list --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl environment list --orgId [orgId]</code>
 </div>
 </pre> 
 
 View a particular environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment view --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl environment view --orgId [orgId]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/create.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/create.md
@@ -15,8 +15,7 @@ Create a new environment by providing the name and description of the environmen
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment create [flags]
-
+<code class='clipboardjs'>mesheryctl environment create [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl environment create [flags]
 Create a new environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment create --orgId [orgId] --name [name] --description [description]
-
+<code class='clipboardjs'>mesheryctl environment create --orgId [orgId] --name [name] --description [description]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/delete.md
@@ -15,8 +15,7 @@ Delete an environment by providing the environment ID
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment delete [flags]
-
+<code class='clipboardjs'>mesheryctl environment delete [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl environment delete [flags]
 delete a new environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment delete [environmentId]
-
+<code class='clipboardjs'>mesheryctl environment delete [environmentId]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/list.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/list.md
@@ -15,8 +15,7 @@ List detailed information of all registered environments
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment list [flags]
-
+<code class='clipboardjs'>mesheryctl environment list [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl environment list [flags]
 List all registered environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment list --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl environment list --orgId [orgId]</code>
 </div>
 </pre> 
 
 List count of all registered environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment list --orgId [orgId] --count
-
+<code class='clipboardjs'>mesheryctl environment list --orgId [orgId] --count</code>
 </div>
 </pre> 
 
 List all registered environment at a specific page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment list --orgId [orgId] --page [page]
-
+<code class='clipboardjs'>mesheryctl environment list --orgId [orgId] --page [page]</code>
 </div>
 </pre> 
 
 List all registered environment with a specific page size
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment list --orgId [orgId] --pagesize [pagesize]
-
+<code class='clipboardjs'>mesheryctl environment list --orgId [orgId] --pagesize [pagesize]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/view.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/view.md
@@ -15,8 +15,7 @@ View details of an environment registered in Meshery Server for a specific organ
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment view [flags]
-
+<code class='clipboardjs'>mesheryctl environment view [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl environment view [flags]
 View details of a specific environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl environment view --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl environment view --orgId [orgId]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/exp.md
+++ b/docs/content/en/reference/references/mesheryctl/exp.md
@@ -14,8 +14,7 @@ Preview experimental commands
 Commands under the Experimental group are for testing and evaluation prior to promotion to general availability. Experimental commands are subject to change.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl exp [flags]
-
+<code class='clipboardjs'>mesheryctl exp [flags]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/_index.md
@@ -15,8 +15,7 @@ Cloud Native Filter Management
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter [flags]
-
+<code class='clipboardjs'>mesheryctl filter [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl filter [flags]
 Base command for WASM filters:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter [subcommands]
-
+<code class='clipboardjs'>mesheryctl filter [subcommands]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/delete.md
@@ -15,8 +15,7 @@ Delete a filter file using the name or ID of a filter.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter delete [filter-name | ID] [flags]
-
+<code class='clipboardjs'>mesheryctl filter delete [filter-name | ID] [flags]</code>
 </div>
 </pre> 
 
@@ -26,8 +25,7 @@ Delete the specified WASM filter file using name or ID
 A unique prefix of the name or ID can also be provided. If the prefix is not unique, the first match will be deleted.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter delete [filter-name | ID]
-
+<code class='clipboardjs'>mesheryctl filter delete [filter-name | ID]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/import.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/import.md
@@ -15,8 +15,7 @@ Import a WASM filter from a URI (http/s) or local filesystem path.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter import [URI] [flags]
-
+<code class='clipboardjs'>mesheryctl filter import [URI] [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl filter import [URI] [flags]
 Import a filter file from local filesystem
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter import /path/to/filter.wasm
-
+<code class='clipboardjs'>mesheryctl filter import /path/to/filter.wasm</code>
 </div>
 </pre> 
 
 Import a filter file from a remote URI
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter import https://example.com/myfilter.wasm
-
+<code class='clipboardjs'>mesheryctl filter import https://example.com/myfilter.wasm</code>
 </div>
 </pre> 
 
@@ -43,16 +40,14 @@ If the string is a valid file in the filesystem, the file is read and passed as 
 Use quotes if the string contains spaces
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter import /path/to/filter.wasm --wasm-config [filepath|string]
-
+<code class='clipboardjs'>mesheryctl filter import /path/to/filter.wasm --wasm-config [filepath|string]</code>
 </div>
 </pre> 
 
 Specify the name of the filter to be imported. Use quotes if the name contains spaces
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter import /path/to/filter.wasm --name [string]
-
+<code class='clipboardjs'>mesheryctl filter import /path/to/filter.wasm --name [string]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/list.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/list.md
@@ -15,8 +15,7 @@ Display list of all available filter files.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter list [flags]
-
+<code class='clipboardjs'>mesheryctl filter list [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl filter list [flags]
 List all WASM filter files present
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter list	(maximum 25 filters)
-
+<code class='clipboardjs'>mesheryctl filter list	(maximum 25 filters)</code>
 </div>
 </pre> 
 
 Search for filter
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter list Test (maximum 25 filters)
-
+<code class='clipboardjs'>mesheryctl filter list Test (maximum 25 filters)</code>
 </div>
 </pre> 
 
 Search for filter with space
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter list 'Test Filter' (maximum 25 filters)
-
+<code class='clipboardjs'>mesheryctl filter list 'Test Filter' (maximum 25 filters)</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/view.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/view.md
@@ -15,8 +15,7 @@ Displays the contents of a specific filter based on name or id.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter view [flags]
-
+<code class='clipboardjs'>mesheryctl filter view [flags]</code>
 </div>
 </pre> 
 
@@ -26,47 +25,35 @@ View the specified WASM filter
 A unique prefix of the name or ID can also be provided. If the prefix is not unique, the first match will be returned.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter view "[filter-name | ID]"
-
+<code class='clipboardjs'>mesheryctl filter view "[filter-name | ID]"</code>
 </div>
 </pre> 
 
 View all filter files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter view --all
-
+<code class='clipboardjs'>mesheryctl filter view --all</code>
 </div>
 </pre> 
 
 View all filter files in json
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter view --all --output-format json
-
+<code class='clipboardjs'>mesheryctl filter view --all --output-format json</code>
 </div>
 </pre> 
 
 View all filter files in json and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter view --all --output-format json -s
-
+<code class='clipboardjs'>mesheryctl filter view --all --output-format json -s</code>
 </div>
 </pre> 
 
 //View multi-word named filter files. Multi-word filter names should be enclosed in quotes
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl filter view "filter name"
-
-</div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-        
-
+<code class='clipboardjs'>mesheryctl filter view "filter name"</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/model/_index.md
@@ -15,8 +15,7 @@ Export, generate, import, list, search and view model(s) and detailed informatio
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model [flags]
-
+<code class='clipboardjs'>mesheryctl model [flags]</code>
 </div>
 </pre> 
 
@@ -25,95 +24,83 @@ mesheryctl model [flags]
 Display number of available models in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model --count
-
+<code class='clipboardjs'>mesheryctl model --count</code>
 </div>
 </pre> 
 
 Export registered models
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model export [model-name]
-
+<code class='clipboardjs'>mesheryctl model export [model-name]</code>
 </div>
 </pre> 
 
 Generate a model from a CSV directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model generate [path-to-csv-directory]
-
+<code class='clipboardjs'>mesheryctl model generate [path-to-csv-directory]</code>
 </div>
 </pre> 
 
 Generate a model from a URL based on a JSON template
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model generate --file [URL] --template [path-to-template.json]
-
+<code class='clipboardjs'>mesheryctl model generate --file [URL] --template [path-to-template.json]</code>
 </div>
 </pre> 
 
 Import model(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import -f [Uri]
-
+<code class='clipboardjs'>mesheryctl model import -f [Uri]</code>
 </div>
 </pre> 
 
 List available model(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model list
-
+<code class='clipboardjs'>mesheryctl model list</code>
 </div>
 </pre> 
 
 Delete available model(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model delete [model-id]
-
+<code class='clipboardjs'>mesheryctl model delete [model-id]</code>
 </div>
 </pre> 
 
 Search for a specific model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model search [model-name]
-
+<code class='clipboardjs'>mesheryctl model search [model-name]</code>
 </div>
 </pre> 
 
 View a specific model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model view [model-name]
-
+<code class='clipboardjs'>mesheryctl model view [model-name]</code>
 </div>
 </pre> 
 
 Scaffold a folder structure for model creation
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model init [model-name]
-
+<code class='clipboardjs'>mesheryctl model init [model-name]</code>
 </div>
 </pre> 
 
 Create an OCI-compliant package from the model files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model build [model-name]
-
+<code class='clipboardjs'>mesheryctl model build [model-name]</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model build [model-name]/[model-version]
-
+<code class='clipboardjs'>mesheryctl model build [model-name]/[model-version]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/build.md
+++ b/docs/content/en/reference/references/mesheryctl/model/build.md
@@ -17,8 +17,7 @@ Expects input to be in the format scaffolded by the model init command.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model build [flags]
-
+<code class='clipboardjs'>mesheryctl model build [flags]</code>
 </div>
 </pre> 
 
@@ -27,22 +26,13 @@ mesheryctl model build [flags]
 Create an OCI-compliant package from the model files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model build [model-name]
-
+<code class='clipboardjs'>mesheryctl model build [model-name]</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model build [model-name]/[model-version]
-
-</div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-    
-
+<code class='clipboardjs'>mesheryctl model build [model-name]/[model-version]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/model/delete.md
@@ -15,8 +15,7 @@ Delete a model by ID or Name
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model delete [model-id | model-name] [flags]
-
+<code class='clipboardjs'>mesheryctl model delete [model-id | model-name] [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl model delete [model-id | model-name] [flags]
 Delete a model by ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model delete [model-id]
-
+<code class='clipboardjs'>mesheryctl model delete [model-id]</code>
 </div>
 </pre> 
 
 Delete a model by name
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model delete [model-name]
-
+<code class='clipboardjs'>mesheryctl model delete [model-name]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/export.md
+++ b/docs/content/en/reference/references/mesheryctl/model/export.md
@@ -15,8 +15,7 @@ Export the registered model to the specified output type
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model export [flags]
-
+<code class='clipboardjs'>mesheryctl model export [flags]</code>
 </div>
 </pre> 
 
@@ -25,40 +24,35 @@ mesheryctl model export [flags]
 Export a model by name 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model export [model-name] -o [oci|tar]  (default is oci)
-
+<code class='clipboardjs'>mesheryctl model export [model-name] -o [oci|tar]  (default is oci)</code>
 </div>
 </pre> 
 
 Export a model by name in JSON type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model export [model-name] -t [yaml|json] (default is YAML)
-
+<code class='clipboardjs'>mesheryctl model export [model-name] -t [yaml|json] (default is YAML)</code>
 </div>
 </pre> 
 
 Export a model by name in YAML type in a specific location
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model export [model-name] -l [path-to-location]
-
+<code class='clipboardjs'>mesheryctl model export [model-name] -l [path-to-location]</code>
 </div>
 </pre> 
 
 Export a model by name in YAML type discarding components and relationships
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model export [model-name] --discard-components --discard-relationships
-
+<code class='clipboardjs'>mesheryctl model export [model-name] --discard-components --discard-relationships</code>
 </div>
 </pre> 
 
 Export a model version by name in YAML type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model export [model-name] --version [version (ex: v0.7.3)]
-
+<code class='clipboardjs'>mesheryctl model export [model-name] --version [version (ex: v0.7.3)]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/model/generate.md
@@ -15,8 +15,7 @@ Generate models by specifying the directory, file, or URL. You can also provide 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model generate [flags]
-
+<code class='clipboardjs'>mesheryctl model generate [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl model generate [flags]
 Generate a model from a CSV directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model generate -f [path-to-csv-directory]
-
+<code class='clipboardjs'>mesheryctl model generate -f [path-to-csv-directory]</code>
 </div>
 </pre> 
 
 Generate a model from a URL based on a JSON template
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model generate -f [URL] -t [path-to-template.json]
-
+<code class='clipboardjs'>mesheryctl model generate -f [URL] -t [path-to-template.json]</code>
 </div>
 </pre> 
 
 Generate a model from a URL based on a JSON template skipping registration
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model generate --file [URL] --template [path-to-template.json] --skip-registration
-
+<code class='clipboardjs'>mesheryctl model generate --file [URL] --template [path-to-template.json] --skip-registration</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/import.md
+++ b/docs/content/en/reference/references/mesheryctl/model/import.md
@@ -15,8 +15,7 @@ Import models by specifying the directory, file, or URL. You can also provide a 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import [flags]
-
+<code class='clipboardjs'>mesheryctl model import [flags]</code>
 </div>
 </pre> 
 
@@ -25,48 +24,42 @@ mesheryctl model import [flags]
 Import model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import --file [URI]
-
+<code class='clipboardjs'>mesheryctl model import --file [URI]</code>
 </div>
 </pre> 
 
 Import model from a URL to a meshery model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import --file [URL]
-
+<code class='clipboardjs'>mesheryctl model import --file [URL]</code>
 </div>
 </pre> 
 
 Import model from an OCI artifact
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import --file [OCI]
-
+<code class='clipboardjs'>mesheryctl model import --file [OCI]</code>
 </div>
 </pre> 
 
 Import model from a tar.gz file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import --file [path-to-model.tar.gz]
-
+<code class='clipboardjs'>mesheryctl model import --file [path-to-model.tar.gz]</code>
 </div>
 </pre> 
 
 Import model from a path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import --file [path-to-model]
-
+<code class='clipboardjs'>mesheryctl model import --file [path-to-model]</code>
 </div>
 </pre> 
 
 Import model using CSV files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model import --file [path-to-csv-directory]
-
+<code class='clipboardjs'>mesheryctl model import --file [path-to-csv-directory]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/init.md
+++ b/docs/content/en/reference/references/mesheryctl/model/init.md
@@ -15,8 +15,7 @@ Generates a folder structure and guides user on model creation
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model init [flags]
-
+<code class='clipboardjs'>mesheryctl model init [flags]</code>
 </div>
 </pre> 
 
@@ -25,39 +24,28 @@ mesheryctl model init [flags]
 generates a folder structure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model init [model-name]
-
+<code class='clipboardjs'>mesheryctl model init [model-name]</code>
 </div>
 </pre> 
 
 generates a folder structure and sets up model version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model init [model-name] --version [version] (default is v0.1.0)
-
+<code class='clipboardjs'>mesheryctl model init [model-name] --version [version] (default is v0.1.0)</code>
 </div>
 </pre> 
 
 generates a folder structure under specified path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model init [model-name] --path [path-to-location] (default is current folder)
-
+<code class='clipboardjs'>mesheryctl model init [model-name] --path [path-to-location] (default is current folder)</code>
 </div>
 </pre> 
 
 generate a folder structure in json format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model init [model-name] --output-format [json|yaml] (default is json)
-
-</div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-    
-
+<code class='clipboardjs'>mesheryctl model init [model-name] --output-format [json|yaml] (default is json)</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/list.md
+++ b/docs/content/en/reference/references/mesheryctl/model/list.md
@@ -15,8 +15,7 @@ List all registered models by pagination (10 models per page)
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model list [flags]
-
+<code class='clipboardjs'>mesheryctl model list [flags]</code>
 </div>
 </pre> 
 
@@ -25,31 +24,21 @@ mesheryctl model list [flags]
 List of models
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model list
-
+<code class='clipboardjs'>mesheryctl model list</code>
 </div>
 </pre> 
 
 List of models for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model list --page [page-number] --pagesize [pagesize]
-
+<code class='clipboardjs'>mesheryctl model list --page [page-number] --pagesize [pagesize]</code>
 </div>
 </pre> 
 
 Display number of available models in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model list --count
-
-</div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-    
-
+<code class='clipboardjs'>mesheryctl model list --count</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/search.md
+++ b/docs/content/en/reference/references/mesheryctl/model/search.md
@@ -15,8 +15,7 @@ Search model(s) by search string
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model search [flags]
-
+<code class='clipboardjs'>mesheryctl model search [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl model search [flags]
 Search model from current provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model search [query-text]
-
+<code class='clipboardjs'>mesheryctl model search [query-text]</code>
 </div>
 </pre> 
 
 Search list of models for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model search [query-text] --page [page-number]
-
+<code class='clipboardjs'>mesheryctl model search [query-text] --page [page-number]</code>
 </div>
 </pre> 
 
 Search list of models for a specified pagesize
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model search [query-text] --pagesize [pagesize-number]
-
+<code class='clipboardjs'>mesheryctl model search [query-text] --pagesize [pagesize-number]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/view.md
+++ b/docs/content/en/reference/references/mesheryctl/model/view.md
@@ -15,8 +15,7 @@ View a model queried by its name or ID
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model view [flags]
-
+<code class='clipboardjs'>mesheryctl model view [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl model view [flags]
 View a specific model from current provider by using [model-name] or [model-id] in default format yaml
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model view [model-name]
-
+<code class='clipboardjs'>mesheryctl model view [model-name]</code>
 </div>
 </pre> 
 
 View a specific model in specified format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model view [model-name] --output-format [json|yaml]
-
+<code class='clipboardjs'>mesheryctl model view [model-name] --output-format [json|yaml]</code>
 </div>
 </pre> 
 
 View a specific model in specified format and save it as a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl model view [model-name] --output-format [json|yaml] --save
-
+<code class='clipboardjs'>mesheryctl model view [model-name] --output-format [json|yaml] --save</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/organization/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/_index.md
@@ -15,8 +15,7 @@ Interact with registered organizations to display detailed information
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl organization [flags]
-
+<code class='clipboardjs'>mesheryctl organization [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl organization [flags]
 Number of  registered orgs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl organization --count
-
+<code class='clipboardjs'>mesheryctl organization --count</code>
 </div>
 </pre> 
 
 List registerd orgs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl organization list
-
+<code class='clipboardjs'>mesheryctl organization list</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/organization/list.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/list.md
@@ -15,8 +15,7 @@ List all registered organizations with their id, name and date of creation. Orga
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl organization list [flags]
-
+<code class='clipboardjs'>mesheryctl organization list [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl organization list [flags]
 list all organizations
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl organization list
-
+<code class='clipboardjs'>mesheryctl organization list</code>
 </div>
 </pre> 
 
 list organizations for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl organization list --page [page-number]
-
+<code class='clipboardjs'>mesheryctl organization list --page [page-number]</code>
 </div>
 </pre> 
 
 Display number of available organizations
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl organization list --count
-
+<code class='clipboardjs'>mesheryctl organization list --count</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/_index.md
@@ -15,8 +15,7 @@ Load generation and performance characterization
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf [flags]
-
+<code class='clipboardjs'>mesheryctl perf [flags]</code>
 </div>
 </pre> 
 
@@ -25,39 +24,34 @@ mesheryctl perf [flags]
 Run performance test:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply test-3 --name "a quick stress test" --url http://192.168.1.15/productpage --qps 300 --concurrent-requests 2 --duration 30s
-
+<code class='clipboardjs'>mesheryctl perf apply test-3 --name "a quick stress test" --url http://192.168.1.15/productpage --qps 300 --concurrent-requests 2 --duration 30s</code>
 </div>
 </pre> 
 
 List performance profiles:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf profile sam-test
-
+<code class='clipboardjs'>mesheryctl perf profile sam-test</code>
 </div>
 </pre> 
 
 List performance results:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf result sam-test
-
+<code class='clipboardjs'>mesheryctl perf result sam-test</code>
 </div>
 </pre> 
 
 Display Perf profile in JSON or YAML:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf result -o json
-
+<code class='clipboardjs'>mesheryctl perf result -o json</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf result -o yaml
-
+<code class='clipboardjs'>mesheryctl perf result -o yaml</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/apply.md
@@ -15,8 +15,7 @@ Run Performance test using existing profiles or using flags.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply [profile-name] [flags]
-
+<code class='clipboardjs'>mesheryctl perf apply [profile-name] [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl perf apply [profile-name] [flags]
 Execute a Performance test with the specified performance profile
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile [flags]
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile [flags]</code>
 </div>
 </pre> 
 
 Execute a Performance test with creating a new performance profile
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile-new --url "https://google.com"
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile-new --url "https://google.com"</code>
 </div>
 </pre> 
 
 Execute a Performance test creating a new performance profile and pass certificate to be used
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile-new --url "https://google.com" --cert-path path/to/cert.pem
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile-new --url "https://google.com" --cert-path path/to/cert.pem</code>
 </div>
 </pre> 
 
 Execute a performance profile without using the certificate present in the profile
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile --url "https://google.com" --disable-cert
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile --url "https://google.com" --disable-cert</code>
 </div>
 </pre> 
 
@@ -58,32 +53,28 @@ Run Performance test using SMP compatible test configuration
 If the profile already exists, the test will be run overriding the values with the ones provided in the configuration file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile -f path/to/perf-config.yaml
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile -f path/to/perf-config.yaml</code>
 </div>
 </pre> 
 
 Run performance test using SMP compatible test configuration and override values with flags
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile -f path/to/perf-config.yaml [flags]
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile -f path/to/perf-config.yaml [flags]</code>
 </div>
 </pre> 
 
 Execute a Performance test with specified queries per second
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile --url https://192.168.1.15/productpage --qps 30
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile --url https://192.168.1.15/productpage --qps 30</code>
 </div>
 </pre> 
 
 Execute a Performance test with specified infrastructure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile --url https://192.168.1.15/productpage --mesh istio
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile --url https://192.168.1.15/productpage --mesh istio</code>
 </div>
 </pre> 
 
@@ -92,22 +83,19 @@ If any options are already present in the profile or passed through flags, the -
 Options for fortio - https://github.com/fortio/fortio/blob/v1.57.0/fhttp/httprunner.go#L77-L84
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile-new --url "https://google.com" --options [filepath|json-string]
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile-new --url "https://google.com" --options [filepath|json-string]</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile-new --url "https://google.com" --options path/to/options.json
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile-new --url "https://google.com" --options path/to/options.json</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf apply meshery-profile-new --url "https://google.com" --load-generator fortio --options '{"MethodOverride": "POST"}'
-
+<code class='clipboardjs'>mesheryctl perf apply meshery-profile-new --url "https://google.com" --load-generator fortio --options '{"MethodOverride": "POST"}'</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/profile.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/profile.md
@@ -15,8 +15,7 @@ List all the available performance profiles.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf profile [profile-name] [flags]
-
+<code class='clipboardjs'>mesheryctl perf profile [profile-name] [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl perf profile [profile-name] [flags]
 List performance profiles (maximum 25 profiles)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf profile
-
+<code class='clipboardjs'>mesheryctl perf profile</code>
 </div>
 </pre> 
 
 List performance profiles with search (maximum 25 profiles)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf profile test 2
-
+<code class='clipboardjs'>mesheryctl perf profile test 2</code>
 </div>
 </pre> 
 
 View single performance profile with detailed information
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf profile test --view
-
+<code class='clipboardjs'>mesheryctl perf profile test --view</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/result.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/result.md
@@ -15,8 +15,7 @@ List all the available test results of a performance profile.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf result [profile-name] [flags]
-
+<code class='clipboardjs'>mesheryctl perf result [profile-name] [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl perf result [profile-name] [flags]
 List Test results (maximum 25 results)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf result saturday-profile
-
+<code class='clipboardjs'>mesheryctl perf result saturday-profile</code>
 </div>
 </pre> 
 
 View other set of performance results with --page (maximum 25 results)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf result saturday-profile --page 2
-
+<code class='clipboardjs'>mesheryctl perf result saturday-profile --page 2</code>
 </div>
 </pre> 
 
 View single performance result with detailed information
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl perf result saturday-profile --view
-
+<code class='clipboardjs'>mesheryctl perf result saturday-profile --view</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/_index.md
@@ -15,8 +15,7 @@ Manage the state and contents of Meshery’s internal registry of capabilities.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry [flags]
-
+<code class='clipboardjs'>mesheryctl registry [flags]</code>
 </div>
 </pre> 
 
@@ -24,8 +23,7 @@ mesheryctl registry [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry [subcommand]
-
+<code class='clipboardjs'>mesheryctl registry [subcommand]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/generate.md
@@ -15,8 +15,7 @@ Prerequisite: Execute this command from the root of a meshery/meshery repo fork.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate [flags]
-
+<code class='clipboardjs'>mesheryctl registry generate [flags]</code>
 </div>
 </pre> 
 
@@ -25,56 +24,49 @@ mesheryctl registry generate [flags]
 Generate Meshery Models from a Google Spreadsheet (i.e. "Meshery Integrations" spreadsheet).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED"
-
+<code class='clipboardjs'>mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED"</code>
 </div>
 </pre> 
 
 Directly generate models from one of the supported registrants by using Registrant Connection Definition and (optional) Registrant Credential Definition
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate --registrant-def [path to connection definition] --registrant-cred [path to credential definition]
-
+<code class='clipboardjs'>mesheryctl registry generate --registrant-def [path to connection definition] --registrant-cred [path to credential definition]</code>
 </div>
 </pre> 
 
 Generate a specific Model from a Google Spreadsheet (i.e. "Meshery Integrations" spreadsheet).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred --model "[model-name]"
-
+<code class='clipboardjs'>mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred --model "[model-name]"</code>
 </div>
 </pre> 
 
 Generate Meshery Models and Component from csv files in a local directory.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate --directory [DIRECTORY_PATH]
-
+<code class='clipboardjs'>mesheryctl registry generate --directory [DIRECTORY_PATH]</code>
 </div>
 </pre> 
 
 Generate Meshery Models from individual CSV files.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate --model-csv [path/to/models.csv] --component-csv [path/to/components.csv] --relationship-csv [path/to/relationships.csv]
-
+<code class='clipboardjs'>mesheryctl registry generate --model-csv [path/to/models.csv] --component-csv [path/to/components.csv] --relationship-csv [path/to/relationships.csv]</code>
 </div>
 </pre> 
 
 Generate models with a custom per-model timeout (e.g., 10 minutes per model).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED" --timeout 10m
-
+<code class='clipboardjs'>mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED" --timeout 10m</code>
 </div>
 </pre> 
 
 Generate only the latest version of each model.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED" --latest-only
-
+<code class='clipboardjs'>mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED" --latest-only</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/publish.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/publish.md
@@ -15,8 +15,7 @@ Publishes metadata about Meshery Models to Websites, Remote Provider, or Meshery
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [models-output-path] [imgs-output-path] [flags]
-
+<code class='clipboardjs'>mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [models-output-path] [imgs-output-path] [flags]</code>
 </div>
 </pre> 
 
@@ -25,63 +24,55 @@ mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [model
 Publish To System
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [models-output-path] [imgs-output-path] -o [output-format]
-
+<code class='clipboardjs'>mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [models-output-path] [imgs-output-path] -o [output-format]</code>
 </div>
 </pre> 
 
 Publish To Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish meshery GoogleCredential GoogleSheetID [repo]/models
-
+<code class='clipboardjs'>mesheryctl registry publish meshery GoogleCredential GoogleSheetID [repo]/models</code>
 </div>
 </pre> 
 
 Publish To Remote Provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish remote-provider GoogleCredential GoogleSheetID [repo]/meshmodels/models [repo]/ui/public/img/meshmodels
-
+<code class='clipboardjs'>mesheryctl registry publish remote-provider GoogleCredential GoogleSheetID [repo]/meshmodels/models [repo]/ui/public/img/meshmodels</code>
 </div>
 </pre> 
 
 Publish To Website
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish website GoogleCredential GoogleSheetID [repo]/integrations [repo]/ui/public/img/meshmodels
-
+<code class='clipboardjs'>mesheryctl registry publish website GoogleCredential GoogleSheetID [repo]/integrations [repo]/ui/public/img/meshmodels</code>
 </div>
 </pre> 
 
 Publishing to meshery docs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-cd docs;
-
+<code class='clipboardjs'>cd docs;</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw docs/pages/integrations docs/assets/img/integrations -o md
-
+<code class='clipboardjs'>mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw docs/pages/integrations docs/assets/img/integrations -o md</code>
 </div>
 </pre> 
 
 Publishing to mesheryio site
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw meshery.io/integrations meshery.io/assets/images/integration -o js
-
+<code class='clipboardjs'>mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw meshery.io/integrations meshery.io/assets/images/integration -o js</code>
 </div>
 </pre> 
 
 Publishing to any website
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw path/to/models path/to/icons -o mdx
-
+<code class='clipboardjs'>mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw path/to/models path/to/icons -o mdx</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/purge.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/purge.md
@@ -19,8 +19,7 @@ The "kubernetes" and "meshery-core" models are always excluded from purging, reg
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry purge [flags]
-
+<code class='clipboardjs'>mesheryctl registry purge [flags]</code>
 </div>
 </pre> 
 
@@ -29,40 +28,35 @@ mesheryctl registry purge [flags]
 Retain only the latest version of every model (default).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry purge
-
+<code class='clipboardjs'>mesheryctl registry purge</code>
 </div>
 </pre> 
 
 Retain the 3 most recent versions of every model.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry purge --retain 3
-
+<code class='clipboardjs'>mesheryctl registry purge --retain 3</code>
 </div>
 </pre> 
 
 Preview what would be removed without deleting anything.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry purge --dry-run
-
+<code class='clipboardjs'>mesheryctl registry purge --dry-run</code>
 </div>
 </pre> 
 
 Additionally skip specific models.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry purge --exclude aws-ec2-controller,cilium
-
+<code class='clipboardjs'>mesheryctl registry purge --exclude aws-ec2-controller,cilium</code>
 </div>
 </pre> 
 
 Skip the confirmation prompt.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry purge --retain 2 -y
-
+<code class='clipboardjs'>mesheryctl registry purge --retain 2 -y</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/update.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/update.md
@@ -15,8 +15,7 @@ Updates the component metadata (SVGs, shapes, styles and other) by referring fro
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry update [flags]
-
+<code class='clipboardjs'>mesheryctl registry update [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl registry update [flags]
 Update models from Meshery Integration Spreadsheet
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry update --spreadsheet-id [id] --spreadsheet-cred "$CRED" -i [path to the directory containing models].
-
+<code class='clipboardjs'>mesheryctl registry update --spreadsheet-id [id] --spreadsheet-cred "$CRED" -i [path to the directory containing models].</code>
 </div>
 </pre> 
 
 Updating models in the meshery/meshery repository based on the spreadsheet
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw --spreadsheet-cred "$CRED"
-
+<code class='clipboardjs'>mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw --spreadsheet-cred "$CRED"</code>
 </div>
 </pre> 
 
 Updating models in the meshery/meshery repository based on flag
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw --spreadsheet-cred "$CRED" --model "[model-name]"
-
+<code class='clipboardjs'>mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw --spreadsheet-cred "$CRED" --model "[model-name]"</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/_index.md
@@ -16,8 +16,7 @@ Meshery uses relationships to define how interconnected components interact.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship [flags]
-
+<code class='clipboardjs'>mesheryctl relationship [flags]</code>
 </div>
 </pre> 
 
@@ -26,40 +25,35 @@ mesheryctl relationship [flags]
 Display number of available relationships in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship --count
-
+<code class='clipboardjs'>mesheryctl relationship --count</code>
 </div>
 </pre> 
 
 Generate a relationship documentation 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship generate [flags]
-
+<code class='clipboardjs'>mesheryctl relationship generate [flags]</code>
 </div>
 </pre> 
 
 List available relationship(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship list [flags]
-
+<code class='clipboardjs'>mesheryctl relationship list [flags]</code>
 </div>
 </pre> 
 
 Search for a specific relationship
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]
-
+<code class='clipboardjs'>mesheryctl relationship search [--kind &lt;kind&gt;] [--type &lt;type&gt;] [--subtype &lt;subtype&gt;] [--model &lt;model&gt;]</code>
 </div>
 </pre> 
 
 View a specific relationship
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship view [model-name]
-
+<code class='clipboardjs'>mesheryctl relationship view [model-name]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/generate.md
@@ -15,8 +15,7 @@ Generate relationships documents from a CSV file or Google Spreadsheet.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship generate [flags]
-
+<code class='clipboardjs'>mesheryctl relationship generate [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl relationship generate [flags]
 Generate relationships documents from a CSV file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship generate --file <path-to-relationships.csv>
-
+<code class='clipboardjs'>mesheryctl relationship generate --file &lt;path-to-relationships.csv&gt;</code>
 </div>
 </pre> 
 
 Generate relationships documents with a custom output path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship generate --file <path-to-relationships.csv> --output <path-to-output.json>
-
+<code class='clipboardjs'>mesheryctl relationship generate --file &lt;path-to-relationships.csv&gt; --output &lt;path-to-output.json&gt;</code>
 </div>
 </pre> 
 
 Generate relationships documents from a Google Spreadsheet
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
-
+<code class='clipboardjs'>mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/list.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/list.md
@@ -15,8 +15,7 @@ List all relationships registered in Meshery Server.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship list [flags]
-
+<code class='clipboardjs'>mesheryctl relationship list [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl relationship list [flags]
 List all relationships
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship list
-
+<code class='clipboardjs'>mesheryctl relationship list</code>
 </div>
 </pre> 
 
 List relationships for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship list --page [page-number]
-
+<code class='clipboardjs'>mesheryctl relationship list --page [page-number]</code>
 </div>
 </pre> 
 
 List relationships with a custom page size
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship list --pagesize [page-size]
-
+<code class='clipboardjs'>mesheryctl relationship list --pagesize [page-size]</code>
 </div>
 </pre> 
 
 Display the total number of available relationships in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship list --count
-
+<code class='clipboardjs'>mesheryctl relationship list --count</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/search.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/search.md
@@ -15,8 +15,7 @@ Search registered relationship(s) used by different models.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship search [flags]
-
+<code class='clipboardjs'>mesheryctl relationship search [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl relationship search [flags]
 Search for a specific relationship
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]
-
+<code class='clipboardjs'>mesheryctl relationship search [--kind &lt;kind&gt;] [--type &lt;type&gt;] [--subtype &lt;subtype&gt;] [--model &lt;model&gt;]</code>
 </div>
 </pre> 
 
 Search a relationship for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship search [--kind <kind>] [--page <int>]
-
+<code class='clipboardjs'>mesheryctl relationship search [--kind &lt;kind&gt;] [--page &lt;int&gt;]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/view.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/view.md
@@ -15,8 +15,7 @@ view a relationship queried by the model name.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship view [flags]
-
+<code class='clipboardjs'>mesheryctl relationship view [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl relationship view [flags]
 View relationships of a model in default format yaml
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship view [model-name]
-
+<code class='clipboardjs'>mesheryctl relationship view [model-name]</code>
 </div>
 </pre> 
 
 View relationships of a model in JSON format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship view [model-name] --output-format json
-
+<code class='clipboardjs'>mesheryctl relationship view [model-name] --output-format json</code>
 </div>
 </pre> 
 
 View relationships of a model in json format and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship view [model-name] --output-format json --save
-
+<code class='clipboardjs'>mesheryctl relationship view [model-name] --output-format json --save</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/_index.md
@@ -15,8 +15,7 @@ Manage the state and configuration of Meshery server, components, and client.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system [flags]
-
+<code class='clipboardjs'>mesheryctl system [flags]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
@@ -15,8 +15,7 @@ Subscribe to a release channel. Choose between either 'stable' or 'edge' channel
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel [flags]
-
+<code class='clipboardjs'>mesheryctl system channel [flags]</code>
 </div>
 </pre> 
 
@@ -25,40 +24,35 @@ mesheryctl system channel [flags]
 Subscribe to release channel or version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel
-
+<code class='clipboardjs'>mesheryctl system channel</code>
 </div>
 </pre> 
 
 To set the channel
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel set [stable|stable-version|edge|edge-version]
-
+<code class='clipboardjs'>mesheryctl system channel set [stable|stable-version|edge|edge-version]</code>
 </div>
 </pre> 
 
 To pin/set the channel to a specific version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel set stable-v0.6.0
-
+<code class='clipboardjs'>mesheryctl system channel set stable-v0.6.0</code>
 </div>
 </pre> 
 
 To view release channel and version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel view
-
+<code class='clipboardjs'>mesheryctl system channel view</code>
 </div>
 </pre> 
 
 To switch release channel and version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel switch [stable|stable-version|edge|edge-version]
-
+<code class='clipboardjs'>mesheryctl system channel switch [stable|stable-version|edge|edge-version]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/set.md
@@ -15,8 +15,7 @@ Set release channel and version of context in focus
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel set [stable|stable-version|edge|edge-version] [flags]
-
+<code class='clipboardjs'>mesheryctl system channel set [stable|stable-version|edge|edge-version] [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version] [flags]
 Subscribe to release channel or version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel set [stable|stable-version|edge|edge-version]
-
+<code class='clipboardjs'>mesheryctl system channel set [stable|stable-version|edge|edge-version]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
@@ -15,8 +15,7 @@ Switch release channel and version of context in focus
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel switch [stable|stable-version|edge|edge-version] [flags]
-
+<code class='clipboardjs'>mesheryctl system channel switch [stable|stable-version|edge|edge-version] [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system channel switch [stable|stable-version|edge|edge-version] [flag
 Switch between release channels
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel switch [stable|stable-version|edge|edge-version]
-
+<code class='clipboardjs'>mesheryctl system channel switch [stable|stable-version|edge|edge-version]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/view.md
@@ -15,8 +15,7 @@ View release channel and version of context in focus
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel view [flags]
-
+<code class='clipboardjs'>mesheryctl system channel view [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl system channel view [flags]
 View current release channel
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel view edge
-
+<code class='clipboardjs'>mesheryctl system channel view edge</code>
 </div>
 </pre> 
 
 View release channel for all contexts
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system channel view --all
-
+<code class='clipboardjs'>mesheryctl system channel view --all</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/check.md
+++ b/docs/content/en/reference/references/mesheryctl/system/check.md
@@ -15,8 +15,7 @@ Verify environment pre/post-deployment of Meshery.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check [flags]
-
+<code class='clipboardjs'>mesheryctl system check [flags]</code>
 </div>
 </pre> 
 
@@ -25,55 +24,48 @@ mesheryctl system check [flags]
 Run all system checks for both pre and post-deployment scenarios
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check
-
+<code class='clipboardjs'>mesheryctl system check</code>
 </div>
 </pre> 
 
 Run pre-deployment checks (Docker and Kubernetes)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check --preflight
-
+<code class='clipboardjs'>mesheryctl system check --preflight</code>
 </div>
 </pre> 
 
 Run pre-deployment checks (Docker and Kubernetes)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check --pre
-
+<code class='clipboardjs'>mesheryctl system check --pre</code>
 </div>
 </pre> 
 
 Run checks for all Meshery adapters
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check --adapters
-
+<code class='clipboardjs'>mesheryctl system check --adapters</code>
 </div>
 </pre> 
 
 Run checks on a specific Meshery adapter
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check --adapter meshery-istio:10000
-
+<code class='clipboardjs'>mesheryctl system check --adapter meshery-istio:10000</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check --adapter meshery-istio
-
+<code class='clipboardjs'>mesheryctl system check --adapter meshery-istio</code>
 </div>
 </pre> 
 
 Verify the health of Meshery Operator's deployment with MeshSync and Broker
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system check --operator
-
+<code class='clipboardjs'>mesheryctl system check --operator</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/_index.md
@@ -15,8 +15,7 @@ Configure and switch between different named Meshery server and component versio
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context [command] [flags]
-
+<code class='clipboardjs'>mesheryctl system context [command] [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system context [command] [flags]
 Base command
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context
-
+<code class='clipboardjs'>mesheryctl system context</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/create.md
@@ -15,8 +15,7 @@ Add a new context to Meshery config.yaml file.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context create context-name [flags]
-
+<code class='clipboardjs'>mesheryctl system context create context-name [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl system context create context-name [flags]
 Create new context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context create [context-name]
-
+<code class='clipboardjs'>mesheryctl system context create [context-name]</code>
 </div>
 </pre> 
 
 Create new context and provide list of components, platform & URL and set it as current context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context create [context-name] --components [meshery-nsm] --platform [docker|kubernetes] --url [server-url] --set --yes
-
+<code class='clipboardjs'>mesheryctl system context create [context-name] --components [meshery-nsm] --platform [docker|kubernetes] --url [server-url] --set --yes</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/delete.md
@@ -15,8 +15,7 @@ Delete an existing context (a named Meshery deployment) from Meshery config file
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context delete [context-name] [flags]
-
+<code class='clipboardjs'>mesheryctl system context delete [context-name] [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system context delete [context-name] [flags]
 ### Delete context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context delete [context name]
-
+<code class='clipboardjs'>mesheryctl system context delete [context name]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/list.md
@@ -15,8 +15,7 @@ List current context and available contexts.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context list [flags]
-
+<code class='clipboardjs'>mesheryctl system context list [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system context list [flags]
 List all contexts present
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context list
-
+<code class='clipboardjs'>mesheryctl system context list</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/switch.md
@@ -15,8 +15,7 @@ Configure mesheryctl to actively use one one context vs. another context.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context switch context-name [flags]
-
+<code class='clipboardjs'>mesheryctl system context switch context-name [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system context switch context-name [flags]
 Switch to context named "sample"
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context switch sample
-
+<code class='clipboardjs'>mesheryctl system context switch sample</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/view.md
@@ -17,8 +17,7 @@ Use this to verify or debug your current CLI settings.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context view [context-name | --context context-name | --all] --flags [flags]
-
+<code class='clipboardjs'>mesheryctl system context view [context-name | --context context-name | --all] --flags [flags]</code>
 </div>
 </pre> 
 
@@ -27,39 +26,28 @@ mesheryctl system context view [context-name | --context context-name | --all] -
 View the default context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context view
-
+<code class='clipboardjs'>mesheryctl system context view</code>
 </div>
 </pre> 
 
 View a specified context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context view context-name
-
+<code class='clipboardjs'>mesheryctl system context view context-name</code>
 </div>
 </pre> 
 
 View a specified context using the --context flag
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context view --context context-name
-
+<code class='clipboardjs'>mesheryctl system context view --context context-name</code>
 </div>
 </pre> 
 
 View configuration of all contexts
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system context view --all
-
-</div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-    
-
+<code class='clipboardjs'>mesheryctl system context view --all</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/dashboard.md
+++ b/docs/content/en/reference/references/mesheryctl/system/dashboard.md
@@ -15,8 +15,7 @@ Open Meshery UI in browser.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system dashboard [flags]
-
+<code class='clipboardjs'>mesheryctl system dashboard [flags]</code>
 </div>
 </pre> 
 
@@ -25,39 +24,34 @@ mesheryctl system dashboard [flags]
 Open Meshery UI in browser
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system dashboard
-
+<code class='clipboardjs'>mesheryctl system dashboard</code>
 </div>
 </pre> 
 
 Open Meshery UI in browser and use port-forwarding (if default port is taken already)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system dashboard --port-forward
-
+<code class='clipboardjs'>mesheryctl system dashboard --port-forward</code>
 </div>
 </pre> 
 
 Open Meshery UI in browser and use port-forwarding, listen on port 9081 locally, forwarding traffic to meshery server in the pod
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system dashboard --port-forward -p 9081
-
+<code class='clipboardjs'>mesheryctl system dashboard --port-forward -p 9081</code>
 </div>
 </pre> 
 
 (optional) skip opening of MesheryUI in browser.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system dashboard --skip-browser
-
+<code class='clipboardjs'>mesheryctl system dashboard --skip-browser</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-Note: Meshery's web-based user interface is embedded in Meshery Server and is available as soon as Meshery starts. The location and port that Meshery UI is exposed varies depending upon your mode of deployment. See accessing \"Meshery UI\" for additional deployment-specific options: https://docs.meshery.io/installation/accessing-meshery-ui.
-
+<code class='clipboardjs'>Note: Meshery's web-based user interface is embedded in Meshery Server and is available as soon as Meshery starts. The location and port that Meshery UI is exposed varies depending upon your mode of deployment. See accessing \"Meshery UI\" for additional deployment-specific options: https://docs.meshery.io/installation/accessing-meshery-ui.</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/delete.md
@@ -15,8 +15,7 @@ Delete Meshery containers. This command removes all Meshery containers created b
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system delete [flags]
-
+<code class='clipboardjs'>mesheryctl system delete [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl system delete [flags]
 Delete Meshery containers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system delete
-
+<code class='clipboardjs'>mesheryctl system delete</code>
 </div>
 </pre> 
 
 Delete Meshery containers without confirmation
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system delete -y
-
+<code class='clipboardjs'>mesheryctl system delete -y</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/login.md
+++ b/docs/content/en/reference/references/mesheryctl/system/login.md
@@ -17,8 +17,7 @@ Authenticate to the Local or a Remote Provider of a Meshery Server
 The authentication mode is web-based browser flow
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system login [flags]
-
+<code class='clipboardjs'>mesheryctl system login [flags]</code>
 </div>
 </pre> 
 
@@ -27,16 +26,14 @@ mesheryctl system login [flags]
 Login with the Meshery Provider of your choice: the Local Provider or a Remote Provider.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system login
-
+<code class='clipboardjs'>mesheryctl system login</code>
 </div>
 </pre> 
 
 Login with the Meshery Provider by specifying it via -p or --provider flag.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system login -p Meshery
-
+<code class='clipboardjs'>mesheryctl system login -p Meshery</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/logout.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logout.md
@@ -17,8 +17,7 @@ Remove authentication for Meshery Server
 This command removes the authentication token from the user's filesystem
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system logout [flags]
-
+<code class='clipboardjs'>mesheryctl system logout [flags]</code>
 </div>
 </pre> 
 
@@ -27,8 +26,7 @@ mesheryctl system logout [flags]
 Logout current session with your Meshery Provider.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system logout
-
+<code class='clipboardjs'>mesheryctl system logout</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/logs.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logs.md
@@ -16,8 +16,7 @@ Print history of Meshery's logs and begin tailing them.
 It also shows the logs of a specific component.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system logs [flags]
-
+<code class='clipboardjs'>mesheryctl system logs [flags]</code>
 </div>
 </pre> 
 
@@ -26,23 +25,20 @@ mesheryctl system logs [flags]
 Show logs (without tailing)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system logs
-
+<code class='clipboardjs'>mesheryctl system logs</code>
 </div>
 </pre> 
 
 Starts tailing Meshery server debug logs (works with components also)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system logs --follow
-
+<code class='clipboardjs'>mesheryctl system logs --follow</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system logs meshery-istio
-
+<code class='clipboardjs'>mesheryctl system logs meshery-istio</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
@@ -14,8 +14,7 @@ Switch between providers
 Enforce a provider. Choose between available Meshery providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider [flags]
-
+<code class='clipboardjs'>mesheryctl system provider [flags]</code>
 </div>
 </pre> 
 
@@ -24,40 +23,35 @@ mesheryctl system provider [flags]
 To view provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider view
-
+<code class='clipboardjs'>mesheryctl system provider view</code>
 </div>
 </pre> 
 
 To list all available providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider list
-
+<code class='clipboardjs'>mesheryctl system provider list</code>
 </div>
 </pre> 
 
 To set a provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider set [provider]
-
+<code class='clipboardjs'>mesheryctl system provider set [provider]</code>
 </div>
 </pre> 
 
 To switch provider and redeploy Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider switch [provider]
-
+<code class='clipboardjs'>mesheryctl system provider switch [provider]</code>
 </div>
 </pre> 
 
 To clear the configured provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider reset
-
+<code class='clipboardjs'>mesheryctl system provider reset</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/list.md
@@ -14,8 +14,7 @@ list available providers
 List current provider and available providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider list [flags]
-
+<code class='clipboardjs'>mesheryctl system provider list [flags]</code>
 </div>
 </pre> 
 
@@ -24,8 +23,7 @@ mesheryctl system provider list [flags]
 List all available providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider list
-
+<code class='clipboardjs'>mesheryctl system provider list</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
@@ -14,8 +14,7 @@ Clear the configured provider
 Clear the configured provider for the current context. This allows users to select a provider on the next Meshery start. This clears the enforced provider so that users are presented with the provider selection UI on next start.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider reset [flags]
-
+<code class='clipboardjs'>mesheryctl system provider reset [flags]</code>
 </div>
 </pre> 
 
@@ -24,8 +23,7 @@ mesheryctl system provider reset [flags]
 Clear the configured provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider reset
-
+<code class='clipboardjs'>mesheryctl system provider reset</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/set.md
@@ -14,8 +14,7 @@ set provider
 Set provider of context in focus. Run `mesheryctl system provider list` to see the available providers.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider set [provider] [flags]
-
+<code class='clipboardjs'>mesheryctl system provider set [provider] [flags]</code>
 </div>
 </pre> 
 
@@ -24,8 +23,7 @@ mesheryctl system provider set [provider] [flags]
 Set provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider set [provider]
-
+<code class='clipboardjs'>mesheryctl system provider set [provider]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
@@ -14,8 +14,7 @@ switch provider and redeploy
 Switch provider of context in focus and redeploy Meshery. Run `mesheryctl system provider list` to see the available providers.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider switch [provider] [flags]
-
+<code class='clipboardjs'>mesheryctl system provider switch [provider] [flags]</code>
 </div>
 </pre> 
 
@@ -24,8 +23,7 @@ mesheryctl system provider switch [provider] [flags]
 Switch provider and redeploy Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider switch [provider]
-
+<code class='clipboardjs'>mesheryctl system provider switch [provider]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/view.md
@@ -15,8 +15,7 @@ View provider of context in focus.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider view [flags]
-
+<code class='clipboardjs'>mesheryctl system provider view [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system provider view [flags]
 View current provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system provider view
-
+<code class='clipboardjs'>mesheryctl system provider view</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/reset.md
@@ -15,8 +15,7 @@ Reset Meshery to it's default configuration.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system reset [flags]
-
+<code class='clipboardjs'>mesheryctl system reset [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl system reset [flags]
 Resets meshery.yaml file with a copy from Meshery repo
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system reset
-
+<code class='clipboardjs'>mesheryctl system reset</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/restart.md
+++ b/docs/content/en/reference/references/mesheryctl/system/restart.md
@@ -15,8 +15,7 @@ Restart all Meshery containers / pods.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system restart [flags]
-
+<code class='clipboardjs'>mesheryctl system restart [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl system restart [flags]
 Restart all Meshery containers, their instances and their connected volumes
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system restart
-
+<code class='clipboardjs'>mesheryctl system restart</code>
 </div>
 </pre> 
 
 (optional) skip checking for new updates available in Meshery.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system restart --skip-update
-
+<code class='clipboardjs'>mesheryctl system restart --skip-update</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/start.md
+++ b/docs/content/en/reference/references/mesheryctl/system/start.md
@@ -15,8 +15,7 @@ Start Meshery and each of its cloud native components.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system start [flags]
-
+<code class='clipboardjs'>mesheryctl system start [flags]</code>
 </div>
 </pre> 
 
@@ -25,48 +24,42 @@ mesheryctl system start [flags]
 Start meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system start
-
+<code class='clipboardjs'>mesheryctl system start</code>
 </div>
 </pre> 
 
 (optional) skip opening of MesheryUI in browser.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system start --skip-browser
-
+<code class='clipboardjs'>mesheryctl system start --skip-browser</code>
 </div>
 </pre> 
 
 (optional) skip checking for new updates available in Meshery.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system start --skip-update
-
+<code class='clipboardjs'>mesheryctl system start --skip-update</code>
 </div>
 </pre> 
 
 Reset Meshery's configuration file to default settings.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system start --reset
-
+<code class='clipboardjs'>mesheryctl system start --reset</code>
 </div>
 </pre> 
 
 Specify Platform to deploy Meshery to.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system start -p docker
-
+<code class='clipboardjs'>mesheryctl system start -p docker</code>
 </div>
 </pre> 
 
 Specify Provider to use.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system start --provider Meshery
-
+<code class='clipboardjs'>mesheryctl system start --provider Meshery</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/status.md
+++ b/docs/content/en/reference/references/mesheryctl/system/status.md
@@ -15,8 +15,7 @@ Check status of Meshery and Meshery components.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system status [flags]
-
+<code class='clipboardjs'>mesheryctl system status [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl system status [flags]
 Check status of Meshery, Meshery adapters, Meshery Operator and its controllers.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system status
-
+<code class='clipboardjs'>mesheryctl system status</code>
 </div>
 </pre> 
 
 (optional) Extra data in status table
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system status --verbose
-
+<code class='clipboardjs'>mesheryctl system status --verbose</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/stop.md
+++ b/docs/content/en/reference/references/mesheryctl/system/stop.md
@@ -15,8 +15,7 @@ Stop all Meshery containers / remove all Meshery resources.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system stop [flags]
-
+<code class='clipboardjs'>mesheryctl system stop [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl system stop [flags]
 Stop Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system stop
-
+<code class='clipboardjs'>mesheryctl system stop</code>
 </div>
 </pre> 
 
 Reset Meshery's configuration file to default settings.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system stop --reset
-
+<code class='clipboardjs'>mesheryctl system stop --reset</code>
 </div>
 </pre> 
 
 (optional) keep the Meshery namespace during uninstallation
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system stop --keep-namespace
-
+<code class='clipboardjs'>mesheryctl system stop --keep-namespace</code>
 </div>
 </pre> 
 
 Stop Meshery forcefully (use it when system stop doesn't work)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system stop --force
-
+<code class='clipboardjs'>mesheryctl system stop --force</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/_index.md
@@ -15,8 +15,7 @@ Manage Meshery user tokens
 	Manipulate user tokens and their context assignments in your meshconfig
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token [flags]
-
+<code class='clipboardjs'>mesheryctl system token [flags]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/create.md
@@ -15,8 +15,7 @@ Create the token with provided token name (optionally token path) to your meshco
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token create [flags]
-
+<code class='clipboardjs'>mesheryctl system token create [flags]</code>
 </div>
 </pre> 
 
@@ -24,22 +23,19 @@ mesheryctl system token create [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token create [token-name] -f [token-path]
-
+<code class='clipboardjs'>mesheryctl system token create [token-name] -f [token-path]</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token create [token-name] (default path is auth.json)
-
+<code class='clipboardjs'>mesheryctl system token create [token-name] (default path is auth.json)</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token create [token-name] -f [token-path] --set
-
+<code class='clipboardjs'>mesheryctl system token create [token-name] -f [token-path] --set</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/delete.md
@@ -14,8 +14,7 @@ Delete a token from your meshconfig
 Delete the token with provided token name from your meshconfig tokens.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token delete [flags]
-
+<code class='clipboardjs'>mesheryctl system token delete [flags]</code>
 </div>
 </pre> 
 
@@ -23,8 +22,7 @@ mesheryctl system token delete [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token delete [token-name]
-
+<code class='clipboardjs'>mesheryctl system token delete [token-name]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/list.md
@@ -14,8 +14,7 @@ List tokens
 List all the tokens in your meshconfig
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token list [flags]
-
+<code class='clipboardjs'>mesheryctl system token list [flags]</code>
 </div>
 </pre> 
 
@@ -23,8 +22,7 @@ mesheryctl system token list [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token list
-
+<code class='clipboardjs'>mesheryctl system token list</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/set.md
@@ -14,8 +14,7 @@ Set token for context
 Set token for current context or context specified with --context flag.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token set [flags]
-
+<code class='clipboardjs'>mesheryctl system token set [flags]</code>
 </div>
 </pre> 
 
@@ -23,8 +22,7 @@ mesheryctl system token set [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token set [token-name] 
-
+<code class='clipboardjs'>mesheryctl system token set [token-name] </code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/view.md
@@ -14,8 +14,7 @@ View token
 View a specific token in meshery config
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token view [flags]
-
+<code class='clipboardjs'>mesheryctl system token view [flags]</code>
 </div>
 </pre> 
 
@@ -23,15 +22,13 @@ mesheryctl system token view [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token view [token-name]
-
+<code class='clipboardjs'>mesheryctl system token view [token-name]</code>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system token view (show token of current context)
-
+<code class='clipboardjs'>mesheryctl system token view (show token of current context)</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/update.md
+++ b/docs/content/en/reference/references/mesheryctl/system/update.md
@@ -15,8 +15,7 @@ Pull new Meshery container images and manifests from artifact repository.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system update [flags]
-
+<code class='clipboardjs'>mesheryctl system update [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl system update [flags]
 Pull new Meshery images from Docker Hub. This does not update mesheryctl. This command may be executed while Meshery is running.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system update
-
+<code class='clipboardjs'>mesheryctl system update</code>
 </div>
 </pre> 
 
 Pull the latest manifest files alone
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl system update --skip-reset
-
+<code class='clipboardjs'>mesheryctl system update --skip-reset</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/version.md
+++ b/docs/content/en/reference/references/mesheryctl/version.md
@@ -14,8 +14,7 @@ Show Meshery CLI and Server versions
 Version of Meshery command line client - mesheryctl.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl version [flags]
-
+<code class='clipboardjs'>mesheryctl version [flags]</code>
 </div>
 </pre> 
 
@@ -24,8 +23,7 @@ mesheryctl version [flags]
 To view the current version and SHA of release binary of mesheryctl client 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl version
-
+<code class='clipboardjs'>mesheryctl version</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/_index.md
@@ -15,8 +15,7 @@ Create, list of workspaces under an organization
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace [flags]
-
+<code class='clipboardjs'>mesheryctl workspace [flags]</code>
 </div>
 </pre> 
 
@@ -25,16 +24,14 @@ mesheryctl workspace [flags]
 To view a list workspaces
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace list --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl workspace list --orgId [orgId]</code>
 </div>
 </pre> 
 
 To create a workspace
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace create --orgId [orgId] --name [name] --description [description]
-
+<code class='clipboardjs'>mesheryctl workspace create --orgId [orgId] --name [name] --description [description]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/create.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/create.md
@@ -15,8 +15,7 @@ Create a new workspace by providing the name, description, and organization ID
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace create [flags]
-
+<code class='clipboardjs'>mesheryctl workspace create [flags]</code>
 </div>
 </pre> 
 
@@ -25,8 +24,7 @@ mesheryctl workspace create [flags]
 Create a new workspace in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace create --orgId [orgId] --name [name] --description [description]
-
+<code class='clipboardjs'>mesheryctl workspace create --orgId [orgId] --name [name] --description [description]</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/list.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/list.md
@@ -15,8 +15,7 @@ List name of all registered workspaces
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace list [flags]
-
+<code class='clipboardjs'>mesheryctl workspace list [flags]</code>
 </div>
 </pre> 
 
@@ -25,24 +24,21 @@ mesheryctl workspace list [flags]
 List of workspace under a specific organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace list --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl workspace list --orgId [orgId]</code>
 </div>
 </pre> 
 
 List of workspace under a specific organization for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace list --orgId [orgId] --page [page-number]
-
+<code class='clipboardjs'>mesheryctl workspace list --orgId [orgId] --page [page-number]</code>
 </div>
 </pre> 
 
 Display number of available  workspace under a specific organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace list --orgId [orgId] --count
-
+<code class='clipboardjs'>mesheryctl workspace list --orgId [orgId] --count</code>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/view.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/view.md
@@ -15,8 +15,7 @@ View a workspace by its ID or name.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace view [workspace-name|workspace-id] [flags]
-
+<code class='clipboardjs'>mesheryctl workspace view [workspace-name|workspace-id] [flags]</code>
 </div>
 </pre> 
 
@@ -25,32 +24,28 @@ mesheryctl workspace view [workspace-name|workspace-id] [flags]
 View details of a specific workspace by ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace view [workspace-id] --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl workspace view [workspace-id] --orgId [orgId]</code>
 </div>
 </pre> 
 
 View details of a specific workspace by name
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace view [workspace-name] --orgId [orgId]
-
+<code class='clipboardjs'>mesheryctl workspace view [workspace-name] --orgId [orgId]</code>
 </div>
 </pre> 
 
 View details of a specific workspace in JSON format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json
-
+<code class='clipboardjs'>mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json</code>
 </div>
 </pre> 
 
 View details of a specific workspace and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json --save
-
+<code class='clipboardjs'>mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json --save</code>
 </div>
 </pre> 
 

--- a/mesheryctl/doc/doc.go
+++ b/mesheryctl/doc/doc.go
@@ -130,6 +130,23 @@ func doc() {
 	fmt.Println("Documentation generated at " + markDownPath)
 }
 
+// codeEscaper escapes the characters that would otherwise be parsed as markup once a
+// command sits inside <code>. Placeholders such as <kind> are swallowed by the HTML
+// parser without this, so the page renders "--kind " and the copy button copies that
+// same truncated text. Quotes need no escaping in element content and are left alone
+// to keep the generated pages readable.
+var codeEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// writeCommandBlock writes a copyable command block into buf.
+//
+// The <code class='clipboardjs'> wrapper is the element docs/static/js/main.js
+// keys on to attach the copy-to-clipboard button, and mirrors the markup that
+// layouts/shortcodes/code.html emits for hand-written pages. Without it the
+// block still renders, but no copy button is ever attached to it.
+func writeCommandBlock(buf *bytes.Buffer, code string) {
+	fmt.Fprintf(buf, "<pre class='codeblock-pre'>\n<div class='codeblock'>\n<code class='clipboardjs'>%s</code>\n</div>\n</pre> \n\n", codeEscaper.Replace(code))
+}
+
 // printOptions prints the options for a command
 func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	flags := cmd.NonInheritedFlags()
@@ -178,7 +195,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, manuallyAddedContent map
 
 	// check if the command is runnable
 	if cmd.Runnable() {
-		fmt.Fprintf(buf, "<pre class='codeblock-pre'>\n<div class='codeblock'>\n%s\n\n</div>\n</pre> \n\n", cmd.UseLine())
+		writeCommandBlock(buf, cmd.UseLine())
 	}
 
 	// check cmd has annotations link and caption
@@ -196,14 +213,14 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, manuallyAddedContent map
 		buf.WriteString("## Examples\n\n")
 		var examples = strings.Split(cmd.Example, "\n")
 		for i := 0; i < len(examples); i++ {
-			if examples[i] != "" && examples[i] != " " && examples[i] != "	" {
+			if strings.TrimSpace(examples[i]) != "" {
 				if strings.HasPrefix(examples[i], "//") {
 					// Description Line
 					buf.WriteString(strings.ReplaceAll(examples[i], "// ", "") + "\n")
 				} else {
 					// Code Block Line
 
-					fmt.Fprintf(buf, "<pre class='codeblock-pre'>\n<div class='codeblock'>\n%s\n\n</div>\n</pre> \n\n", examples[i])
+					writeCommandBlock(buf, examples[i])
 				}
 			}
 		}

--- a/mesheryctl/doc/doc_test.go
+++ b/mesheryctl/doc/doc_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -160,6 +161,8 @@ func TestDoc(t *testing.T) {
 		output := buf.String()
 		assert.Contains(t, output, "test_link")
 		assert.Contains(t, output, "codeblock-pre")
+		// The copy-to-clipboard button in docs/static/js/main.js binds to '.clipboardjs'.
+		assert.Contains(t, output, "<code class='clipboardjs'>")
 		assert.Contains(t, output, "test_caption")
 		assert.Contains(t, output, "test_example")
 		assert.Contains(t, output, "See Also")
@@ -206,5 +209,68 @@ func TestDoc(t *testing.T) {
 		output = buf.String()
 		assert.Contains(t, output, "## Options inherited from parent commands")
 		assert.Contains(t, output, "--parentFlag")
+	})
+}
+
+func TestWriteCommandBlock(t *testing.T) {
+	t.Run("emits the clipboardjs hook the docs copy button binds to", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		writeCommandBlock(buf, "mesheryctl system start")
+
+		expected := "<pre class='codeblock-pre'>\n" +
+			"<div class='codeblock'>\n" +
+			"<code class='clipboardjs'>mesheryctl system start</code>\n" +
+			"</div>\n</pre> \n\n"
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("escapes markup so placeholders survive the HTML parser", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		writeCommandBlock(buf, "mesheryctl relationship search [--kind <kind>] & more")
+
+		out := buf.String()
+		// <kind> would otherwise be parsed as a tag and vanish from the rendered page.
+		assert.Contains(t, out, "[--kind &lt;kind&gt;] &amp; more")
+		assert.NotContains(t, out, "<kind>")
+	})
+
+	t.Run("does not double-escape an ampersand it just inserted", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		writeCommandBlock(buf, "a < b")
+
+		assert.Contains(t, buf.String(), "a &lt; b")
+		assert.NotContains(t, buf.String(), "&amp;lt;")
+	})
+}
+
+func TestGenMarkdownCustomExamples(t *testing.T) {
+	t.Run("every example command block is copyable", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "start", Short: "short"}
+		cmd.Run = func(cmd *cobra.Command, args []string) {}
+		cmd.Example = "// Start Meshery\nmesheryctl system start\n// Start in debug mode\nmesheryctl system start --debug"
+
+		buf := &bytes.Buffer{}
+		err := GenMarkdownCustom(cmd, buf, map[int]string{})
+		assert.NoError(t, err)
+		output := buf.String()
+
+		// Two examples plus the synopsis usage line are all copyable.
+		assert.Equal(t, 3, strings.Count(output, "<code class='clipboardjs'>"))
+		assert.Contains(t, output, "<code class='clipboardjs'>mesheryctl system start</code>")
+		assert.Contains(t, output, "<code class='clipboardjs'>mesheryctl system start --debug</code>")
+		// Description lines stay prose, not code blocks.
+		assert.Contains(t, output, "Start Meshery\n")
+	})
+
+	t.Run("whitespace-only example lines produce no empty block", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "start", Short: "short"}
+		cmd.Example = "mesheryctl system start\n\t\t\n   \n\t"
+
+		buf := &bytes.Buffer{}
+		err := GenMarkdownCustom(cmd, buf, map[int]string{})
+		assert.NoError(t, err)
+
+		// Only the single real example is emitted; the blank lines are dropped.
+		assert.Equal(t, 1, strings.Count(buf.String(), "<code class='clipboardjs'>"))
 	})
 }


### PR DESCRIPTION
The generated mesheryctl reference pages rendered command blocks as bare text inside `<div class='codeblock'>`. The docs copy button is injected by docs/static/js/main.js, which binds to `.clipboardjs` — an element those blocks never emitted — so no reference page ever showed a copy button, while hand-written pages using the `code` shortcode did.

Route the Synopsis usage line and every Examples block through a new writeCommandBlock helper that wraps the command in `<code class='clipboardjs'>`, matching the markup
layouts/shortcodes/code.html already emits. Options blocks are left as plain text: they are flag listings, not runnable commands.

Two defects surfaced while wiring this up and are fixed here, since both would otherwise ship a copy button that copies the wrong thing:

- Whitespace-only example lines slipped past the old three-way comparison (it caught "", " " and a single tab, but not "\t\t") and rendered as empty blocks, which would each have gained a button copying nothing. Filter on strings.TrimSpace instead.
- Placeholders such as `<kind>` were parsed as HTML tags and silently dropped, so `mesheryctl relationship search [--kind <kind>]` rendered as `[--kind ]`. Escape `&`, `<` and `>` before writing the block. Quotes need no escaping in element content and are left alone to keep the generated pages readable.

Regenerated pages: 402 command blocks now carry the clipboard hook across 100 files, 7 empty blocks are gone, and 13 blocks are correctly escaped.

Fixes #21631

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized CLI reference examples with consistent, copy-to-clipboard-ready code blocks.
  * Improved formatting across adapter, component, connection, design, environment, filter, model, performance, registry, relationship, system, and workspace command documentation.
  * Removed stray blank code blocks and whitespace.
  * Corrected select command examples and placeholder formatting for greater clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->