### PR TITLE
docs(contributing): center DCO VS Code screenshot on wide screens

### DIFF
--- a/docs/content/en/project/contributing/_index.md
+++ b/docs/content/en/project/contributing/_index.md
@@ -54,7 +54,9 @@ To ensure all your commits are signed, you may choose to add this alias to your 
   commit = commit -s
 </code></pre>
 
-Or you may configure your IDE, for example, VSCode to automatically sign-off commits for you:<a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"/></a>
+Or you may configure your IDE, for example, VSCode to automatically sign-off commits for you:
+
+<div style="text-align: center;"><a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"/></a></div>
 
 </li>
 


### PR DESCRIPTION
## Summary
- Center the VS Code DCO sign-off configuration screenshot using a centered div wrapper
- Ensures proper alignment on all screen sizes

## Issue
Fixes #21538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the DCO sign-off guidance by separating the VSCode configuration instruction from its accompanying image.
  * Centered the image on its own line for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->