### PR TITLE
[Models] Add relationships for Azure Batch

### DIFF
--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-binding-permission-btuai.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-binding-permission-btuai.json
@@ -1,0 +1,129 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge permission relationship between UserAssignedIdentity and BatchAccount identity",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "UserAssignedIdentity",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-managed-identity",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "identity",
+                  "userAssignedIdentities",
+                  "0",
+                  "reference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "identity",
+                  "userAssignedIdentities",
+                  "0",
+                  "reference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "identity",
+                  "userAssignedIdentities",
+                  "0",
+                  "reference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btakv.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btakv.json
@@ -1,0 +1,135 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship connecting BatchAccount keyVaultReference to Key Vault",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "reference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "reference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "reference",
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "url"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Vault",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-key-vault",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "properties",
+                  "vaultUri"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btpve.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btpve.json
@@ -1,0 +1,126 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship connecting PrivateEndpoint to BatchAccount for private link access",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "PrivateEndpoint",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "privateLinkServiceConnections",
+                  "0",
+                  "privateLinkServiceReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "privateLinkServiceConnections",
+                  "0",
+                  "privateLinkServiceReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "privateLinkServiceConnections",
+                  "0",
+                  "privateLinkServiceReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "azureName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btstr.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btstr.json
@@ -1,0 +1,123 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship connecting BatchAccount autoStorage to StorageAccount",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "autoStorage",
+                  "storageAccountReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "autoStorage",
+                  "storageAccountReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "autoStorage",
+                  "storageAccountReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "StorageAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-storage",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-btrgp.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-btrgp.json
@@ -1,0 +1,98 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "A hierarchical parent inventory relationship between ResourceGroup and BatchAccount",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.13.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "owner",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ResourceGroup",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-resources",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-binding-permission-btuai.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-binding-permission-btuai.json
@@ -1,0 +1,129 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge permission relationship between UserAssignedIdentity and BatchAccount identity",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "UserAssignedIdentity",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-managed-identity",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "identity",
+                  "userAssignedIdentities",
+                  "0",
+                  "reference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "identity",
+                  "userAssignedIdentities",
+                  "0",
+                  "reference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "identity",
+                  "userAssignedIdentities",
+                  "0",
+                  "reference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "permission",
+  "status": "enabled",
+  "type": "binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btakv.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btakv.json
@@ -1,0 +1,135 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship connecting BatchAccount keyVaultReference to Key Vault",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "reference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "reference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "reference",
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "keyVaultReference",
+                  "url"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Vault",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-key-vault",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "properties",
+                  "vaultUri"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btpve.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btpve.json
@@ -1,0 +1,126 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship connecting PrivateEndpoint to BatchAccount for private link access",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "PrivateEndpoint",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-network",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "privateLinkServiceConnections",
+                  "0",
+                  "privateLinkServiceReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "privateLinkServiceConnections",
+                  "0",
+                  "privateLinkServiceReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "privateLinkServiceConnections",
+                  "0",
+                  "privateLinkServiceReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "azureName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btstr.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btstr.json
@@ -1,0 +1,123 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An edge reference relationship connecting BatchAccount autoStorage to StorageAccount",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "autoStorage",
+                  "storageAccountReference",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "autoStorage",
+                  "storageAccountReference",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "autoStorage",
+                  "storageAccountReference",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "StorageAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-storage",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "group"
+                ],
+                [
+                  "configuration",
+                  "kind"
+                ],
+                [
+                  "configuration",
+                  "spec",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}

--- a/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-btrgp.json
+++ b/models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-btrgp.json
@@ -1,0 +1,98 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "hierarchical",
+  "metadata": {
+    "description": "A hierarchical parent inventory relationship between ResourceGroup and BatchAccount",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "azureserviceoperator_customresourcedefinitions_v2.14.0.yaml"
+    },
+    "name": "azure-batch",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "BatchAccount",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-batch",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "owner",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "ResourceGroup",
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "azure-resources",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "inventory",
+  "status": "enabled",
+  "type": "parent",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21403

This PR adds relationship definitions for Azure Batch (`BatchAccount`) across both supported Azure Service Operator (ASO) definitions (`v2.13.0` and `v2.14.0`).

### Added Relationships:

1. **ResourceGroup Containment (`hierarchical / parent/inventory`)**:
   - Links `BatchAccount.spec.owner.name` to `ResourceGroup` in `azure-resources`.
2. **AutoStorage Reference (`edge / non-binding / reference`)**:
   - Links `BatchAccount.spec.autoStorage.storageAccountReference` (`group`, `kind`, `name`) to `StorageAccount` in `azure-storage`.
3. **Key Vault Reference (`edge / non-binding / reference`)**:
   - Links `BatchAccount.spec.keyVaultReference` (`reference` and `url`) to `Vault` in `azure-key-vault` for customer-managed encryption keys.
4. **User-Assigned Managed Identity (`edge/binding/permission`)**:
   - Binds `UserAssignedIdentity` in `azure-managed-identity` to `BatchAccount.spec.identity.userAssignedIdentities`.
5. **Private Endpoint Reference (`edge / non-binding / reference`)**:
   - Links `PrivateEndpoint.spec.privateLinkServiceConnections` to `BatchAccount` for private network connectivity.

<details>
<summary>Verification Output</summary>
```text
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-binding-permission-btuai.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btakv.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btpve.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btstr.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.13.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-btrgp.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-binding-permission-btuai.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btakv.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btpve.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/edge-non-binding-reference-btstr.json
VALID: models/azure-batch/azureserviceoperator_customresourcedefinitions_v2.14.0.yaml/v1.0.0/relationships/hierarchical-parent-inventory-btrgp.json
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure Batch relationship support across supported model versions.
  * Azure Batch accounts can now connect to user-assigned identities, Key Vaults, private endpoints, and storage accounts.
  * Added hierarchical relationships between Batch accounts and resource groups.
  * Added reference synchronization for related resource names, types, groups, URLs, and ownership details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->