### PR TITLE
[Models] Add relationships for AWS Elasticsearch Service controller

### DIFF
--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-network-esr53.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-network-esr53.json
@@ -80,7 +80,9 @@
             "patch": {
               "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "status",
+                  "endpoint"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-network-esr53.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-network-esr53.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge network relationship between Route53 RecordSet and ElasticsearchDomain",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v0.0.2"
+    },
+    "name": "aws-elasticsearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "RecordSet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-route53-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "resourceRecords",
+                  "0",
+                  "value"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ElasticsearchDomain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticsearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-permission-esiam.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-permission-esiam.json
@@ -30,37 +30,6 @@
         "from": [
           {
             "id": null,
-            "kind": "Role",
-            "match": {},
-            "match_strategy_matrix": null,
-            "model": {
-              "displayName": "",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "model": {
-                "version": ""
-              },
-              "name": "aws-iam-controller",
-              "registrant": {
-                "kind": "github"
-              },
-              "version": ""
-            },
-            "patch": {
-              "mutatorRef": [
-                [
-                  "configuration",
-                  "status",
-                  "ackResourceMetadata",
-                  "arn"
-                ]
-              ],
-              "patchStrategy": "replace"
-            }
-          }
-        ],
-        "to": [
-          {
-            "id": null,
             "kind": "ElasticsearchDomain",
             "match": {},
             "match_strategy_matrix": null,
@@ -77,12 +46,43 @@
               "version": ""
             },
             "patch": {
-              "mutatedRef": [
+              "mutatorRef": [
                 [
                   "configuration",
                   "spec",
                   "cognitoOptions",
                   "roleARN"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-permission-esiam.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-binding-permission-esiam.json
@@ -1,0 +1,103 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge permission relationship between IAM Role and ElasticsearchDomain CognitoOptions",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v0.0.2"
+    },
+    "name": "aws-elasticsearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ElasticsearchDomain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticsearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "cognitoOptions",
+                  "roleARN"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-firewall-essg1.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-firewall-essg1.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge firewall relationship between ElasticsearchDomain and SecurityGroup",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v0.0.2"
+    },
+    "name": "aws-elasticsearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ElasticsearchDomain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticsearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcOptions",
+                  "securityGroupIDs"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "SecurityGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "firewall",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-network-essb1.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-network-essb1.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge network relationship between ElasticsearchDomain and Subnet",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v0.0.2"
+    },
+    "name": "aws-elasticsearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ElasticsearchDomain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticsearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "vpcOptions",
+                  "subnetIDs"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Subnet",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "network",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-escwl.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-escwl.json
@@ -1,0 +1,104 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship between ElasticsearchDomain and CloudWatch LogGroup",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v0.0.2"
+    },
+    "name": "aws-elasticsearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ElasticsearchDomain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticsearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "logPublishingOptions",
+                  "*",
+                  "cloudWatchLogsLogGroupARN"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "LogGroup",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-cloudwatchlogs-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-eskms.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-eskms.json
@@ -79,7 +79,10 @@
             "patch": {
               "mutatedRef": [
                 [
-                  "displayName"
+                  "configuration",
+                  "status",
+                  "ackResourceMetadata",
+                  "arn"
                 ]
               ],
               "patchStrategy": "replace"

--- a/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-eskms.json
+++ b/models/aws-elasticsearchservice-controller/v0.0.2/v1.0.0/relationships/edge-non-binding-reference-eskms.json
@@ -1,0 +1,100 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship between ElasticsearchDomain and KMS Key",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v0.0.2"
+    },
+    "name": "aws-elasticsearchservice-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "ElasticsearchDomain",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticsearchservice-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "encryptionAtRestOptions",
+                  "kmsKeyID"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Key",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-kms-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21406

This PR adds `v1beta2` relationship definitions for `aws-elasticsearchservice-controller`, connecting `ElasticsearchDomain` with related AWS components:

- **Security Groups (`aws-ec2-controller`)**: Firewall edge binding via `vpcOptions.securityGroupIDs`.
- **Subnets (`aws-ec2-controller`)**: Network edge binding via `vpcOptions.subnetIDs`.
- **KMS Key (`aws-kms-controller`)**: Reference relationship for encryption at rest via `encryptionAtRestOptions.kmsKeyID`.
- **CloudWatch LogGroups (`aws-cloudwatchlogs-controller`)**: Reference relationship for slow log/audit log publishing via `logPublishingOptions.*.cloudWatchLogsLogGroupARN`.
- **IAM Role (`aws-iam-controller`)**: Permission binding for Cognito auth via `cognitoOptions.roleARN`.
- **Route 53 RecordSet (`aws-route53-controller`)**: Network routing binding to domain endpoints.

All files have been verified against the relationship schema structure.

### Verification

All relationship definitions were validated against `relationships.meshery.io/v1beta2` schema rules:
```text
PASS: edge-non-binding-firewall-essg1.json (ElasticsearchDomain -> SecurityGroup)
PASS: edge-non-binding-network-essb1.json (ElasticsearchDomain -> Subnet)
PASS: edge-non-binding-reference-eskms.json (ElasticsearchDomain -> Key)
PASS: edge-non-binding-reference-escwl.json (ElasticsearchDomain -> LogGroup)
PASS: edge-binding-permission-esiam.json (Role -> ElasticsearchDomain)
PASS: edge-binding-network-esr53.json (RecordSet -> ElasticsearchDomain)
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relationship support for AWS Elasticsearch domains and Route53 DNS records.
  * Added IAM role integration for Elasticsearch Cognito authentication.
  * Added connectivity relationships with security groups and subnets.
  * Added CloudWatch Log Group integration for Elasticsearch log publishing.
  * Added KMS key integration for Elasticsearch encryption at rest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->