### PR TITLE
[mesheryctl] Fix adapter validate using adapter location as mesh name

### DIFF
--- a/mesheryctl/internal/cli/root/adapter/validate.go
+++ b/mesheryctl/internal/cli/root/adapter/validate.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshery/server/models"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -66,13 +67,11 @@ mesheryctl adapter validate istio --adapter meshery-istio --spec smi
 		if err != nil {
 			return ErrGettingSessionData(err)
 		}
-		//resolve adapterUrl to adapter Location
-		for _, adapter := range prefs.MeshAdapters {
-			adapterName := strings.Split(adapter.Location, ":")
-			if adapterName[0] == adapterURL {
-				adapterURL = adapter.Location
-				meshName = adapter.Location
-			}
+		//resolve adapterUrl to adapter Location, pulling both Location and
+		//Name off the same matched adapter so they can never disagree
+		if adapter, ok := findAdapter(prefs.MeshAdapters, adapterURL); ok {
+			adapterURL = adapter.Location
+			meshName = adapter.Name
 		}
 		//sync with available adapters
 		if err = validateAdapter(mctlCfg, meshName); err != nil {
@@ -107,6 +106,20 @@ mesheryctl adapter validate istio --adapter meshery-istio --spec smi
 
 		return nil
 	},
+}
+
+// findAdapter looks up the registered mesh adapter whose Location's host
+// (the part before an optional ":port") matches adapterURL, and returns
+// that adapter so the caller can read Name and Location off the same match
+// instead of mixing fields from two different resolution passes.
+func findAdapter(adapters []*models.Adapter, adapterURL string) (*models.Adapter, bool) {
+	for _, adapter := range adapters {
+		host := strings.Split(adapter.Location, ":")[0]
+		if host == adapterURL {
+			return adapter, true
+		}
+	}
+	return nil, false
 }
 
 func init() {

--- a/mesheryctl/internal/cli/root/adapter/validate_test.go
+++ b/mesheryctl/internal/cli/root/adapter/validate_test.go
@@ -1,0 +1,86 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"testing"
+
+	"github.com/meshery/meshery/server/models"
+)
+
+// TestFindAdapter covers resolving a registered mesh adapter by the host
+// portion of its Location, including the no-port case from
+// https://github.com/meshery/meshery/issues/21630 where matching used to
+// leak adapter.Location into the caller's meshName instead of adapter.Name.
+func TestFindAdapter(t *testing.T) {
+	adapters := []*models.Adapter{
+		{Name: "ISTIO", Location: "meshery-istio:10000"},
+		{Name: "NSM", Location: "meshery-nsm"}, // registered without a port
+	}
+
+	tests := []struct {
+		name       string
+		adapterURL string
+		wantFound  bool
+		wantName   string
+		wantLoc    string
+	}{
+		{
+			name:       "adapter registered with a port",
+			adapterURL: "meshery-istio",
+			wantFound:  true,
+			wantName:   "ISTIO",
+			wantLoc:    "meshery-istio:10000",
+		},
+		{
+			name:       "adapter registered without a port",
+			adapterURL: "meshery-nsm",
+			wantFound:  true,
+			wantName:   "NSM",
+			wantLoc:    "meshery-nsm",
+		},
+		{
+			name:       "no matching adapter",
+			adapterURL: "meshery-linkerd",
+			wantFound:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := findAdapter(adapters, tt.adapterURL)
+
+			if ok != tt.wantFound {
+				t.Fatalf("findAdapter() found = %v, want %v", ok, tt.wantFound)
+			}
+			if !tt.wantFound {
+				if got != nil {
+					t.Fatalf("findAdapter() adapter = %#v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("findAdapter() returned nil adapter")
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("adapter Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.Location != tt.wantLoc {
+				t.Errorf("adapter Location = %q, want %q", got.Location, tt.wantLoc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
adapter validate's PreRunE assigned adapter.Location to meshName instead of adapter.Name, so validation failed whenever the matched adapter had no explicit port. Replaced the loop with a findAdapter helper and added test coverage for the no-port case.

Fixes #21630

**Notes for Reviewers**

`mesheryctl adapter validate`'s `PreRunE` re-resolves the adapter a second
time (the parent `adapter` command's `PersistentPreRunE` already resolved
it correctly via `validateAdapter`) by matching the host portion of
`adapter.Location` against the `--adapter` value. On a match it
overwrote `meshName` with `adapter.Location` instead of `adapter.Name`.

- Adapter registered **with** a port (`meshery-istio:10000`): the
  host-only comparison never matched, so the bug stayed hidden.
- Adapter registered **without** a port (`meshery-istio`): the
  comparison *did* match, clobbering `meshName` with the location
  string. The subsequent `validateAdapter(mctlCfg, meshName)` call could
  then never find an adapter whose `Name` equalled that location, and
  validation failed with `Unable to sync with available adapters`.

**Fix**: replaced the loop with a `findAdapter(adapters, adapterURL)` helper
that returns the matched `*models.Adapter` itself, so `Name` and
`Location` are always read off the *same* match and can't be crossed
again.

Added `TestFindAdapter` covering the with-port, without-port, and
no-match cases.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adapter validation by matching adapters against the host in the configured location.
  * Correctly identifies and displays the matched adapter’s name and location.
  * Supports adapter locations with or without ports and handles unmatched locations reliably.

* **Tests**
  * Added coverage for successful adapter matches, port-based locations, and unmatched URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->