### PR TITLE
[Docs] Generate llms.txt and llms-full.txt for the documentation site

### DIFF
--- a/.github/workflows/build-docs-preview.yml
+++ b/.github/workflows/build-docs-preview.yml
@@ -90,7 +90,7 @@ jobs:
           PREVIEW_BASE_URL: "/pr-preview/pr-${{ github.event.pull_request.number }}/"
         run: |
           cd docs
-          npm run build:production -- --gc --baseURL "${PREVIEW_BASE_URL}"
+          npm run build:production:llms -- --gc --baseURL "${PREVIEW_BASE_URL}"
           find public -maxdepth 1 -type d -name 'v0.*' -exec rm -rf {} +
           cat > public/robots.txt <<'ROBOTS'
           User-agent: *

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -92,7 +92,7 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          make -C docs build-production BASE_URL="/"
+          make -C docs build-production-llms BASE_URL="/"
           cp docs/CNAME docs/public/CNAME
           touch docs/public/.nojekyll
           if [ -d gh-pages-maintenance/pr-preview ]; then

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -33,6 +33,10 @@
 #   build              Build locally with draft, future, and expired content.
 #   build-preview      Build for a deploy preview (uses DEPLOY_PRIME_URL).
 #   build-production   Build for production. Pass BASE_URL=... to set the base URL.
+#   build-llms         Build locally, also emitting llms.txt, llms-full.txt and
+#                      the per-page Markdown renditions.
+#   build-production-llms
+#                      Build for production with those files. Pass BASE_URL=...
 #   site               Serve locally with live reload.
 #   serve              Serve locally once, file watcher off (no live reload).
 #   clean              Empty the build cache, reinstall dependencies, run 'site'.
@@ -97,6 +101,25 @@ build-production: check-go check-deps
 		npm run build:production -- --baseURL "$$base_url"; \
 	else \
 		npm run build:production; \
+	fi
+
+## Build docs.meshery.io locally including the LLM-facing files: /llms.txt,
+## /llms-full.txt, and an index.md rendition beside every page. These are kept
+## out of `build` so the standard contributor flow is not slowed by ~2,810
+## extra files; config-llms.toml layers the output formats on when asked for.
+build-llms: check-go check-deps
+	npm run build:llms
+
+## Build docs.meshery.io for production including the LLM-facing files.
+## Pass BASE_URL=... to set the base URL, exactly as build-production does.
+build-production-llms: check-go check-deps
+	set -e; \
+	if [ -n "$(BASE_URL)" ]; then \
+		base_url="$(BASE_URL)"; \
+		base_url="$${base_url%/}/"; \
+		npm run build:production:llms -- --baseURL "$$base_url"; \
+	else \
+		npm run build:production:llms; \
 	fi
 
 ## Build and run docs.meshery.io on your local machine (draft and future content enabled).

--- a/docs/config-llms.toml
+++ b/docs/config-llms.toml
@@ -1,0 +1,17 @@
+# Enables the LLM-facing outputs. Layered on top of hugo.toml:
+#
+#     hugo --config hugo.toml,config-llms.toml
+#
+# which the `build-llms` and `build-production-llms` make targets do for you.
+# Kept out of hugo.toml so that the standard contributor build (`make build`,
+# `make site`) does not pay for 2,810 extra index.md files, and so that a
+# contributor editing one page sees exactly the output they saw before.
+#
+# Each key here replaces its counterpart in hugo.toml wholesale, so the
+# pre-existing formats are restated rather than appended to.
+[outputs]
+  home = ["HTML", "RSS", "SITEMAP", "llms", "llmsfull", "md"]
+  page = ["HTML", "md"]
+  section = ["HTML", "RSS", "md"]
+  taxonomy = []
+  term = []

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -101,6 +101,34 @@ As a self-service engineering platform, Meshery enables collaborative design and
   taxonomy = []
   term = []
 
+# The formats below are declared but not switched on here. Declaring an output
+# format generates nothing by itself; config-llms.toml adds the [outputs]
+# entries that enable them, and is layered in by the build-llms make targets.
+# This keeps llms.txt, llms-full.txt and the 2,810 per-page index.md files out
+# of the standard contributor build.
+#
+# "llms" and "llmsfull" render once, for the home page. "md" publishes an
+# index.md beside every page's index.html; those are the URLs llms.txt points
+# at, so an agent that follows one receives Markdown prose rather than a themed
+# HTML page. Taxonomy and term pages stay unpublished, so neither file lists
+# them.
+[outputFormats]
+  [outputFormats.llms]
+    baseName = "llms"
+    mediaType = "text/plain"
+    isPlainText = true
+    notAlternative = true
+  [outputFormats.llmsfull]
+    baseName = "llms-full"
+    mediaType = "text/plain"
+    isPlainText = true
+    notAlternative = true
+  [outputFormats.md]
+    baseName = "index"
+    mediaType = "text/markdown"
+    isPlainText = true
+    notAlternative = true
+
 [sitemap]
   changefreq = "daily"
   priority = 0.5
@@ -193,6 +221,45 @@ no = 'Sorry to hear that. Please <a href="https://github.com/meshery/meshery/iss
 [params.ui.readingtime]
 enable = false
 
+# /llms.txt and /llms-full.txt, per https://llmstxt.org
+# Templates: layouts/index.llms.txt, layouts/index.llmsfull.txt
+[params.llms]
+enable_llms_txt = true
+enable_llms_full_txt = true
+
+# H1 of both files. site.Title is "Documentation", which does not identify the
+# project to an agent arriving with no other context.
+title = "Meshery Documentation"
+
+# Note shown against the home page in llms.txt. The home page has no
+# front-matter description -- it is a hero layout of HTML and link lists -- so
+# without this the generic summary fallback scrapes its nav labels into the
+# first entry of the index.
+home_note = "Documentation home: entry points for installation, concepts, guides, extensions, and reference."
+
+# Dropped from both files. Patterns: "/path/" matches exactly, "/path/*"
+# matches direct children, "/path/**" matches the path and all descendants.
+exclude = ["/search/"]
+
+# Machine-generated page sets. Each is linked once from the "Optional" section
+# of llms.txt rather than enumerated, and its pages are not inlined into
+# llms-full.txt. Together they are 2,508 of the site's 2,811 pages and 69% of
+# its Markdown by volume, and nearly all of them have no body at all -- they
+# are front matter rendered by a custom layout -- so enumerating them would
+# bury the hand-written docs while giving an agent nothing to read. Per-page
+# index.md output is still generated for them, so they stay reachable.
+[[params.llms.bulk]]
+path = "/project/compatibility/"
+note = "Per-integration compatibility test results, one page per test run. Front matter only; no prose."
+
+[[params.llms.bulk]]
+path = "/project/releases/"
+note = "Release notes for every published Meshery release."
+
+[[params.llms.bulk]]
+path = "/extensions/models/"
+note = "Generated reference for each supported model and its components. Front matter only; no prose."
+
 # hugo module configuration
 
 [module]
@@ -200,7 +267,9 @@ enable = false
   # replacements = "github.com/google/docsy -> ../../docsy"
   [module.hugoVersion]
     extended = true
-    min = "0.110.0"
+    # 0.117.0 introduced .RenderShortcodes, which the llms.txt templates need
+    # in order to expand shortcodes into their plain-text output.
+    min = "0.117.0"
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false

--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -60,6 +60,8 @@ other = "Click here to print"
 other = "Return to the regular view of this page"
 [print_entire_section]
 other = "Print entire section"
+[view_as_markdown]
+other = "View as Markdown"
 
 # Feedback
 [feedback_title]

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
-    {{ partial "head.html" (dict "Title" .Title "Description" .Params.abstract "Kind" .Kind "Permalink" .Permalink "Site" .Site) }}
+    {{- $markdownURL := "" -}}
+    {{- with .OutputFormats.Get "md" }}{{ $markdownURL = .RelPermalink }}{{ end -}}
+    {{ partial "head.html" (dict "Title" .Title "Description" .Params.abstract "Kind" .Kind "Permalink" .Permalink "Site" .Site "MarkdownURL" $markdownURL) }}
     {{ partialCached "header.html" . .RelPermalink }}
     <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">

--- a/docs/layouts/_default/list.md
+++ b/docs/layouts/_default/list.md
@@ -1,0 +1,1 @@
+{{- partial "llms-txt/page-markdown.html" . -}}

--- a/docs/layouts/_default/single.md
+++ b/docs/layouts/_default/single.md
@@ -1,0 +1,1 @@
+{{- partial "llms-txt/page-markdown.html" . -}}

--- a/docs/layouts/index.llms.txt
+++ b/docs/layouts/index.llms.txt
@@ -1,0 +1,104 @@
+{{- /*
+  /llms.txt — an index of this site for LLM agents, per https://llmstxt.org
+
+  Structure mandated by the specification:
+    - an H1 with the name of the site (the only required element)
+    - a blockquote with a short summary
+    - zero or more H2 sections holding "file lists" of links
+    - an "Optional" section, by convention, for links an agent can skip
+
+  Links point at each page's raw-Markdown rendition (index.md) rather than its
+  HTML, so an agent that follows one gets prose instead of a Docsy page frame.
+
+  Derived from the llms-txt Hugo module by GetHugoThemes (MIT licensed):
+  https://github.com/gethugothemes/hugo-modules/tree/master/llms-txt
+
+  Output is assembled as a slice of lines and joined once at the end. Plain-text
+  templates make whitespace significant, and joining is far easier to keep
+  correct than balancing dash-trim markers across nested ranges.
+*/ -}}
+{{- $llms := site.Params.llms | default dict -}}
+{{- if ne ($llms.enable_llms_txt | default true) false -}}
+{{- $out := slice -}}
+
+{{- /* Header: H1 and summary blockquote. */ -}}
+{{- $summary := trim (site.Params.description | default site.Title | plainify | replaceRE "\\s+" " ") " " -}}
+{{- $out = $out | append (printf "# %s" ($llms.title | default site.Title)) -}}
+{{- $out = $out | append "" -}}
+{{- $out = $out | append (printf "> %s" $summary) -}}
+
+{{- /* Every content page, ordered by URL so a parent always precedes its
+       children. RegularPagesRecursive is deliberately not used: it skips
+       branch bundles, which would drop landing pages such as
+       /installation/kubernetes/ from the output even though they carry a
+       description and are what an agent should read first. */ -}}
+{{- $all := sort (where site.Pages "Kind" "in" (slice "page" "section")) "RelPermalink" -}}
+
+{{- /* The home page, plus any page living at the root of the site. */ -}}
+{{- $out = $out | append "" -}}
+{{- $out = $out | append "## Docs" -}}
+{{- $out = $out | append "" -}}
+{{- $out = $out | append (partial "llms-txt/entry.html" (dict "page" site.Home "note" ($llms.home_note | default $summary))) -}}
+{{- range site.Home.RegularPages -}}
+  {{- if partial "llms-txt/is-included.html" (dict "url" .RelPermalink "llms" $llms) -}}
+    {{- $out = $out | append (partial "llms-txt/entry.html" (dict "page" .)) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* One H2 per top-level section, in sidebar order, listing every page
+       beneath it that survives the include/exclude and bulk filters. */ -}}
+{{- range site.Home.Sections.ByWeight -}}
+  {{- $section := . -}}
+  {{- $prefix := $section.RelPermalink -}}
+  {{- if partial "llms-txt/is-included.html" (dict "url" $prefix "llms" $llms) -}}
+    {{- $entries := slice -}}
+    {{- /* This rescans $all per section, which reads as O(sections x pages) --
+           but the hasPrefix guard below runs before the partial, and a page
+           lives under exactly one top-level section, so is-included fires once
+           per page, not once per section-page pair. Measured on the full site
+           (5,684 pages, --templateMetrics): is-included ran 5,616 times across
+           both llms templates -- ~2,808 each, i.e. once per page -- for 80ms
+           total, 0.004% of the build. Bucketing pages by section first would
+           trade that for map-building and a second place to get the baseURL
+           prefix handling right. Not worth it; left flat on purpose. */ -}}
+    {{- range $all -}}
+      {{- if and (hasPrefix .RelPermalink $prefix) (ne .RelPermalink $prefix) -}}
+        {{- if partial "llms-txt/is-included.html" (dict "url" .RelPermalink "llms" $llms) -}}
+          {{- $entries = $entries | append (partial "llms-txt/entry.html" (dict "page" .)) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $out = $out | append "" -}}
+    {{- $out = $out | append (printf "## %s" $section.Title) -}}
+    {{- $out = $out | append "" -}}
+    {{- $out = $out | append (partial "llms-txt/entry.html" (dict "page" $section)) -}}
+    {{- range $entries -}}
+      {{- $out = $out | append . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Machine-generated sets are linked at section level only. Enumerating
+       them would bury the hand-written docs, and their pages carry no prose
+       for an agent to read. Per-page index.md output still exists for each,
+       so anything here remains reachable by an agent that needs it. */ -}}
+{{- $optional := slice -}}
+{{- range $llms.bulk | default slice -}}
+  {{- $note := .note -}}
+  {{- with site.GetPage (strings.TrimSuffix "/" .path) -}}
+    {{- $optional = $optional | append (partial "llms-txt/entry.html" (dict "page" . "note" $note)) -}}
+  {{- end -}}
+{{- end -}}
+{{- if $optional -}}
+  {{- $out = $out | append "" -}}
+  {{- $out = $out | append "## Optional" -}}
+  {{- $out = $out | append "" -}}
+  {{- range $optional -}}
+    {{- $out = $out | append . -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* A trailing empty element makes the join end the file with a newline. */ -}}
+{{- $out = $out | append "" -}}
+{{- delimit $out "\n" -}}
+{{- end -}}

--- a/docs/layouts/index.llmsfull.txt
+++ b/docs/layouts/index.llmsfull.txt
@@ -1,0 +1,66 @@
+{{- /*
+  /llms-full.txt — the full text of the documentation in one file, for agents
+  that ingest a whole corpus rather than following links.
+
+  Note that llmstxt.org specifies llms.txt only; llms-full.txt is a widely used
+  convention with no formal spec, so the layout here is chosen for legibility:
+  the same header as llms.txt, then one rule-delimited stanza per page.
+
+  Traversal deliberately mirrors index.llms.txt, including the bulk and exclude
+  filters, so the two files never disagree about what the corpus contains.
+*/ -}}
+{{- $llms := site.Params.llms | default dict -}}
+{{- if ne ($llms.enable_llms_full_txt | default true) false -}}
+{{- $out := slice -}}
+
+{{- $summary := trim (site.Params.description | default site.Title | plainify | replaceRE "\\s+" " ") " " -}}
+{{- $out = $out | append (printf "# %s" ($llms.title | default site.Title)) -}}
+{{- $out = $out | append "" -}}
+{{- $out = $out | append (printf "> %s" $summary) -}}
+
+{{- /* Every content page, ordered by URL so a parent always precedes its
+       children. RegularPagesRecursive is deliberately not used: it skips
+       branch bundles, which would drop landing pages such as
+       /installation/kubernetes/ from the output even though they carry a
+       description and are what an agent should read first. */ -}}
+{{- $all := sort (where site.Pages "Kind" "in" (slice "page" "section")) "RelPermalink" -}}
+
+{{- /* Home page, then any page at the root of the site. */ -}}
+{{- with partial "llms-txt/full-entry.html" site.Home -}}
+  {{- $out = $out | append "" -}}
+  {{- $out = $out | append . -}}
+{{- end -}}
+{{- range site.Home.RegularPages -}}
+  {{- if partial "llms-txt/is-included.html" (dict "url" .RelPermalink "llms" $llms) -}}
+    {{- with partial "llms-txt/full-entry.html" . -}}
+      {{- $out = $out | append "" -}}
+      {{- $out = $out | append . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Every top-level section, in sidebar order, then its pages. */ -}}
+{{- range site.Home.Sections.ByWeight -}}
+  {{- $section := . -}}
+  {{- $prefix := $section.RelPermalink -}}
+  {{- if partial "llms-txt/is-included.html" (dict "url" $prefix "llms" $llms) -}}
+    {{- with partial "llms-txt/full-entry.html" $section -}}
+      {{- $out = $out | append "" -}}
+      {{- $out = $out | append . -}}
+    {{- end -}}
+    {{- range $all -}}
+      {{- if and (hasPrefix .RelPermalink $prefix) (ne .RelPermalink $prefix) -}}
+        {{- if partial "llms-txt/is-included.html" (dict "url" .RelPermalink "llms" $llms) -}}
+          {{- with partial "llms-txt/full-entry.html" . -}}
+            {{- $out = $out | append "" -}}
+            {{- $out = $out | append . -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $out = $out | append "" -}}
+{{- delimit $out "\n" -}}
+{{- end -}}

--- a/docs/layouts/index.md
+++ b/docs/layouts/index.md
@@ -1,0 +1,1 @@
+{{- partial "llms-txt/page-markdown.html" . -}}

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -7,6 +7,14 @@
   </small>
   {{ end }}
 
+  {{/* Site-wide index for LLM agents (https://llmstxt.org). Shown only when the
+       build actually produced it, i.e. with config-llms.toml layered in. */}}
+  {{- with site.Home.OutputFormats.Get "llms" }}
+  <small class="ml-1">
+    <a href="{{ .RelPermalink }}">llms.txt</a>
+  </small>
+  {{- end }}
+
   <div class="footer-icons-list">
     <div class="footer-icons">
       <a

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -17,6 +17,19 @@
     href="{{ "index.xml" | relURL }}"
   />
 
+  {{/* Markdown rendition of this page, for agents that would otherwise have to
+       scrape the rendered HTML. Empty unless the site was built with
+       config-llms.toml layered in. Supplied by baseof.html: this partial is
+       called with a dict, so the Page's own OutputFormats are not reachable
+       from here. */}}
+  {{- with .MarkdownURL }}
+  <link
+    rel="alternate"
+    type="text/markdown"
+    href="{{ . }}"
+  />
+  {{- end }}
+
   <link
     rel="shortcut icon"
     href="{{ "favicons/favicon.ico" | relURL }}"

--- a/docs/layouts/partials/llms-txt/entry.html
+++ b/docs/layouts/partials/llms-txt/entry.html
@@ -1,0 +1,33 @@
+{{- /*
+  Returns one llms.txt file-list line for a page:
+
+      - [Title](https://docs.meshery.io/section/page/index.md): description
+
+  Per the llms.txt specification a list item is "a required markdown hyperlink
+  [name](url), then optionally a : and notes about the file".
+
+  Call with:
+    page  the Page to describe
+    note  optional string used in place of the page's own description
+*/ -}}
+{{- $p := .page -}}
+{{- $url := partial "llms-txt/md-url.html" $p -}}
+{{- $desc := .note | default $p.Description -}}
+{{- if not $desc -}}
+  {{- $desc = $p.Summary | plainify -}}
+{{- end -}}
+{{- $desc = htmlUnescape (truncate 200 (trim ($desc | plainify | replaceRE "\\s+" " ") " ")) -}}
+{{- $title := $p.Title | default $p.LinkTitle | default "Untitled" -}}
+{{- /* A Markdown link label ends at its first unescaped "]", so a title
+       containing a bracket would cut the label short and leave the URL behind
+       as plain text -- the entry would still look like prose but would no
+       longer be a link. Escape the backslash first, so that the escapes added
+       for the brackets are not themselves re-escaped. */ -}}
+{{- $title = replace $title "\\" "\\\\" -}}
+{{- $title = replace $title "[" "\\[" -}}
+{{- $title = replace $title "]" "\\]" -}}
+{{- $line := printf "- [%s](%s)" $title $url -}}
+{{- with $desc -}}
+  {{- $line = printf "%s: %s" $line . -}}
+{{- end -}}
+{{- return $line -}}

--- a/docs/layouts/partials/llms-txt/full-entry.html
+++ b/docs/layouts/partials/llms-txt/full-entry.html
@@ -1,0 +1,42 @@
+{{- /*
+  Returns one llms-full.txt stanza for a page: a rule-delimited metadata header
+  followed by the page's Markdown body. Returns an empty string for pages that
+  carry neither a body nor a description, so that data-only pages do not pad the
+  file with empty stanzas.
+
+  The body comes from .RenderShortcodes, not .RawContent. .RawContent is the
+  unprocessed source, which in this site would emit literal shortcode calls --
+  every "ref" shortcode would reach the agent as template syntax instead of the
+  URL it resolves to. .RenderShortcodes expands them first.
+
+  Call with a Page.
+*/ -}}
+{{- $rule := strings.Repeat 80 "-" -}}
+{{- $body := "" -}}
+{{- if .RawContent -}}
+  {{- $body = printf "%s" .RenderShortcodes -}}
+{{- else -}}
+  {{- $body = .Description -}}
+{{- end -}}
+{{- $out := "" -}}
+{{- if $body -}}
+  {{- $lines := slice $rule -}}
+  {{- $lines = $lines | append (printf "title: %s" (.Title | default "Untitled")) -}}
+  {{- $lines = $lines | append (printf "url: %s" (partial "llms-txt/md-url.html" .)) -}}
+  {{- with .Description -}}
+    {{- $lines = $lines | append (printf "description: %s" (trim (. | plainify | replaceRE "\\s+" " ") " ")) -}}
+  {{- end -}}
+  {{- /* Test IsZero explicitly rather than leaning on `with`. Hugo's own
+         truthiness honours the IsZero interface, so `with .Date` happens to
+         skip undated pages -- but plain Go templates treat any struct as true,
+         and that implicit dependency is not worth relying on for a date line
+         that would otherwise read "0001-01-01" on 294 of 296 stanzas. */ -}}
+  {{- if not .Date.IsZero -}}
+    {{- $lines = $lines | append (printf "date: %s" (.Date.Format "2006-01-02")) -}}
+  {{- end -}}
+  {{- $lines = $lines | append $rule -}}
+  {{- $lines = $lines | append "" -}}
+  {{- $lines = $lines | append (trim $body "\r\n") -}}
+  {{- $out = delimit $lines "\n" -}}
+{{- end -}}
+{{- return $out -}}

--- a/docs/layouts/partials/llms-txt/is-included.html
+++ b/docs/layouts/partials/llms-txt/is-included.html
@@ -1,0 +1,61 @@
+{{- /*
+  Reports whether a page belongs in llms.txt and llms-full.txt.
+
+  Derived from the llms-txt Hugo module by GetHugoThemes (MIT licensed):
+  https://github.com/gethugothemes/hugo-modules/tree/master/llms-txt
+
+  Call with:
+    url   .RelPermalink of the page under test
+    llms  site.Params.llms
+
+  Pattern syntax accepted in llms.exclude:
+    /path/     exact match
+    /path/*    direct children of /path/
+    /path/**   /path/ and everything beneath it
+
+  Pages beneath an llms.bulk path are always excluded here. Those sets are
+  machine-generated and would otherwise dominate the index, so llms.txt links
+  them once at section level from its "Optional" section instead.
+*/ -}}
+{{- $url := .url -}}
+{{- $llms := .llms -}}
+{{- $included := true -}}
+
+{{- /* Patterns are written relative to the site root, but .RelPermalink carries
+       whatever path the baseURL has. A deploy under a subpath -- the PR preview
+       at /pr-preview/pr-NNNN/, or a versioned doc set -- would otherwise match
+       nothing at all and silently include every excluded page. Strip the site
+       root first so the patterns mean the same thing wherever the site is
+       served from. */ -}}
+{{- $root := site.Home.RelPermalink -}}
+{{- if and (ne $root "/") (hasPrefix $url $root) -}}
+  {{- $url = printf "/%s" (strings.TrimPrefix $root $url) -}}
+{{- end -}}
+
+{{- range $llms.bulk | default slice -}}
+  {{- if and .path (hasPrefix $url .path) -}}
+    {{- $included = false -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $included -}}
+  {{- range $llms.exclude | default slice -}}
+    {{- if hasSuffix . "/**" -}}
+      {{- if hasPrefix $url (strings.TrimSuffix "**" .) -}}
+        {{- $included = false -}}
+      {{- end -}}
+    {{- else if hasSuffix . "/*" -}}
+      {{- $dir := strings.TrimSuffix "*" . -}}
+      {{- $rest := strings.TrimSuffix "/" (strings.TrimPrefix $dir $url) -}}
+      {{- if and (hasPrefix $url $dir) (ne $url $dir) (not (strings.Contains $rest "/")) -}}
+        {{- $included = false -}}
+      {{- end -}}
+    {{- else -}}
+      {{- if eq $url . -}}
+        {{- $included = false -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $included -}}

--- a/docs/layouts/partials/llms-txt/md-url.html
+++ b/docs/layouts/partials/llms-txt/md-url.html
@@ -1,0 +1,11 @@
+{{- /*
+  Returns the permalink of a page's raw-Markdown rendition when the "md"
+  output format is enabled for it, falling back to the HTML permalink.
+
+  Call with a Page.
+*/ -}}
+{{- $url := .Permalink -}}
+{{- with .OutputFormats.Get "md" -}}
+  {{- $url = .Permalink -}}
+{{- end -}}
+{{- return $url -}}

--- a/docs/layouts/partials/llms-txt/page-markdown.html
+++ b/docs/layouts/partials/llms-txt/page-markdown.html
@@ -1,0 +1,23 @@
+{{- /*
+  Returns the raw-Markdown rendition of a single page: an H1, the front-matter
+  description as a blockquote, a link back to the canonical HTML page, and the
+  body with shortcodes expanded.
+
+  This is what the "md" output format publishes as index.md alongside each
+  page's index.html, and what every link in llms.txt points at.
+
+  Call with a Page.
+*/ -}}
+{{- $lines := slice (printf "# %s" (.Title | default site.Title)) -}}
+{{- with .Description -}}
+  {{- $lines = $lines | append "" -}}
+  {{- $lines = $lines | append (printf "> %s" (trim (. | plainify | replaceRE "\\s+" " ") " ")) -}}
+{{- end -}}
+{{- $lines = $lines | append "" -}}
+{{- $lines = $lines | append (printf "Source: %s" .Permalink) -}}
+{{- with .RawContent -}}
+  {{- $lines = $lines | append "" -}}
+  {{- $lines = $lines | append (trim (printf "%s" $.RenderShortcodes) "\r\n") -}}
+{{- end -}}
+{{- $lines = $lines | append "" -}}
+{{- return (delimit $lines "\n") -}}

--- a/docs/layouts/partials/page-meta-links.html
+++ b/docs/layouts/partials/page-meta-links.html
@@ -34,5 +34,12 @@
 {{ with .CurrentSection.AlternativeOutputFormats.Get "print" -}}
   <a id="print" href="{{ .RelPermalink | safeURL }}"><i class="fa-solid fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
 {{ end }}
+{{/* Only present when the site was built with config-llms.toml layered in, so
+     the standard build renders exactly what it did before. The md format is
+     notAlternative and therefore absent from AlternativeOutputFormats, so it
+     has to be looked up by name. */ -}}
+{{ with .OutputFormats.Get "md" -}}
+  <a id="markdown" href="{{ .RelPermalink | safeURL }}"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "view_as_markdown" }}</a>
+{{ end }}
 </div>
 {{ end -}}

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,8 @@
     "build": "npm run _build",
     "build:preview": "npm run _hugo-dev -- --cleanDestinationDir --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --cleanDestinationDir --minify --gc",
+    "build:llms": "npm run _hugo -- -e dev -DFE --cleanDestinationDir --config hugo.toml,config-llms.toml",
+    "build:production:llms": "npm run _hugo -- --cleanDestinationDir --minify --gc --config hugo.toml,config-llms.toml",
     "site": "npm run _site",
     "serve": "npm run _serve",
     "clean": "rm -Rf public/* resources",


### PR DESCRIPTION
**Notes for Reviewers**

- This PR addresses meshery/meshery.io#2921 (the issue is filed on the website repo, but the docs Hugo config lives here).

Publishes `/llms.txt` and `/llms-full.txt` per the [llmstxt.org](https://llmstxt.org) spec, plus a raw-Markdown rendition of every page at `<page-url>index.md`, so AI agents can consume the docs without scraping rendered HTML.

### What changed

- Registers three output formats — `llms`, `llmsfull`, `md` — and enables them for the `home`, `page` and `section` kinds. Taxonomy and term output stay disabled, as they are today.
- Adds a `[params.llms]` block for the title, exclusions and the "Optional" groupings.
- Adds the generation templates under `layouts/` and `layouts/partials/llms-txt/`.
- Raises the Hugo floor from 0.110.0 to 0.117.0 (see below). CI already builds with 0.157.0 and `package.json` pins 0.158.0, so nothing in the pipeline moves.

### Why the templates are vendored rather than the community module imported

The issue suggested importing [`gethugothemes/hugo-modules/llms-txt`](https://github.com/gethugothemes/hugo-modules/tree/master/llms-txt). I evaluated it and it is not usable here as published, for one decisive reason: it renders page bodies with `.RawContent`, which does not expand shortcodes.

This site leans on shortcodes exactly where it matters — **35 of 37** installation pages, **43 of 53** guides, **116 of 119** reference pages and **20 of 22** concepts contain them, and the `ref` shortcode alone appears **1,113 times**. Every internal cross-link would have reached an agent as literal template syntax instead of a URL. Worse, pages whose body is a single shortcode (`installation/accessing-meshery-ui.md`, for one) would have produced no content at all.

These templates use `.RenderShortcodes` instead, which is what moves the Hugo floor to 0.117.0. Four of the module's five templates would have needed overriding anyway, which would have left only its output-format declarations actually in use while masking any upstream fixes — hence vendoring. The templates are derived from that module and retain its MIT notice.

### Why some pages are grouped under "Optional"

`project/compatibility`, `project/releases` and `extensions/models` are **2,508 of the site's 2,811 pages and 69% of its Markdown by volume**, and nearly all of them have no body at all — they are front matter rendered by a custom layout. Enumerating them would bury the hand-written docs while giving an agent nothing to read, so each is linked once from the spec's conventional `## Optional` section. Per-page `index.md` output is still generated for them, so nothing becomes unreachable. These three groupings are configuration, not hard-coded, and are the part of this PR I'd most expect review feedback on.

### Verification

Verified against a full production build (5,684 pages, clean build):

| | |
|---|---|
| `llms.txt` | 71 KB, 303 entries across 8 sections, **0 unresolved links** |
| `llms-full.txt` | 3.32 MB, 296 stanzas |
| per-page `index.md` | 2,810 files at a predictable path |
| unrendered shortcode syntax | **0** (57 occurrences, all from the two pages that *document* shortcodes and escape it deliberately) |

A structural validator checks `llms.txt` against the spec — H1, blockquote summary, H2 file lists, `- [name](url): notes` item grammar, absolute URLs, `Optional` last — plus that every listed URL was actually published. It is negative-tested (a corrupted H1, a malformed item and a dead link are all rejected), so the pass is meaningful.

### Notes and known limitations

- `llms-full.txt` at 3.32 MB (~870K tokens) exceeds any current model's context even after filtering. It suits ingestion pipelines rather than single-request reading; happy to drop it or trim it further if maintainers prefer.
- 224 of 2,810 `index.md` files contain block HTML, because Docsy/Meshery shortcodes emit HTML — 153 wrap code in `<pre class="codeblock-pre">` rather than fenced blocks. Valid Markdown and readable, but not pristine. Possible follow-up.
- The partials live in `layouts/partials/llms-txt/`, not `layouts/partials/llms/`, because the bare `LLMs` entry at `.gitignore:106` matches a directory named `llms` on case-insensitive filesystems. Linux CI is unaffected, but the files would have silently vanished for contributors on Windows and macOS. Worth tightening that ignore rule separately.
- Not yet done: pointing a live ChatGPT/Claude session at the generated files. That needs a preview deploy; I verified navigation deterministically against the build instead (index entry → `index.md` → does the page actually answer the question).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added machine-readable Markdown versions of documentation pages.
  * Added “View as Markdown” links and Markdown discovery metadata.
  * Added `llms.txt` with page links, descriptions, exclusions, and optional bulk collections.
  * Added `llms-full.txt`, containing the complete documentation corpus in Markdown.
  * Added configurable titles, notes, exclusions, and bulk page sets.

* **Improvements**
  * Updated documentation builds to generate these formats.
  * Raised the minimum supported Hugo version to 0.117.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->