### PR TITLE
docs: fix typo arguements -> arguments

### DIFF
--- a/docs/content/en/project/releases/v0.6.0-rc-3.md
+++ b/docs/content/en/project/releases/v0.6.0-rc-3.md
@@ -28,7 +28,7 @@ tag: v0.6.0-rc-3
 ## 🖥 Meshery UI
 
 - [RJSF] Add title and some styling changes to rjsf components @Abhishek-kumar09 (#4840)
-- fix : Update update handler function to change the order of arguements @sudo-NithishKarthik (#4832)
+- fix : Update update handler function to change the order of arguments @sudo-NithishKarthik (#4832)
 - [ Visualizer ] restructuring to visualizer terminal | CU-1wn5nzk | CU-1c5dt1 @manav1403 (#4829)
 - added Meshsync status to tooltip @warunicorn19 (#4827)
 - Add meshsync status logo in header @Prakhar-Agarwal-byte (#4785)


### PR DESCRIPTION
Corrects a single misspelling of `arguements` in `docs/content/en/project/releases/v0.6.0-rc-3.md`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the v0.6.0-rc-3 release notes, changing “arguements” to “arguments.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->