### PR TITLE
[mesheryctl] Fix CLI panics from index out of range errors in provider selection and system check

### DIFF
--- a/mesheryctl/internal/cli/root/system/check.go
+++ b/mesheryctl/internal/cli/root/system/check.go
@@ -305,7 +305,16 @@ func (hc *HealthChecker) runDockerHealthChecks() error {
 	if hc.Options.PrintLogs {
 		utils.Log.Info("\nDocker \n--------------")
 	}
-	endpointParts := strings.Split(hc.context.GetEndpoint(), ":")
+	
+	// Validate endpoint format (should be host:port or similar)
+	endpoint := hc.context.GetEndpoint()
+	if endpoint == "" {
+		return ErrDockerContext(errors.New("context endpoint is invalid: endpoint is empty"))
+	}
+	endpointParts := strings.Split(endpoint, ":")
+	if len(endpointParts) < 2 {
+		return ErrDockerContext(errors.New("context endpoint is invalid: expected host:port format"))
+	}
 
 	// Check whether docker daemon is running using Docker client API
 	dockerCli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())

--- a/mesheryctl/internal/cli/root/system/check_test.go
+++ b/mesheryctl/internal/cli/root/system/check_test.go
@@ -6,11 +6,24 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("update", false, "update golden files")
+
+func TestRunDockerHealthChecks_InvalidEndpointDoesNotPanic(t *testing.T) {
+	hc := &HealthChecker{
+		Options: &HealthCheckOptions{PrintLogs: false},
+		context: &config.Context{Endpoint: "localhost"},
+	}
+
+	err := hc.runDockerHealthChecks()
+	if err == nil {
+		t.Fatal("expected an error for an invalid docker endpoint")
+	}
+}
 
 // This is an Integration test
 func TestPreflightCmdIntegration(t *testing.T) {

--- a/mesheryctl/pkg/utils/auth.go
+++ b/mesheryctl/pkg/utils/auth.go
@@ -446,7 +446,7 @@ func chooseDirectProvider(provs map[string]Provider, option string) (Provider, e
 			return provArray[i], nil
 		}
 	}
-	return provArray[1], fmt.Errorf("the specified provider '%s' is not available. Please try giving correct provider name", option)
+	return Provider{}, fmt.Errorf("the specified provider '%s' is not available. Please try giving correct provider name", option)
 }
 
 func createProviderURI(provider Provider, host string, port int) (string, error) {

--- a/mesheryctl/pkg/utils/auth_test.go
+++ b/mesheryctl/pkg/utils/auth_test.go
@@ -98,3 +98,17 @@ func TestProviderUnmarshalJSON(t *testing.T) {
 		}
 	})
 }
+
+func TestChooseDirectProvider_InvalidProviderDoesNotPanic(t *testing.T) {
+	providers := map[string]Provider{
+		"local": {ProviderName: "Local", ProviderURL: "http://localhost:8080"},
+	}
+
+	provider, err := chooseDirectProvider(providers, "InvalidProvider")
+	if err == nil {
+		t.Fatal("expected an error for an invalid provider")
+	}
+	if provider != (Provider{}) {
+		t.Fatalf("expected zero-value provider on invalid input, got %#v", provider)
+	}
+}

--- a/server/handlers/error.go
+++ b/server/handlers/error.go
@@ -216,7 +216,7 @@ const (
 	ErrTelemetryPrometheusAuthCode         = "meshery-server-1435"
 	ErrMeshsyncReconcileCode               = "meshery-server-1442"
 	ErrUnsafeFilePathCode                  = "meshery-server-1443"
-	ErrModelNotFoundCode                   = "meshery-server-1484"
+	ErrModelNotFoundCode                   = "meshery-server-1485"
 	// Environment, workspace, organization, user and key operations previously
 	// reported every failure as ErrGetResult ("unable to get result", probable
 	// cause "Result Identifier provided is not valid") - a performance-results

--- a/server/helpers/component_info.json
+++ b/server/helpers/component_info.json
@@ -1,5 +1,5 @@
 {
   "name": "meshery-server",
   "type": "component",
-  "next_error_code": 1485
+  "next_error_code": 1486
 }


### PR DESCRIPTION
[mesheryctl] Fix CLI panics from index out of range errors in provider selection and system check.
- Fix chooseDirectProvider: return Provider{} instead of provArray[1] when invalid provider specified
- Fix runDockerHealthChecks: validate endpoint format before accessing split parts
- Prevents panics when len(array) == 1 and [1] is accessed
- Returns descriptive errors for invalid inputs instead of runtime panics

Closes #21676
Closes #21696

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Docker health checks to gracefully handle missing or malformed connection endpoints instead of crashing.
  - Corrected provider selection error handling so unavailable providers no longer fall back to an unintended provider.
  - Updated model-not-found error tracking to use the correct error code, improving consistency when diagnosing missing models.
  - Added safeguards and validation coverage for invalid Docker endpoints and provider selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->