### PR TITLE
[Docs] Add copy button to mesheryctl reference command blocks

### DIFF
--- a/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
@@ -14,8 +14,10 @@ Deploy infrastructure to the Kubernetes cluster
 Deploy infrastructure to the connected Kubernetes cluster
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter deploy [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,39 +26,40 @@ mesheryctl adapter deploy [flags]
 Deploy a infrastructure from an interactive on the default namespace
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter deploy
 
+</div>
 </div>
 </pre> 
 
 Deploy infrastructure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter deploy linkerd
 
+</div>
 </div>
 </pre> 
 
 Deploy Linkerd mesh on a specific namespace
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter deploy linkerd --namespace linkerd-ns
 
+</div>
 </div>
 </pre> 
 
 Deploy Linkerd mesh and wait for it to be deployed
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter deploy linkerd --watch
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-		
-
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/adapter/remove.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/remove.md
@@ -14,8 +14,10 @@ remove cloud and cloud native infrastructure
 remove cloud and cloud native infrastructure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter remove [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,23 +26,20 @@ mesheryctl adapter remove [flags]
 Remove Linkerd deployment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter remove linkerd
 
+</div>
 </div>
 </pre> 
 
 Remove a Linkerd control plane found under a specific namespace (linkerd-ns)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter remove linkerd --namespace linkerd-ns
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-		
-
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/adapter/validate.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/validate.md
@@ -14,8 +14,10 @@ Validate conformance to predefined standards
 Validate predefined conformance to different standard specifications
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter validate [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,16 +26,20 @@ mesheryctl adapter validate [flags]
 Validate conformance to predefined standards
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter validate [mesh name] --adapter [name of the adapter] --tokenPath [path to token for authentication] --spec [specification to be used for conformance test] --namespace [namespace to be used]
 
+</div>
 </div>
 </pre> 
 
 Validate Istio to predefined standards
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl adapter validate istio --adapter meshery-istio --spec smi
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/completion.md
+++ b/docs/content/en/reference/references/mesheryctl/completion.md
@@ -14,8 +14,10 @@ Generate shell completion scripts
 Output shell completion code
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl completion [bash|zsh|fish]
 
+</div>
 </div>
 </pre> 
 
@@ -24,8 +26,10 @@ mesheryctl completion [bash|zsh|fish]
 ### bash <= 3.2
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-source /dev/stdin <<< "$(mesheryctl completion bash)"
+<div class='clipboardjs'>
+source /dev/stdin &lt;&lt;&lt; "$(mesheryctl completion bash)"
 
+</div>
 </div>
 </pre> 
 
@@ -33,38 +37,48 @@ bash <= 3.2 on osx
 ensure you have bash-completion 1.3+
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 brew install bash-completion 
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion bash > $(brew --prefix)/etc/bash_completion.d/mesheryctl
+<div class='clipboardjs'>
+mesheryctl completion bash &gt; $(brew --prefix)/etc/bash_completion.d/mesheryctl
 
+</div>
 </div>
 </pre> 
 
 ### bash >= 4.0
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-source <(mesheryctl completion bash)
+<div class='clipboardjs'>
+source &lt;(mesheryctl completion bash)
 
+</div>
 </div>
 </pre> 
 
 bash >= 4.0 on osx
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 brew install bash-completion@2
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion bash > $(brew --prefix)/etc/bash_completion.d/mesheryctl
+<div class='clipboardjs'>
+mesheryctl completion bash &gt; $(brew --prefix)/etc/bash_completion.d/mesheryctl
 
+</div>
 </div>
 </pre> 
 
@@ -74,39 +88,49 @@ to enable it.  You can execute the following once:
 Might need to start a new shell for this setup to take effect.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+<div class='clipboardjs'>
+$ echo "autoload -U compinit; compinit" &gt;&gt; ~/.zshrc
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-source <(mesheryctl completion zsh)
+<div class='clipboardjs'>
+source &lt;(mesheryctl completion zsh)
 
+</div>
 </div>
 </pre> 
 
 zsh on osx / oh-my-zsh
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-COMPLETION_DIR=$(echo $fpath | grep -o '[^ ]*completions' | grep -v cache) && mkdir -p $COMPLETION_DIR && mesheryctl completion zsh > "${COMPLETION_DIR}/_mesheryctl"
+<div class='clipboardjs'>
+COMPLETION_DIR=$(echo $fpath | grep -o '[^ ]*completions' | grep -v cache) &amp;&amp; mkdir -p $COMPLETION_DIR &amp;&amp; mesheryctl completion zsh &gt; "${COMPLETION_DIR}/_mesheryctl"
 
+</div>
 </div>
 </pre> 
 
 ### fish:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl completion fish | source
 
+</div>
 </div>
 </pre> 
 
 To load fish shell completions for each session, execute once:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl completion fish > ~/.config/fish/completions/mesheryctl.fish
+<div class='clipboardjs'>
+mesheryctl completion fish &gt; ~/.config/fish/completions/mesheryctl.fish
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/component/_index.md
@@ -15,8 +15,10 @@ List, search and view component(s) and detailed informations
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl component [flags]
 Display number of available components in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component --count
 
+</div>
 </div>
 </pre> 
 
 List available component(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component list
 
+</div>
 </div>
 </pre> 
 
 Search for component(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component search [component-name]
 
+</div>
 </div>
 </pre> 
 
 View a specific component
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component view [component-name | component-id]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/list.md
+++ b/docs/content/en/reference/references/mesheryctl/component/list.md
@@ -15,8 +15,10 @@ List all components registered in Meshery Server
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl component list [flags]
 View list of components
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component list
 
+</div>
 </div>
 </pre> 
 
 View list of components with specified page number (10 components per page)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component list --page [page-number]
 
+</div>
 </div>
 </pre> 
 
 View list of components with specified page number with specified number of components per page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component list --page [page-number] --pagesize [page-size]
 
+</div>
 </div>
 </pre> 
 
 Display the number of components present in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component list --count
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/search.md
+++ b/docs/content/en/reference/references/mesheryctl/component/search.md
@@ -15,8 +15,10 @@ Search components registered in Meshery Server based on kind
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component search [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl component search [flags]
 Search for components using a query
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component search [query-text]
 
+</div>
 </div>
 </pre> 
 
 Search for multi-word component names (must be quoted)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component search "Component name"
 
+</div>
 </div>
 </pre> 
 
 Search list of components of specified page [int]
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component search [query-text] [--page 1]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/component/view.md
+++ b/docs/content/en/reference/references/mesheryctl/component/view.md
@@ -15,8 +15,10 @@ View a component registered in Meshery Server
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl component view [flags]
 View details of a specific component
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component view [component-name | component-id]
 
+</div>
 </div>
 </pre> 
 
 View details of a specific component in specified format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component view [component-name | component-id] -o [json|yaml]
 
+</div>
 </div>
 </pre> 
 
 View details of a specific component in specified format and save it as a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl component view [component-name | component-id] -o [json|yaml] --save
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/_index.md
@@ -15,8 +15,10 @@ View and manage your Meshery connection.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,60 +27,76 @@ mesheryctl connection [flags]
 Display total count of all available connections
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection --count
 
+</div>
 </div>
 </pre> 
 
 Create a new Kubernetes connection using a specific type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create --type aks
 
 </div>
+</div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create --type eks
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl connection create --type gke
-
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
+mesheryctl connection create --type gke
+
+</div>
+</div>
+</pre> 
+
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create --type minikube
 
+</div>
 </div>
 </pre> 
 
 List all the connection
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list --count
 
+</div>
 </div>
 </pre> 
 
 Delete a connection
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection delete [connection_id]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/create.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/create.md
@@ -15,8 +15,10 @@ Create a new connection to a Kubernetes cluster or other supported platform.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,37 +27,47 @@ mesheryctl connection create [flags]
 Create a new Kubernetes connection using a specific type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create --type aks
 
 </div>
+</div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create --type eks
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl connection create --type gke
-
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
+mesheryctl connection create --type gke
+
+</div>
+</div>
+</pre> 
+
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create --type minikube
 
+</div>
 </div>
 </pre> 
 
 Create a connection with a token
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection create --type gke --token auth.json
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/delete.md
@@ -15,8 +15,10 @@ Delete a connection.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection delete [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl connection delete [flags]
 Delete a connection
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection delete [connection_id]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/list.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/list.md
@@ -15,8 +15,10 @@ List all available connections.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,40 +27,50 @@ mesheryctl connection list [flags]
 List all the connections
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list
 
+</div>
 </div>
 </pre> 
 
 List all the connections with page number
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list --page [page-number]
 
+</div>
 </div>
 </pre> 
 
 List all the connections matching a specific kind and status
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list --kind [kind] --status [status]
 
+</div>
 </div>
 </pre> 
 
 List all the connections matching a set of kinds and statuses
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list --kind [kind] --kind [kind] --status [status] --status [status]
 
+</div>
 </div>
 </pre> 
 
 Display total count of all available connections
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection list --count
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/connection/view.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/view.md
@@ -15,8 +15,10 @@ View a connection by its ID or name.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl connection view [flags]
 View details of a specific connection in default format (yaml)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection view [connection-name|connection-id]
 
+</div>
 </div>
 </pre> 
 
 View details of a specific connection in JSON format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection view [connection-name|connection-id] --output-format json
 
+</div>
 </div>
 </pre> 
 
 View details of a specific connection in json format and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl connection view [connection-name|connection-id] --output-format json --save
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/design/_index.md
@@ -15,8 +15,10 @@ Manage cloud and cloud native infrastructure using predefined designs.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl design [flags]
 Apply design file:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design apply --file [path to design file | URL of the file]
 
+</div>
 </div>
 </pre> 
 
 Delete design file:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design delete --file [path to design file]
 
+</div>
 </div>
 </pre> 
 
 View design file:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design view [design name | ID]
 
+</div>
 </div>
 </pre> 
 
 List all designs:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design list
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/design/apply.md
@@ -15,8 +15,10 @@ Apply design will trigger deploy of the design file.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design apply [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl design apply [flags]
 apply a design file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design apply -f [file | URL]
 
+</div>
 </div>
 </pre> 
 
 deploy a saved design
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design apply [design-name]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/design/delete.md
@@ -15,8 +15,10 @@ delete design file will trigger deletion of the design file.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design delete [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl design delete [flags]
 delete a design file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design delete [file | URL]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/deploy.md
@@ -15,8 +15,10 @@ Command will trigger deploy of design.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design deploy [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl design deploy [flags]
 Deploy design by providing file path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design deploy -f [filepath] -s [source type]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/evaluate.md
+++ b/docs/content/en/reference/references/mesheryctl/design/evaluate.md
@@ -16,8 +16,10 @@ The evaluated design is saved to the specified output file while an overview
 of evaluation actions is printed to the terminal.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design evaluate [ID] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -26,24 +28,30 @@ mesheryctl design evaluate [ID] [flags]
 Evaluate a design from a file and save the result
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design evaluate -f design.yaml -o evaluated-design.yaml
 
+</div>
 </div>
 </pre> 
 
 Evaluate a design by ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design evaluate 12345678-abcd-efgh-ijkl-123456789012 -o result.yaml
 
+</div>
 </div>
 </pre> 
 
 Evaluate and save as JSON
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design evaluate -f design.yaml --output-format json -o evaluated-design.json
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/export.md
+++ b/docs/content/en/reference/references/mesheryctl/design/export.md
@@ -18,8 +18,10 @@ By default, the exported design will be saved in the current directory. The diff
 type allowed are oci, original, and current. The default design type is current.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design export [pattern-name | ID] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -28,32 +30,40 @@ mesheryctl design export [pattern-name | ID] [flags]
 Export a design with a specific ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design export [pattern-name | ID]
 
+</div>
 </div>
 </pre> 
 
 Export a design with a specific ID and type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design export [pattern-name | ID] --type [design-type]
 
+</div>
 </div>
 </pre> 
 
 Export a design and save it to a specific directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design export [pattern-name | ID] --output ./designs
 
+</div>
 </div>
 </pre> 
 
 Export a design with a specific type and save it to a directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design export [pattern-name | ID] --type [design-type] --output ./exports
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/import.md
+++ b/docs/content/en/reference/references/mesheryctl/design/import.md
@@ -22,8 +22,10 @@ Import a Meshery design
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design import [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -32,29 +34,37 @@ mesheryctl design import [flags]
 Import design manifest
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design import -f [file/URL] -s [source-type] -n [name]
 
 </div>
+</div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design import -f design.tar
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl design import -f design.yml -n design-name
-
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
+mesheryctl design import -f design.yml -n design-name
+
+</div>
+</div>
+</pre> 
+
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design import -f design.yml -s "Kubernetes Manifest" -n design-name
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/list.md
+++ b/docs/content/en/reference/references/mesheryctl/design/list.md
@@ -15,8 +15,10 @@ Display list of all available designs.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,40 +27,50 @@ mesheryctl design list [flags]
 Display a list of all available designs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design list
 
+</div>
 </div>
 </pre> 
 
 Display a list of all available designs with verbose output
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design list --verbose
 
+</div>
 </div>
 </pre> 
 
 Display a list of all available designs with specified page number (10 designs per page by default)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design list --page [pange-number]
 
+</div>
 </div>
 </pre> 
 
 Display a list of all available designs with custom page size (10 designs per page by default)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design list --pagesize [page-size]
 
+</div>
 </div>
 </pre> 
 
 Display only the count of all available designs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design list --count
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/undeploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/undeploy.md
@@ -15,8 +15,10 @@ Undeploy design will trigger undeploy of design.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design undeploy [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl design undeploy [flags]
 Undeploy design by providing file path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design undeploy -f [filepath]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/design/view.md
+++ b/docs/content/en/reference/references/mesheryctl/design/view.md
@@ -15,8 +15,10 @@ Display the content of a specific design based on name or id.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design view design name [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl design view design name [flags]
 view a design
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl design view [design-name | ID]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/_index.md
@@ -15,8 +15,10 @@ Create, delete, list of view details of environment(s) of a specific organizatio
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl environment [flags]
 Create an environment in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment create --orgId [orgId] --name [name] --description [description]
 
+</div>
 </div>
 </pre> 
 
 Delete an environment in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment delete environment-id
 
+</div>
 </div>
 </pre> 
 
 List of registered environments in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment list --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 
 View a particular environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment view --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/create.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/create.md
@@ -15,8 +15,10 @@ Create a new environment by providing the name and description of the environmen
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment create [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl environment create [flags]
 Create a new environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment create --orgId [orgId] --name [name] --description [description]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/delete.md
@@ -15,8 +15,10 @@ Delete an environment by providing the environment ID
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment delete [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl environment delete [flags]
 delete a new environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment delete [environmentId]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/list.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/list.md
@@ -15,8 +15,10 @@ List detailed information of all registered environments
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl environment list [flags]
 List all registered environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment list --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 
 List count of all registered environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment list --orgId [orgId] --count
 
+</div>
 </div>
 </pre> 
 
 List all registered environment at a specific page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment list --orgId [orgId] --page [page]
 
+</div>
 </div>
 </pre> 
 
 List all registered environment with a specific page size
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment list --orgId [orgId] --pagesize [pagesize]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/environment/view.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/view.md
@@ -15,8 +15,10 @@ View details of an environment registered in Meshery Server for a specific organ
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl environment view [flags]
 View details of a specific environment
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl environment view --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/exp.md
+++ b/docs/content/en/reference/references/mesheryctl/exp.md
@@ -14,8 +14,10 @@ Preview experimental commands
 Commands under the Experimental group are for testing and evaluation prior to promotion to general availability. Experimental commands are subject to change.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl exp [flags]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/_index.md
@@ -15,8 +15,10 @@ Cloud Native Filter Management
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl filter [flags]
 Base command for WASM filters:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter [subcommands]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/delete.md
@@ -15,8 +15,10 @@ Delete a filter file using the name or ID of a filter.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter delete [filter-name | ID] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -26,8 +28,10 @@ Delete the specified WASM filter file using name or ID
 A unique prefix of the name or ID can also be provided. If the prefix is not unique, the first match will be deleted.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter delete [filter-name | ID]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/import.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/import.md
@@ -15,8 +15,10 @@ Import a WASM filter from a URI (http/s) or local filesystem path.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter import [URI] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl filter import [URI] [flags]
 Import a filter file from local filesystem
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter import /path/to/filter.wasm
 
+</div>
 </div>
 </pre> 
 
 Import a filter file from a remote URI
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter import https://example.com/myfilter.wasm
 
+</div>
 </div>
 </pre> 
 
@@ -43,16 +49,20 @@ If the string is a valid file in the filesystem, the file is read and passed as 
 Use quotes if the string contains spaces
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter import /path/to/filter.wasm --wasm-config [filepath|string]
 
+</div>
 </div>
 </pre> 
 
 Specify the name of the filter to be imported. Use quotes if the name contains spaces
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter import /path/to/filter.wasm --name [string]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/list.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/list.md
@@ -15,8 +15,10 @@ Display list of all available filter files.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl filter list [flags]
 List all WASM filter files present
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter list	(maximum 25 filters)
 
+</div>
 </div>
 </pre> 
 
 Search for filter
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter list Test (maximum 25 filters)
 
+</div>
 </div>
 </pre> 
 
 Search for filter with space
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter list 'Test Filter' (maximum 25 filters)
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/filter/view.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/view.md
@@ -15,8 +15,10 @@ Displays the contents of a specific filter based on name or id.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -26,47 +28,50 @@ View the specified WASM filter
 A unique prefix of the name or ID can also be provided. If the prefix is not unique, the first match will be returned.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter view "[filter-name | ID]"
 
+</div>
 </div>
 </pre> 
 
 View all filter files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter view --all
 
+</div>
 </div>
 </pre> 
 
 View all filter files in json
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter view --all --output-format json
 
+</div>
 </div>
 </pre> 
 
 View all filter files in json and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter view --all --output-format json -s
 
+</div>
 </div>
 </pre> 
 
 //View multi-word named filter files. Multi-word filter names should be enclosed in quotes
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl filter view "filter name"
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-        
-
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/model/_index.md
@@ -15,8 +15,10 @@ Export, generate, import, list, search and view model(s) and detailed informatio
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,95 +27,119 @@ mesheryctl model [flags]
 Display number of available models in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model --count
 
+</div>
 </div>
 </pre> 
 
 Export registered models
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model export [model-name]
 
+</div>
 </div>
 </pre> 
 
 Generate a model from a CSV directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model generate [path-to-csv-directory]
 
+</div>
 </div>
 </pre> 
 
 Generate a model from a URL based on a JSON template
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model generate --file [URL] --template [path-to-template.json]
 
+</div>
 </div>
 </pre> 
 
 Import model(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import -f [Uri]
 
+</div>
 </div>
 </pre> 
 
 List available model(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model list
 
+</div>
 </div>
 </pre> 
 
 Delete available model(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model delete [model-id]
 
+</div>
 </div>
 </pre> 
 
 Search for a specific model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model search [model-name]
 
+</div>
 </div>
 </pre> 
 
 View a specific model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model view [model-name]
 
+</div>
 </div>
 </pre> 
 
 Scaffold a folder structure for model creation
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model init [model-name]
 
+</div>
 </div>
 </pre> 
 
 Create an OCI-compliant package from the model files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model build [model-name]
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model build [model-name]/[model-version]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/build.md
+++ b/docs/content/en/reference/references/mesheryctl/model/build.md
@@ -17,8 +17,10 @@ Expects input to be in the format scaffolded by the model init command.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model build [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -27,22 +29,19 @@ mesheryctl model build [flags]
 Create an OCI-compliant package from the model files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model build [model-name]
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl model build [model-name]/[model-version]
-
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-    
+<div class='clipboardjs'>
+mesheryctl model build [model-name]/[model-version]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/model/delete.md
@@ -15,8 +15,10 @@ Delete a model by ID or Name
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model delete [model-id | model-name] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl model delete [model-id | model-name] [flags]
 Delete a model by ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model delete [model-id]
 
+</div>
 </div>
 </pre> 
 
 Delete a model by name
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model delete [model-name]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/export.md
+++ b/docs/content/en/reference/references/mesheryctl/model/export.md
@@ -15,8 +15,10 @@ Export the registered model to the specified output type
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model export [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,40 +27,50 @@ mesheryctl model export [flags]
 Export a model by name 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model export [model-name] -o [oci|tar]  (default is oci)
 
+</div>
 </div>
 </pre> 
 
 Export a model by name in JSON type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model export [model-name] -t [yaml|json] (default is YAML)
 
+</div>
 </div>
 </pre> 
 
 Export a model by name in YAML type in a specific location
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model export [model-name] -l [path-to-location]
 
+</div>
 </div>
 </pre> 
 
 Export a model by name in YAML type discarding components and relationships
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model export [model-name] --discard-components --discard-relationships
 
+</div>
 </div>
 </pre> 
 
 Export a model version by name in YAML type
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model export [model-name] --version [version (ex: v0.7.3)]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/model/generate.md
@@ -15,8 +15,10 @@ Generate models by specifying the directory, file, or URL. You can also provide 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model generate [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl model generate [flags]
 Generate a model from a CSV directory
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model generate -f [path-to-csv-directory]
 
+</div>
 </div>
 </pre> 
 
 Generate a model from a URL based on a JSON template
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model generate -f [URL] -t [path-to-template.json]
 
+</div>
 </div>
 </pre> 
 
 Generate a model from a URL based on a JSON template skipping registration
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model generate --file [URL] --template [path-to-template.json] --skip-registration
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/import.md
+++ b/docs/content/en/reference/references/mesheryctl/model/import.md
@@ -15,8 +15,10 @@ Import models by specifying the directory, file, or URL. You can also provide a 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,48 +27,60 @@ mesheryctl model import [flags]
 Import model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import --file [URI]
 
+</div>
 </div>
 </pre> 
 
 Import model from a URL to a meshery model
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import --file [URL]
 
+</div>
 </div>
 </pre> 
 
 Import model from an OCI artifact
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import --file [OCI]
 
+</div>
 </div>
 </pre> 
 
 Import model from a tar.gz file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import --file [path-to-model.tar.gz]
 
+</div>
 </div>
 </pre> 
 
 Import model from a path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import --file [path-to-model]
 
+</div>
 </div>
 </pre> 
 
 Import model using CSV files
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model import --file [path-to-csv-directory]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/init.md
+++ b/docs/content/en/reference/references/mesheryctl/model/init.md
@@ -15,8 +15,10 @@ Generates a folder structure and guides user on model creation
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model init [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,39 +27,40 @@ mesheryctl model init [flags]
 generates a folder structure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model init [model-name]
 
+</div>
 </div>
 </pre> 
 
 generates a folder structure and sets up model version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model init [model-name] --version [version] (default is v0.1.0)
 
+</div>
 </div>
 </pre> 
 
 generates a folder structure under specified path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model init [model-name] --path [path-to-location] (default is current folder)
 
+</div>
 </div>
 </pre> 
 
 generate a folder structure in json format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model init [model-name] --output-format [json|yaml] (default is json)
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-    
-
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/list.md
+++ b/docs/content/en/reference/references/mesheryctl/model/list.md
@@ -15,8 +15,10 @@ List all registered models by pagination (10 models per page)
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,31 +27,30 @@ mesheryctl model list [flags]
 List of models
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model list
 
+</div>
 </div>
 </pre> 
 
 List of models for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model list --page [page-number] --pagesize [pagesize]
 
+</div>
 </div>
 </pre> 
 
 Display number of available models in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model list --count
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-    
-
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/search.md
+++ b/docs/content/en/reference/references/mesheryctl/model/search.md
@@ -15,8 +15,10 @@ Search model(s) by search string
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model search [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl model search [flags]
 Search model from current provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model search [query-text]
 
+</div>
 </div>
 </pre> 
 
 Search list of models for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model search [query-text] --page [page-number]
 
+</div>
 </div>
 </pre> 
 
 Search list of models for a specified pagesize
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model search [query-text] --pagesize [pagesize-number]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/model/view.md
+++ b/docs/content/en/reference/references/mesheryctl/model/view.md
@@ -15,8 +15,10 @@ View a model queried by its name or ID
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl model view [flags]
 View a specific model from current provider by using [model-name] or [model-id] in default format yaml
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model view [model-name]
 
+</div>
 </div>
 </pre> 
 
 View a specific model in specified format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model view [model-name] --output-format [json|yaml]
 
+</div>
 </div>
 </pre> 
 
 View a specific model in specified format and save it as a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl model view [model-name] --output-format [json|yaml] --save
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/organization/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/_index.md
@@ -15,8 +15,10 @@ Interact with registered organizations to display detailed information
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl organization [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl organization [flags]
 Number of  registered orgs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl organization --count
 
+</div>
 </div>
 </pre> 
 
 List registerd orgs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl organization list
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/organization/list.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/list.md
@@ -15,8 +15,10 @@ List all registered organizations with their id, name and date of creation. Orga
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl organization list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl organization list [flags]
 list all organizations
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl organization list
 
+</div>
 </div>
 </pre> 
 
 list organizations for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl organization list --page [page-number]
 
+</div>
 </div>
 </pre> 
 
 Display number of available organizations
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl organization list --count
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/_index.md
@@ -15,8 +15,10 @@ Load generation and performance characterization
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,39 +27,49 @@ mesheryctl perf [flags]
 Run performance test:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply test-3 --name "a quick stress test" --url http://192.168.1.15/productpage --qps 300 --concurrent-requests 2 --duration 30s
 
+</div>
 </div>
 </pre> 
 
 List performance profiles:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf profile sam-test
 
+</div>
 </div>
 </pre> 
 
 List performance results:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf result sam-test
 
+</div>
 </div>
 </pre> 
 
 Display Perf profile in JSON or YAML:
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf result -o json
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf result -o yaml
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/apply.md
@@ -15,8 +15,10 @@ Run Performance test using existing profiles or using flags.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply [profile-name] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl perf apply [profile-name] [flags]
 Execute a Performance test with the specified performance profile
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile [flags]
 
+</div>
 </div>
 </pre> 
 
 Execute a Performance test with creating a new performance profile
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile-new --url "https://google.com"
 
+</div>
 </div>
 </pre> 
 
 Execute a Performance test creating a new performance profile and pass certificate to be used
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile-new --url "https://google.com" --cert-path path/to/cert.pem
 
+</div>
 </div>
 </pre> 
 
 Execute a performance profile without using the certificate present in the profile
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile --url "https://google.com" --disable-cert
 
+</div>
 </div>
 </pre> 
 
@@ -58,32 +68,40 @@ Run Performance test using SMP compatible test configuration
 If the profile already exists, the test will be run overriding the values with the ones provided in the configuration file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile -f path/to/perf-config.yaml
 
+</div>
 </div>
 </pre> 
 
 Run performance test using SMP compatible test configuration and override values with flags
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile -f path/to/perf-config.yaml [flags]
 
+</div>
 </div>
 </pre> 
 
 Execute a Performance test with specified queries per second
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile --url https://192.168.1.15/productpage --qps 30
 
+</div>
 </div>
 </pre> 
 
 Execute a Performance test with specified infrastructure
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile --url https://192.168.1.15/productpage --mesh istio
 
+</div>
 </div>
 </pre> 
 
@@ -92,22 +110,28 @@ If any options are already present in the profile or passed through flags, the -
 Options for fortio - https://github.com/fortio/fortio/blob/v1.57.0/fhttp/httprunner.go#L77-L84
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile-new --url "https://google.com" --options [filepath|json-string]
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl perf apply meshery-profile-new --url "https://google.com" --options path/to/options.json
-
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
+mesheryctl perf apply meshery-profile-new --url "https://google.com" --options path/to/options.json
+
+</div>
+</div>
+</pre> 
+
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf apply meshery-profile-new --url "https://google.com" --load-generator fortio --options '{"MethodOverride": "POST"}'
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/profile.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/profile.md
@@ -15,8 +15,10 @@ List all the available performance profiles.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf profile [profile-name] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl perf profile [profile-name] [flags]
 List performance profiles (maximum 25 profiles)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf profile
 
+</div>
 </div>
 </pre> 
 
 List performance profiles with search (maximum 25 profiles)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf profile test 2
 
+</div>
 </div>
 </pre> 
 
 View single performance profile with detailed information
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf profile test --view
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/perf/result.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/result.md
@@ -15,8 +15,10 @@ List all the available test results of a performance profile.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf result [profile-name] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl perf result [profile-name] [flags]
 List Test results (maximum 25 results)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf result saturday-profile
 
+</div>
 </div>
 </pre> 
 
 View other set of performance results with --page (maximum 25 results)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf result saturday-profile --page 2
 
+</div>
 </div>
 </pre> 
 
 View single performance result with detailed information
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl perf result saturday-profile --view
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/_index.md
@@ -15,8 +15,10 @@ Manage the state and contents of Meshery’s internal registry of capabilities.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,8 +26,10 @@ mesheryctl registry [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry [subcommand]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/generate.md
@@ -15,8 +15,10 @@ Prerequisite: Execute this command from the root of a meshery/meshery repo fork.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,56 +27,70 @@ mesheryctl registry generate [flags]
 Generate Meshery Models from a Google Spreadsheet (i.e. "Meshery Integrations" spreadsheet).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED"
 
+</div>
 </div>
 </pre> 
 
 Directly generate models from one of the supported registrants by using Registrant Connection Definition and (optional) Registrant Credential Definition
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate --registrant-def [path to connection definition] --registrant-cred [path to credential definition]
 
+</div>
 </div>
 </pre> 
 
 Generate a specific Model from a Google Spreadsheet (i.e. "Meshery Integrations" spreadsheet).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred --model "[model-name]"
 
+</div>
 </div>
 </pre> 
 
 Generate Meshery Models and Component from csv files in a local directory.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate --directory [DIRECTORY_PATH]
 
+</div>
 </div>
 </pre> 
 
 Generate Meshery Models from individual CSV files.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate --model-csv [path/to/models.csv] --component-csv [path/to/components.csv] --relationship-csv [path/to/relationships.csv]
 
+</div>
 </div>
 </pre> 
 
 Generate models with a custom per-model timeout (e.g., 10 minutes per model).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED" --timeout 10m
 
+</div>
 </div>
 </pre> 
 
 Generate only the latest version of each model.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry generate --spreadsheet-id "1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw" --spreadsheet-cred "$CRED" --latest-only
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/publish.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/publish.md
@@ -15,8 +15,10 @@ Publishes metadata about Meshery Models to Websites, Remote Provider, or Meshery
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [models-output-path] [imgs-output-path] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,63 +27,79 @@ mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [model
 Publish To System
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish [system] [google-sheet-credential] [sheet-id] [models-output-path] [imgs-output-path] -o [output-format]
 
+</div>
 </div>
 </pre> 
 
 Publish To Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish meshery GoogleCredential GoogleSheetID [repo]/models
 
+</div>
 </div>
 </pre> 
 
 Publish To Remote Provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish remote-provider GoogleCredential GoogleSheetID [repo]/meshmodels/models [repo]/ui/public/img/meshmodels
 
+</div>
 </div>
 </pre> 
 
 Publish To Website
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish website GoogleCredential GoogleSheetID [repo]/integrations [repo]/ui/public/img/meshmodels
 
+</div>
 </div>
 </pre> 
 
 Publishing to meshery docs
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 cd docs;
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw docs/pages/integrations docs/assets/img/integrations -o md
 
+</div>
 </div>
 </pre> 
 
 Publishing to mesheryio site
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw meshery.io/integrations meshery.io/assets/images/integration -o js
 
+</div>
 </div>
 </pre> 
 
 Publishing to any website
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry publish website "$CRED" 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw path/to/models path/to/icons -o mdx
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/purge.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/purge.md
@@ -19,8 +19,10 @@ The "kubernetes" and "meshery-core" models are always excluded from purging, reg
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry purge [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -29,40 +31,50 @@ mesheryctl registry purge [flags]
 Retain only the latest version of every model (default).
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry purge
 
+</div>
 </div>
 </pre> 
 
 Retain the 3 most recent versions of every model.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry purge --retain 3
 
+</div>
 </div>
 </pre> 
 
 Preview what would be removed without deleting anything.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry purge --dry-run
 
+</div>
 </div>
 </pre> 
 
 Additionally skip specific models.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry purge --exclude aws-ec2-controller,cilium
 
+</div>
 </div>
 </pre> 
 
 Skip the confirmation prompt.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry purge --retain 2 -y
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/registry/update.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/update.md
@@ -15,8 +15,10 @@ Updates the component metadata (SVGs, shapes, styles and other) by referring fro
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry update [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl registry update [flags]
 Update models from Meshery Integration Spreadsheet
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry update --spreadsheet-id [id] --spreadsheet-cred "$CRED" -i [path to the directory containing models].
 
+</div>
 </div>
 </pre> 
 
 Updating models in the meshery/meshery repository based on the spreadsheet
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw --spreadsheet-cred "$CRED"
 
+</div>
 </div>
 </pre> 
 
 Updating models in the meshery/meshery repository based on flag
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl registry update --spreadsheet-id 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw --spreadsheet-cred "$CRED" --model "[model-name]"
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/_index.md
@@ -16,8 +16,10 @@ Meshery uses relationships to define how interconnected components interact.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -26,40 +28,50 @@ mesheryctl relationship [flags]
 Display number of available relationships in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship --count
 
+</div>
 </div>
 </pre> 
 
 Generate a relationship documentation 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship generate [flags]
 
+</div>
 </div>
 </pre> 
 
 List available relationship(s)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship list [flags]
 
+</div>
 </div>
 </pre> 
 
 Search for a specific relationship
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]
+<div class='clipboardjs'>
+mesheryctl relationship search [--kind &lt;kind&gt;] [--type &lt;type&gt;] [--subtype &lt;subtype&gt;] [--model &lt;model&gt;]
 
+</div>
 </div>
 </pre> 
 
 View a specific relationship
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship view [model-name]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/generate.md
@@ -15,8 +15,10 @@ Generate relationships documents from a CSV file or Google Spreadsheet.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship generate [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl relationship generate [flags]
 Generate relationships documents from a CSV file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship generate --file <path-to-relationships.csv>
+<div class='clipboardjs'>
+mesheryctl relationship generate --file &lt;path-to-relationships.csv&gt;
 
+</div>
 </div>
 </pre> 
 
 Generate relationships documents with a custom output path
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship generate --file <path-to-relationships.csv> --output <path-to-output.json>
+<div class='clipboardjs'>
+mesheryctl relationship generate --file &lt;path-to-relationships.csv&gt; --output &lt;path-to-output.json&gt;
 
+</div>
 </div>
 </pre> 
 
 Generate relationships documents from a Google Spreadsheet
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred $CRED
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/list.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/list.md
@@ -15,8 +15,10 @@ List all relationships registered in Meshery Server.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl relationship list [flags]
 List all relationships
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship list
 
+</div>
 </div>
 </pre> 
 
 List relationships for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship list --page [page-number]
 
+</div>
 </div>
 </pre> 
 
 List relationships with a custom page size
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship list --pagesize [page-size]
 
+</div>
 </div>
 </pre> 
 
 Display the total number of available relationships in Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship list --count
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/search.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/search.md
@@ -15,8 +15,10 @@ Search registered relationship(s) used by different models.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship search [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl relationship search [flags]
 Search for a specific relationship
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship search [--kind <kind>] [--type <type>] [--subtype <subtype>] [--model <model>]
+<div class='clipboardjs'>
+mesheryctl relationship search [--kind &lt;kind&gt;] [--type &lt;type&gt;] [--subtype &lt;subtype&gt;] [--model &lt;model&gt;]
 
+</div>
 </div>
 </pre> 
 
 Search a relationship for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
-mesheryctl relationship search [--kind <kind>] [--page <int>]
+<div class='clipboardjs'>
+mesheryctl relationship search [--kind &lt;kind&gt;] [--page &lt;int&gt;]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/relationship/view.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/view.md
@@ -15,8 +15,10 @@ view a relationship queried by the model name.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl relationship view [flags]
 View relationships of a model in default format yaml
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship view [model-name]
 
+</div>
 </div>
 </pre> 
 
 View relationships of a model in JSON format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship view [model-name] --output-format json
 
+</div>
 </div>
 </pre> 
 
 View relationships of a model in json format and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl relationship view [model-name] --output-format json --save
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/_index.md
@@ -15,8 +15,10 @@ Manage the state and configuration of Meshery server, components, and client.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system [flags]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
@@ -15,8 +15,10 @@ Subscribe to a release channel. Choose between either 'stable' or 'edge' channel
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,40 +27,50 @@ mesheryctl system channel [flags]
 Subscribe to release channel or version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel
 
+</div>
 </div>
 </pre> 
 
 To set the channel
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel set [stable|stable-version|edge|edge-version]
 
+</div>
 </div>
 </pre> 
 
 To pin/set the channel to a specific version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel set stable-v0.6.0
 
+</div>
 </div>
 </pre> 
 
 To view release channel and version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel view
 
+</div>
 </div>
 </pre> 
 
 To switch release channel and version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel switch [stable|stable-version|edge|edge-version]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/set.md
@@ -15,8 +15,10 @@ Set release channel and version of context in focus
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel set [stable|stable-version|edge|edge-version] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system channel set [stable|stable-version|edge|edge-version] [flags]
 Subscribe to release channel or version
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel set [stable|stable-version|edge|edge-version]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
@@ -15,8 +15,10 @@ Switch release channel and version of context in focus
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel switch [stable|stable-version|edge|edge-version] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system channel switch [stable|stable-version|edge|edge-version] [flag
 Switch between release channels
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel switch [stable|stable-version|edge|edge-version]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/channel/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/view.md
@@ -15,8 +15,10 @@ View release channel and version of context in focus
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl system channel view [flags]
 View current release channel
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel view edge
 
+</div>
 </div>
 </pre> 
 
 View release channel for all contexts
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system channel view --all
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/check.md
+++ b/docs/content/en/reference/references/mesheryctl/system/check.md
@@ -15,8 +15,10 @@ Verify environment pre/post-deployment of Meshery.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system check [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,55 +27,69 @@ mesheryctl system check [flags]
 Run all system checks for both pre and post-deployment scenarios
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system check
 
 </div>
-</pre> 
-
-Run pre-deployment checks (Docker and Kubernetes)
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl system check --preflight
-
 </div>
 </pre> 
 
 Run pre-deployment checks (Docker and Kubernetes)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
+mesheryctl system check --preflight
+
+</div>
+</div>
+</pre> 
+
+Run pre-deployment checks (Docker and Kubernetes)
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system check --pre
 
+</div>
 </div>
 </pre> 
 
 Run checks for all Meshery adapters
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system check --adapters
 
+</div>
 </div>
 </pre> 
 
 Run checks on a specific Meshery adapter
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system check --adapter meshery-istio:10000
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system check --adapter meshery-istio
 
+</div>
 </div>
 </pre> 
 
 Verify the health of Meshery Operator's deployment with MeshSync and Broker
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system check --operator
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/_index.md
@@ -15,8 +15,10 @@ Configure and switch between different named Meshery server and component versio
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context [command] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system context [command] [flags]
 Base command
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/create.md
@@ -15,8 +15,10 @@ Add a new context to Meshery config.yaml file.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context create context-name [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl system context create context-name [flags]
 Create new context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context create [context-name]
 
+</div>
 </div>
 </pre> 
 
 Create new context and provide list of components, platform & URL and set it as current context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context create [context-name] --components [meshery-nsm] --platform [docker|kubernetes] --url [server-url] --set --yes
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/delete.md
@@ -15,8 +15,10 @@ Delete an existing context (a named Meshery deployment) from Meshery config file
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context delete [context-name] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system context delete [context-name] [flags]
 ### Delete context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context delete [context name]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/list.md
@@ -15,8 +15,10 @@ List current context and available contexts.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system context list [flags]
 List all contexts present
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context list
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/switch.md
@@ -15,8 +15,10 @@ Configure mesheryctl to actively use one one context vs. another context.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context switch context-name [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system context switch context-name [flags]
 Switch to context named "sample"
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context switch sample
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/context/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/view.md
@@ -17,8 +17,10 @@ Use this to verify or debug your current CLI settings.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context view [context-name | --context context-name | --all] --flags [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -27,39 +29,40 @@ mesheryctl system context view [context-name | --context context-name | --all] -
 View the default context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context view
 
+</div>
 </div>
 </pre> 
 
 View a specified context
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context view context-name
 
+</div>
 </div>
 </pre> 
 
 View a specified context using the --context flag
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context view --context context-name
 
+</div>
 </div>
 </pre> 
 
 View configuration of all contexts
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system context view --all
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-    
-
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/dashboard.md
+++ b/docs/content/en/reference/references/mesheryctl/system/dashboard.md
@@ -15,8 +15,10 @@ Open Meshery UI in browser.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system dashboard [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,39 +27,49 @@ mesheryctl system dashboard [flags]
 Open Meshery UI in browser
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system dashboard
 
+</div>
 </div>
 </pre> 
 
 Open Meshery UI in browser and use port-forwarding (if default port is taken already)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system dashboard --port-forward
 
+</div>
 </div>
 </pre> 
 
 Open Meshery UI in browser and use port-forwarding, listen on port 9081 locally, forwarding traffic to meshery server in the pod
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system dashboard --port-forward -p 9081
 
+</div>
 </div>
 </pre> 
 
 (optional) skip opening of MesheryUI in browser.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system dashboard --skip-browser
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 Note: Meshery's web-based user interface is embedded in Meshery Server and is available as soon as Meshery starts. The location and port that Meshery UI is exposed varies depending upon your mode of deployment. See accessing \"Meshery UI\" for additional deployment-specific options: https://docs.meshery.io/installation/accessing-meshery-ui.
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/delete.md
@@ -15,8 +15,10 @@ Delete Meshery containers. This command removes all Meshery containers created b
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system delete [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl system delete [flags]
 Delete Meshery containers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system delete
 
+</div>
 </div>
 </pre> 
 
 Delete Meshery containers without confirmation
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system delete -y
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/login.md
+++ b/docs/content/en/reference/references/mesheryctl/system/login.md
@@ -17,8 +17,10 @@ Authenticate to the Local or a Remote Provider of a Meshery Server
 The authentication mode is web-based browser flow
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system login [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -27,16 +29,20 @@ mesheryctl system login [flags]
 Login with the Meshery Provider of your choice: the Local Provider or a Remote Provider.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system login
 
+</div>
 </div>
 </pre> 
 
 Login with the Meshery Provider by specifying it via -p or --provider flag.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system login -p Meshery
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/logout.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logout.md
@@ -17,8 +17,10 @@ Remove authentication for Meshery Server
 This command removes the authentication token from the user's filesystem
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system logout [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -27,8 +29,10 @@ mesheryctl system logout [flags]
 Logout current session with your Meshery Provider.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system logout
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/logs.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logs.md
@@ -16,8 +16,10 @@ Print history of Meshery's logs and begin tailing them.
 It also shows the logs of a specific component.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system logs [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -26,23 +28,29 @@ mesheryctl system logs [flags]
 Show logs (without tailing)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system logs
 
+</div>
 </div>
 </pre> 
 
 Starts tailing Meshery server debug logs (works with components also)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system logs --follow
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system logs meshery-istio
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
@@ -14,8 +14,10 @@ Switch between providers
 Enforce a provider. Choose between available Meshery providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,40 +26,50 @@ mesheryctl system provider [flags]
 To view provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider view
 
+</div>
 </div>
 </pre> 
 
 To list all available providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider list
 
+</div>
 </div>
 </pre> 
 
 To set a provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider set [provider]
 
+</div>
 </div>
 </pre> 
 
 To switch provider and redeploy Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider switch [provider]
 
+</div>
 </div>
 </pre> 
 
 To clear the configured provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider reset
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/list.md
@@ -14,8 +14,10 @@ list available providers
 List current provider and available providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,8 +26,10 @@ mesheryctl system provider list [flags]
 List all available providers
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider list
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
@@ -14,8 +14,10 @@ Clear the configured provider
 Clear the configured provider for the current context. This allows users to select a provider on the next Meshery start. This clears the enforced provider so that users are presented with the provider selection UI on next start.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider reset [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,8 +26,10 @@ mesheryctl system provider reset [flags]
 Clear the configured provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider reset
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/set.md
@@ -14,8 +14,10 @@ set provider
 Set provider of context in focus. Run `mesheryctl system provider list` to see the available providers.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider set [provider] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,8 +26,10 @@ mesheryctl system provider set [provider] [flags]
 Set provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider set [provider]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
@@ -14,8 +14,10 @@ switch provider and redeploy
 Switch provider of context in focus and redeploy Meshery. Run `mesheryctl system provider list` to see the available providers.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider switch [provider] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,8 +26,10 @@ mesheryctl system provider switch [provider] [flags]
 Switch provider and redeploy Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider switch [provider]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/provider/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/view.md
@@ -15,8 +15,10 @@ View provider of context in focus.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system provider view [flags]
 View current provider
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system provider view
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/reset.md
@@ -15,8 +15,10 @@ Reset Meshery to it's default configuration.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system reset [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl system reset [flags]
 Resets meshery.yaml file with a copy from Meshery repo
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system reset
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/restart.md
+++ b/docs/content/en/reference/references/mesheryctl/system/restart.md
@@ -15,8 +15,10 @@ Restart all Meshery containers / pods.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system restart [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl system restart [flags]
 Restart all Meshery containers, their instances and their connected volumes
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system restart
 
+</div>
 </div>
 </pre> 
 
 (optional) skip checking for new updates available in Meshery.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system restart --skip-update
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/start.md
+++ b/docs/content/en/reference/references/mesheryctl/system/start.md
@@ -15,8 +15,10 @@ Start Meshery and each of its cloud native components.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system start [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,48 +27,60 @@ mesheryctl system start [flags]
 Start meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system start
 
+</div>
 </div>
 </pre> 
 
 (optional) skip opening of MesheryUI in browser.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system start --skip-browser
 
+</div>
 </div>
 </pre> 
 
 (optional) skip checking for new updates available in Meshery.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system start --skip-update
 
+</div>
 </div>
 </pre> 
 
 Reset Meshery's configuration file to default settings.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system start --reset
 
+</div>
 </div>
 </pre> 
 
 Specify Platform to deploy Meshery to.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system start -p docker
 
+</div>
 </div>
 </pre> 
 
 Specify Provider to use.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system start --provider Meshery
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/status.md
+++ b/docs/content/en/reference/references/mesheryctl/system/status.md
@@ -15,8 +15,10 @@ Check status of Meshery and Meshery components.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system status [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl system status [flags]
 Check status of Meshery, Meshery adapters, Meshery Operator and its controllers.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system status
 
+</div>
 </div>
 </pre> 
 
 (optional) Extra data in status table
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system status --verbose
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/stop.md
+++ b/docs/content/en/reference/references/mesheryctl/system/stop.md
@@ -15,8 +15,10 @@ Stop all Meshery containers / remove all Meshery resources.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system stop [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl system stop [flags]
 Stop Meshery
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system stop
 
+</div>
 </div>
 </pre> 
 
 Reset Meshery's configuration file to default settings.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system stop --reset
 
+</div>
 </div>
 </pre> 
 
 (optional) keep the Meshery namespace during uninstallation
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system stop --keep-namespace
 
+</div>
 </div>
 </pre> 
 
 Stop Meshery forcefully (use it when system stop doesn't work)
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system stop --force
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/_index.md
@@ -15,8 +15,10 @@ Manage Meshery user tokens
 	Manipulate user tokens and their context assignments in your meshconfig
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token [flags]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/create.md
@@ -15,8 +15,10 @@ Create the token with provided token name (optionally token path) to your meshco
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token create [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,22 +26,28 @@ mesheryctl system token create [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token create [token-name] -f [token-path]
 
 </div>
-</pre> 
-
-<pre class='codeblock-pre'>
-<div class='codeblock'>
-mesheryctl system token create [token-name] (default path is auth.json)
-
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
+mesheryctl system token create [token-name] (default path is auth.json)
+
+</div>
+</div>
+</pre> 
+
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token create [token-name] -f [token-path] --set
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/delete.md
@@ -14,8 +14,10 @@ Delete a token from your meshconfig
 Delete the token with provided token name from your meshconfig tokens.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token delete [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -23,8 +25,10 @@ mesheryctl system token delete [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token delete [token-name]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/list.md
@@ -14,8 +14,10 @@ List tokens
 List all the tokens in your meshconfig
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -23,8 +25,10 @@ mesheryctl system token list [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token list
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/set.md
@@ -14,8 +14,10 @@ Set token for context
 Set token for current context or context specified with --context flag.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token set [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -23,8 +25,10 @@ mesheryctl system token set [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token set [token-name] 
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/token/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/view.md
@@ -14,8 +14,10 @@ View token
 View a specific token in meshery config
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token view [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -23,15 +25,19 @@ mesheryctl system token view [flags]
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token view [token-name]
 
+</div>
 </div>
 </pre> 
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system token view (show token of current context)
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/system/update.md
+++ b/docs/content/en/reference/references/mesheryctl/system/update.md
@@ -15,8 +15,10 @@ Pull new Meshery container images and manifests from artifact repository.
 	
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system update [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl system update [flags]
 Pull new Meshery images from Docker Hub. This does not update mesheryctl. This command may be executed while Meshery is running.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system update
 
+</div>
 </div>
 </pre> 
 
 Pull the latest manifest files alone
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl system update --skip-reset
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/version.md
+++ b/docs/content/en/reference/references/mesheryctl/version.md
@@ -14,8 +14,10 @@ Show Meshery CLI and Server versions
 Version of Meshery command line client - mesheryctl.
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl version [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -24,8 +26,10 @@ mesheryctl version [flags]
 To view the current version and SHA of release binary of mesheryctl client 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl version
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/_index.md
@@ -15,8 +15,10 @@ Create, list of workspaces under an organization
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,16 +27,20 @@ mesheryctl workspace [flags]
 To view a list workspaces
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace list --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 
 To create a workspace
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace create --orgId [orgId] --name [name] --description [description]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/create.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/create.md
@@ -15,8 +15,10 @@ Create a new workspace by providing the name, description, and organization ID
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace create [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,8 +27,10 @@ mesheryctl workspace create [flags]
 Create a new workspace in an organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace create --orgId [orgId] --name [name] --description [description]
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/list.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/list.md
@@ -15,8 +15,10 @@ List name of all registered workspaces
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace list [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,24 +27,30 @@ mesheryctl workspace list [flags]
 List of workspace under a specific organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace list --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 
 List of workspace under a specific organization for a specified page
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace list --orgId [orgId] --page [page-number]
 
+</div>
 </div>
 </pre> 
 
 Display number of available  workspace under a specific organization
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace list --orgId [orgId] --count
 
+</div>
 </div>
 </pre> 
 

--- a/docs/content/en/reference/references/mesheryctl/workspace/view.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/view.md
@@ -15,8 +15,10 @@ View a workspace by its ID or name.
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace view [workspace-name|workspace-id] [flags]
 
+</div>
 </div>
 </pre> 
 
@@ -25,32 +27,40 @@ mesheryctl workspace view [workspace-name|workspace-id] [flags]
 View details of a specific workspace by ID
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace view [workspace-id] --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 
 View details of a specific workspace by name
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace view [workspace-name] --orgId [orgId]
 
+</div>
 </div>
 </pre> 
 
 View details of a specific workspace in JSON format
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json
 
+</div>
 </div>
 </pre> 
 
 View details of a specific workspace and save it to a file
 <pre class='codeblock-pre'>
 <div class='codeblock'>
+<div class='clipboardjs'>
 mesheryctl workspace view [workspace-id] --orgId [orgId] --output-format json --save
 
+</div>
 </div>
 </pre> 
 

--- a/mesheryctl/doc/doc.go
+++ b/mesheryctl/doc/doc.go
@@ -130,6 +130,15 @@ func doc() {
 	fmt.Println("Documentation generated at " + markDownPath)
 }
 
+var codeEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// writeCodeBlock writes an escaped, copyable code block for a command
+func writeCodeBlock(buf *bytes.Buffer, code string) {
+	fmt.Fprintf(buf,
+		"<pre class='codeblock-pre'>\n<div class='codeblock'>\n<div class='clipboardjs'>\n%s\n\n</div>\n</div>\n</pre> \n\n",
+		codeEscaper.Replace(code))
+}
+
 // printOptions prints the options for a command
 func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	flags := cmd.NonInheritedFlags()
@@ -178,7 +187,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, manuallyAddedContent map
 
 	// check if the command is runnable
 	if cmd.Runnable() {
-		fmt.Fprintf(buf, "<pre class='codeblock-pre'>\n<div class='codeblock'>\n%s\n\n</div>\n</pre> \n\n", cmd.UseLine())
+		writeCodeBlock(buf, cmd.UseLine())
 	}
 
 	// check cmd has annotations link and caption
@@ -196,14 +205,14 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, manuallyAddedContent map
 		buf.WriteString("## Examples\n\n")
 		var examples = strings.Split(cmd.Example, "\n")
 		for i := 0; i < len(examples); i++ {
-			if examples[i] != "" && examples[i] != " " && examples[i] != "	" {
+			if strings.TrimSpace(examples[i]) != "" {
 				if strings.HasPrefix(examples[i], "//") {
 					// Description Line
 					buf.WriteString(strings.ReplaceAll(examples[i], "// ", "") + "\n")
 				} else {
 					// Code Block Line
 
-					fmt.Fprintf(buf, "<pre class='codeblock-pre'>\n<div class='codeblock'>\n%s\n\n</div>\n</pre> \n\n", examples[i])
+					writeCodeBlock(buf, examples[i])
 				}
 			}
 		}

--- a/mesheryctl/doc/doc_test.go
+++ b/mesheryctl/doc/doc_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -206,5 +207,67 @@ func TestDoc(t *testing.T) {
 		output = buf.String()
 		assert.Contains(t, output, "## Options inherited from parent commands")
 		assert.Contains(t, output, "--parentFlag")
+	})
+}
+
+// TestCodeBlockCopyButton checks that command blocks are copyable and options blocks are not
+func TestCodeBlockCopyButton(t *testing.T) {
+
+	newCmd := func(example string) *cobra.Command {
+		cmd := &cobra.Command{
+			Use:               "test",
+			Long:              "test_long",
+			Example:           example,
+			Run:               func(cmd *cobra.Command, args []string) {},
+			DisableAutoGenTag: true,
+		}
+		cmd.Flags().String("flag1", "default1", "description1")
+		return cmd
+	}
+
+	render := func(t *testing.T, cmd *cobra.Command) string {
+		t.Helper()
+		buf := &bytes.Buffer{}
+		assert.NoError(t, GenMarkdownCustom(cmd, buf, nil))
+		return buf.String()
+	}
+
+	t.Run("Command blocks are copyable", func(t *testing.T) {
+		output := render(t, newCmd("mesheryctl test --flag1 value"))
+
+		assert.Equal(t, 3, strings.Count(output, "codeblock-pre"))
+		assert.Equal(t, 2, strings.Count(output, "<div class='clipboardjs'>"))
+	})
+
+	t.Run("Options blocks are not copyable", func(t *testing.T) {
+		output := render(t, newCmd("mesheryctl test"))
+
+		index := strings.Index(output, "## Options")
+		assert.NotEqual(t, -1, index, "the command under test must emit an Options section")
+
+		assert.NotContains(t, output[index:], "clipboardjs")
+		assert.Contains(t, output[index:], "--flag1")
+	})
+
+	t.Run("Placeholders survive as text", func(t *testing.T) {
+		output := render(t, newCmd("mesheryctl test --file <path-to-file>"))
+
+		assert.Contains(t, output, "--file &lt;path-to-file&gt;")
+		assert.NotContains(t, output, "<path-to-file>")
+	})
+
+	t.Run("Ampersands are escaped before the angle brackets", func(t *testing.T) {
+		output := render(t, newCmd("mesheryctl test a && b"))
+
+		assert.Contains(t, output, "a &amp;&amp; b")
+		assert.NotContains(t, output, "&amp;lt;")
+	})
+
+	t.Run("A whitespace only example writes no block", func(t *testing.T) {
+		output := render(t, newCmd("mesheryctl test\n\t\t"))
+
+		assert.Equal(t, 3, strings.Count(output, "codeblock-pre"))
+		assert.Equal(t, 2, strings.Count(output, "<div class='clipboardjs'>"))
+		assert.NotContains(t, output, "<div class='clipboardjs'>\n\n\n")
 	})
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21631 

**Only 2 files are hand-edited: `mesheryctl/doc/doc.go` and `mesheryctl/doc/doc_test.go`.** The other 100 files are the output of `make docs-mesheryctl`. Please review the 2 files. The rest is auto-generated.

### The cause
`docs/static/js/main.js` puts the copy button after a `.clipboardjs` element. The generator wrote only two HTML levels. No reference page held that element, so no reference page held a button.

This change adds the third level to the two write points that emit commands.

Line | Writes | Change
-- | -- | --
181 | the Synopsis usage line | button added
206 | every Examples block | button added
138 | the ## Options block | no change
146 | the ## Options inherited block | no change

The `Options` blocks have no copy button on purpose. Those blocks list the flags. A reader reads them. A reader does not run them.

### Two small fixes that come with it

1. **The diff removes 13 command lines and puts them back.** Some commands hold angle brackets, like `<kind>`. The browser read them as HTML tags and hid them. So the site showed `mesheryctl relationship search [--kind ` and the rest was gone. The brackets are now written in a safe form, so the whole command shows again. This had to be fixed here. The copy button copies what the block shows, so a broken block would hand the reader a broken command.

2. **Seven empty code blocks are gone.** Some examples ended with blank space, and the generator turned that blank space into an empty box on the page. Those boxes are removed.


### Screenshots 
|**BEFORE**|
|--|
<img width="1587" height="809" alt="copybutton_Before" src="https://github.com/user-attachments/assets/6f09eacf-a6e7-46bc-943a-10f012c09c86" />

<br>
<img width="1586" height="808" alt="Before_copypaste_NewFix" src="https://github.com/user-attachments/assets/3177268c-74b2-4e63-98f2-483145dcf5a2" />

<br>
<img width="1589" height="809" alt="Before_copypaste_NewFix2" src="https://github.com/user-attachments/assets/3088ec63-3373-4305-a66b-e0165885354a" />


<br> <br>
|**AFTER**|
--|
<img width="1918" height="977" alt="Screenshot From 2026-08-28 13-41-48" src="https://github.com/user-attachments/assets/4f17eb91-4501-4486-91e2-84f13b285947" />

<br>

<img width="1918" height="977" alt="Screenshot From 2026-08-28 13-44-48" src="https://github.com/user-attachments/assets/b483e4cb-7480-4c28-933a-38518c89a734" />

<br>
<img width="1918" height="977" alt="Screenshot From 2026-08-28 19-05-50" src="https://github.com/user-attachments/assets/68fc791c-3cd5-4a5e-9b93-63537b4f44d9" />


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added copy-to-clipboard support across Meshery CLI reference examples and synopsis commands.
  - Expanded and clarified examples for pagination, filtering, force-stop, token deletion, and registry publishing.
  - Improved formatting and removed empty code blocks.
  - Ensured command placeholders and special characters display correctly in generated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->