### PR TITLE
docs(windows): fix broken Docker Desktop installation link

### DIFF
--- a/docs/content/en/project/contributing/meshery-windows/index.md
+++ b/docs/content/en/project/contributing/meshery-windows/index.md
@@ -109,7 +109,7 @@ The Docker Desktop application for Windows includes a comprehensive set of tools
   </tr>
   <tr>
     <td>Home</td>
-    <td><a href="https://docs.docker.com/docker-for-windows/install-windows-home/">Docker Desktop for Windows Home</a></td>
+    <td><a href="https://docs.docker.com/desktop/install/windows-install/">Docker Desktop for Windows</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Description

Fixes broken Docker Desktop documentation link in the Windows WSL2 setup guide.

## Changes

Updated the Docker Desktop for Windows installation link from the outdated `docker-for-windows/install-windows-home` URL to the current `desktop/install/windows-install` URL. The old path is no longer maintained by Docker.

## Related Issue

Closes #21005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Windows Docker Desktop installation link to the current URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->