### PR TITLE
[UI] Let LegacyRJSFModal disable Submit while it is pending

### DIFF
--- a/ui/components/shared/Modal/LegacyRJSFModal.tsx
+++ b/ui/components/shared/Modal/LegacyRJSFModal.tsx
@@ -75,6 +75,9 @@ const SchemaVersion: FC<SchemaVersionProps> = ({ schema_array, type, schemaChang
  * @param {Object} props.showInfoIcon - Determines whether to show the info icon adjacent to the modal button.
  * @param {string} props.submitBtnText - The text for the submit button.
  * @param {Object} props.uiSchema - The UI schema for the form fields.
+ * @param {boolean} props.submitDisabled - Disables the submit button for a consumer-owned
+ * reason, OR-ed with the modal's own reasons (a forbidden title, and the pending state while
+ * the schema is still loading). Defaults to false.
  */
 
 // Meshery extensions also uses this modal
@@ -94,6 +97,7 @@ function Modal(props) {
     helpText,
     RJSFWrapperComponent = null,
     initialData = {},
+    submitDisabled = false,
   } = props;
 
   const [canNotSubmit, setCanNotSubmit] = useState(false);
@@ -175,7 +179,7 @@ function Modal(props) {
             secondaryText="Cancel"
             primaryButtonProps={{
               onClick: handleFormSubmit,
-              disabled: canNotSubmit,
+              disabled: canNotSubmit || loadingSchema || submitDisabled,
             }}
             secondaryButtonProps={{
               onClick: handleClose,
@@ -201,6 +205,7 @@ function RJSFModalWrapper({
   helpText,
   widgets = {},
   isSubmitting = false,
+  submitDisabled = false,
 }) {
   const formRef = useRef();
   const formStateRef = useRef();
@@ -270,7 +275,7 @@ function RJSFModalWrapper({
           secondaryText="Cancel"
           primaryButtonProps={{
             onClick: handleFormSubmit,
-            disabled: canNotSubmit || isSubmitting,
+            disabled: canNotSubmit || loadingSchema || isSubmitting || submitDisabled,
             startIcon: isSubmitting ? <CircularProgress size={16} /> : undefined,
           }}
           secondaryButtonProps={{

--- a/ui/components/shared/Modal/__tests__/LegacyRJSFModal.submitDisabled.test.tsx
+++ b/ui/components/shared/Modal/__tests__/LegacyRJSFModal.submitDisabled.test.tsx
@@ -1,0 +1,93 @@
+// The Submit button in LegacyRJSFModal lives outside the `loadingSchema` branch,
+// so it renders while the modal is still pending. Its click path is guarded by
+// `formRef.current`, which is null until RJSFWrapper mounts - so a click during
+// that window does nothing at all: no submit, no close, no feedback.
+//
+// These tests pin the two inputs that close that gap (issue #21227): the button
+// is disabled for the whole pending window, and a consumer can disable it for
+// its own reasons through `submitDisabled`. The title-derived `canNotSubmit`
+// heuristic is asserted alongside them so the OR is not silently narrowed later.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const notify = vi.fn();
+vi.mock('@/utils/hooks/useNotification', () => ({
+  useNotification: () => ({ notify }),
+}));
+
+// RJSFWrapper pulls the whole RJSF stack in; the form itself is not under test
+// here, only whether the footer button is disabled.
+vi.mock('../../../meshery-mesh-interface/PatternService/RJSF_wrapper', () => ({
+  default: () => <div data-testid="rjsf-wrapper" />,
+}));
+
+vi.mock('../../../meshery-mesh-interface/PatternService/helper', () => ({
+  getSchema: () => ({}),
+}));
+
+import { SistentThemeProvider } from '@/theme';
+import Modal from '../LegacyRJSFModal';
+
+const schema = { type: 'object', properties: {} };
+
+const renderModal = (props: Record<string, unknown> = {}) =>
+  render(
+    <SistentThemeProvider>
+      <Modal
+        open
+        title="Help & Support"
+        handleClose={vi.fn()}
+        handleSubmit={vi.fn()}
+        schema_array={[]}
+        type="helpAndSupport"
+        schemaChangeHandler={vi.fn()}
+        {...props}
+      />
+    </SistentThemeProvider>,
+  );
+
+const submitButton = () => screen.getByRole('button', { name: /submit/i });
+
+describe('LegacyRJSFModal submit button', () => {
+  beforeEach(() => {
+    notify.mockReset();
+  });
+
+  it('is disabled while the modal is still pending, so the dead click cannot happen', () => {
+    // No schema yet - the modal renders its spinner and RJSFWrapper is unmounted,
+    // which is exactly when handleFormSubmit's formRef guard makes a click inert.
+    renderModal();
+
+    expect(screen.queryByTestId('rjsf-wrapper')).not.toBeInTheDocument();
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('is enabled once the schema resolves and the form is mounted', () => {
+    renderModal({ schema });
+
+    expect(screen.getByTestId('rjsf-wrapper')).toBeInTheDocument();
+    expect(submitButton()).toBeEnabled();
+  });
+
+  it('stays disabled when the consumer sets submitDisabled, even with a schema', () => {
+    renderModal({ schema, submitDisabled: true });
+
+    expect(screen.getByTestId('rjsf-wrapper')).toBeInTheDocument();
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('defaults submitDisabled to false, so existing consumers are unaffected', () => {
+    renderModal({ schema, submitDisabled: undefined });
+
+    expect(submitButton()).toBeEnabled();
+  });
+
+  it('still honours the title-derived canNotSubmit heuristic', () => {
+    renderModal({ schema, title: 'Untitled Design' });
+
+    expect(notify).toHaveBeenCalled();
+    expect(submitButton()).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Description

`LegacyRJSFModal` renders `PrimaryActionButtons` in `ModalFooter` **outside** the `loadingSchema` branch, so Submit is on screen and enabled while the modal is still pending. Its only disable input was `canNotSubmit`, derived solely from the title matching `'untitled design'` / `'Untitled'` / `'lfx'` — so any other title (for example `"Help & Support"`) rendered Submit enabled throughout.

Clicking it during that window reaches `handleFormSubmit`, whose `if (formRef.current && ...)` guard is false because `RJSFWrapper` is not mounted yet. The click therefore does nothing at all: no submit, no close, no feedback — a dead click a consumer had no way to prevent.

## Changes

`ui/components/shared/Modal/LegacyRJSFModal.tsx`, both suggestions from the issue:

- **`loadingSchema`** is OR-ed into the disabled state. In that state the submit path is inert by construction, so this only stops an inert button from presenting as clickable.
- **A new `submitDisabled` prop** (default `false`) lets a consumer gate Submit on its own readiness, OR-ed with the modal's own reasons.

| component | before | after |
|---|---|---|
| `Modal` (also used by Meshery extensions) | `canNotSubmit` | `canNotSubmit \|\| loadingSchema \|\| submitDisabled` |
| `RJSFModalWrapper` | `canNotSubmit \|\| isSubmitting` | `canNotSubmit \|\| loadingSchema \|\| isSubmitting \|\| submitDisabled` |

`RJSFModalWrapper` already disabled on `isSubmitting` but not on `loadingSchema`, so it gains both inputs for consistency.

Nothing enabled today becomes disabled once a schema resolves: `loadingSchema` flips to `false` and the button behaves exactly as before. `submitDisabled` defaults to `false`, so consumers that do not pass it are unaffected.

## Testing

New `ui/components/shared/Modal/__tests__/LegacyRJSFModal.submitDisabled.test.tsx`, 5 cases: disabled while pending, enabled once the schema resolves, disabled when `submitDisabled` is set, `submitDisabled` defaulting to false, and the existing title-derived heuristic still firing. It renders the real Sistent components inside `SistentThemeProvider` (per the note in `vitest.config.ts` about shallow `@sistent/sistent` stubs), mocking only `RJSFWrapper` and `useNotification`.

Verified the tests are not vacuous: reverting the `Modal` disable expression to `canNotSubmit` fails exactly the two cases that cover the new behaviour, and passes the other three.

Fixes #21227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to disable modal submission buttons when needed.
  - Submission buttons now remain disabled while schemas are loading or submissions are in progress.

- **Bug Fixes**
  - Prevented submission when modal validation conditions indicate it is unavailable.

- **Tests**
  - Added coverage for disabled, enabled, loading, and validation-related submission states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->