### PR TITLE
[Docs] Add Meshery project vision

### DIFF
--- a/VISION.answers.md
+++ b/VISION.answers.md
@@ -1,0 +1,164 @@
+# Meshery vision review answers
+
+This file preserves the author's recorded decisions that calibrate `VISION.md`.
+
+## Round 1 - 2026-08-26
+
+### H-1 - A generic resource importer without a model
+
+Verdict: In vision.
+
+Reasoning: Users can use annotation-only components and annotation-only relationships (like those offered in the meshery-core and meshery-shapes models) to visually depict their full architecture or to visually and collaboratively convey a concept with the acknowledgement that those annotation-only components and relationships are not semantically meaningful; they do not bear configuration properties that can be orchestrated or deployed.
+
+Reasoning: That annotation-only components are excluded from deployment operations.
+
+### H-2 - A marketplace extension with a trust banner
+
+Verdict: In vision.
+
+### H-3 - A temporary local API endpoint
+
+Verdict: Off mission.
+
+Reasoning: We need to ratchet away from the local API endpoints.
+
+Reasoning: Meshery is a schema-driven project.
+
+Reasoning: The source of truth for all API endpoints shall be sourced from https://github.com/meshery/schemas.
+
+### H-4 - Canonicalize credentials on the next save
+
+Verdict: In vision.
+
+### H-5 - Keep a permission-denied design entry visible
+
+Verdict: Off mission.
+
+### H-6 - Allow an unverified explicit chart pin
+
+Verdict: In vision.
+
+### H-7 - Skip missing protected-branch credentials
+
+Verdict: In vision.
+
+### H-8 - Run relationship integration tests nightly
+
+Verdict: Conditional.
+
+Reasoning: Not now.
+
+Reasoning: Perhaps, in the future.
+
+### H-9 - Make annotation edges operational by default
+
+Verdict: Off mission.
+
+### H-10 - Relax a conservative SQL lint rule globally
+
+Verdict: Off mission.
+
+## Round 2 - 2026-08-27
+
+### H-11 - Curate the extension marketplace
+
+Verdict: In vision.
+
+### H-12 - Auto-update marketplace extensions
+
+Verdict: In vision.
+
+### H-13 - Consume a schemas prerelease
+
+Verdict: In vision.
+
+### H-14 - Drop unknown fields during credential canonicalization
+
+Verdict: In vision.
+
+### H-15 - Allow skipped provider coverage to merge
+
+Verdict: In vision.
+
+### H-16 - Scope relationship integration by changed path
+
+Verdict: In vision.
+
+Reasoning: Skip on documentation-only changes and provider-ui-only changes, but execute on all other PRs.
+
+### H-17 - Verify an air-gapped pin from local evidence
+
+Verdict: In vision.
+
+### H-18 - Allow a generated-code safety baseline
+
+Verdict: In vision.
+
+### H-19 - Let remote providers publish private schemas
+
+Verdict: In vision.
+
+### H-20 - Use encrypted production-derived test fixtures
+
+Verdict: In vision.
+
+### A-1 - Approve the revised acceptance policy
+
+Verdict: In vision.
+
+## Verbatim queued verdicts
+
+```text
+H-1 (A generic resource importer without a model): In vision. Reasoning: Users can use annotation-only components and annotation-only relationships (like those offered in the meshery-core and meshery-shapes models) to visually depict their full architecture or to visually and collaboratively convey a concept with the acknowledgement that those annotation-only components and relationships are not semantically meaningful; they do not bear configuration properties that can be orchestrated or deployed. That annotation-only components are excluded from deployment operations.
+H-2 (A marketplace extension with a trust banner): In vision.
+H-3 (A temporary local API endpoint): Off mission. Reasoning: We need to ratchet away from the local API endpoints. Meshery is a schema-driven project. The source of truth for all API endpoints shall be sourced from https://github.com/meshery/schemas.
+H-4 (Canonicalize credentials on the next save): In vision.
+H-5 (Keep a permission-denied design entry visible): Off mission.
+H-6 (Allow an unverified explicit chart pin): In vision.
+H-7 (Skip missing protected-branch credentials): In vision.
+H-8 (Run relationship integration tests nightly): Conditional. Reasoning: Not now. Perhaps, in the future.
+H-9 (Make annotation edges operational by default): Off mission.
+H-10 (Relax a conservative SQL lint rule globally): Off mission.
+All 10 hypotheticals are answered. Fold every verdict into the draft and send back the next round.
+```
+
+## Round 2 verbatim queued verdicts
+
+```text
+H-11 (Curate the extension marketplace): In vision.
+H-12 (Auto-update marketplace extensions): In vision.
+H-13 (Consume a schemas prerelease): In vision.
+H-14 (Drop unknown fields during credential canonicalization): In vision.
+H-15 (Allow skipped provider coverage to merge): In vision.
+H-16 (Scope relationship integration by changed path): In vision. Reasoning: Skip on documentation-only changes and provider-ui-only changes, but execute on all other PRs.
+H-17 (Verify an air-gapped pin from local evidence): In vision.
+H-18 (Allow a generated-code safety baseline): In vision.
+H-19 (Let remote providers publish private schemas): In vision.
+H-20 (Use encrypted production-derived test fixtures): In vision.
+A-1 (Approve the revised acceptance policy): In vision.
+All 11 hypotheticals are answered. Fold every verdict into the draft and send back the next round.
+```
+
+## Changelog
+
+- H-1 In vision -> `Design carries operational meaning` now permits explicitly non-semantic, annotation-only components and relationships that carry no deployment configuration and are excluded from deployment operations.
+- H-2 In vision -> `Interoperability is schema-driven` now permits a signed third-party extension marketplace when activation makes the extension trust boundary explicit.
+- H-3 Off mission -> `Interoperability is schema-driven` now names meshery/schemas as the source of every HTTP API contract and refuses local endpoint or contract copies.
+- H-4 In vision -> `Intent changes visibly` now permits canonicalization of legacy credentials on an intentional save while keeping tolerant reads during transition.
+- H-5 Off mission -> `Access and outcomes are explicit` now requires inaccessible entry points to be hidden rather than leading to a permission-denied page.
+- H-6 In vision -> `Intent changes visibly` now permits an air-gapped explicit chart pin after a typed acknowledgement of responsibility.
+- H-7 In vision -> `Access and outcomes are explicit` now treats unavailable provider credentials as a visibly skipped CI project, including on protected branches.
+- H-8 Conditional -> `Proof follows real use` retains pull-request relationship integration coverage today and leaves nightly-only coverage for a future decision.
+- H-9 Off mission -> `Design carries operational meaning` now states that user-created annotation relationships never become operational by default.
+- H-10 Off mission -> `Access and outcomes are explicit` now prefers documented narrow safety exceptions over global relaxation of a security gate.
+- H-11 In vision -> `Interoperability is schema-driven` now requires maintainer review for marketplace publishers.
+- H-12 In vision -> `Interoperability is schema-driven` now permits automatic update of enabled marketplace extensions to their latest verified version at restart with a post-update changelog.
+- H-13 In vision -> `Interoperability is schema-driven` now permits a signed, expiring meshery/schemas prerelease for coordinated cross-repository work.
+- H-14 In vision -> `Intent changes visibly` now drops fields absent from canonical credential schema during intentional canonicalization and logs the migration.
+- H-15 In vision -> `Access and outcomes are explicit` now allows a visible skipped provider check to remain non-blocking for merge.
+- H-16 In vision -> `Proof follows real use` now runs relationship integration scenarios on every pull request except documentation-only and provider-ui-only changes.
+- H-17 In vision -> `Intent changes visibly` now accepts locally uploaded chart and checksum evidence for an air-gapped explicit pin.
+- H-18 In vision -> `Access and outcomes are explicit` now permits a documented package-level generated-code SQL safety baseline only when its generator test proves the safety property.
+- H-19 In vision -> `Interoperability is schema-driven` now permits provider-owned private schema constructs instead of local endpoint copies.
+- H-20 In vision -> `Proof follows real use` now permits encrypted, redacted production-derived design fixtures from a controlled test store.
+- A-1 In vision -> the author approved the fully folded `VISION.md` as Meshery's current acceptance policy.

--- a/VISION.hypotheticals.md
+++ b/VISION.hypotheticals.md
@@ -1,0 +1,222 @@
+# Meshery vision hypotheticals
+
+This record preserves the complete review set, its steelman, and the author's verdicts.
+
+## Round 1 - 2026-08-26
+
+### H-1 - A generic resource importer without a model
+
+Proposal: Add an import path that lets any Kubernetes or cloud resource appear in Meshery without a model, relationship behavior, or adapter capability.
+Proposal: Teams can view and manually apply those resources while an integration is still being built.
+Proposal: The importer would make new infrastructure visible sooner than a model release can.
+Tests: "A Meshery design represents components and relationships that the platform can evaluate, render, and operate."
+Why the answer is not obvious: Teams need fast coverage for long-tail infrastructure and a useful stopgap before a full integration exists.
+Why the answer is not obvious: Rendering objects that Meshery cannot evaluate or safely operate dilutes the owned surface and makes capability ambiguous.
+Verdict: In vision.
+Reasoning: Users can use annotation-only components and annotation-only relationships (like those offered in the meshery-core and meshery-shapes models) to visually depict their full architecture or to visually and collaboratively convey a concept with the acknowledgement that those annotation-only components and relationships are not semantically meaningful; they do not bear configuration properties that can be orchestrated or deployed.
+Reasoning: That annotation-only components are excluded from deployment operations.
+
+### H-2 - A marketplace extension with a trust banner
+
+Proposal: Allow any signed third-party UI extension to install from a marketplace after an administrator reads and accepts a trust warning.
+Proposal: The extension still runs in the Meshery browser origin because sandboxing would break current extension capabilities.
+Proposal: The marketplace would centralize discovery without adding a new isolation model.
+Tests: "Meshery treats an enabled extension as code inside the deployment's trust boundary."
+Why the answer is not obvious: A trust banner and administrator consent may be enough for an ecosystem where integrations need a practical distribution path.
+Why the answer is not obvious: Centralizing installation can make a known trust boundary feel safer than it is and normalize unsafe defaults.
+Verdict: In vision.
+
+### H-3 - A temporary local API endpoint
+
+Proposal: Let the UI add a hand-written endpoint and response type for a schema-owned API while a generated schemas release is delayed.
+Proposal: The local endpoint can carry a cache tag that a generated hook currently lacks.
+Proposal: The implementation would be deleted after the next schemas release.
+Tests: "Meshery uses a generated schema client and type when that shared contract already exists."
+Why the answer is not obvious: It can unblock a time-sensitive product fix and preserve precise cache behavior.
+Why the answer is not obvious: Temporary duplicate contracts routinely outlive their deadline and silently diverge across Meshery and its providers.
+Verdict: Off mission.
+Reasoning: We need to ratchet away from the local API endpoints.
+Reasoning: Meshery is a schema-driven project.
+Reasoning: The source of truth for all API endpoints shall be sourced from https://github.com/meshery/schemas.
+
+### H-4 - Canonicalize credentials on the next save
+
+Proposal: When a user edits any legacy credential, rewrite its secret into the canonical schema before saving.
+Proposal: The read path remains tolerant, but the fleet converges gradually without a separate migration job.
+Proposal: The UI would show only a normal successful save message.
+Tests: "Meshery preserves legacy persisted data during a canonical form transition through tolerant reads rather than silent rewrites."
+Why the answer is not obvious: Each ordinary edit becomes a low-cost opportunity to reduce format diversity.
+Why the answer is not obvious: A normal save is not informed migration consent, and a write-side change can alter data the user did not intend to migrate.
+Verdict: In vision.
+
+### H-5 - Keep a permission-denied design entry visible
+
+Proposal: Always show the Design Configurator entry to organization members, even when they lack View Designs permission.
+Proposal: Selecting it opens the standard permission-denied page with a link to request access.
+Proposal: This would make capability discovery and support diagnosis easier for custom roles.
+Tests: "Meshery gates protected content as well as protected controls and prevents denied content from loading."
+Why the answer is not obvious: A visible route can explain why access is unavailable and help users request the right role.
+Why the answer is not obvious: Controls that knowingly lead to denial are misleading and normalize a gap between navigation and authorization.
+Verdict: Off mission.
+
+### H-6 - Allow an unverified explicit chart pin
+
+Proposal: Permit an air-gapped administrator to install an explicitly pinned operator chart that Meshery cannot verify against the public repository.
+Proposal: Require a typed confirmation that the operator accepts responsibility for the version.
+Proposal: This would support disconnected enterprise deployments without changing derived-version behavior.
+Tests: "Meshery honors an operator's explicit configuration or refuses it with an actionable diagnostic."
+Why the answer is not obvious: An explicit operator choice in a disconnected environment may be safer than blocking deployment outright.
+Why the answer is not obvious: A confirmation can turn an unsupported state into an apparently supported one and make later diagnosis unreliable.
+Verdict: In vision.
+
+### H-7 - Skip missing protected-branch credentials
+
+Proposal: Change CI so a missing remote-provider credential always skips the provider project, including protected branches.
+Proposal: Forks and external contributors would keep a green run when they cannot access secrets.
+Proposal: A mainline secret regression would no longer fail the workflow before tests begin.
+Tests: "Meshery fails a required remote-provider setup in CI rather than passing a suite that did not run."
+Why the answer is not obvious: Contributors should not receive a red result for credentials they cannot access or repair.
+Why the answer is not obvious: Protected branches need an unmistakable signal when their required suite has not exercised its promised coverage.
+Verdict: In vision.
+
+### H-8 - Run relationship integration tests nightly
+
+Proposal: Run only fast Rego lint and unit tests on relationship-policy pull requests, and move complete design integration scenarios to a nightly workflow.
+Proposal: The pull-request cycle becomes faster and the nightly suite can use more expensive fixtures.
+Proposal: A failed nightly run is triaged after merge.
+Tests: "Meshery tests relationship policy against complete designs and real registrant shapes."
+Why the answer is not obvious: Policy contributors get faster feedback and a richer nightly environment may uncover more cases.
+Why the answer is not obvious: Merging before realistic relationship evaluation runs makes a passing pull request less meaningful and delays the failure to users or maintainers.
+Verdict: Conditional.
+Reasoning: Not now.
+Reasoning: Perhaps, in the future.
+
+### H-9 - Make annotation edges operational by default
+
+Proposal: Treat every user-created annotation relationship as a lifecycle constraint so that users do not have to choose between semantic and non-semantic edges.
+Proposal: The canvas becomes more uniform and policy authors can use every connection.
+Proposal: Existing annotations would gain behavior unless explicitly opted out.
+Tests: "Meshery distinguishes relationships that guide lifecycle behavior from annotations that only aid human understanding."
+Why the answer is not obvious: One relationship model is simpler to teach and expands the policy surface.
+Why the answer is not obvious: Visual grouping and human notes would accidentally acquire deployment authority, violating the distinction that protects operator intent.
+Verdict: Off mission.
+
+### H-10 - Relax a conservative SQL lint rule globally
+
+Proposal: Accept any interface-typed ORDER BY value without a diagnostic after a partner generic helper triggers a conservative false positive.
+Proposal: The change removes friction for reusable query helpers and avoids per-call suppressions.
+Proposal: It also makes an interface value carrying an untrusted string unprovable to the analyzer.
+Tests: "Meshery favors a documented, narrow false positive over a silent security false negative."
+Why the answer is not obvious: Excessive false positives can discourage adoption of a safety rule and block valid abstraction.
+Why the answer is not obvious: Broad relaxation recreates the exact unobserved path the rule exists to prevent, while a narrow suppression keeps the risk visible.
+Verdict: Off mission.
+
+## Round 2 - 2026-08-27
+
+### H-11 - Curate the extension marketplace
+
+Proposal: Require Meshery maintainers to manually review each marketplace publisher before the first installation can be approved.
+Proposal: The marketplace would still show signature and trust-boundary information, but review would signal an additional project-level judgment.
+Proposal: This slows the long tail of integrations.
+Tests: "Meshery may distribute signed third-party extensions through a marketplace when administrator activation makes the trust boundary explicit."
+Why the answer is not obvious: Manual review can prevent a marketplace from looking like a list of unvetted code and protects users who equate discovery with endorsement.
+Why the answer is not obvious: Centralized review can bottleneck ecosystem growth and blur the administrator responsibility that the explicit trust boundary is meant to preserve.
+Verdict: In vision.
+
+### H-12 - Auto-update marketplace extensions
+
+Proposal: Let an enabled marketplace extension update automatically to the latest verified version during the next Meshery restart.
+Proposal: Administrators receive a changelog after the update rather than approving each version.
+Proposal: Vulnerability repairs reach deployments faster, but a plugin behavior change can arrive without a chosen maintenance window.
+Tests: "Meshery treats an enabled extension as code inside the deployment trust boundary."
+Why the answer is not obvious: Automatic updates reduce known-vulnerable extension time and operational work.
+Why the answer is not obvious: Code running inside a deployment trust boundary should not change without a deliberate operator choice.
+Verdict: In vision.
+
+### H-13 - Consume a schemas prerelease
+
+Proposal: Permit a Meshery provider to depend on a signed prerelease of meshery/schemas when a contract must ship before the normal schemas release.
+Proposal: The endpoint remains generated from schemas, but repositories can coordinate through an expiring prerelease version.
+Proposal: The prerelease tag would be removed after release.
+Tests: "Every HTTP API endpoint sources its contract from the meshery/schemas repository."
+Why the answer is not obvious: The source of truth remains schemas while urgent cross-repository work is not blocked on release timing.
+Why the answer is not obvious: Prerelease ranges can become an untracked second release channel and weaken contract discipline.
+Verdict: In vision.
+
+### H-14 - Drop unknown fields during credential canonicalization
+
+Proposal: When intentional credential save encounters obsolete fields that do not exist in the canonical schema, drop them and write canonical state rather than preserving a legacy envelope.
+Proposal: The save completes normally and logs a migration event.
+Proposal: This makes later reads simple but can lose information no current schema recognizes.
+Tests: "Meshery canonicalizes legacy credential data on an intentional save while retaining tolerant reads during the transition."
+Why the answer is not obvious: Canonicalization should reduce persistent complexity instead of carrying obsolete fields forever.
+Why the answer is not obvious: Unknown fields may carry provider-specific intent that the current schema has not yet modeled.
+Verdict: In vision.
+
+### H-15 - Allow skipped provider coverage to merge
+
+Proposal: Allow a protected-branch pull request to merge when its required provider project is visibly skipped because credentials are unavailable.
+Proposal: A required-check summary names the missing suite, but the skipped check does not block the merge.
+Proposal: This turns visible skipped coverage into a delivery rule.
+Tests: "Meshery marks a provider CI project as skipped when required credentials are unavailable, including on protected branches."
+Why the answer is not obvious: A credential outage should not indefinitely block unrelated urgent fixes.
+Why the answer is not obvious: A protected branch could merge a provider regression while its promised coverage is absent.
+Verdict: In vision.
+
+### H-16 - Scope relationship integration by changed path
+
+Proposal: Run complete relationship integration scenarios only when a pull request changes policy, model, or deployment-engine paths.
+Proposal: Documentation, UI styling, and unrelated API changes would retain unit and lint coverage but bypass relationship scenarios.
+Proposal: This preserves pull-request coverage where change detection believes it matters.
+Tests: "Meshery keeps relationship integration coverage on pull requests today rather than deferring it to a nightly-only job."
+Why the answer is not obvious: Targeted execution shortens feedback for changes with no relationship behavior.
+Why the answer is not obvious: Path rules miss indirect coupling and can make a green pull request less meaningful.
+Verdict: In vision.
+Reasoning: Skip on documentation-only changes and provider-ui-only changes, but execute on all other PRs.
+
+### H-17 - Verify an air-gapped pin from local evidence
+
+Proposal: Let an air-gapped administrator upload an operator chart and manifest checksum to a local Meshery registry before choosing an explicit chart pin.
+Proposal: Meshery verifies the selected pin against that local evidence without contacting a public chart index.
+Proposal: This gives an explicit pin a stronger audit trail while adding artifact lifecycle responsibility to Meshery.
+Tests: "Meshery permits an air-gapped administrator to use an unverified explicit chart pin only after a typed acknowledgement of responsibility."
+Why the answer is not obvious: Local checksums preserve operator control while making the chosen artifact auditable.
+Why the answer is not obvious: A local artifact registry expands Meshery from control surface into a package distribution system.
+Verdict: In vision.
+
+### H-18 - Allow a generated-code safety baseline
+
+Proposal: Allow a generated package to register a package-level SQL lint exception after its generator has a test proving it cannot emit an untrusted ORDER BY value.
+Proposal: The generated code would no longer need line-by-line narrow suppressions.
+Proposal: A future generator change could expand the exception beyond the proof.
+Tests: "Meshery favors a documented, narrow safety exception over a global relaxation that creates a silent security false negative."
+Why the answer is not obvious: Generated code should be assessed at its source and not burden every generated call site.
+Why the answer is not obvious: A broad package exception can outlive the generator proof and hide a later unsafe path.
+Verdict: In vision.
+
+### H-19 - Let remote providers publish private schemas
+
+Proposal: Allow a remote provider to publish a private schema construct that emits generated endpoints without merging that construct into the public meshery/schemas repository.
+Proposal: The generated client retains a schema source, but contract governance becomes distributed.
+Proposal: This could serve proprietary provider capabilities without local endpoint copies.
+Tests: "Every HTTP API endpoint sources its contract from the meshery/schemas repository."
+Why the answer is not obvious: Private providers need a way to evolve proprietary capabilities without exposing their contracts publicly.
+Why the answer is not obvious: Distributed schema ownership erodes the single source of truth that prevents consumer drift.
+Verdict: In vision.
+
+### H-20 - Use encrypted production-derived test fixtures
+
+Proposal: Allow relationship integration tests to load encrypted, redacted production-derived design fixtures from a controlled test store.
+Proposal: This exercises real metadata patterns that synthetic fixtures miss.
+Proposal: It adds credentials, retention, and reproducibility obligations to the test system.
+Tests: "Meshery tests relationship policy against complete designs and real registrant shapes."
+Why the answer is not obvious: Production-derived fixtures expose the shapes that have already defeated synthetic coverage.
+Why the answer is not obvious: Sensitive data handling and external test dependencies can make a safety suite less portable and less trustworthy.
+Verdict: In vision.
+
+### A-1 - Approve the revised acceptance policy
+
+Proposal: Adopt the full revised VISION.md as the current acceptance policy for Meshery.
+Tests: The full revised draft is visible in the review board.
+Why the answer is not obvious: Approval makes the recorded decisions govern future change review, while a final adjustment can name the sentence that still needs work.
+Verdict: In vision.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,65 @@
+# Vision
+
+Meshery exists so that platform engineers, site reliability engineers, and DevSecOps teams can collaboratively design and operate cloud native infrastructure.
+It serves teams managing infrastructure and workloads across Kubernetes clusters, clouds, and integrations, and it turns their declared designs into evaluated, deployable, and observable operations.
+It owns exactly one thing: the relationship-aware control surface between an infrastructure design and its safe operation.
+
+## Design carries operational meaning
+
+A Meshery design represents components and relationships that the platform can evaluate, render, and operate.
+Meshery distinguishes relationships that guide lifecycle behavior from annotations that only aid human understanding.
+Meshery welcomes annotation-only components and relationships for visual and collaborative representation when they are explicitly non-semantic.
+Annotation-only components and relationships carry no deployment configuration and are excluded from deployment operations.
+Every new visual object states whether it changes lifecycle semantics.
+Meshery never makes user-created annotation relationships operational by default.
+Meshery makes dependency behavior explicit so a failed component cannot make dependent work appear successful.
+
+## Interoperability is schema-driven
+
+Meshery grows integrations through designated models, adapters, providers, APIs, and UI extension points.
+Meshery distributes signed third-party extensions through a marketplace only after maintainers review each publisher and administrator activation makes the trust boundary explicit.
+Meshery automatically updates an enabled marketplace extension to its latest verified version on the next restart and gives administrators a changelog afterward.
+Meshery keeps provider-owned identity, authorization, and durable persistence behind the provider boundary.
+Every HTTP API endpoint sources its contract from meshery/schemas or a provider-owned private schema construct.
+Meshery uses a generated schema client and type rather than a local endpoint or local contract copy.
+Meshery treats an enabled extension as code inside the deployment's trust boundary.
+
+## Intent changes visibly
+
+Meshery honors an operator's explicit configuration or refuses it with an actionable diagnostic.
+Meshery corrects only derived defaults against verified published state and reports each correction.
+Meshery permits an air-gapped administrator to use an explicit chart pin with locally uploaded chart and checksum evidence or a typed acknowledgement of responsibility.
+Meshery preserves legacy persisted data during a canonical form transition through tolerant reads rather than silent rewrites.
+Meshery canonicalizes legacy credential data on an intentional save, drops fields absent from the canonical schema, logs the migration, and retains tolerant reads during the transition.
+Meshery centralizes format resolution at shared layer boundaries instead of scattering shape assumptions across readers.
+
+## Access and outcomes are explicit
+
+Meshery gates protected content as well as protected controls and prevents denied content from loading.
+Meshery hides entry points that a user cannot access rather than directing users to a permission-denied page.
+Meshery reserves an explicit post-login onboarding exception rather than allowing unbounded ungated pages.
+Meshery enforces configured provider selection at server startup rather than relying on a chooser, cookie, header, query parameter, or page visibility.
+Meshery marks a provider CI project as skipped when required credentials are unavailable, including on protected branches, keeps that coverage visible, and does not let the visible skip block a merge.
+Meshery makes test and lint gates reflect actual command failures.
+Meshery permits a documented package-level SQL safety baseline for generated code only when its generator test proves it cannot emit an untrusted ORDER BY value.
+
+## Proof follows real use
+
+Meshery tests relationship policy against complete designs and real registrant shapes.
+Meshery may use encrypted and redacted production-derived design fixtures from a controlled test store when they improve realistic coverage.
+Meshery adds a regression test that fails against the reported defect before it claims a fix.
+Meshery runs complete relationship integration scenarios on every pull request except documentation-only and provider-ui-only changes.
+Meshery runs locally the checks that decide whether a change can merge.
+Meshery documents a contract or safety boundary where contributors will encounter it.
+
+## Scope
+
+Meshery is not a replacement for a provider's identity or authorization system.
+Meshery is not a security sandbox for extensions.
+Meshery is not a generic annotation canvas whose every relationship changes lifecycle state.
+Meshery is not a blind data-migration service or an unbounded compatibility layer.
+Meshery is not a source of hand-written HTTP API contracts without a schemas-based source.
+Meshery does not turn an unsupported explicit deployment choice into a different choice without telling the operator.
+
+A change aligns when it improves how a declared design is evaluated, operated, authorized, extended through a named contract, or verified against the shape operators actually use.
+A change should be resisted when it adds behavior without lifecycle meaning, creates an HTTP API without a schema source, bypasses a named trust boundary, hides skipped coverage, globally weakens a safety gate, or changes persisted data outside an intentional canonicalization path.


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes: N/A.
- Adds the author-approved `VISION.md` so future changes can be evaluated against a concrete Meshery acceptance policy.
- Grounds the policy in documented product behavior and merged pull request history, then preserves all 21 stress-test hypotheticals, two rounds of author verdicts, and the exact edit trace.
- Captures decisions that are easy to misread in isolation: annotation-only items remain non-operational, HTTP APIs stay schema-sourced, marketplace extensions are reviewed and update at restart, canonicalization follows an intentional save, and provider test skips remain visible but non-blocking.
- No production code or API behavior changes are included.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project vision and design principles covering interoperability, trust boundaries, access controls, intent handling, migrations, and testing expectations.
  * Added documented reviews of hypothetical proposals, including supporting tests, considerations, verdicts, and rationale.
  * Recorded changes across two review rounds and linked decisions to the project’s guiding principles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->