### PR TITLE
docs(contributing): enable section-index page titles

### DIFF
--- a/docs/content/en/project/contributing/cli/_index.md
+++ b/docs/content/en/project/contributing/cli/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery CLI
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to the Meshery CLI and its commands.

--- a/docs/content/en/project/contributing/contributing-docs/_index.md
+++ b/docs/content/en/project/contributing/contributing-docs/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery Docs
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to Meshery Docs.

--- a/docs/content/en/project/contributing/models/_index.md
+++ b/docs/content/en/project/contributing/models/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery Models
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to the Meshery models and their components.

--- a/docs/content/en/project/contributing/ui/_index.md
+++ b/docs/content/en/project/contributing/ui/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Contributing to Meshery UI
-display_title: false
 categories: [contributing]
 display-suggested-reading: false
 description: How to contribute to the Meshery UI and its components.


### PR DESCRIPTION
## Description

Fix missing page headings on section-index pages in the contributing documentation.

## Changes

Removed `display_title: false` from four section-index pages:
- cli/_index.md
- ui/_index.md  
- models/_index.md
- contributing-docs/_index.md

This allows the page titles to render as `<h1>` headings, providing proper visual hierarchy and confirming to users which section they are viewing.

## Related Issue

Fixes #21178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Page titles are now displayed on the CLI, documentation, models, and UI contributing guide pages.
  * Improved consistency across contributing documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->