### PR TITLE
fix: Add missing workspaceID validation in workspace handlers (#21205)

### DIFF
--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -13,6 +13,17 @@ import (
 	workspace "github.com/meshery/schemas/models/v1beta3/workspace"
 )
 
+// validateWorkspaceID validates that workspaceID is not empty
+func (h *Handler) validateWorkspaceID(w http.ResponseWriter, workspaceID string) bool {
+	if workspaceID == "" {
+		missingInput := models.ErrWorkspaceMissingInput()
+		h.log.Error(missingInput)
+		writeMeshkitError(w, missingInput, http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
 // workspacePayloadWire is a handler-local dual-accept wrapper around
 // workspace.WorkspacePayload (now v1beta3, canonical-camelCase). The
 // canonical wire form emits `organizationId`; the legacy `organization_id`
@@ -116,6 +127,9 @@ func (h *Handler) GetWorkspacesHandler(w http.ResponseWriter, req *http.Request,
 
 func (h *Handler) GetWorkspaceByIdHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(r)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	q := r.URL.Query()
 	// Canonical form is `orgId`; `orgID` is dual-accepted during the Phase 2
 	// deprecation window. Retire once Phase 3 consumer migration completes.
@@ -259,6 +273,9 @@ func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Reques
 
 func (h *Handler) GetEnvironmentsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	q := req.URL.Query()
 	resp, err := provider.GetEnvironmentsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
@@ -276,6 +293,9 @@ func (h *Handler) GetEnvironmentsOfWorkspaceHandler(w http.ResponseWriter, req *
 
 func (h *Handler) GetDesignsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	q := req.URL.Query()
 	resp, err := provider.GetDesignsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"), q["visibility"])
 	if err != nil {
@@ -293,6 +313,9 @@ func (h *Handler) GetDesignsOfWorkspaceHandler(w http.ResponseWriter, req *http.
 
 func (h *Handler) AddEnvironmentToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	environmentID := mux.Vars(req)["environmentID"]
 	resp, err := provider.AddEnvironmentToWorkspace(req, workspaceID, environmentID)
 	if err != nil {
@@ -309,6 +332,9 @@ func (h *Handler) AddEnvironmentToWorkspaceHandler(w http.ResponseWriter, req *h
 
 func (h *Handler) RemoveEnvironmentFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	environmentID := mux.Vars(req)["environmentID"]
 	resp, err := provider.RemoveEnvironmentFromWorkspace(req, workspaceID, environmentID)
 	if err != nil {
@@ -325,6 +351,9 @@ func (h *Handler) RemoveEnvironmentFromWorkspaceHandler(w http.ResponseWriter, r
 
 func (h *Handler) AddDesignToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	designID := mux.Vars(req)["designID"]
 	resp, err := provider.AddDesignToWorkspace(req, workspaceID, designID)
 	if err != nil {
@@ -341,6 +370,9 @@ func (h *Handler) AddDesignToWorkspaceHandler(w http.ResponseWriter, req *http.R
 
 func (h *Handler) RemoveDesignFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	designID := mux.Vars(req)["designID"]
 	resp, err := provider.RemoveDesignFromWorkspace(req, workspaceID, designID)
 	if err != nil {
@@ -357,6 +389,9 @@ func (h *Handler) RemoveDesignFromWorkspaceHandler(w http.ResponseWriter, req *h
 
 func (h *Handler) GetViewsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	q := req.URL.Query()
 	resp, err := provider.GetViewsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
@@ -373,6 +408,9 @@ func (h *Handler) GetViewsOfWorkspaceHandler(w http.ResponseWriter, req *http.Re
 
 func (h *Handler) AddViewToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	viewID := mux.Vars(req)["viewID"]
 	resp, err := provider.AddViewToWorkspace(req, workspaceID, viewID)
 	if err != nil {
@@ -389,6 +427,9 @@ func (h *Handler) AddViewToWorkspaceHandler(w http.ResponseWriter, req *http.Req
 
 func (h *Handler) RemoveViewFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	viewID := mux.Vars(req)["viewID"]
 	resp, err := provider.RemoveViewFromWorkspace(req, workspaceID, viewID)
 	if err != nil {
@@ -405,6 +446,9 @@ func (h *Handler) RemoveViewFromWorkspaceHandler(w http.ResponseWriter, req *htt
 
 func (h *Handler) GetTeamsOfWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	q := req.URL.Query()
 	resp, err := provider.GetTeamsOfWorkspace(req, workspaceID, q.Get("page"), q.Get("pagesize"), q.Get("search"), q.Get("order"), q.Get("filter"))
 	if err != nil {
@@ -421,6 +465,9 @@ func (h *Handler) GetTeamsOfWorkspaceHandler(w http.ResponseWriter, req *http.Re
 
 func (h *Handler) AddTeamToWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	teamID := mux.Vars(req)["teamID"]
 	resp, err := provider.AddTeamToWorkspace(req, workspaceID, teamID)
 	if err != nil {
@@ -437,6 +484,9 @@ func (h *Handler) AddTeamToWorkspaceHandler(w http.ResponseWriter, req *http.Req
 
 func (h *Handler) RemoveTeamFromWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if !h.validateWorkspaceID(w, workspaceID) {
+		return
+	}
 	teamID := mux.Vars(req)["teamID"]
 	resp, err := provider.RemoveTeamFromWorkspace(req, workspaceID, teamID)
 	if err != nil {

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -198,10 +198,7 @@ func (h *Handler) SaveWorkspaceHandler(w http.ResponseWriter, req *http.Request,
 
 func (h *Handler) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(r)["id"]
-	if workspaceID == "" {
-		missingInput := models.ErrWorkspaceMissingInput()
-		h.log.Error(missingInput)
-		writeMeshkitError(w, missingInput, http.StatusBadRequest)
+	if !h.validateWorkspaceID(w, workspaceID) {
 		return
 	}
 	resp, err := provider.DeleteWorkspace(r, workspaceID)
@@ -220,10 +217,7 @@ func (h *Handler) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request,
 
 func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
-	if workspaceID == "" {
-		missingInput := models.ErrWorkspaceMissingInput()
-		h.log.Error(missingInput)
-		writeMeshkitError(w, missingInput, http.StatusBadRequest)
+	if !h.validateWorkspaceID(w, workspaceID) {
 		return
 	}
 	bd, err := io.ReadAll(req.Body)

--- a/server/handlers/workspace_handlers.go
+++ b/server/handlers/workspace_handlers.go
@@ -184,6 +184,12 @@ func (h *Handler) SaveWorkspaceHandler(w http.ResponseWriter, req *http.Request,
 
 func (h *Handler) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request, _ *models.Preference, _ *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(r)["id"]
+	if workspaceID == "" {
+		missingInput := models.ErrWorkspaceMissingInput()
+		h.log.Error(missingInput)
+		writeMeshkitError(w, missingInput, http.StatusBadRequest)
+		return
+	}
 	resp, err := provider.DeleteWorkspace(r, workspaceID)
 	if err != nil {
 		handlerErr := ErrDeleteWorkspace(err)
@@ -200,6 +206,12 @@ func (h *Handler) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request,
 
 func (h *Handler) UpdateWorkspaceHandler(w http.ResponseWriter, req *http.Request, _ *models.Preference, user *models.User, provider models.Provider) {
 	workspaceID := mux.Vars(req)["id"]
+	if workspaceID == "" {
+		missingInput := models.ErrWorkspaceMissingInput()
+		h.log.Error(missingInput)
+		writeMeshkitError(w, missingInput, http.StatusBadRequest)
+		return
+	}
 	bd, err := io.ReadAll(req.Body)
 	if err != nil {
 		h.log.Error(ErrRequestBody(err))

--- a/server/handlers/workspace_handlers_test.go
+++ b/server/handlers/workspace_handlers_test.go
@@ -458,7 +458,7 @@ func TestGetWorkspaceByIdHandler_ReturnsErrorOnMissingWorkspaceID(t *testing.T) 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
-	if !provider.called {
+	if provider.called {
 		t.Errorf("provider should not be called when workspaceID is empty")
 	}
 }

--- a/server/handlers/workspace_handlers_test.go
+++ b/server/handlers/workspace_handlers_test.go
@@ -422,3 +422,60 @@ func TestSaveWorkspaceHandler_SetsContentTypeOnSuccess(t *testing.T) {
 		t.Errorf("Content-Type = %q, want application/json", ct)
 	}
 }
+
+// TestDeleteWorkspaceHandler_ReturnsErrorOnMissingWorkspaceID verifies that
+// DeleteWorkspaceHandler returns 400 Bad Request when workspaceID is empty.
+func TestDeleteWorkspaceHandler_ReturnsErrorOnMissingWorkspaceID(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := newWorkspaceSpyProvider()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": ""})
+	rec := httptest.NewRecorder()
+
+	h.DeleteWorkspaceHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "workspaceId") {
+		t.Errorf("expected 400 body to mention workspaceId, got %q", rec.Body.String())
+	}
+}
+
+// TestGetWorkspaceByIdHandler_ReturnsErrorOnMissingWorkspaceID verifies that
+// GetWorkspaceByIdHandler returns 400 Bad Request when workspaceID is empty.
+func TestGetWorkspaceByIdHandler_ReturnsErrorOnMissingWorkspaceID(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := newWorkspaceSpyProvider()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/?orgId=11111111-1111-1111-1111-111111111111", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": ""})
+	rec := httptest.NewRecorder()
+
+	h.GetWorkspaceByIdHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !provider.called {
+		t.Errorf("provider should not be called when workspaceID is empty")
+	}
+}
+
+// TestGetEnvironmentsOfWorkspaceHandler_ReturnsErrorOnMissingWorkspaceID verifies
+// that nested handlers also validate workspaceID and return 400.
+func TestGetEnvironmentsOfWorkspaceHandler_ReturnsErrorOnMissingWorkspaceID(t *testing.T) {
+	h := newTestHandler(t, map[string]models.Provider{}, "")
+	provider := newWorkspaceSpyProvider()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces//environments", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": ""})
+	rec := httptest.NewRecorder()
+
+	h.GetEnvironmentsOfWorkspaceHandler(rec, req, nil, nil, provider)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body=%q)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Add validation to ensure workspaceID is not empty in both DeleteWorkspaceHandler and UpdateWorkspaceHandler before passing to provider methods.

## Problem

Missing validation causes runtime errors when the route parameter 'id' is missing or empty. This results in empty workspace IDs being passed to provider methods, causing unexpected behavior.

## Solution

Added validation in both handlers to return a proper 400 Bad Request error with ErrWorkspaceMissingInput when workspaceID is empty, matching the pattern used in GetWorkspacesHandler.

## Testing

The fix prevents empty workspaceID values from reaching provider methods and returns proper error responses to the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded workspace ID validation across workspace, environment, design, view, and team operations.
  * Requests missing a workspace ID now receive a clear HTTP 400 Bad Request response before processing.
  * Workspace update and deletion requests validate missing IDs consistently.
  * Invalid requests no longer trigger unnecessary provider operations, improving reliability and preventing unintended processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->