### PR TITLE
[UI]: Remove duplicate View Connection link from connection creation toast

### DIFF
--- a/ui/components/connections/ConnectionWizard.helpers.test.ts
+++ b/ui/components/connections/ConnectionWizard.helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { CoreConnectionKinds } from '@/utils/Enum';
+import { EVENT_TYPES } from 'lib/event-types';
 import {
   buildConnectionWizardKindConfigs,
   buildCredentialSecret,
@@ -304,9 +305,27 @@ describe('ConnectionWizard.helpers', () => {
     vi.unstubAllGlobals();
   });
 
-  it('formats kubernetes import notify summaries', () => {
+  it('formats kubernetes import notify summaries without duplicate link action', () => {
     vi.stubGlobal('window', { location: { pathname: '/dashboard' } });
-    expect(kubernetesImportedNotify(2).message).toBe('Imported 2 Kubernetes connections.');
+
+    const singular = kubernetesImportedNotify(1);
+    expect(singular.message).toBe('Imported 1 Kubernetes connection.');
+    expect(singular.event_type).toBe(EVENT_TYPES.SUCCESS);
+    expect(singular.link).toBeUndefined();
+
+    const plural = kubernetesImportedNotify(2);
+    expect(plural.message).toBe('Imported 2 Kubernetes connections.');
+    expect(plural.event_type).toBe(EVENT_TYPES.SUCCESS);
+    expect(plural.link).toBeUndefined();
+
+    const zero = kubernetesImportedNotify(0);
+    expect(zero.message).toBe('Imported 0 Kubernetes connections.');
+    expect(zero.event_type).toBe(EVENT_TYPES.WARNING);
+    expect(zero.link).toBeUndefined();
+
+    vi.stubGlobal('window', { location: { pathname: '/management/connections' } });
+    expect(kubernetesImportedNotify(1).link).toBeUndefined();
+
     vi.unstubAllGlobals();
   });
 });

--- a/ui/components/connections/ConnectionWizard.helpers.test.ts
+++ b/ui/components/connections/ConnectionWizard.helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { CoreConnectionKinds } from '@/utils/Enum';
 import { EVENT_TYPES } from 'lib/event-types';
 import {
@@ -295,38 +295,30 @@ describe('ConnectionWizard.helpers', () => {
     expect(isCreateConnectionQuery('false')).toBe(false);
   });
 
-  it('builds connection-created notify payloads with optional View connections action', () => {
-    vi.stubGlobal('window', { location: { pathname: '/dashboard' } });
-    const payload = connectionCreatedNotify('Prometheus');
-    expect(payload.message).toBe('Prometheus connection created.');
-    expect(payload.link?.href).toBe('/management/connections');
-    vi.stubGlobal('window', { location: { pathname: '/management/connections' } });
-    expect(connectionCreatedNotify('Grafana').link).toBeUndefined();
-    vi.unstubAllGlobals();
+  it('builds connection-created notify payloads', () => {
+    expect(connectionCreatedNotify('Prometheus')).toEqual({
+      message: 'Prometheus connection created.',
+      event_type: EVENT_TYPES.SUCCESS,
+    });
+    expect(connectionCreatedNotify('')).toEqual({
+      message: 'Connection created.',
+      event_type: EVENT_TYPES.SUCCESS,
+    });
   });
 
-  it('formats kubernetes import notify summaries without duplicate link action', () => {
-    vi.stubGlobal('window', { location: { pathname: '/dashboard' } });
-
-    const singular = kubernetesImportedNotify(1);
-    expect(singular.message).toBe('Imported 1 Kubernetes connection.');
-    expect(singular.event_type).toBe(EVENT_TYPES.SUCCESS);
-    expect(singular.link).toBeUndefined();
-
-    const plural = kubernetesImportedNotify(2);
-    expect(plural.message).toBe('Imported 2 Kubernetes connections.');
-    expect(plural.event_type).toBe(EVENT_TYPES.SUCCESS);
-    expect(plural.link).toBeUndefined();
-
-    const zero = kubernetesImportedNotify(0);
-    expect(zero.message).toBe('Imported 0 Kubernetes connections.');
-    expect(zero.event_type).toBe(EVENT_TYPES.WARNING);
-    expect(zero.link).toBeUndefined();
-
-    vi.stubGlobal('window', { location: { pathname: '/management/connections' } });
-    expect(kubernetesImportedNotify(1).link).toBeUndefined();
-
-    vi.unstubAllGlobals();
+  it('formats kubernetes import notify summaries', () => {
+    expect(kubernetesImportedNotify(1)).toEqual({
+      message: 'Imported 1 Kubernetes connection.',
+      event_type: EVENT_TYPES.SUCCESS,
+    });
+    expect(kubernetesImportedNotify(2)).toEqual({
+      message: 'Imported 2 Kubernetes connections.',
+      event_type: EVENT_TYPES.SUCCESS,
+    });
+    expect(kubernetesImportedNotify(0)).toEqual({
+      message: 'Imported 0 Kubernetes connections.',
+      event_type: EVENT_TYPES.WARNING,
+    });
   });
 });
 

--- a/ui/components/connections/ConnectionWizard.helpers.tsx
+++ b/ui/components/connections/ConnectionWizard.helpers.tsx
@@ -50,26 +50,17 @@ export const isCreateConnectionQuery = (value: string | string[] | undefined): b
 export type ConnectionCreatedNotifyPayload = {
   message: string;
   event_type: typeof EVENT_TYPES.SUCCESS | typeof EVENT_TYPES.WARNING;
-  link?: { href: string; label: string };
 };
 
-const isOnConnectionsPage = (): boolean =>
-  typeof window !== 'undefined' && window.location.pathname.startsWith(CONNECTIONS_PATH);
-
 /**
- * Success snackbar after create/import. Plain string (BasicMarkdown-safe) plus an
- * optional same-tab action when not already on the Connections page.
+ * Success snackbar after create/import. Plain string (BasicMarkdown-safe).
  */
 export const connectionCreatedNotify = (label: string): ConnectionCreatedNotifyPayload => {
   const name = (label && String(label).trim()) || '';
   const summary = name ? `${name} connection created.` : 'Connection created.';
-  if (isOnConnectionsPage()) {
-    return { message: summary, event_type: EVENT_TYPES.SUCCESS };
-  }
   return {
     message: summary,
     event_type: EVENT_TYPES.SUCCESS,
-    link: { href: CONNECTIONS_PATH, label: 'View connections' },
   };
 };
 

--- a/ui/components/connections/ConnectionWizard.helpers.tsx
+++ b/ui/components/connections/ConnectionWizard.helpers.tsx
@@ -77,13 +77,9 @@ export const kubernetesImportedNotify = (count: number): ConnectionCreatedNotify
   const noun = count === 1 ? 'connection' : 'connections';
   const summary = `Imported ${count} Kubernetes ${noun}.`;
   const event_type = count > 0 ? EVENT_TYPES.SUCCESS : EVENT_TYPES.WARNING;
-  if (isOnConnectionsPage() || count === 0) {
-    return { message: summary, event_type };
-  }
   return {
     message: summary,
     event_type,
-    link: { href: CONNECTIONS_PATH, label: 'View connections' },
   };
 };
 


### PR DESCRIPTION
## Summary

- Removed the duplicate `View connections` action from the Kubernetes connection import success toast.
- Kept the existing `connections` navigation link in the Kubernetes receipt modal.
- Updated unit tests to verify that the toast no longer contains the duplicate navigation link.

## Validation

- `vitest run components/connections` — 145/145 tests passed.
- ESLint — 0 errors/warnings.
- Verified the Kubernetes connection import flow in Google Chrome from:
  - `/management/connections`
  - `/` (Dashboard)
- Confirmed the success toast no longer displays the duplicate `View connections` action.
- Confirmed the modal's `connections` link remains functional.

## Preview

The attached screenshots show the updated connection creation flow and the removal of the duplicate `View connections` link from the success toast.

<img width="1200" height="2029" alt="pr-preview-toast-and-modal" src="https://github.com/user-attachments/assets/45bb2b1e-1874-4b30-a5c2-3aad369a646d" />

Closes #21687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes connection import notifications to accurately reflect success or warning states based on the number of connections imported.
  * Removed the “View connections” navigation link from connection-related notifications.
  * Simplified notification details to show only the relevant message and status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->