### PR TITLE
fix(server): add nil check for machineInst to prevent potential crash

### DIFF
--- a/server/machines/helpers/auto_register.go
+++ b/server/machines/helpers/auto_register.go
@@ -105,8 +105,9 @@ func (arh *AutoRegistrationHelper) processRegistration() {
 
 						machineInst, err := InitializeMachineWithContext(connectionPayload, ctx, id, data.MeshsyncDataHandler.UserID, arh.smInstanceTracker, arh.log, data.MeshsyncDataHandler.Provider, machines.DISCOVERED, connType, nil)
 
-						if err != nil {
+						if err != nil || machineInst == nil {
 							arh.log.Error(ErrAutoRegister(err, connType))
+							continue
 						}
 
 						_, err = machineInst.SendEvent(ctx, machines.Register, connectionPayload)


### PR DESCRIPTION
## Description
Fixes a potential nil pointer dereference crash in auto registration flow.

## Issue
Fixes #20821

## Problem
In auto_register.go, if InitializeMachineWithContext fails, machineInst can be nil. However, the code continues and attempts to call SendEvent() on the nil pointer without checking, causing a panic.

## Solution
- Added nil check after machine initialization
- Added continue statement to skip to next URL on failure
- Prevents nil pointer dereference while maintaining intended error handling behavior

## Changes
- Line 108: Updated condition to check both err != nil AND machineInst == nil
- Line 109: Added continue to skip to next iteration if initialization failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic registration reliability by handling unavailable machine instances as failures.
  - Failed registration attempts are now logged, while processing continues with other eligible machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->