### PR TITLE
[Models] Add relationship definitions targeting NotificationTopic in …

### DIFF
--- a/models/aws-elasticache-controller/v1.9.0/v1.0.0/relationships/edge-non-binding-reference-notificationtopic.json
+++ b/models/aws-elasticache-controller/v1.9.0/v1.0.0/relationships/edge-non-binding-reference-notificationtopic.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.9.0"
+    },
+    "name": "aws-elasticache-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "CacheCluster",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-elasticache-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "notificationTopicRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "Topic",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-sns-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
Fixes #21305
**Description**
This PR adds the `edge-non-binding-reference-notificationtopic.json` relationship definition targeting `Topic` (NotificationTopic) from `aws-sns-controller` for the latest `aws-elasticache-controller` model version (`v1.9.0`).
**Changes**
- Added `models/aws-elasticache-controller/v1.9.0/v1.0.0/relationships/edge-non-binding-reference-notificationtopic.json`.
- Defined non-binding reference relationship for:
  - `CacheCluster` $\rightarrow$ `Topic` (`spec.notificationTopicRef.from.name`)
- Validated model build with `mesheryctl model build aws-elasticache-controller/v1.9.0 --path ./models`.
- Verified interactive connection and configuration patching in Kanvas Designer.

## Screen Recording


https://github.com/user-attachments/assets/100dc9aa-3b39-42af-8e32-41f94d97d48b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting AWS ElastiCache cache clusters to Amazon SNS topics through non-binding references.
  * Cache cluster notification topic references can now be populated from the selected topic’s display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->