### PR TITLE
[UI] Keep the Notification Center icon out of Redux as a serializable name

### DIFF
--- a/ui/components/layout/NotificationCenter/__tests__/notificationIcons.test.ts
+++ b/ui/components/layout/NotificationCenter/__tests__/notificationIcons.test.ts
@@ -1,0 +1,66 @@
+// The Notification Center header used to read a React component straight out of
+// Redux (`uiConfig.icon || BellIcon`), which is what put a non-serializable
+// value at `events.ui.icon` (issue #16873). The store now carries a name and the
+// header resolves it here, so this is the half that has to stay total: every
+// input, including the component an older extension might still send, must
+// produce a renderable component rather than undefined.
+
+import { describe, expect, it } from 'vitest';
+import BellIcon from '../../../../assets/icons/BellIcon';
+import AlertIcon from '../../../../assets/icons/AlertIcon';
+import {
+  DEFAULT_NOTIFICATION_ICON,
+  NOTIFICATION_ICONS,
+  resolveNotificationIcon,
+} from '../notificationIcons';
+
+describe('resolveNotificationIcon', () => {
+  it('resolves a registered name to its component', () => {
+    expect(resolveNotificationIcon('bell')).toBe(BellIcon);
+    expect(resolveNotificationIcon('alert')).toBe(AlertIcon);
+  });
+
+  it('falls back to the bell for an unknown name', () => {
+    expect(resolveNotificationIcon('no-such-icon')).toBe(BellIcon);
+  });
+
+  it('falls back to the bell when no icon is set', () => {
+    expect(resolveNotificationIcon(undefined)).toBe(BellIcon);
+    expect(resolveNotificationIcon(null)).toBe(BellIcon);
+    expect(resolveNotificationIcon('')).toBe(BellIcon);
+  });
+
+  it('falls back to the bell for a component, which the store no longer keeps', () => {
+    const LegacyIcon = () => null;
+    expect(resolveNotificationIcon(LegacyIcon)).toBe(BellIcon);
+  });
+
+  it('never returns undefined, so the header always has something to render', () => {
+    const inputs = [
+      'bell',
+      'alert',
+      'error',
+      'info',
+      'nope',
+      '',
+      null,
+      undefined,
+      42,
+      {},
+      () => null,
+    ];
+    inputs.forEach((input) => {
+      expect(resolveNotificationIcon(input)).toBeTypeOf('function');
+    });
+  });
+
+  it('exposes a default that is itself a registered name', () => {
+    expect(NOTIFICATION_ICONS[DEFAULT_NOTIFICATION_ICON]).toBe(BellIcon);
+  });
+
+  it('registers only serializable names, so any of them can live in Redux', () => {
+    Object.keys(NOTIFICATION_ICONS).forEach((name) => {
+      expect(typeof name).toBe('string');
+    });
+  });
+});

--- a/ui/components/layout/NotificationCenter/index.tsx
+++ b/ui/components/layout/NotificationCenter/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@sistent/sistent';
 import Filter from './filter';
 import BellIcon from '../../../assets/icons/BellIcon';
+import { resolveNotificationIcon } from './notificationIcons';
 import { iconMedium } from '../../../css/icons.styles';
 import {
   NOTIFICATION_CENTER_TOGGLE_CLASS,
@@ -216,7 +217,7 @@ const Header = ({ handleFilter, handleClose }) => {
     });
   };
 
-  const Icon = uiConfig.icon || BellIcon;
+  const Icon = resolveNotificationIcon(uiConfig.icon);
   return (
     <NotificationContainer>
       <Title>

--- a/ui/components/layout/NotificationCenter/notificationIcons.ts
+++ b/ui/components/layout/NotificationCenter/notificationIcons.ts
@@ -1,0 +1,35 @@
+import AlertIcon from '../../../assets/icons/AlertIcon';
+import BellIcon from '../../../assets/icons/BellIcon';
+import ErrorIcon from '../../../assets/icons/ErrorIcon';
+import InfoIcon from '../../../assets/icons/InfoIcon';
+
+/**
+ * Icons the Notification Center header can be opened with, keyed by a
+ * serializable name.
+ *
+ * `openNotificationCenter` is dispatched into the Meshery store by extensions
+ * over the event bus (see `store/index.ts`), so whatever it carries is held in
+ * Redux state. A React component is not serializable, so the store carries the
+ * name and the header resolves it to a component at render time.
+ *
+ * Extensions that want an icon here pass one of these names. Adding a new one
+ * is a one-line entry in this map.
+ */
+export const NOTIFICATION_ICONS = {
+  bell: BellIcon,
+  alert: AlertIcon,
+  error: ErrorIcon,
+  info: InfoIcon,
+};
+
+export const DEFAULT_NOTIFICATION_ICON = 'bell';
+
+/**
+ * Resolves a stored icon name to its component, falling back to the bell for
+ * an unknown name, a missing one, or anything that is not a string - including
+ * a component passed by an older extension, which no longer reaches the store.
+ */
+export const resolveNotificationIcon = (name) => {
+  if (typeof name !== 'string') return NOTIFICATION_ICONS[DEFAULT_NOTIFICATION_ICON];
+  return NOTIFICATION_ICONS[name] || NOTIFICATION_ICONS[DEFAULT_NOTIFICATION_ICON];
+};

--- a/ui/store/slices/__tests__/events.test.ts
+++ b/ui/store/slices/__tests__/events.test.ts
@@ -4,6 +4,7 @@ import eventsReducer, {
   setEvents,
   toggleNotificationCenter,
   closeNotificationCenter,
+  openNotificationCenter,
 } from '../events';
 
 const makeEvent = (overrides = {}) => ({
@@ -65,5 +66,88 @@ describe('events slice', () => {
     state = eventsReducer(state, closeNotificationCenter());
     expect(state.isNotificationCenterOpen).toBe(false);
     expect(state.current_view.page).toBe(0);
+  });
+});
+
+// Extensions dispatch openNotificationCenter into this store over the event bus
+// (store/index.ts), so its payload is not under this repo's control. A React
+// icon component used to arrive in `ui` and sit in Redux state, which is what
+// RTK's serializable-state check flagged at `events.ui.icon` (issue #16873).
+
+const hasNonSerializable = (value) => {
+  const type = typeof value;
+  if (value === null || type === 'string' || type === 'number' || type === 'boolean') {
+    return false;
+  }
+  if (type !== 'object') return true;
+  return Object.values(value).some(hasNonSerializable);
+};
+
+describe('openNotificationCenter keeps the store serializable', () => {
+  const open = (ui) => {
+    const initial = eventsReducer(undefined, { type: 'unknown' });
+    return eventsReducer(initial, openNotificationCenter({ ui }));
+  };
+
+  it('drops an icon passed as a React component', () => {
+    const IconComponent = () => null;
+    const state = open({ icon: IconComponent, title: 'Kanvas' });
+
+    expect(state.ui.icon).toBeUndefined();
+    expect(typeof state.ui.icon).not.toBe('function');
+    // the serializable siblings still land
+    expect(state.ui.title).toBe('Kanvas');
+    expect(state.isNotificationCenterOpen).toBe(true);
+  });
+
+  it('keeps an icon passed as a registry name', () => {
+    const state = open({ icon: 'alert', title: 'Alerts' });
+
+    expect(state.ui.icon).toBe('alert');
+    expect(state.ui.title).toBe('Alerts');
+  });
+
+  it('drops a React element and other non-serializable values', () => {
+    const element = { $$typeof: Symbol.for('react.element'), type: 'svg', props: {} };
+    const state = open({ icon: element, onClick: () => {}, history_mode: true });
+
+    expect(state.ui.icon).toBeUndefined();
+    expect(state.ui.onClick).toBeUndefined();
+    expect(state.ui.history_mode).toBe(true);
+  });
+
+  it('leaves no non-serializable value anywhere under events.ui', () => {
+    const state = open({ icon: () => null, nested: { deep: () => null }, title: 'X' });
+
+    expect(hasNonSerializable(state.ui)).toBe(false);
+    expect(() => JSON.stringify(state.ui)).not.toThrow();
+  });
+
+  it('preserves the defaults an extension does not override', () => {
+    const state = open({ icon: 'bell' });
+
+    expect(state.ui.title).toBe('Notifications');
+    expect(state.ui.empty_message).toBe('No notifications found');
+  });
+
+  it('screens the raw action object too, which is how extensions dispatch it', () => {
+    // store/index.ts forwards whatever an extension puts on the event bus
+    // straight to dispatch, so the action never goes through the creator.
+    const initial = eventsReducer(undefined, { type: 'unknown' });
+    const state = eventsReducer(initial, {
+      type: 'events/openNotificationCenter',
+      payload: { ui: { icon: () => null, title: 'Extension' } },
+    });
+
+    expect(state.ui.icon).toBeUndefined();
+    expect(state.ui.title).toBe('Extension');
+  });
+
+  it('closeNotificationCenter resets ui back to the serializable defaults', () => {
+    const opened = open({ icon: 'error', title: 'Errors' });
+    const closed = eventsReducer(opened, closeNotificationCenter());
+
+    expect(closed.ui.icon).toBeUndefined();
+    expect(closed.ui.title).toBe('Notifications');
   });
 });

--- a/ui/store/slices/events.ts
+++ b/ui/store/slices/events.ts
@@ -27,6 +27,31 @@ const initialState = {
   isNotificationCenterOpen: false,
 };
 
+/**
+ * `openNotificationCenter` is dispatched into this store by Meshery extensions
+ * over the event bus (see `store/index.ts`), so its payload is whatever the
+ * extension chose to send. Anything non-serializable that lands in `ui` is held
+ * in Redux state forever - a React icon *component* used to, which trips RTK's
+ * serializable-state check and breaks state persistence and time-travel.
+ *
+ * Values are therefore screened on the way in. The icon travels as a name and
+ * is resolved to a component at render time by `resolveNotificationIcon`.
+ */
+const isSerializable = (value) => {
+  const type = typeof value;
+  if (value === null || type === 'string' || type === 'number' || type === 'boolean') {
+    return true;
+  }
+  // Functions (a bare icon component), symbols and undefined never are. A React
+  // element is caught by the recursion below: its `$$typeof` value is a symbol.
+  if (type !== 'object') return false;
+  if (Array.isArray(value)) return value.every(isSerializable);
+  return Object.values(value).every(isSerializable);
+};
+
+const serializableUi = (ui) =>
+  Object.fromEntries(Object.entries(ui || {}).filter(([, value]) => isSerializable(value)));
+
 const defaultEventProperties = {
   severity: SEVERITY.INFO,
   status: STATUS.UNREAD,
@@ -131,7 +156,7 @@ export const eventsSlice = createSlice({
       if (action.payload.ui) {
         state.ui = {
           ...state.ui,
-          ...action.payload.ui,
+          ...serializableUi(action.payload.ui),
         };
       }
     },
@@ -151,6 +176,7 @@ export const {
   updateEvent,
   toggleNotificationCenter,
   closeNotificationCenter,
+  openNotificationCenter,
   updateEvents,
 } = eventsSlice.actions;
 


### PR DESCRIPTION
## Description

`components/layout/NotificationCenter/index.tsx:219` read its icon straight out of Redux:

```js
const Icon = uiConfig.icon || BellIcon;
```

so a React SVG component sat in the store at `events.ui.icon` and tripped RTK's serializable-state check — the warning in the issue.

It gets there from outside this repo. `store/index.ts` subscribes to `MESHERY_EXTENSION_EVENT.DispatchToMesheryStore` and forwards whatever a Meshery extension puts on the event bus straight to `dispatch`; the `openNotificationCenter` reducer then spread `action.payload.ui` into `state.ui` unfiltered. Nothing in this repo dispatches it, which is why the value only appears with extensions loaded.

## Changes

| File | Change |
|---|---|
| `components/layout/NotificationCenter/notificationIcons.ts` *(new)* | Name→component registry (`bell`, `alert`, `error`, `info`) and `resolveNotificationIcon` |
| `components/layout/NotificationCenter/index.tsx` | `uiConfig.icon \|\| BellIcon` → `resolveNotificationIcon(uiConfig.icon)` |
| `store/slices/events.ts` | Screen non-serializable values out of `ui` in `openNotificationCenter`; export `openNotificationCenter` |

Two deliberate choices:

- **The screen is general, not icon-specific.** `isSerializable` rejects functions and symbols and recurses through objects and arrays, so a React element (caught by its `$$typeof` symbol) or a stray callback under any `ui` key is dropped, not just `icon`.
- **`resolveNotificationIcon` is total.** An unknown name, a missing one, or a component sent by an older extension all resolve to the bell, so the header always has something to render.

Also exports `openNotificationCenter` from the slice — it was the only reducer missing from the action-creator export list, so no in-repo code could dispatch it by creator.

## Behaviour change worth reviewing

An extension still passing a React component now renders the bell instead of its own icon, until that icon is added to `NOTIFICATION_ICONS`. That is the trade the issue asks for ("store a string identifier … the mapping … should happen at the UI component level"), and adding an icon is a one-line entry — but it is extension-visible, so I would rather flag it here than have it found later.

## Testing

- `components/layout/NotificationCenter/__tests__/notificationIcons.test.ts` — resolution for registered names, unknown names, `null`/`undefined`/`''`, a legacy component, and a totality check that no input yields `undefined`.
- `store/slices/__tests__/events.test.ts` — a component, a React element, and a nested function are all dropped while serializable siblings survive; the raw action object is screened too (the event-bus path never goes through the action creator); `closeNotificationCenter` still resets to serializable defaults.

20/20 targeted tests pass. Verified they are not vacuous: reverting the screen in the reducer fails exactly 4 of them. Full vitest suite run twice — 2788 passed, 0 failures both times. ESLint clean on all five files.

Fixes #16873


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configurable Notification Center icons, including bell, alert, error, and info options.
  - Invalid or legacy icon values now safely fall back to the default bell icon.
  - Notification Center UI settings now retain only serializable values for more reliable behavior.

- **Bug Fixes**
  - Prevented unsupported data such as callbacks, components, and undefined values from affecting notification state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->