### PR TITLE
docs(contributing): enable section-index page titles

### DIFF
--- a/docs/content/en/project/contributing/cli/_index.md
+++ b/docs/content/en/project/contributing/cli/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery CLI
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to the Meshery CLI and its commands.

--- a/docs/content/en/project/contributing/contributing-docs/_index.md
+++ b/docs/content/en/project/contributing/contributing-docs/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery Docs
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to Meshery Docs.

--- a/docs/content/en/project/contributing/meshery-windows/index.md
+++ b/docs/content/en/project/contributing/meshery-windows/index.md
@@ -109,7 +109,7 @@ The Docker Desktop application for Windows includes a comprehensive set of tools
   </tr>
   <tr>
     <td>Home</td>
-    <td><a href="https://docs.docker.com/docker-for-windows/install-windows-home/">Docker Desktop for Windows Home</a></td>
+    <td><a href="https://docs.docker.com/desktop/install/windows-install/">Docker Desktop for Windows</a></td>
   </tr>
 </table>
 

--- a/docs/content/en/project/contributing/models/_index.md
+++ b/docs/content/en/project/contributing/models/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery Models
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to the Meshery models and their components.

--- a/docs/content/en/project/contributing/ui/_index.md
+++ b/docs/content/en/project/contributing/ui/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery UI
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to the Meshery UI and its components.


### PR DESCRIPTION
## Description

Fix missing page headings on section-index pages in the contributing documentation.

## Changes

Removed `display_title: false` from four section-index pages:
- cli/_index.md
- ui/_index.md  
- models/_index.md
- contributing-docs/_index.md

This allows the page titles to render as `<h1>` headings, providing proper visual hierarchy and confirming to users which section they are viewing.

## Related Issue

Fixes #21178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing documentation pages to display their titles by default.
  * Updated the Windows 10 Home Docker Desktop installation link to the current documentation page.
  * Improved consistency and navigation across contributor setup and guidance pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->