### PR TITLE
fix(docs): standardize OpenAPI schema URL

### DIFF
--- a/docs/layouts/rest-apis/single.html
+++ b/docs/layouts/rest-apis/single.html
@@ -9,7 +9,7 @@
 {{ $components := index $spec "components" | default dict }}
 {{ $securitySchemes := index $components "securitySchemes" | default dict }}
 {{ $tagGroups := index $spec "x-tagGroups" | default (slice) }}
-{{ $schemaURL := "https://raw.githubusercontent.com/meshery/meshery/refs/heads/master/docs/data/openapi.yml" }}
+{{ $schemaURL := "https://raw.githubusercontent.com/meshery/meshery/master/docs/data/openapi.yml" }}
 {{ $defaultOssServer := dict
   "url" "http://localhost:9081"
   "description" "Meshery Server default URL"


### PR DESCRIPTION
## Description

Standardize the OpenAPI schema URL used by the REST API documentation layout.

The REST API reference is rendered server-side from the Jekyll OpenAPI data source, with Meshery Server operations selected using the schema's `x-internal` metadata. This change aligns `docs/layouts/rest-apis/single.html` with the canonical raw GitHub URL already used by the default REST API layout.

## Scope

- Documentation-only change
- One-line URL normalization
- No server/runtime code modified
- No generated OpenAPI schema modified
- No client-side schema fetching introduced

## Validation

- `git diff --check`
- Confirmed the change is limited to `docs/layouts/rest-apis/single.html`
- Confirmed the working tree is clean after commit

Fixes #21409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the REST API overview’s OpenAPI schema link to use the canonical master branch URL.
  - The “generated from OpenAPI schema” link now resolves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->