### PR TITLE
fix(mesheryctl): prevent nil response panic in auth update

### DIFF
--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -216,6 +216,15 @@ func AddAuthDetails(req *http.Request, filepath string) error {
 
 // UpdateAuthDetails checks gets the token (old/refreshed) from meshery server and writes it back to the config file
 func UpdateAuthDetails(filepath string) error {
+	return updateAuthDetails(&http.Client{}, filepath)
+}
+
+// updateAuthDetails updates authentication details using the provided HTTP client and saves them to filepath.
+func updateAuthDetails(client *http.Client, filepath string) error {
+	if client == nil {
+		client = &http.Client{}
+	}
+
 	mctlCfg, err := config.GetMesheryCtl(viper.GetViper())
 	if err != nil {
 		return ErrLoadConfig(err)
@@ -230,14 +239,12 @@ func UpdateAuthDetails(filepath string) error {
 		return err
 	}
 
-	client := &http.Client{}
 	resp, err := client.Do(req)
-	defer SafeClose(resp.Body)
-
 	if err != nil {
-		err = errors.Wrap(err, "error dispatching there request: ")
+		err = errors.Wrap(err, "error dispatching the request: ")
 		return err
 	}
+	defer SafeClose(resp.Body)
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -16,12 +16,18 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
+	"github.com/spf13/viper"
 )
 
 // testcases for auth.go
@@ -95,6 +101,148 @@ func TestProviderUnmarshalJSON(t *testing.T) {
 		}
 		if provider.ProviderURL != "https://cloud.meshery.io" {
 			t.Fatalf("expected provider URL https://cloud.meshery.io, got %q", provider.ProviderURL)
+		}
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type redirectTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqCopy := req.Clone(req.Context())
+	reqCopy.URL.Scheme = t.target.Scheme
+	reqCopy.URL.Host = t.target.Host
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(reqCopy)
+}
+
+func createTestTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "token.json")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("failed to create test token file: %v", err)
+	}
+	return path
+}
+
+func TestUpdateAuthDetails(t *testing.T) {
+	viper.Set("current-context", "local")
+	viper.Set("contexts.local.endpoint", "http://localhost:9081")
+	t.Cleanup(func() {
+		viper.Reset()
+	})
+
+	validTokenContent := `{"token":"test-token","meshery-provider":"Local"}`
+
+	t.Run("nil response and error", func(t *testing.T) {
+		t.Parallel()
+		tokenPath := createTestTokenFile(t, validTokenContent)
+
+		expectedErr := errors.New("network failure")
+		client := &http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, expectedErr
+			}),
+		}
+
+		err := updateAuthDetails(client, tokenPath)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error dispatching the request") {
+			t.Errorf("expected error message to contain 'error dispatching the request', got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "network failure") {
+			t.Errorf("expected underlying error 'network failure', got: %v", err)
+		}
+	})
+
+	t.Run("successful response", func(t *testing.T) {
+		t.Parallel()
+		tokenPath := createTestTokenFile(t, validTokenContent)
+
+		refreshedTokenJSON := `{"token":"refreshed-token","meshery-provider":"Local"}`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, refreshedTokenJSON)
+		}))
+		defer srv.Close()
+
+		srvURL, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatalf("failed to parse test server URL: %v", err)
+		}
+
+		client := &http.Client{
+			Transport: &redirectTransport{
+				target: srvURL,
+				base:   srv.Client().Transport,
+			},
+		}
+
+		if err := updateAuthDetails(client, tokenPath); err != nil {
+			t.Fatalf("unexpected error updating auth details: %v", err)
+		}
+
+		updatedContent, err := os.ReadFile(tokenPath)
+		if err != nil {
+			t.Fatalf("failed to read updated token file: %v", err)
+		}
+
+		if string(updatedContent) != refreshedTokenJSON {
+			t.Errorf("expected updated token content %q, got %q", refreshedTokenJSON, string(updatedContent))
+		}
+	})
+
+	t.Run("HTML unexpected response", func(t *testing.T) {
+		t.Parallel()
+		tokenPath := createTestTokenFile(t, validTokenContent)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = fmt.Fprint(w, "<html><body>Login Page</body></html>")
+		}))
+		defer srv.Close()
+
+		srvURL, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatalf("failed to parse test server URL: %v", err)
+		}
+
+		client := &http.Client{
+			Transport: &redirectTransport{
+				target: srvURL,
+				base:   srv.Client().Transport,
+			},
+		}
+
+		err = updateAuthDetails(client, tokenPath)
+		if err == nil {
+			t.Fatal("expected error for HTML response, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid body") {
+			t.Errorf("expected error 'invalid body', got: %v", err)
+		}
+	})
+
+	t.Run("non-existent token file", func(t *testing.T) {
+		t.Parallel()
+		nonExistentPath := filepath.Join(t.TempDir(), "nonexistent_token.json")
+
+		err := UpdateAuthDetails(nonExistentPath)
+		if err == nil {
+			t.Fatal("expected error for non-existent token file, got nil")
 		}
 	})
 }

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -105,17 +105,21 @@ func TestProviderUnmarshalJSON(t *testing.T) {
 	})
 }
 
+// roundTripFunc adapts a custom function to the http.RoundTripper interface for testing.
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
+// RoundTrip executes the custom transport function f on the incoming HTTP request.
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+// redirectTransport redirects HTTP requests to a target test server URL.
 type redirectTransport struct {
 	target *url.URL
 	base   http.RoundTripper
 }
 
+// RoundTrip rewrites the scheme and host of req to target and forwards it to the base transport.
 func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	reqCopy := req.Clone(req.Context())
 	reqCopy.URL.Scheme = t.target.Scheme
@@ -127,6 +131,7 @@ func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	return base.RoundTrip(reqCopy)
 }
 
+// createTestTokenFile creates a temporary token file containing contents and returns its file path.
 func createTestTokenFile(t *testing.T, contents string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "token.json")
@@ -136,6 +141,7 @@ func createTestTokenFile(t *testing.T, contents string) string {
 	return path
 }
 
+// TestUpdateAuthDetails tests UpdateAuthDetails for network errors, successful token updates, HTML responses, and non-existent token files.
 func TestUpdateAuthDetails(t *testing.T) {
 	viper.Set("current-context", "local")
 	viper.Set("contexts.local.endpoint", "http://localhost:9081")


### PR DESCRIPTION
**Notes for Reviewers**

* This PR fixes #21681.

**[[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

* [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] when applicable.
2. Reference the related issue using "Fixes #<issue-number>".
3. Describe the changes clearly and concisely.
-->

## Description

Fixes #21681.

`UpdateAuthDetails` could panic when `client.Do(req)` returned a `nil` response together with an error. The response body was being accessed before the request error was handled.

This change ensures that the request error is handled before accessing `resp.Body`, preventing a nil-pointer panic while preserving the existing behavior for successful responses.

## Changes Made

* Handle the error returned by `client.Do(req)` before accessing `resp.Body`.
* Prevent nil-pointer panics when the HTTP response is `nil`.
* Inject the HTTP client into the internal helper for improved testability.
* Avoid mutating `http.DefaultTransport` during tests.
* Preserve existing authentication and token-file error handling.

## Tests

* Added deterministic `(nil, error)` regression coverage using a custom `RoundTripper`.
* Used `httptest.NewServer` for successful-response and HTML-response scenarios.
* Isolated token files for each subtest using `t.TempDir()`.
* Restored Viper global state using `t.Cleanup()`.
* Preserved existing token-file and authentication error handling.

## Validation

The following checks were run successfully:

```bash
go test ./mesheryctl/pkg/utils -run TestUpdateAuthDetails -v
```

```bash
go test ./mesheryctl/pkg/utils -run "TestUpdateAuthDetails|TestProviderUnmarshalJSON" -v
```

```bash
git diff --check
```

All relevant tests passed successfully.

## Additional Notes

`TestPrereq` in `helpers_test.go` failed locally because it depends on the `uname` command, which is not available in the local Windows environment. This failure is unrelated to `auth.go` or `UpdateAuthDetails`.

All unit tests directly related to `mesheryctl/pkg/utils/auth.go` pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication detail updates with clearer request error reporting.
  * Successfully refreshed authentication data now updates the local token file correctly.
  * Added handling for invalid response content and missing token files.
  * Improved reliability when communicating with the authentication service.

* **Tests**
  * Expanded coverage for successful updates, request failures, invalid responses, and missing files.
  * Added validation for refreshed token data and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->