### PR TITLE
[CI] Migrate integration test mesh configuration to Registry identifier

### DIFF
--- a/.github/integration-test-config.yaml
+++ b/.github/integration-test-config.yaml
@@ -24,5 +24,4 @@ test:
 
 # Service mesh under test in Service Mesh Performance Spec format
 # See: https://github.com/service-mesh-performance/service-mesh-performance/blob/master/protos/service_mesh.proto
-mesh:
-  type: 3
+mesh: istio


### PR DESCRIPTION
**Notes for Reviewers**

### Description

The scheduled mesheryctl-e2e workflow currently uses the legacy SMP representation for the mesh in .github/integration-test-config.yaml:

mesh:
  type: 3

The current PerformanceTestConfigFile expects mesh to be a string representing a Meshery Registry model name. Since type: 3 corresponds to Istio and the current Registry identifier is istio, this updates the configuration to:

mesh: istio

This resolves the configuration type mismatch encountered during mesheryctl perf apply.

Testing

Validated the configuration against the current PerformanceTestConfigFile implementation. The E2E workflow will be used to verify the change in CI.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test configuration to identify Istio as the service mesh using the current configuration format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->