### PR TITLE
[Designs] Add deployable GitOps-on-EKS Kanvas design

### DIFF
--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -1,0 +1,98 @@
+# GitOps Pipeline on Amazon EKS
+
+A Meshery design that recreates an end-to-end GitOps architecture — commit to
+production on a private EKS cluster — as a Kanvas canvas that is also
+deployable.
+
+Import `design.yaml` into Kanvas (**Designs → Import → Upload File**), or from
+the CLI:
+
+```bash
+mesheryctl design import -f designs/gitops-eks-pipeline/design.yaml
+```
+
+## What is in it
+
+87 components: 57 that Meshery applies to a cluster, and 30 annotations that
+carry the diagram's structure (region/VPC/subnet boundaries, the CI lane, the
+actors) without ever being deployed.
+
+| Region of the canvas | Components |
+|---|---|
+| Continuous Integration | GitHub, GitHub Actions, checkout → build → Trivy scan → push, GHCR — all annotations; GitHub Actions has no cluster-side resource |
+| AWS network | `VPC`, four `Subnet`s (2 public / 2 private), `InternetGateway`, `NATGateway`, `ElasticIPAddress`, two `RouteTable`s, `SecurityGroup`, bastion `Instance` — AWS Controllers for Kubernetes (ACK) |
+| Cluster | `Cluster` (private endpoint, public access disabled) and `Nodegroup` in the private subnets |
+| Continuous Delivery | `ArgoCD` control plane, an `Application` carrying the Image Updater annotations, and the `argocd-image-updater` Deployment |
+| Ingress | `GatewayClass` → `Gateway` → `HTTPRoute`, the AWS Load Balancer Controller, and `external-dns` |
+| Application | four service `Deployment`s, `redis-cart` and `postgres-orders` `StatefulSet`s, their `Service`s, a load generator, and a `HorizontalPodAutoscaler` |
+| Logging | ECK — `Elasticsearch`, `Kibana`, `Beat` (filebeat), and the operator `StatefulSet` |
+| Monitoring | `Prometheus`, `Alertmanager`, an `AlertmanagerConfig` that routes to Slack, `ServiceMonitor`, `PrometheusRule`, and Grafana |
+| Identity | an IAM `Role` for IRSA, an EKS `PodIdentityAssociation`, the `eks-pod-identity-agent` DaemonSet, and IRSA-annotated `ServiceAccount`s |
+
+### Two provisioning paths, deliberately
+
+The source diagram provisions AWS with Terraform and keeps state in S3. Those
+two remain annotations, because Terraform state is not a cluster resource.
+
+The AWS layer is *also* modelled as ACK custom resources, so the design can
+provision it from inside a management cluster if you would rather not run
+Terraform. **Pick one.** If your VPC and cluster already exist, deploy only the
+in-cluster components and leave the `ack-system` namespace out — nothing else in
+the design depends on those resources at apply time.
+
+## Before you deploy
+
+The design applies cleanly only where the CRDs it references are installed:
+
+| Components | Requires |
+|---|---|
+| `ec2/eks/iam.services.k8s.aws` | ACK controllers for EC2, EKS and IAM |
+| `argoproj.io` | Argo CD Operator |
+| `gateway.networking.k8s.io` | Gateway API CRDs + AWS Load Balancer Controller ≥ 2.9 |
+| `monitoring.coreos.com` | kube-prometheus-stack (Prometheus Operator) |
+| `*.k8s.elastic.co` | ECK operator |
+
+Placeholders to replace — every one is a `111122223333`-style dummy, so nothing
+here resolves to a real account:
+
+- AWS account id `111122223333` in every role ARN
+- the ACM certificate ARN on the `boutique-gateway` Gateway
+- the OIDC provider URL and `EXAMPLED539D4633E53DE1B716D3041E` id in the
+  `external-dns-irsa` trust policy
+- `shop.example.com` and the `--domain-filter` on `external-dns`
+- `https://github.com/example-org/boutique-gitops.git` and
+  `ghcr.io/example-org/boutique-app` on the Argo CD Application
+- `ami-0c02fb55956c7d316` on the bastion (region-specific)
+- `bastion-sg` allows SSH from `10.0.0.0/16`; narrow it to your own range
+
+Three Secrets are referenced but deliberately not included — create them
+yourself rather than committing them:
+
+```bash
+kubectl -n monitoring create secret generic alertmanager-slack \
+  --from-literal=webhook-url='https://hooks.slack.com/services/...'
+kubectl -n monitoring create secret generic grafana-admin --from-literal=password='...'
+kubectl -n boutique-app create secret generic postgres-orders \
+  --from-literal=username=orders --from-literal=password='...'
+```
+
+## Notes on the modelling
+
+- **Relationships are left empty.** Kanvas's relationship evaluation engine
+  derives hierarchical and network edges on load, so hand-authoring them would
+  only go stale.
+- **Namespace comes from `configuration.metadata.namespace`**, which is what
+  `getNamespaceForComponent` reads when Meshery applies a component.
+- **Gateway API components use the `gko` model**, the only model in the
+  registry that carries the full `gateway.networking.k8s.io/v1` set. The
+  apiVersion, kind and configuration are what get applied, so the manifests are
+  correct regardless of which model supplies the icon.
+- **Model versions need not match your registry exactly.** Component lookup
+  prefers an exact `model.version` match and falls back to any version of the
+  same model, so the design keeps resolving as the registry moves on.
+- **Every annotation carries a real apiVersion**, which is why the diagram
+  furniture is drawn from `meshery-shapes` and `meshery-flowchart` rather than
+  `meshery-dev-icons`. The validation stage resolves *every* component —
+  annotations are only set aside later, during provisioning — and it rejects an
+  empty apiVersion outright. A single dev-icon would therefore abort the whole
+  deploy, which is a fine trade for a diagram-only design but not for this one.

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -37,8 +37,38 @@ two remain annotations, because Terraform state is not a cluster resource.
 The AWS layer is *also* modelled as ACK custom resources, so the design can
 provision it from inside a management cluster if you would rather not run
 Terraform. **Pick one.** If your VPC and cluster already exist, deploy only the
-in-cluster components and leave the `ack-system` namespace out — nothing else in
-the design depends on those resources at apply time.
+in-cluster components and leave the `ack-system` namespace out.
+
+That split is clean for networking, but **not for identity**. Dropping
+`ack-system` also drops the one IAM role the design creates, and several
+workloads carry a `role-arn` annotation regardless of which path you take.
+Kubernetes will happily create a ServiceAccount whose annotation points at a
+role that does not exist — nothing fails at apply time, and the workload then
+cannot reach AWS at runtime. Read the next section before you deploy either
+way.
+
+### Identity is mostly a prerequisite, not part of the design
+
+The design references six IAM roles and creates exactly one. This is
+deliberate — a role's trust policy is specific to your account and cluster OIDC
+provider, so the design cannot supply a working one — but it means the other
+five must exist before the workloads that name them will function:
+
+| Role | Named by | Supplied by |
+|---|---|---|
+| `external-dns-irsa` | `external-dns` ServiceAccount | the design, in `ack-system` |
+| `aws-load-balancer-controller-irsa` | `aws-load-balancer-controller` ServiceAccount | **you** |
+| `argocd-image-updater-irsa` | `argocd-image-updater` ServiceAccount | **you** |
+| `boutique-app-pod-identity` | the `PodIdentityAssociation` | **you** |
+| `eks-cluster-role` | the EKS `Cluster` | **you**, before the cluster |
+| `eks-node-role` | the `Nodegroup` | **you**, before the node group |
+
+`external-dns-irsa` shows the shape to copy: an `iam.services.k8s.aws` `Role`
+with a web-identity trust policy naming your OIDC provider and the
+`system:serviceaccount:<ns>:<name>` subject, plus a least-privilege inline
+policy. The cluster and node roles are the standard EKS service roles and have
+to exist before the resources that reference them, so they are outside what
+this design can bootstrap.
 
 ## Before you deploy
 
@@ -108,12 +138,15 @@ kubectl -n boutique-app create secret generic postgres-orders \
 # config also keeps other registries' credentials, and any credsStore
 # indirection, out of the Secret.
 export DOCKER_CONFIG="$(mktemp -d)"
+# Arm the cleanup before the token is written anywhere. Without this, a failed
+# docker login or kubectl call aborts the script and leaves both the PAT file
+# and a docker config containing the token on disk.
+trap 'rm -rf "$DOCKER_CONFIG"; rm -f ./ghcr-pat.txt' EXIT INT TERM
 docker login ghcr.io --username '<github-username>' --password-stdin < ./ghcr-pat.txt
 kubectl -n argocd create secret generic ghcr-creds \
   --type=kubernetes.io/dockerconfigjson \
   --from-file=.dockerconfigjson="$DOCKER_CONFIG/config.json"
 docker logout ghcr.io
-rm -rf "$DOCKER_CONFIG"; unset DOCKER_CONFIG
 
 # Remove the credential files. shred is GNU coreutils and is absent on macOS,
 # where this would otherwise fail and quietly leave the files behind. Note that

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -52,19 +52,28 @@ The design applies cleanly only where the CRDs it references are installed:
 | `monitoring.coreos.com` | kube-prometheus-stack (Prometheus Operator) |
 | `*.k8s.elastic.co` | ECK operator |
 
-Placeholders to replace — every one is a `111122223333`-style dummy, so nothing
-here resolves to a real account:
+The design is seeded with dummy values throughout, and no ARN in it points at a
+real AWS account — but they are not all `111122223333`-style, so work the list
+rather than grepping for one pattern. Replace every one of these:
 
-- AWS account ID `111122223333` in every role ARN
+- AWS account ID `111122223333`, in every role ARN
 - the ACM certificate ARN on the `boutique-gateway` Gateway
 - the OIDC provider URL and `EXAMPLED539D4633E53DE1B716D3041E` ID in the
   `external-dns-irsa` trust policy
 - `Z0EXAMPLEHOSTEDZONE` in the `external-dns-irsa` inline policy — the hosted
   zone External DNS is allowed to write to
-- `shop.example.com` and the `--domain-filter` on `external-dns`
+- `shop.example.com`, on both the Gateway listener and the `--domain-filter`
+  argument to `external-dns`
 - `https://github.com/example-org/boutique-gitops.git` and
   `ghcr.io/example-org/boutique-app` on the Argo CD Application
-- `ami-0c02fb55956c7d316` on the bastion (region-specific)
+- `us-east-1`, and the `us-east-1a` / `us-east-1b` availability zones on the
+  subnets and node group — the region is baked into the ACK resources, the role
+  ARNs and the OIDC URL alike
+- `ami-0c02fb55956c7d316` on the bastion. Unlike the rest of this list it is a
+  real Amazon Linux 2 image, but AMI IDs are per-region: it resolves only in
+  `us-east-1` and must change with the region above.
+- the `10.0.0.0/16` VPC CIDR and its four subnet CIDRs, if they collide with a
+  network you already peer with
 - `bastion-sg` allows SSH from `10.0.0.0/16`; narrow it to your own range
 
 Four Secrets are referenced but deliberately not included — create them

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -77,9 +77,10 @@ rather than grepping for one pattern. Replace every one of these:
 - `bastion-sg` allows SSH from `10.0.0.0/16`; narrow it to your own range
 
 Four Secrets are referenced but deliberately not included — create them
-yourself rather than committing them. Put each value in a file first: a
-`--from-literal` secret lands in your shell history and is briefly visible in
-`ps` while the command runs.
+yourself rather than committing them. Put each *secret* value in a file first:
+a `--from-literal` lands in your shell history and is briefly visible in `ps`
+while the command runs. Non-sensitive values are fine as literals, which is why
+the postgres username below still is one.
 
 ```bash
 # Slack webhook for the slack-alerts AlertmanagerConfig
@@ -114,7 +115,15 @@ kubectl -n argocd create secret generic ghcr-creds \
 docker logout ghcr.io
 rm -rf "$DOCKER_CONFIG"; unset DOCKER_CONFIG
 
-shred -u ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./ghcr-pat.txt
+# Remove the credential files. shred is GNU coreutils and is absent on macOS,
+# where this would otherwise fail and quietly leave the files behind. Note that
+# neither command reliably destroys data on a copy-on-write or wear-levelled
+# filesystem — write the files to a tmpfs mount if that matters to you.
+if command -v shred >/dev/null 2>&1; then
+  shred -u ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./ghcr-pat.txt
+else
+  rm -f ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./ghcr-pat.txt
+fi
 ```
 
 ## Notes on the modelling

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -100,10 +100,19 @@ kubectl -n boutique-app create secret generic postgres-orders \
 # and without it Image Updater cannot read tags from GHCR — the CD half of the
 # pipeline then does nothing, without failing loudly. Needs a PAT with
 # `read:packages`, and must be a `kubernetes.io/dockerconfigjson` secret.
-kubectl -n argocd create secret docker-registry ghcr-creds \
-  --docker-server=ghcr.io \
-  --docker-username='<github-username>' \
-  --docker-password="$(< ./ghcr-pat.txt)"
+# `create secret docker-registry` cannot read the password from a file, and
+# `--docker-password="$(< file)"` is expanded by the shell before kubectl starts,
+# so the token would land in argv. Log in against a throwaway DOCKER_CONFIG
+# instead and build the Secret from the config file it writes. The temporary
+# config also keeps other registries' credentials, and any credsStore
+# indirection, out of the Secret.
+export DOCKER_CONFIG="$(mktemp -d)"
+docker login ghcr.io --username '<github-username>' --password-stdin < ./ghcr-pat.txt
+kubectl -n argocd create secret generic ghcr-creds \
+  --type=kubernetes.io/dockerconfigjson \
+  --from-file=.dockerconfigjson="$DOCKER_CONFIG/config.json"
+docker logout ghcr.io
+rm -rf "$DOCKER_CONFIG"; unset DOCKER_CONFIG
 
 shred -u ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./ghcr-pat.txt
 ```
@@ -119,9 +128,12 @@ shred -u ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./gh
   registry that carries the full `gateway.networking.k8s.io/v1` set. The
   apiVersion, kind and configuration are what get applied, so the manifests are
   correct regardless of which model supplies the icon.
-- **Model versions need not match your registry exactly.** Component lookup
-  prefers an exact `model.version` match and falls back to any version of the
-  same model, so the design keeps resolving as the registry moves on.
+- **Every `model.version` here matches the registry exactly, deliberately.**
+  `FindCompDefinitionWithVersion` breaks on an exact `model.version` match but
+  otherwise assigns `match` on each iteration, so with no exact match you get
+  whichever entity the registry returned last. That is a best-effort fallback,
+  not a stable one — it can change as the registry gains versions. Keep the
+  versions aligned when you want predictable validation and provisioning.
 - **Every annotation carries a real apiVersion**, which is why the diagram
   furniture is drawn from `meshery-shapes` and `meshery-flowchart` rather than
   `meshery-dev-icons`. The validation stage resolves *every* component —

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -137,25 +137,30 @@ kubectl -n boutique-app create secret generic postgres-orders \
 # instead and build the Secret from the config file it writes. The temporary
 # config also keeps other registries' credentials, and any credsStore
 # indirection, out of the Secret.
-export DOCKER_CONFIG="$(mktemp -d)"
-# Arm the cleanup before the token is written anywhere. Without this, a failed
-# docker login or kubectl call aborts the script and leaves both the PAT file
-# and a docker config containing the token on disk.
-trap 'rm -rf "$DOCKER_CONFIG"; rm -f ./ghcr-pat.txt' EXIT INT TERM
-docker login ghcr.io --username '<github-username>' --password-stdin < ./ghcr-pat.txt
-kubectl -n argocd create secret generic ghcr-creds \
-  --type=kubernetes.io/dockerconfigjson \
-  --from-file=.dockerconfigjson="$DOCKER_CONFIG/config.json"
-docker logout ghcr.io
+# Runs in a subshell so the EXIT trap fires when the block ends rather than when
+# your shell does, and so the DOCKER_CONFIG override never escapes into the
+# calling session. set -e aborts on the first failure; the trap still runs, so
+# neither the token nor the config it lives in survives an interrupted setup.
+(
+  set -e
+  export DOCKER_CONFIG="$(mktemp -d)"
+  trap 'rm -rf "$DOCKER_CONFIG"; rm -f ./ghcr-pat.txt' EXIT
+  docker login ghcr.io --username '<github-username>' --password-stdin < ./ghcr-pat.txt
+  kubectl -n argocd create secret generic ghcr-creds \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-file=.dockerconfigjson="$DOCKER_CONFIG/config.json"
+  docker logout ghcr.io
+)
 
-# Remove the credential files. shred is GNU coreutils and is absent on macOS,
+# Remove the remaining credential files (the GHCR PAT is already gone, removed
+# by the subshell's trap above). shred is GNU coreutils and is absent on macOS,
 # where this would otherwise fail and quietly leave the files behind. Note that
 # neither command reliably destroys data on a copy-on-write or wear-levelled
 # filesystem — write the files to a tmpfs mount if that matters to you.
 if command -v shred >/dev/null 2>&1; then
-  shred -u ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./ghcr-pat.txt
+  shred -u ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt
 else
-  rm -f ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./ghcr-pat.txt
+  rm -f ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt
 fi
 ```
 

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -150,15 +150,20 @@ kubectl -n boutique-app create secret generic postgres-orders \
 # neither the token nor the config it lives in survives an interrupted setup.
 (
   set -e
+  # Arm cleanup before anything exists, so a failure during setup still removes
+  # the PAT file. The trap targets its own variable, initialised empty, so it
+  # can never delete a DOCKER_CONFIG the caller had already exported.
+  ghcr_tmp=""
+  trap 'rm -rf "$ghcr_tmp"; rm -f ./ghcr-pat.txt' EXIT
   # A bare `mktemp -d` is GNU-only; BSD/macOS mktemp requires a template.
   # Assign first and export separately: `export VAR="$(cmd)"` takes its exit
   # status from the export builtin, so `set -e` would not fire if mktemp failed
   # — DOCKER_CONFIG would be empty, docker would fall back to the real
   # ~/.docker/config.json, and the PAT would be written there for good.
-  DOCKER_CONFIG="$(mktemp -d "${TMPDIR:-/tmp}/ghcr-creds.XXXXXX")"
-  [ -n "$DOCKER_CONFIG" ] && [ -d "$DOCKER_CONFIG" ] || exit 1
+  ghcr_tmp="$(mktemp -d "${TMPDIR:-/tmp}/ghcr-creds.XXXXXX")"
+  [ -n "$ghcr_tmp" ] && [ -d "$ghcr_tmp" ] || exit 1
+  DOCKER_CONFIG="$ghcr_tmp"
   export DOCKER_CONFIG
-  trap 'rm -rf "$DOCKER_CONFIG"; rm -f ./ghcr-pat.txt' EXIT
   docker login ghcr.io --username '<github-username>' --password-stdin < ./ghcr-pat.txt
   kubectl -n argocd create secret generic ghcr-creds \
     --type=kubernetes.io/dockerconfigjson \

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -55,10 +55,12 @@ The design applies cleanly only where the CRDs it references are installed:
 Placeholders to replace — every one is a `111122223333`-style dummy, so nothing
 here resolves to a real account:
 
-- AWS account id `111122223333` in every role ARN
+- AWS account ID `111122223333` in every role ARN
 - the ACM certificate ARN on the `boutique-gateway` Gateway
-- the OIDC provider URL and `EXAMPLED539D4633E53DE1B716D3041E` id in the
+- the OIDC provider URL and `EXAMPLED539D4633E53DE1B716D3041E` ID in the
   `external-dns-irsa` trust policy
+- `Z0EXAMPLEHOSTEDZONE` in the `external-dns-irsa` inline policy — the hosted
+  zone External DNS is allowed to write to
 - `shop.example.com` and the `--domain-filter` on `external-dns`
 - `https://github.com/example-org/boutique-gitops.git` and
   `ghcr.io/example-org/boutique-app` on the Argo CD Application

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -151,7 +151,13 @@ kubectl -n boutique-app create secret generic postgres-orders \
 (
   set -e
   # A bare `mktemp -d` is GNU-only; BSD/macOS mktemp requires a template.
-  export DOCKER_CONFIG="$(mktemp -d "${TMPDIR:-/tmp}/ghcr-creds.XXXXXX")"
+  # Assign first and export separately: `export VAR="$(cmd)"` takes its exit
+  # status from the export builtin, so `set -e` would not fire if mktemp failed
+  # — DOCKER_CONFIG would be empty, docker would fall back to the real
+  # ~/.docker/config.json, and the PAT would be written there for good.
+  DOCKER_CONFIG="$(mktemp -d "${TMPDIR:-/tmp}/ghcr-creds.XXXXXX")"
+  [ -n "$DOCKER_CONFIG" ] && [ -d "$DOCKER_CONFIG" ] || exit 1
+  export DOCKER_CONFIG
   trap 'rm -rf "$DOCKER_CONFIG"; rm -f ./ghcr-pat.txt' EXIT
   docker login ghcr.io --username '<github-username>' --password-stdin < ./ghcr-pat.txt
   kubectl -n argocd create secret generic ghcr-creds \

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -76,7 +76,7 @@ The design applies cleanly only where the CRDs it references are installed:
 
 | Components | Requires |
 |---|---|
-| `ec2/eks/iam.services.k8s.aws` | ACK controllers for EC2, EKS and IAM |
+| `ec2.services.k8s.aws`, `eks.services.k8s.aws`, `iam.services.k8s.aws` | the ACK controllers for EC2, EKS and IAM respectively |
 | `argoproj.io` | Argo CD Operator |
 | `gateway.networking.k8s.io` | Gateway API CRDs + AWS Load Balancer Controller ≥ 2.9 |
 | `monitoring.coreos.com` | kube-prometheus-stack (Prometheus Operator) |
@@ -131,11 +131,12 @@ kubectl -n boutique-app create secret generic postgres-orders \
 # and without it Image Updater cannot read tags from GHCR — the CD half of the
 # pipeline then does nothing, without failing loudly. Needs a PAT with
 # `read:packages`, and must be a `kubernetes.io/dockerconfigjson` secret.
-# `create secret docker-registry` cannot read the password from a file, and
-# `--docker-password="$(< file)"` is expanded by the shell before kubectl starts,
-# so the token would land in argv. Log in against a throwaway DOCKER_CONFIG
-# instead and build the Secret from the config file it writes. The temporary
-# config also keeps other registries' credentials, and any credsStore
+# `create secret docker-registry` has no file-based option for the password — it
+# only takes it as a flag value — and a command substitution reading the token
+# from a file is expanded by the shell before kubectl starts, so the token would
+# still land in argv and show up in `ps`. Log in against a throwaway
+# DOCKER_CONFIG instead and build the Secret from the config file it writes. The
+# temporary config also keeps other registries' credentials, and any credsStore
 # indirection, out of the Secret.
 # Runs in a subshell so the EXIT trap fires when the block ends rather than when
 # your shell does, and so the DOCKER_CONFIG override never escapes into the

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -67,15 +67,36 @@ here resolves to a real account:
 - `ami-0c02fb55956c7d316` on the bastion (region-specific)
 - `bastion-sg` allows SSH from `10.0.0.0/16`; narrow it to your own range
 
-Three Secrets are referenced but deliberately not included — create them
-yourself rather than committing them:
+Four Secrets are referenced but deliberately not included — create them
+yourself rather than committing them. Put each value in a file first: a
+`--from-literal` secret lands in your shell history and is briefly visible in
+`ps` while the command runs.
 
 ```bash
+# Slack webhook for the slack-alerts AlertmanagerConfig
 kubectl -n monitoring create secret generic alertmanager-slack \
-  --from-literal=webhook-url='https://hooks.slack.com/services/...'
-kubectl -n monitoring create secret generic grafana-admin --from-literal=password='...'
+  --from-file=webhook-url=./slack-webhook.txt
+
+# Grafana admin password
+kubectl -n monitoring create secret generic grafana-admin \
+  --from-file=password=./grafana-password.txt
+
+# postgres-orders credentials (the username is not sensitive)
 kubectl -n boutique-app create secret generic postgres-orders \
-  --from-literal=username=orders --from-literal=password='...'
+  --from-literal=username=orders \
+  --from-file=password=./postgres-password.txt
+
+# GHCR credentials for Argo CD Image Updater. Required: the Application's
+# `app.pull-secret: pullsecret:argocd/ghcr-creds` annotation resolves to this,
+# and without it Image Updater cannot read tags from GHCR — the CD half of the
+# pipeline then does nothing, without failing loudly. Needs a PAT with
+# `read:packages`, and must be a `kubernetes.io/dockerconfigjson` secret.
+kubectl -n argocd create secret docker-registry ghcr-creds \
+  --docker-server=ghcr.io \
+  --docker-username='<github-username>' \
+  --docker-password="$(< ./ghcr-pat.txt)"
+
+shred -u ./slack-webhook.txt ./grafana-password.txt ./postgres-password.txt ./ghcr-pat.txt
 ```
 
 ## Notes on the modelling

--- a/designs/gitops-eks-pipeline/README.md
+++ b/designs/gitops-eks-pipeline/README.md
@@ -87,13 +87,19 @@ real AWS account — but they are not all `111122223333`-style, so work the list
 rather than grepping for one pattern. Replace every one of these:
 
 - AWS account ID `111122223333`, in every role ARN
-- the ACM certificate ARN on the `boutique-gateway` Gateway
+- the ACM certificate ARN, which appears **twice** on the `boutique-gateway`
+  Gateway — once in the `alb.ingress.kubernetes.io/certificate-arn` annotation
+  and again in the HTTPS listener's `tls.options`. Change both; changing one
+  leaves the listener and the controller disagreeing about the certificate.
 - the OIDC provider URL and `EXAMPLED539D4633E53DE1B716D3041E` ID in the
   `external-dns-irsa` trust policy
 - `Z0EXAMPLEHOSTEDZONE` in the `external-dns-irsa` inline policy — the hosted
   zone External DNS is allowed to write to
-- `shop.example.com`, on both the Gateway listener and the `--domain-filter`
-  argument to `external-dns`
+- `shop.example.com`, on the Gateway listeners and the
+  `external-dns.alpha.kubernetes.io/hostname` annotation
+- `example.com` separately, as the `--domain-filter` argument to
+  `external-dns`. It is the parent zone, not the host — a find-and-replace
+  on `shop.example.com` alone will not touch it
 - `https://github.com/example-org/boutique-gitops.git` and
   `ghcr.io/example-org/boutique-app` on the Argo CD Application
 - `us-east-1`, and the `us-east-1a` / `us-east-1b` availability zones on the
@@ -131,10 +137,10 @@ kubectl -n boutique-app create secret generic postgres-orders \
 # and without it Image Updater cannot read tags from GHCR — the CD half of the
 # pipeline then does nothing, without failing loudly. Needs a PAT with
 # `read:packages`, and must be a `kubernetes.io/dockerconfigjson` secret.
-# `create secret docker-registry` has no file-based option for the password — it
-# only takes it as a flag value — and a command substitution reading the token
-# from a file is expanded by the shell before kubectl starts, so the token would
-# still land in argv and show up in `ps`. Log in against a throwaway
+# `create secret docker-registry` takes the password only through its
+# `--docker-password` flag, with no file-based alternative, and a command
+# substitution reading the token from a file is expanded by the shell before
+# kubectl starts — so the token would still land in argv and show up in `ps`. Log in against a throwaway
 # DOCKER_CONFIG instead and build the Secret from the config file it writes. The
 # temporary config also keeps other registries' credentials, and any credsStore
 # indirection, out of the Secret.
@@ -144,7 +150,8 @@ kubectl -n boutique-app create secret generic postgres-orders \
 # neither the token nor the config it lives in survives an interrupted setup.
 (
   set -e
-  export DOCKER_CONFIG="$(mktemp -d)"
+  # A bare `mktemp -d` is GNU-only; BSD/macOS mktemp requires a template.
+  export DOCKER_CONFIG="$(mktemp -d "${TMPDIR:-/tmp}/ghcr-creds.XXXXXX")"
   trap 'rm -rf "$DOCKER_CONFIG"; rm -f ./ghcr-pat.txt' EXIT
   docker login ghcr.io --username '<github-username>' --password-stdin < ./ghcr-pat.txt
   kubectl -n argocd create secret generic ghcr-creds \

--- a/designs/gitops-eks-pipeline/design.yaml
+++ b/designs/gitops-eks-pipeline/design.yaml
@@ -1,0 +1,10952 @@
+id: 7c1e9d4a-3b52-5f68-9a0d-2e4f6b81c3d7
+name: GitOps Pipeline on Amazon EKS
+schemaVersion: designs.meshery.io/v1beta1
+version: 0.0.1
+components:
+- id: 3f048a85-f431-54db-893d-ded525ebdbb8
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ci-boundary
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -284.8
+      y: -652.8
+    primaryColor: '#8A8A8A'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: Continuous Integration (CI)
+    body-text-color: '#8A8A8A'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 984.0
+    height: 296.0
+    locked: true
+    opacity: 1
+    border-color: '#8A8A8A'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: bca9f96a-c237-5feb-81d3-e1d545d23d16
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: aws-account
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 344.0
+      y: 112.0
+    primaryColor: '#E1218A'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: AWS Account
+    body-text-color: '#E1218A'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 2304.0
+    height: 1216.0
+    locked: true
+    opacity: 1
+    border-color: '#E1218A'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 0688233b-4a84-5078-a424-96a10f8033da
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: aws-region
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 360.0
+      y: 115.2
+    primaryColor: '#00B39F'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: Region  ·  us-east-1
+    body-text-color: '#00B39F'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 2208.0
+    height: 1120.0
+    locked: true
+    opacity: 1
+    border-color: '#00B39F'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 722ddcbb-a592-531b-8fa1-2ef9d2db2a37
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: aws-vpc
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 344.0
+      y: 120.0
+    primaryColor: '#A055F5'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: VPC  ·  10.0.0.0/16
+    body-text-color: '#A055F5'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 1872.0
+    height: 1008.0
+    locked: true
+    opacity: 1
+    border-color: '#A055F5'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: a3949aea-a581-5b26-b9e6-76c8c005b999
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: public-subnet
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -104.0
+      y: 88.0
+    primaryColor: '#7AA116'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: Public subnet
+    body-text-color: '#7AA116'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 592.0
+    height: 528.0
+    locked: true
+    opacity: 1
+    border-color: '#7AA116'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: c1a2c2f0-30c6-5886-a6e6-08ec4eb8feb6
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: private-subnet
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 752.0
+      y: 144.0
+    primaryColor: '#3E8FD0'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: Private subnet
+    body-text-color: '#3E8FD0'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 1024.0
+    height: 872.0
+    locked: true
+    opacity: 1
+    border-color: '#3E8FD0'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: baf6b393-a667-5efb-a47e-feb96e5f3e41
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ns-logging-box
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 552.0
+      y: -48.0
+    primaryColor: '#FEC514'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: logging
+    body-text-color: '#FEC514'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 320.0
+    height: 280.0
+    locked: true
+    opacity: 1
+    border-color: '#FEC514'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 5168f1cf-5632-5648-a104-6a8a4ef0b14e
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ns-argocd-box
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 1056.0
+      y: -48.0
+    primaryColor: '#fe733e'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: argocd
+    body-text-color: '#fe733e'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 320.0
+    height: 240.0
+    locked: true
+    opacity: 1
+    border-color: '#fe733e'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 35b119d4-9d7e-5a75-b38d-6fc92e308f99
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ns-kubesystem-box
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 456.0
+      y: 224.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: kube-system
+    body-text-color: '#326CE5'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 176.0
+    height: 192.0
+    locked: true
+    opacity: 1
+    border-color: '#326CE5'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: f1a6ed0f-42c6-5a92-99d0-558b64134106
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ns-boutique-box
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 712.0
+      y: 320.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: boutique-app
+    body-text-color: '#326CE5'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 336.0
+    height: 336.0
+    locked: true
+    opacity: 1
+    border-color: '#326CE5'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: c25ef374-d897-55ff-840b-682ccc3123b1
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ns-monitoring-box
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Rectangle
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 1072.0
+      y: 320.0
+    primaryColor: '#e75225'
+    secondaryColor: '#00D3A9'
+    z-index: 0
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/rectangle-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/rectangle-white.svg
+    body-text: monitoring
+    body-text-color: '#e75225'
+    body-text-font-size: 13
+    body-text-font-weight: '600'
+    body-text-vertical-align: top
+    body-text-horizontal-align: left
+    width: 336.0
+    height: 336.0
+    locked: true
+    opacity: 1
+    border-color: '#e75225'
+    border-style: dashed
+    border-width: 2
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 1b28e865-0a70-5c3b-a396-a59fb7469888
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Continuous Delivery (CD)
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Core
+    id: ca787272-67cc-ecda-9340-974f01e11ad8
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-core/color/meshery-core-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-core/white/meshery-core-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-core
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: TextBox
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 632.0
+      y: -652.8
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 12
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-core/color/textbox-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-core/white/textbox-white.svg
+    body-text: Continuous Delivery (CD)
+    body-text-color: '#D0D0D0'
+    body-text-font-size: 15
+    body-text-font-weight: '600'
+    body-text-vertical-align: center
+    body-text-horizontal-align: center
+    width: 300
+    height: 26
+    border-style: none
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: d3ac72d0-77ff-5521-83ce-3b3649510a58
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: AWS network (ACK)
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Core
+    id: ca787272-67cc-ecda-9340-974f01e11ad8
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-core/color/meshery-core-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-core/white/meshery-core-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-core
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: TextBox
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -368.0
+      y: 392.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 13
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-core/color/textbox-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-core/white/textbox-white.svg
+    body-text: AWS network (ACK)
+    body-text-color: '#ED7100'
+    body-text-font-size: 10
+    body-text-font-weight: '500'
+    body-text-vertical-align: center
+    body-text-horizontal-align: left
+    width: 190
+    height: 20
+    border-style: none
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: f790ab77-9134-5379-b696-44c94733a02a
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Gateway API · ALB
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Core
+    id: ca787272-67cc-ecda-9340-974f01e11ad8
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-core/color/meshery-core-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-core/white/meshery-core-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-core
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: TextBox
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 64.0
+      y: 483.2
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 14
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-core/color/textbox-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-core/white/textbox-white.svg
+    body-text: Gateway API  ·  ALB
+    body-text-color: '#00B39F'
+    body-text-font-size: 10
+    body-text-font-weight: '500'
+    body-text-vertical-align: center
+    body-text-horizontal-align: center
+    width: 220
+    height: 20
+    border-style: none
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 40473ea8-e015-5f8b-9d22-ad1d3bee7300
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: GitHub
+  description: Source of truth. Every push triggers the CI workflow.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: StoredData
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -952.0
+      y: -576.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 15
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/storeddata-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/storeddata-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 6971880c-8ad7-5e82-9d00-9fb1416598bf
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: GitHub Actions
+  description: 'Workflow runner: checkout, build, scan, push.'
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: PredefinedProcess
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -480.0
+      y: -576.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 16
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/predefinedprocess-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/predefinedprocess-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: f5c116b7-3ae9-5ae0-8888-782f2ff33607
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Checkout
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Process
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -336.0
+      y: -576.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 17
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/process-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/process-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 3a9d9504-a7b5-5871-af3f-1dfed179abbd
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Build image
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Process
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -200.0
+      y: -576.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 18
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/process-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/process-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 2b9ef285-8b00-56d1-b439-435879f5b2d8
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Trivy scan
+  description: Fails the pipeline on HIGH/CRITICAL CVEs before the image ships.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Decision
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -64.0
+      y: -576.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 19
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/decision-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/decision-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 4f899249-871d-529a-8d0d-233f16739024
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Push
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Process
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 72.0
+      y: -576.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 20
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/process-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/process-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: f9204ae9-a4f7-5ecc-939a-9828a8ed6e8f
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: GHCR
+  description: GitHub Container Registry - the image source Argo CD Image Updater polls.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Database
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -704.0
+      y: -720.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 21
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/database-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/database-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: c4b5c591-c6b2-5796-a7b1-34a53c8d8418
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Local machine
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Terminal
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -1368.0
+      y: -16.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 22
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/terminal-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/terminal-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 88815c3c-ef6b-5cac-990b-1e3d37ca230f
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Terraform
+  description: Provisions the AWS layer. The ACK resources in this design are the cluster-native alternative.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Flowchart
+    id: 90970641-26f8-2ff0-d3cd-1cd73372e502
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/meshery-flowchart-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/meshery-flowchart-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-flowchart
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: PredefinedProcess
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -1008.0
+      y: 8.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 23
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-flowchart/color/predefinedprocess-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-flowchart/white/predefinedprocess-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 9122a1f8-37fc-54f8-b6cd-a7900d80ab8e
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Developer / DevOps
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Actor
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -1400.0
+      y: 208.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 24
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/actor-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/actor-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: bc0821da-5311-571d-aaba-caf2dcdbc135
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: User
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: User
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -1387.2
+      y: 640.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 25
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/user-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/user-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: f6cb57ae-5e79-59fe-999b-9cb95d3f7150
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: 'Slack  #alerts'
+  description: Alertmanager routes firing alerts here - see the slack-alerts AlertmanagerConfig.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Meshery Shapes
+    id: 3d2cd78d-d9fd-cf06-af5d-05b0564f0f32
+    metadata:
+      isAnnotation: true
+      primaryColor: '#00b39F'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/meshery-shapes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/meshery-shapes-white.svg
+    model:
+      version: 0.7.2
+    name: meshery-shapes
+    registrant:
+      created_at: '2024-09-11T22:58:52.970005699Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+      kind: meshery
+      name: meshery
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:52.970005699Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 56fc1fd1-f0c1-21ab-983f-9efa8fec5b2f
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: App Definition and Development
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Message
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -620.8
+      y: 808.0
+    primaryColor: '#00b39F'
+    secondaryColor: '#00D3A9'
+    z-index: 26
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/meshery-shapes/color/message-color.svg
+    svgWhite: ui/public/static/img/meshmodels/meshery-shapes/white/message-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: d603724c-19bc-5cbb-bb6a-daa8a07c1d35
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: S3  ·  Terraform remote state
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: Amazon Web Services
+    id: 53d42b4d-87a1-3111-2cc2-e618a3cc5048
+    metadata:
+      isAnnotation: true
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws/color/aws-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws/white/aws-white.svg
+    model:
+      version: 0.7.2
+    name: aws
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: AWS Simple Storage Service
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -644.8
+      y: 160.0
+    primaryColor: '#7AA116'
+    secondaryColor: '#00D3A9'
+    z-index: 27
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/aws/color/aws simple storage service-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws/white/aws simple storage service-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 1940279c-640d-5043-9693-c77ff9bdf8ee
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: Route 53
+  description: Records are written automatically by External DNS.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: Amazon Web Services
+    id: 53d42b4d-87a1-3111-2cc2-e618a3cc5048
+    metadata:
+      isAnnotation: true
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws/color/aws-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws/white/aws-white.svg
+    model:
+      version: 0.7.2
+    name: aws
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: AWS Route 53
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -640.0
+      y: 364.8
+    primaryColor: '#8C4FFF'
+    secondaryColor: '#00D3A9'
+    z-index: 28
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/aws/color/aws route 53-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws/white/aws route 53-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: ab1a8959-6c74-58f4-92b6-6f56f7cc350f
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ACM
+  description: TLS certificate referenced by the Gateway listener annotation.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: Amazon Web Services
+    id: 53d42b4d-87a1-3111-2cc2-e618a3cc5048
+    metadata:
+      isAnnotation: true
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws/color/aws-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws/white/aws-white.svg
+    model:
+      version: 0.7.2
+    name: aws
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: AWS Certificate Manager
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -640.0
+      y: 524.8
+    primaryColor: '#DD344C'
+    secondaryColor: '#00D3A9'
+    z-index: 29
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/aws/color/aws certificate manager-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws/white/aws certificate manager-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 5fd73bd1-01a6-5123-9089-62ffa0b4a817
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: LBC  ·  ALB
+  description: Application Load Balancer provisioned by the AWS Load Balancer Controller for the Gateway.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: Amazon Web Services
+    id: 53d42b4d-87a1-3111-2cc2-e618a3cc5048
+    metadata:
+      isAnnotation: true
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws/color/aws-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws/white/aws-white.svg
+    model:
+      version: 0.7.2
+    name: aws
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: AWS Elastic Load Balancing
+    schema: ''
+    version: core.meshery.io/v1alpha1
+  configuration:
+    metadata:
+      annotations: {}
+      labels: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  - description: Add text to nodes body
+    displayName: Body Text
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: body-text
+    type: style
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -240.0
+      y: 160.0
+    primaryColor: '#8C4FFF'
+    secondaryColor: '#00D3A9'
+    z-index: 30
+    background-opacity: 0
+    svgColor: ui/public/static/img/meshmodels/aws/color/aws elastic load balancing-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws/white/aws elastic load balancing-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: true
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 3ee64803-9787-5ef5-bfa8-3483ab9f1142
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: ack-system
+  description: ACK controllers
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Namespace
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: gitops-eks-pipeline
+      annotations: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -544.0
+      y: 448.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 31
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 5f0b4d2b-67ca-5afe-9c06-3a06ddff7cc8
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: logging
+  description: ECK logging stack
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Namespace
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: gitops-eks-pipeline
+      annotations: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 435.2
+      y: -99.2
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 32
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 0302bd28-649f-5306-b3c5-6ec127335e7a
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: argocd
+  description: Argo CD control plane
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Namespace
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: gitops-eks-pipeline
+      annotations: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 944.0
+      y: -105.6
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 33
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 6e3f1c0e-977e-5dd3-bf23-4d727422c68b
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-app
+  description: Application workloads
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Namespace
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: gitops-eks-pipeline
+      annotations: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 595.2
+      y: 214.4
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 34
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 45da2aa4-4435-5005-aa82-8ed0afa13656
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: monitoring
+  description: Prometheus / Grafana / Alertmanager
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Namespace
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: gitops-eks-pipeline
+      annotations: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 960.0
+      y: 214.4
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 35
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/namespace-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/namespace-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: a94e4778-9622-5ba1-b3ca-d840c515b253
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: gitops-eks-vpc
+  description: Cluster VPC. Public/private subnet separation as in the diagram.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: VPC
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      cidrBlocks:
+      - 10.0.0.0/16
+      enableDNSSupport: true
+      enableDNSHostnames: true
+      tags:
+      - key: Name
+        value: gitops-eks-vpc
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -416.0
+      y: 448.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 36
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/vpc-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/vpc-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 36760a88-6b6f-5afb-8978-ff0d65c649a7
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: public-subnet-1a
+  description: Public subnet in us-east-1a.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Subnet
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      cidrBlock: 10.0.1.0/24
+      availabilityZone: us-east-1a
+      mapPublicIPOnLaunch: true
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: public-subnet-1a
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+      - key: kubernetes.io/role/elb
+        value: '1'
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -288.0
+      y: 448.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 37
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/subnet-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/subnet-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 45abb040-aa38-5be6-a29a-54552a12a4df
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: public-subnet-1b
+  description: Public subnet in us-east-1b.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Subnet
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      cidrBlock: 10.0.2.0/24
+      availabilityZone: us-east-1b
+      mapPublicIPOnLaunch: true
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: public-subnet-1b
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+      - key: kubernetes.io/role/elb
+        value: '1'
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -160.0
+      y: 448.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 38
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/subnet-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/subnet-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: f4161a85-92ec-573f-8445-3a5e4867efd6
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: private-subnet-1a
+  description: Private subnet in us-east-1a.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Subnet
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      cidrBlock: 10.0.11.0/24
+      availabilityZone: us-east-1a
+      mapPublicIPOnLaunch: false
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: private-subnet-1a
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+      - key: kubernetes.io/role/internal-elb
+        value: '1'
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -32.0
+      y: 448.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 39
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/subnet-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/subnet-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: b1e3ab47-9b46-556a-8e6d-b56bd6fda30b
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: private-subnet-1b
+  description: Private subnet in us-east-1b.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Subnet
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      cidrBlock: 10.0.12.0/24
+      availabilityZone: us-east-1b
+      mapPublicIPOnLaunch: false
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: private-subnet-1b
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+      - key: kubernetes.io/role/internal-elb
+        value: '1'
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 96.0
+      y: 448.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 40
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/subnet-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/subnet-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: c4e2f424-854f-5c02-859a-aab02c54d436
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: gitops-eks-igw
+  description: Internet gateway for the public subnets.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: InternetGateway
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: gitops-eks-igw
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 16.0
+      y: -128.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 41
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/internetgateway-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/internetgateway-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: bfeabc59-d185-5463-a180-6a545803ae86
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: nat-eip
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: ElasticIPAddress
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      tags:
+      - key: Name
+        value: nat-eip
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 128.0
+      y: -44.8
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 42
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/elasticipaddress-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/elasticipaddress-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: a8c83f36-70b6-53b6-a136-4cbc11ba64a3
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: gitops-eks-nat
+  description: Egress for the private subnets where the node group runs.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: NATGateway
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      subnetRef:
+        from:
+          name: public-subnet-1a
+          namespace: ack-system
+      allocationRef:
+        from:
+          name: nat-eip
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: gitops-eks-nat
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 128.0
+      y: -128.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 43
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/natgateway-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/natgateway-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: d4b73a91-1c1a-539f-9377-dfde7a5b1e91
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: public-rt
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: RouteTable
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      routes:
+      - destinationCIDRBlock: 0.0.0.0/0
+        gatewayRef:
+          from:
+            name: gitops-eks-igw
+            namespace: ack-system
+      tags:
+      - key: Name
+        value: public-rt
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -416.0
+      y: 540.8
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 44
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/routetable-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/routetable-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: bc8f7b6b-88bd-5e24-a268-f157909226fb
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: private-rt
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: RouteTable
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      routes:
+      - destinationCIDRBlock: 0.0.0.0/0
+        natGatewayRef:
+          from:
+            name: gitops-eks-nat
+            namespace: ack-system
+      tags:
+      - key: Name
+        value: private-rt
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -288.0
+      y: 540.8
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 45
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/routetable-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/routetable-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 5accd3d1-1c35-5348-8c72-64fa90ed89b2
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: bastion-sg
+  description: SSH to the bastion. Narrow cidrIP to your own range before deploying.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: SecurityGroup
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      name: bastion-sg
+      description: SSH access to the bastion host
+      vpcRef:
+        from:
+          name: gitops-eks-vpc
+          namespace: ack-system
+      ingressRules:
+      - ipProtocol: tcp
+        fromPort: 22
+        toPort: 22
+        ipRanges:
+        - cidrIP: 10.0.0.0/16
+          description: VPC-internal SSH only
+      tags:
+      - key: Name
+        value: bastion-sg
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -240.0
+      y: 76.8
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 46
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/securitygroup-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/securitygroup-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: f1404766-19b6-5a9f-8475-67601ee56eee
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: bastion-host
+  description: Jump host into the private-only EKS API endpoint. kubectl/helm run from here.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS EC2
+    id: cfcbff86-d7ff-ec19-c19f-b08c511d1df4
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/aws-ec2-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/aws-ec2-controller-white.svg
+    model:
+      version: v1.20.0
+    name: aws-ec2-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Automation & Configuration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Instance
+    schema: ''
+    version: ec2.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      instanceType: t3.micro
+      imageID: ami-0c02fb55956c7d316
+      minCount: 1
+      maxCount: 1
+      subnetRef:
+        from:
+          name: public-subnet-1a
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: bastion-host
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: -240.0
+      y: 0.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 47
+    svgColor: ui/public/static/img/meshmodels/aws-ec2-controller/color/instance-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-ec2-controller/white/instance-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: eda117de-9d56-510d-bc6e-ece885c35642
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: gitops-eks
+  description: Private EKS control plane - public endpoint access disabled, as in the diagram.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: AWS Elastic Kubernetes Service
+    id: 3f411b2e-3f85-463b-6fc5-341b6b3fca1b
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-eks-controller/color/aws-eks-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-eks-controller/white/aws-eks-controller-white.svg
+    model:
+      version: v1.21.0
+    name: aws-eks-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Containers
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Cluster
+    schema: ''
+    version: eks.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      name: gitops-eks
+      version: '1.31'
+      roleARN: arn:aws:iam::111122223333:role/eks-cluster-role
+      resourcesVPCConfig:
+        endpointPrivateAccess: true
+        endpointPublicAccess: false
+        subnetRefs:
+        - from:
+            name: private-subnet-1a
+            namespace: ack-system
+        - from:
+            name: private-subnet-1b
+            namespace: ack-system
+        - from:
+            name: public-subnet-1a
+            namespace: ack-system
+        - from:
+            name: public-subnet-1b
+            namespace: ack-system
+      logging:
+        clusterLogging:
+        - types:
+          - api
+          - audit
+          - authenticator
+          enabled: true
+      tags:
+      - key: Name
+        value: gitops-eks
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 184.0
+      y: -272.0
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 48
+    svgColor: ui/public/static/img/meshmodels/aws-eks-controller/color/cluster-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-eks-controller/white/cluster-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: d75fafe9-7ae9-5c97-a0e2-a29468682f7c
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: gitops-eks-ng
+  description: Managed node group in the private subnets.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: AWS Elastic Kubernetes Service
+    id: 3f411b2e-3f85-463b-6fc5-341b6b3fca1b
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-eks-controller/color/aws-eks-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-eks-controller/white/aws-eks-controller-white.svg
+    model:
+      version: v1.21.0
+    name: aws-eks-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Containers
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Nodegroup
+    schema: ''
+    version: eks.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      name: gitops-eks-ng
+      clusterRef:
+        from:
+          name: gitops-eks
+          namespace: ack-system
+      nodeRole: arn:aws:iam::111122223333:role/eks-node-role
+      instanceTypes:
+      - t3.large
+      amiType: AL2_x86_64
+      capacityType: ON_DEMAND
+      diskSize: 50
+      scalingConfig:
+        minSize: 2
+        maxSize: 6
+        desiredSize: 3
+      subnetRefs:
+      - from:
+          name: private-subnet-1a
+          namespace: ack-system
+      - from:
+          name: private-subnet-1b
+          namespace: ack-system
+      tags:
+      - key: Name
+        value: gitops-eks-ng
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 464.0
+      y: -220.8
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 49
+    svgColor: ui/public/static/img/meshmodels/aws-eks-controller/color/nodegroup-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-eks-controller/white/nodegroup-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: c57cca5e-7608-5fdc-b761-689e2c322579
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: external-dns-irsa
+  description: IRSA role assumed by External DNS to write Route 53 records.
+  format: JSON
+  model:
+    category:
+      name: Provisioning
+    displayName: AWS Identity and Access Management
+    id: 9c900596-c0ea-195f-0c21-d2e68625097e
+    metadata:
+      isAnnotation: false
+      primaryColor: '#DD344C'
+      secondaryColor: '#00D3A9'
+      shape: shield
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-iam-controller/color/aws-iam-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-iam-controller/white/aws-iam-controller-white.svg
+    model:
+      version: v1.9.0
+    name: aws-iam-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Key Management
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Role
+    schema: ''
+    version: iam.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      name: external-dns-irsa
+      description: External DNS - Route 53 record management
+      policies:
+      - arn:aws:iam::aws:policy/AmazonRoute53FullAccess
+      assumeRolePolicyDocument: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"arn:aws:iam::111122223333:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringEquals":{"oidc.eks.us-east-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E:sub":"system:serviceaccount:kube-system:external-dns"}}}]}'
+      tags:
+      - key: Name
+        value: external-dns-irsa
+      - key: app.kubernetes.io/part-of
+        value: gitops-eks-pipeline
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: shield
+    position:
+      x: 328.0
+      y: 40.0
+    primaryColor: '#DD344C'
+    secondaryColor: '#00D3A9'
+    z-index: 50
+    svgColor: ui/public/static/img/meshmodels/aws-iam-controller/color/role-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-iam-controller/white/role-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 07aeb4d0-5504-5b99-b9d0-9288709205d7
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-app-pod-identity
+  description: EKS Pod Identity association - no OIDC trust policy plumbing per workload.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: AWS Elastic Kubernetes Service
+    id: 3f411b2e-3f85-463b-6fc5-341b6b3fca1b
+    metadata:
+      isAnnotation: false
+      primaryColor: '#ED7100'
+      secondaryColor: '#00D3A9'
+      shape: rectangle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/aws-eks-controller/color/aws-eks-controller-color.svg
+      svgWhite: ui/public/static/img/meshmodels/aws-eks-controller/white/aws-eks-controller-white.svg
+    model:
+      version: v1.21.0
+    name: aws-eks-controller
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Containers
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: PodIdentityAssociation
+    schema: ''
+    version: eks.services.k8s.aws/v1alpha1
+  configuration:
+    spec:
+      clusterRef:
+        from:
+          name: gitops-eks
+          namespace: ack-system
+      namespace: boutique-app
+      serviceAccount: boutique-app
+      roleARN: arn:aws:iam::111122223333:role/boutique-app-pod-identity
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: ack-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: rectangle
+    position:
+      x: 328.0
+      y: 147.2
+    primaryColor: '#ED7100'
+    secondaryColor: '#00D3A9'
+    z-index: 51
+    svgColor: ui/public/static/img/meshmodels/aws-eks-controller/color/podidentityassociation-color.svg
+    svgWhite: ui/public/static/img/meshmodels/aws-eks-controller/white/podidentityassociation-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 49bf7f26-e9ad-56f5-8b1a-67b78ec34233
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: eks-pod-identity-agent
+  description: Node-local agent that vends credentials to pods using EKS Pod Identity.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: DaemonSet
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: eks-pod-identity-agent
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: eks-pod-identity-agent
+        spec:
+          hostNetwork: true
+          priorityClassName: system-node-critical
+          tolerations:
+          - operator: Exists
+          initContainers:
+          - name: eks-pod-identity-agent-init
+            image: public.ecr.aws/eks/eks-pod-identity-agent:0.1.15
+            command:
+            - /go-runner
+            - /eks-pod-identity-agent
+            - initialize
+            securityContext:
+              privileged: true
+          containers:
+          - name: eks-pod-identity-agent
+            image: public.ecr.aws/eks/eks-pod-identity-agent:0.1.15
+            args:
+            - --port
+            - '80'
+            - --cluster-name
+            - gitops-eks
+            - --probe-port
+            - '2703'
+            ports:
+            - containerPort: 80
+              name: proxy
+              protocol: TCP
+            - containerPort: 2703
+              name: probes-port
+              protocol: TCP
+            securityContext:
+              capabilities:
+                add:
+                - CAP_NET_BIND_SERVICE
+            resources:
+              requests:
+                cpu: 50m
+                memory: 24Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: kube-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 328.0
+      y: 371.2
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 52
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/daemonset-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/daemonset-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 0c46612d-9732-5114-b356-7e3cf2e912d9
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: argocd
+  description: Argo CD control plane. Reconciles the cluster against Git continuously.
+  format: JSON
+  model:
+    category:
+      name: App Definition and Development
+    displayName: Argo CD Operator
+    id: 786c2707-c943-aa65-2b02-9a31fedd5c1e
+    metadata:
+      isAnnotation: false
+      primaryColor: '#fe733e'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/argocd-operator/color/argocd-operator-color.svg
+      svgWhite: ui/public/static/img/meshmodels/argocd-operator/white/argocd-operator-white.svg
+    model:
+      version: 0.5.0
+    name: argocd-operator
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Continuous Integration & Delivery
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: ArgoCD
+    schema: ''
+    version: argoproj.io/v1alpha1
+  configuration:
+    spec:
+      server:
+        service:
+          type: ClusterIP
+        insecure: true
+        autoscale:
+          enabled: false
+      applicationSet:
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+      controller:
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+      repo:
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+      rbac:
+        defaultPolicy: role:readonly
+      ha:
+        enabled: false
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: argocd
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 1040.0
+      y: -60.8
+    primaryColor: '#fe733e'
+    secondaryColor: '#00D3A9'
+    z-index: 53
+    svgColor: ui/public/static/img/meshmodels/argocd-operator/color/argocd-color.svg
+    svgWhite: ui/public/static/img/meshmodels/argocd-operator/white/argocd-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: f9103b79-3a76-5c51-9de3-cde9cdf06477
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-app
+  description: Watches Git, syncs boutique-app. Image Updater annotations drive automatic image bumps.
+  format: JSON
+  model:
+    category:
+      name: App Definition and Development
+    displayName: Argo CD Operator
+    id: 786c2707-c943-aa65-2b02-9a31fedd5c1e
+    metadata:
+      isAnnotation: false
+      primaryColor: '#fe733e'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/argocd-operator/color/argocd-operator-color.svg
+      svgWhite: ui/public/static/img/meshmodels/argocd-operator/white/argocd-operator-white.svg
+    model:
+      version: 0.5.0
+    name: argocd-operator
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Continuous Integration & Delivery
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Application
+    schema: ''
+    version: argoproj.io/v1alpha1
+  configuration:
+    metadata:
+      annotations:
+        argocd-image-updater.argoproj.io/image-list: app=ghcr.io/example-org/boutique-app
+        argocd-image-updater.argoproj.io/app.update-strategy: newest-build
+        argocd-image-updater.argoproj.io/app.pull-secret: pullsecret:argocd/ghcr-creds
+        argocd-image-updater.argoproj.io/write-back-method: git
+        argocd-image-updater.argoproj.io/git-branch: main
+      finalizers:
+      - resources-finalizer.argocd.argoproj.io
+      labels: {}
+      namespace: argocd
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/example-org/boutique-gitops.git
+        targetRevision: main
+        path: manifests/overlays/prod
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: boutique-app
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        - PruneLast=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 1040.0
+      y: 22.4
+    primaryColor: '#fe733e'
+    secondaryColor: '#00D3A9'
+    z-index: 54
+    svgColor: ui/public/static/img/meshmodels/argocd-operator/color/application-color.svg
+    svgWhite: ui/public/static/img/meshmodels/argocd-operator/white/application-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: b8b34764-424f-553b-8454-00ae247bebd9
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: argocd-image-updater
+  description: Polls GHCR for new tags and writes the bump back to Git - Git stays the source of truth.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-image-updater
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: argocd-image-updater
+        spec:
+          serviceAccountName: argocd-image-updater
+          containers:
+          - name: argocd-image-updater
+            image: quay.io/argoprojlabs/argocd-image-updater:v0.15.2
+            command:
+            - /usr/local/bin/argocd-image-updater
+            - run
+            env:
+            - name: APPLICATIONS_API
+              value: argocd
+            - name: ARGOCD_GRPC_WEB
+              value: 'true'
+            - name: ARGOCD_SERVER
+              value: argocd-server.argocd.svc.cluster.local
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 200m
+                memory: 192Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: argocd
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 1164.8
+      y: -60.8
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 55
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 469b432a-91a8-5bd4-8e87-67eb8b86f6bb
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: argocd-image-updater
+  description: IRSA-annotated service account for Image Updater.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: ServiceAccount
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/argocd-image-updater-irsa
+      labels: {}
+      namespace: argocd
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: bottom-round-rectangle
+    position:
+      x: 1164.8
+      y: 22.4
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 56
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 4dfe8c71-2cd1-5b05-a757-e65b8bd6bb95
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: aws-load-balancer-controller
+  description: Provisions the ALB that backs the Gateway.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: aws-load-balancer-controller
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: aws-load-balancer-controller
+        spec:
+          serviceAccountName: aws-load-balancer-controller
+          containers:
+          - name: controller
+            image: public.ecr.aws/eks/aws-load-balancer-controller:v2.9.2
+            args:
+            - --cluster-name=gitops-eks
+            - --ingress-class=alb
+            - --feature-gates=NLBHealthCheckAdvancedConfig=true
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: kube-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: -240.0
+      y: 236.8
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 57
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 896e3a33-68fc-51b8-bcc7-bb6e2efa63ef
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: aws-load-balancer-controller
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: ServiceAccount
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/aws-load-balancer-controller-irsa
+      labels: {}
+      namespace: kube-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: bottom-round-rectangle
+    position:
+      x: -240.0
+      y: 313.6
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 58
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: c2f61b4a-aec0-5b2a-a02e-3ff723e2bbad
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: external-dns
+  description: Watches Gateway/HTTPRoute and keeps Route 53 records in step automatically.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 1
+      strategy:
+        type: Recreate
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: external-dns
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: external-dns
+        spec:
+          serviceAccountName: external-dns
+          containers:
+          - name: external-dns
+            image: registry.k8s.io/external-dns/external-dns:v0.15.0
+            args:
+            - --source=gateway-httproute
+            - --source=service
+            - --domain-filter=example.com
+            - --provider=aws
+            - --policy=upsert-only
+            - --aws-zone-type=public
+            - --registry=txt
+            - --txt-owner-id=gitops-eks
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 200m
+                memory: 128Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: kube-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 456.0
+      y: 195.2
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 59
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: d33dc652-7493-5402-85b7-8d70bca190c0
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: external-dns
+  description: Bound to the external-dns-irsa role defined above.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: ServiceAccount
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/external-dns-irsa
+      labels: {}
+      namespace: kube-system
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: bottom-round-rectangle
+    position:
+      x: 456.0
+      y: 284.8
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 60
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: ae3a4046-7604-5f1b-bf70-78fcc629dfad
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: alb
+  description: Binds the Gateway API to the AWS Load Balancer Controller.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Gateway API
+    id: 00000000-0000-0000-0000-000000000000
+    metadata:
+      isAnnotation: false
+      primaryColor: '#00B39F'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/gko/color/gko-color.svg
+      svgWhite: ui/public/static/img/meshmodels/gko/white/gko-white.svg
+    model:
+      version: 4.9.8
+    name: gko
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Networking
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: GatewayClass
+    schema: ''
+    version: gateway.networking.k8s.io/v1
+  configuration:
+    spec:
+      controllerName: gateway.k8s.aws/alb
+    metadata:
+      labels: {}
+      annotations: {}
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: -64.0
+      y: 560.0
+    primaryColor: '#00B39F'
+    secondaryColor: '#00D3A9'
+    z-index: 61
+    svgColor: ui/public/static/img/meshmodels/gko/color/gatewayclass-color.svg
+    svgWhite: ui/public/static/img/meshmodels/gko/white/gatewayclass-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: false
+    published: false
+    whiteboardData: {}
+- id: 5d3a3f72-6a90-5098-bb5c-4bf8cce78b04
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-gateway
+  description: Public entry point. ACM terminates TLS on the ALB; External DNS publishes the hostname.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Gateway API
+    id: 00000000-0000-0000-0000-000000000000
+    metadata:
+      isAnnotation: false
+      primaryColor: '#00B39F'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/gko/color/gko-color.svg
+      svgWhite: ui/public/static/img/meshmodels/gko/white/gko-white.svg
+    model:
+      version: 4.9.8
+    name: gko
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Networking
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Gateway
+    schema: ''
+    version: gateway.networking.k8s.io/v1
+  configuration:
+    metadata:
+      annotations:
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:111122223333:certificate/EXAMPLE-1111-2222-3333-444455556666
+        external-dns.alpha.kubernetes.io/hostname: shop.example.com
+      labels: {}
+      namespace: boutique-app
+    spec:
+      gatewayClassName: alb
+      listeners:
+      - name: https
+        protocol: HTTPS
+        port: 443
+        hostname: shop.example.com
+        tls:
+          mode: Terminate
+          options:
+            alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:111122223333:certificate/EXAMPLE-1111-2222-3333-444455556666
+        allowedRoutes:
+          namespaces:
+            from: Same
+      - name: http
+        protocol: HTTP
+        port: 80
+        hostname: shop.example.com
+        allowedRoutes:
+          namespaces:
+            from: Same
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 64.0
+      y: 560.0
+    primaryColor: '#00B39F'
+    secondaryColor: '#00D3A9'
+    z-index: 62
+    svgColor: ui/public/static/img/meshmodels/gko/color/gateway-color.svg
+    svgWhite: ui/public/static/img/meshmodels/gko/white/gateway-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 8bc65030-046a-595e-b6ff-e060d9157786
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-route
+  description: Routes shop.example.com to the frontend Service.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Gateway API
+    id: 00000000-0000-0000-0000-000000000000
+    metadata:
+      isAnnotation: false
+      primaryColor: '#00B39F'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/gko/color/gko-color.svg
+      svgWhite: ui/public/static/img/meshmodels/gko/white/gko-white.svg
+    model:
+      version: 4.9.8
+    name: gko
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Networking
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: HTTPRoute
+    schema: ''
+    version: gateway.networking.k8s.io/v1
+  configuration:
+    spec:
+      parentRefs:
+      - name: boutique-gateway
+        namespace: boutique-app
+      hostnames:
+      - shop.example.com
+      rules:
+      - matches:
+        - path:
+            type: PathPrefix
+            value: /
+        backendRefs:
+        - name: frontend
+          port: 80
+          weight: 100
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 192.0
+      y: 560.0
+    primaryColor: '#00B39F'
+    secondaryColor: '#00D3A9'
+    z-index: 63
+    svgColor: ui/public/static/img/meshmodels/gko/color/httproute-color.svg
+    svgWhite: ui/public/static/img/meshmodels/gko/white/httproute-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: b3f8fa62-933b-5726-a784-d996c5a76257
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: frontend
+  description: Public-facing web tier - the HTTPRoute backend.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: frontend
+      template:
+        metadata:
+          labels:
+            app: frontend
+        spec:
+          serviceAccountName: boutique-app
+          containers:
+          - name: server
+            image: gcr.io/google-samples/microservices-demo/frontend:v0.10.2
+            ports:
+            - containerPort: 8080
+            env:
+            - name: PRODUCT_CATALOG_SERVICE_ADDR
+              value: productcatalogservice:3550
+            - name: CART_SERVICE_ADDR
+              value: cartservice:7070
+            - name: CHECKOUT_SERVICE_ADDR
+              value: checkoutservice:5050
+            readinessProbe:
+              tcpSocket:
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            livenessProbe:
+              tcpSocket:
+                port: 8080
+              initialDelaySeconds: 20
+              periodSeconds: 15
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 624.0
+      y: 264.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 64
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: c6ece4fd-ea15-5024-b7de-d4607eb4ef71
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: productcatalogservice
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: productcatalogservice
+      template:
+        metadata:
+          labels:
+            app: productcatalogservice
+        spec:
+          serviceAccountName: boutique-app
+          containers:
+          - name: server
+            image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.10.2
+            ports:
+            - containerPort: 3550
+            env: []
+            readinessProbe:
+              tcpSocket:
+                port: 3550
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            livenessProbe:
+              tcpSocket:
+                port: 3550
+              initialDelaySeconds: 20
+              periodSeconds: 15
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 752.0
+      y: 264.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 65
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 45d7b310-61c8-59cf-bd96-ed6234f01ec1
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: cartservice
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: cartservice
+      template:
+        metadata:
+          labels:
+            app: cartservice
+        spec:
+          serviceAccountName: boutique-app
+          containers:
+          - name: server
+            image: gcr.io/google-samples/microservices-demo/cartservice:v0.10.2
+            ports:
+            - containerPort: 7070
+            env:
+            - name: REDIS_ADDR
+              value: redis-cart:6379
+            readinessProbe:
+              tcpSocket:
+                port: 7070
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            livenessProbe:
+              tcpSocket:
+                port: 7070
+              initialDelaySeconds: 20
+              periodSeconds: 15
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 624.0
+      y: 344.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 66
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: e01c9018-eefb-59d4-b0d3-bfe0712813c0
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: checkoutservice
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: checkoutservice
+      template:
+        metadata:
+          labels:
+            app: checkoutservice
+        spec:
+          serviceAccountName: boutique-app
+          containers:
+          - name: server
+            image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.10.2
+            ports:
+            - containerPort: 5050
+            env:
+            - name: PRODUCT_CATALOG_SERVICE_ADDR
+              value: productcatalogservice:3550
+            - name: CART_SERVICE_ADDR
+              value: cartservice:7070
+            readinessProbe:
+              tcpSocket:
+                port: 5050
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            livenessProbe:
+              tcpSocket:
+                port: 5050
+              initialDelaySeconds: 20
+              periodSeconds: 15
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 752.0
+      y: 344.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 67
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: e633996e-8005-503b-8f5c-91a5f4951ebf
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: redis-cart
+  description: Cart session store.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: StatefulSet
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      serviceName: redis-cart
+      replicas: 1
+      selector:
+        matchLabels:
+          app: redis-cart
+      template:
+        metadata:
+          labels:
+            app: redis-cart
+        spec:
+          containers:
+          - name: redis
+            image: redis:7.2-alpine
+            ports:
+            - containerPort: 6379
+            volumeMounts:
+            - name: data
+              mountPath: /data
+            resources:
+              requests:
+                cpu: 70m
+                memory: 200Mi
+              limits:
+                cpu: 250m
+                memory: 256Mi
+      volumeClaimTemplates:
+      - metadata:
+          name: data
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 2Gi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 624.0
+      y: 419.2
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 68
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 1eb8928b-cbdd-57fb-9e60-5ae2cfa81ed9
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: postgres-orders
+  description: Order store. Credentials come from the postgres-orders Secret, created out of band.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: StatefulSet
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      serviceName: postgres-orders
+      replicas: 1
+      selector:
+        matchLabels:
+          app: postgres-orders
+      template:
+        metadata:
+          labels:
+            app: postgres-orders
+        spec:
+          containers:
+          - name: postgres
+            image: postgres:16-alpine
+            ports:
+            - containerPort: 5432
+            env:
+            - name: POSTGRES_DB
+              value: orders
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-orders
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-orders
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+      volumeClaimTemplates:
+      - metadata:
+          name: data
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 752.0
+      y: 419.2
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 69
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 3b992ac5-bea5-50cb-84f1-3bb4890d12cd
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: frontend
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Service
+    schema: ''
+    version: v1
+  configuration:
+    spec:
+      type: ClusterIP
+      selector:
+        app: frontend
+      ports:
+      - name: http
+        port: 80
+        targetPort: 8080
+        protocol: TCP
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-triangle
+    position:
+      x: 568.0
+      y: 520.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 70
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 87d0781a-ad9c-52bd-a512-e12061632632
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: productcatalogservice
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Service
+    schema: ''
+    version: v1
+  configuration:
+    spec:
+      type: ClusterIP
+      selector:
+        app: productcatalogservice
+      ports:
+      - name: tcp
+        port: 3550
+        targetPort: 3550
+        protocol: TCP
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-triangle
+    position:
+      x: 672.0
+      y: 520.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 71
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 273a6790-e80d-52ff-bf8b-358b5043f063
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: cartservice
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Service
+    schema: ''
+    version: v1
+  configuration:
+    spec:
+      type: ClusterIP
+      selector:
+        app: cartservice
+      ports:
+      - name: tcp
+        port: 7070
+        targetPort: 7070
+        protocol: TCP
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-triangle
+    position:
+      x: 776.0
+      y: 520.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 72
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 66bcd9af-3e6b-5af0-9a3e-533029c2801e
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: redis-cart
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Service
+    schema: ''
+    version: v1
+  configuration:
+    spec:
+      type: ClusterIP
+      selector:
+        app: redis-cart
+      ports:
+      - name: tcp
+        port: 6379
+        targetPort: 6379
+        protocol: TCP
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-triangle
+    position:
+      x: 880.0
+      y: 520.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 73
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 950507ab-f4ce-5c08-9c61-3cf5357f4235
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-app
+  description: Bound to an IAM role through the EKS Pod Identity association above.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: ServiceAccount
+    schema: ''
+    version: v1
+  configuration:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: boutique-app
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: bottom-round-rectangle
+    position:
+      x: 851.2
+      y: 419.2
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 74
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/serviceaccount-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/serviceaccount-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: fe222a6c-4e65-569b-9579-1c51cd063684
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: frontend-hpa
+  description: Scales the web tier on CPU - the reliability half of the story.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: HorizontalPodAutoscaler
+    schema: ''
+    version: autoscaling/v1
+  configuration:
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: frontend
+      minReplicas: 2
+      maxReplicas: 12
+      targetCPUUtilizationPercentage: 70
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 328.0
+      y: -64.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 75
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/horizontalpodautoscaler-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/horizontalpodautoscaler-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 3377290b-1c1b-5984-992a-9f3d51a6cb00
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: loadgenerator
+  description: Synthetic traffic so the HPA and the dashboards have something to show.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: loadgenerator
+      template:
+        metadata:
+          labels:
+            app: loadgenerator
+        spec:
+          restartPolicy: Always
+          containers:
+          - name: main
+            image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.10.2
+            env:
+            - name: FRONTEND_ADDR
+              value: frontend:80
+            - name: USERS
+              value: '10'
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: boutique-app
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 800.0
+      y: -128.0
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 76
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 6c0f35fd-745c-56a9-815c-35c2c32bbe21
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: elastic-operator
+  description: ECK operator. Reconciles the Elasticsearch / Kibana / Beat custom resources.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: StatefulSet
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      serviceName: elastic-operator
+      replicas: 1
+      selector:
+        matchLabels:
+          control-plane: elastic-operator
+      template:
+        metadata:
+          labels:
+            control-plane: elastic-operator
+        spec:
+          serviceAccountName: elastic-operator
+          containers:
+          - name: manager
+            image: docker.elastic.co/eck/eck-operator:2.14.0
+            args:
+            - manager
+            - --config=/conf/eck.yaml
+            - --distribution-channel=all-in-one
+            env:
+            - name: NAMESPACES
+              value: logging
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            resources:
+              requests:
+                cpu: 100m
+                memory: 150Mi
+              limits:
+                memory: 1Gi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: logging
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 665.6
+      y: -12.8
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 77
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/statefulset-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/statefulset-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 71f8c424-4a94-51c1-acb5-d58b4c425b83
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: logging-es
+  description: Log store. Three nodes so a single node loss is survivable.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Elastic Search
+    id: 2d878ce2-b779-1594-7baf-d9392c294ea6
+    metadata:
+      isAnnotation: false
+      primaryColor: '#FEC514'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/elasticsearch-operator/color/elasticsearch-operator-color.svg
+      svgWhite: ui/public/static/img/meshmodels/elasticsearch-operator/white/elasticsearch-operator-white.svg
+    model:
+      version: v2.14.0
+    name: elasticsearch-operator
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Logging
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Elasticsearch
+    schema: ''
+    version: elasticsearch.k8s.elastic.co/v1
+  configuration:
+    spec:
+      version: 8.15.3
+      nodeSets:
+      - name: default
+        count: 3
+        config:
+          node.store.allow_mmap: false
+          node.roles:
+          - master
+          - data
+          - ingest
+        volumeClaimTemplates:
+        - metadata:
+            name: elasticsearch-data
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: logging
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 556.8
+      y: -128.0
+    primaryColor: '#FEC514'
+    secondaryColor: '#00D3A9'
+    z-index: 78
+    svgColor: ui/public/static/img/meshmodels/elasticsearch-operator/color/elasticsearch-color.svg
+    svgWhite: ui/public/static/img/meshmodels/elasticsearch-operator/white/elasticsearch-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 90827af9-d682-5c8f-8646-332a4b4c11dc
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: logging-kibana
+  description: Log UI, wired to logging-es.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Elastic Search
+    id: 2d878ce2-b779-1594-7baf-d9392c294ea6
+    metadata:
+      isAnnotation: false
+      primaryColor: '#FEC514'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/elasticsearch-operator/color/elasticsearch-operator-color.svg
+      svgWhite: ui/public/static/img/meshmodels/elasticsearch-operator/white/elasticsearch-operator-white.svg
+    model:
+      version: v2.14.0
+    name: elasticsearch-operator
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Logging
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Kibana
+    schema: ''
+    version: kibana.k8s.elastic.co/v1
+  configuration:
+    spec:
+      version: 8.15.3
+      count: 1
+      elasticsearchRef:
+        name: logging-es
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: logging
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 665.6
+      y: -128.0
+    primaryColor: '#FEC514'
+    secondaryColor: '#00D3A9'
+    z-index: 79
+    svgColor: ui/public/static/img/meshmodels/elasticsearch-operator/color/kibana-color.svg
+    svgWhite: ui/public/static/img/meshmodels/elasticsearch-operator/white/kibana-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 1b0ce0e6-f587-57a5-aa39-1528100e608c
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: filebeat
+  description: DaemonSet shipper - collects container logs from every node.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Elastic Search
+    id: 2d878ce2-b779-1594-7baf-d9392c294ea6
+    metadata:
+      isAnnotation: false
+      primaryColor: '#FEC514'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/elasticsearch-operator/color/elasticsearch-operator-color.svg
+      svgWhite: ui/public/static/img/meshmodels/elasticsearch-operator/white/elasticsearch-operator-white.svg
+    model:
+      version: v2.14.0
+    name: elasticsearch-operator
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Logging
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Beat
+    schema: ''
+    version: beat.k8s.elastic.co/v1beta1
+  configuration:
+    spec:
+      type: filebeat
+      version: 8.15.3
+      elasticsearchRef:
+        name: logging-es
+      kibanaRef:
+        name: logging-kibana
+      config:
+        filebeat.inputs:
+        - type: container
+          paths:
+          - /var/log/containers/*.log
+      daemonSet:
+        podTemplate:
+          spec:
+            serviceAccountName: filebeat
+            automountServiceAccountToken: true
+            terminationGracePeriodSeconds: 30
+            dnsPolicy: ClusterFirstWithHostNet
+            hostNetwork: true
+            containers:
+            - name: filebeat
+              securityContext:
+                runAsUser: 0
+              volumeMounts:
+              - name: varlogcontainers
+                mountPath: /var/log/containers
+              - name: varlogpods
+                mountPath: /var/log/pods
+              - name: varlibdockercontainers
+                mountPath: /var/lib/docker/containers
+            volumes:
+            - name: varlogcontainers
+              hostPath:
+                path: /var/log/containers
+            - name: varlogpods
+              hostPath:
+                path: /var/log/pods
+            - name: varlibdockercontainers
+              hostPath:
+                path: /var/lib/docker/containers
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: logging
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 556.8
+      y: -12.8
+    primaryColor: '#FEC514'
+    secondaryColor: '#00D3A9'
+    z-index: 80
+    svgColor: ui/public/static/img/meshmodels/elasticsearch-operator/color/beat-color.svg
+    svgWhite: ui/public/static/img/meshmodels/elasticsearch-operator/white/beat-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 0ff1aa33-adfe-5854-b47c-f07f4f878de5
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: prometheus
+  description: Scrapes every workload that exposes a ServiceMonitor.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Kube Prometheus Stack
+    id: c089dd09-8511-db1f-8552-d9c519993172
+    metadata:
+      isAnnotation: false
+      primaryColor: '#e75225'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/kube-prometheus-stack-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/kube-prometheus-stack-white.svg
+    model:
+      version: 80.10.0
+    name: kube-prometheus-stack
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Monitoring
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Prometheus
+    schema: ''
+    version: monitoring.coreos.com/v1
+  configuration:
+    spec:
+      replicas: 2
+      retention: 15d
+      serviceAccountName: prometheus
+      serviceMonitorSelector:
+        matchLabels:
+          release: kube-prometheus-stack
+      serviceMonitorNamespaceSelector: {}
+      ruleSelector:
+        matchLabels:
+          release: kube-prometheus-stack
+      alerting:
+        alertmanagers:
+        - namespace: monitoring
+          name: alertmanager-operated
+          port: web
+      resources:
+        requests:
+          cpu: 500m
+          memory: 2Gi
+      storage:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: monitoring
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 976.0
+      y: 268.8
+    primaryColor: '#e75225'
+    secondaryColor: '#00D3A9'
+    z-index: 81
+    svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/prometheus-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/prometheus-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: e5fd76da-b546-5f6b-83ed-e691b5e9581f
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: alertmanager
+  description: Deduplicates and routes alerts. Picks up the slack-alerts config below.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Kube Prometheus Stack
+    id: c089dd09-8511-db1f-8552-d9c519993172
+    metadata:
+      isAnnotation: false
+      primaryColor: '#e75225'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/kube-prometheus-stack-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/kube-prometheus-stack-white.svg
+    model:
+      version: 80.10.0
+    name: kube-prometheus-stack
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Monitoring
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Alertmanager
+    schema: ''
+    version: monitoring.coreos.com/v1
+  configuration:
+    spec:
+      replicas: 3
+      alertmanagerConfigSelector:
+        matchLabels:
+          alertmanagerConfig: slack
+      alertmanagerConfigNamespaceSelector: {}
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: monitoring
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 1155.2
+      y: 268.8
+    primaryColor: '#e75225'
+    secondaryColor: '#00D3A9'
+    z-index: 82
+    svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/alertmanager-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/alertmanager-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 70138f50-ee3f-5ad3-b2d8-aad46a5399ad
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: slack-alerts
+  description: Routes firing alerts to Slack. The webhook lives in the alertmanager-slack Secret.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Kube Prometheus Stack
+    id: c089dd09-8511-db1f-8552-d9c519993172
+    metadata:
+      isAnnotation: false
+      primaryColor: '#e75225'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/kube-prometheus-stack-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/kube-prometheus-stack-white.svg
+    model:
+      version: 80.10.0
+    name: kube-prometheus-stack
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Monitoring
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: AlertmanagerConfig
+    schema: ''
+    version: monitoring.coreos.com/v1alpha1
+  configuration:
+    metadata:
+      labels:
+        alertmanagerConfig: slack
+      annotations: {}
+      namespace: monitoring
+    spec:
+      route:
+        receiver: slack
+        groupBy:
+        - alertname
+        - namespace
+        groupWait: 30s
+        groupInterval: 5m
+        repeatInterval: 4h
+      receivers:
+      - name: slack
+        slackConfigs:
+        - apiURL:
+            name: alertmanager-slack
+            key: webhook-url
+          channel: '#alerts'
+          sendResolved: true
+          title: '{{ .CommonLabels.alertname }} in {{ .CommonLabels.namespace }}'
+          text: '{{ range .Alerts }}{{ .Annotations.summary }}
+
+            {{ end }}'
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 1155.2
+      y: 348.8
+    primaryColor: '#e75225'
+    secondaryColor: '#00D3A9'
+    z-index: 83
+    svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/alertmanagerconfig-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/alertmanagerconfig-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 8b55efc8-9d00-5089-a1a8-e6b325d14925
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-app
+  description: Tells Prometheus which boutique-app Services to scrape.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Kube Prometheus Stack
+    id: c089dd09-8511-db1f-8552-d9c519993172
+    metadata:
+      isAnnotation: false
+      primaryColor: '#e75225'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/kube-prometheus-stack-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/kube-prometheus-stack-white.svg
+    model:
+      version: 80.10.0
+    name: kube-prometheus-stack
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Monitoring
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: ServiceMonitor
+    schema: ''
+    version: monitoring.coreos.com/v1
+  configuration:
+    metadata:
+      labels:
+        release: kube-prometheus-stack
+      annotations: {}
+      namespace: monitoring
+    spec:
+      namespaceSelector:
+        matchNames:
+        - boutique-app
+      selector:
+        matchLabels:
+          app: frontend
+      endpoints:
+      - port: http
+        path: /metrics
+        interval: 30s
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 1155.2
+      y: 428.8
+    primaryColor: '#e75225'
+    secondaryColor: '#00D3A9'
+    z-index: 84
+    svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/servicemonitor-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/servicemonitor-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 26949981-78c8-53da-b73f-af95b37e02f1
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: boutique-alerts
+  description: The alerts that actually page - they end up in Slack.
+  format: JSON
+  model:
+    category:
+      name: Observability and Analysis
+    displayName: Kube Prometheus Stack
+    id: c089dd09-8511-db1f-8552-d9c519993172
+    metadata:
+      isAnnotation: false
+      primaryColor: '#e75225'
+      secondaryColor: '#00D3A9'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/kube-prometheus-stack-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/kube-prometheus-stack-white.svg
+    model:
+      version: 80.10.0
+    name: kube-prometheus-stack
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Monitoring
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: PrometheusRule
+    schema: ''
+    version: monitoring.coreos.com/v1
+  configuration:
+    metadata:
+      labels:
+        release: kube-prometheus-stack
+      annotations: {}
+      namespace: monitoring
+    spec:
+      groups:
+      - name: boutique-app.rules
+        rules:
+        - alert: FrontendHighErrorRate
+          expr: sum(rate(http_requests_total{job="frontend",status=~"5.."}[5m])) / sum(rate(http_requests_total{job="frontend"}[5m]))
+            > 0.05
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Frontend 5xx rate above 5% for 10 minutes
+        - alert: FrontendPodsNotReady
+          expr: kube_deployment_status_replicas_available{deployment="frontend",namespace="boutique-app"}
+            < 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Fewer than two frontend replicas are ready
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: circle
+    position:
+      x: 1120.0
+      y: 214.4
+    primaryColor: '#e75225'
+    secondaryColor: '#00D3A9'
+    z-index: 85
+    svgColor: ui/public/static/img/meshmodels/kube-prometheus-stack/color/prometheusrule-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kube-prometheus-stack/white/prometheusrule-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: 5d75b518-80f3-5dcf-85eb-5496837438db
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: grafana
+  description: Dashboards over the Prometheus data source.
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Deployment
+    schema: ''
+    version: apps/v1
+  configuration:
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: grafana
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: grafana
+        spec:
+          securityContext:
+            fsGroup: 472
+            runAsUser: 472
+          containers:
+          - name: grafana
+            image: grafana/grafana:11.3.1
+            ports:
+            - containerPort: 3000
+              name: http-grafana
+            env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: password
+            - name: GF_SERVER_ROOT_URL
+              value: https://grafana.example.com
+            readinessProbe:
+              httpGet:
+                path: /api/health
+                port: 3000
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: monitoring
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-rectangle
+    position:
+      x: 976.0
+      y: 348.8
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 86
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/deployment-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/deployment-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+- id: ead7bf34-995e-598a-8fc4-d594fe09136d
+  schemaVersion: components.meshery.io/v1beta1
+  version: v1.0.0
+  displayName: grafana
+  description: ''
+  format: JSON
+  model:
+    category:
+      name: Orchestration & Management
+    displayName: Kubernetes
+    id: bba54c44-a440-773a-a524-0114ebde5397
+    metadata:
+      isAnnotation: false
+      primaryColor: '#326CE5'
+      secondaryColor: '#7aa1f0'
+      shape: circle
+      styleOverrides: ''
+      svgColor: ui/public/static/img/meshmodels/kubernetes/color/kubernetes-color.svg
+      svgWhite: ui/public/static/img/meshmodels/kubernetes/white/kubernetes-white.svg
+    model:
+      version: v1.37.0
+    name: kubernetes
+    registrant:
+      created_at: '2024-09-11T22:58:51.679403649Z'
+      credential_id: 00000000-0000-0000-0000-000000000000
+      deleted_at: '0001-01-01T00:00:00Z'
+      id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+      kind: github
+      name: Github
+      status: registered
+      sub_type: ''
+      type: registry
+      updated_at: '2024-09-11T22:58:51.679403649Z'
+      user_id: 00000000-0000-0000-0000-000000000000
+    connection_id: 9e04779c-94b6-6a03-575c-66f4c57541eb
+    schemaVersion: models.meshery.io/v1beta1
+    status: enabled
+    subCategory: Scheduling & Orchestration
+    version: v1.0.0
+    components: null
+    relationships: null
+    components_count: 0
+    relationships_count: 0
+  component:
+    kind: Service
+    schema: ''
+    version: v1
+  configuration:
+    spec:
+      type: ClusterIP
+      selector:
+        app.kubernetes.io/name: grafana
+      ports:
+      - name: http
+        port: 3000
+        targetPort: 3000
+        protocol: TCP
+    metadata:
+      labels: {}
+      annotations: {}
+      namespace: monitoring
+  capabilities:
+  - description: Configure the visual styles for the component
+    displayName: Styling
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: ''
+    type: style
+    version: 0.7.0
+  - description: Change the shape of the component
+    displayName: Change Shape
+    entityState:
+    - declaration
+    key: ''
+    kind: mutate
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: shape
+    type: style
+    version: 0.7.0
+  - description: Drag and Drop a component into a parent component in graph view
+    displayName: Compound Drag And Drop
+    entityState:
+    - declaration
+    key: ''
+    kind: interaction
+    metadata: null
+    schemaVersion: capability.meshery.io/v1alpha1
+    status: enabled
+    subType: compoundDnd
+    type: graph
+    version: 0.7.0
+  status: enabled
+  styles:
+    shape: round-triangle
+    position:
+      x: 976.0
+      y: 428.8
+    primaryColor: '#326CE5'
+    secondaryColor: '#7aa1f0'
+    z-index: 87
+    svgColor: ui/public/static/img/meshmodels/kubernetes/color/service-color.svg
+    svgWhite: ui/public/static/img/meshmodels/kubernetes/white/service-white.svg
+  metadata:
+    dependsOn: []
+    fieldRefData: {}
+    genealogy: ''
+    isAnnotation: false
+    isNamespaced: true
+    published: false
+    whiteboardData: {}
+relationships: []

--- a/designs/gitops-eks-pipeline/design.yaml
+++ b/designs/gitops-eks-pipeline/design.yaml
@@ -6101,8 +6101,8 @@ components:
     spec:
       name: external-dns-irsa
       description: External DNS - Route 53 record management
-      policies:
-      - arn:aws:iam::aws:policy/AmazonRoute53FullAccess
+      inlinePolicies:
+        external-dns-route53: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["route53:ChangeResourceRecordSets"],"Resource":["arn:aws:route53:::hostedzone/Z0EXAMPLEHOSTEDZONE"]},{"Effect":"Allow","Action":["route53:ListHostedZones","route53:ListResourceRecordSets","route53:ListTagsForResources"],"Resource":["*"]}]}'
       assumeRolePolicyDocument: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":"arn:aws:iam::111122223333:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E"},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringEquals":{"oidc.eks.us-east-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E:sub":"system:serviceaccount:kube-system:external-dns"}}}]}'
       tags:
       - key: Name


### PR DESCRIPTION
**Notes for Reviewers**

Adds `designs/gitops-eks-pipeline/` — a Meshery design that recreates an end-to-end GitOps architecture (commit to production on a private EKS cluster) as a canvas that renders in Kanvas **and** can be applied to a cluster.

87 components: **57 deployable** and **30 annotations** that carry the diagram's structure — account/region/VPC/subnet boundaries, the CI lane, the external actors — without ever reaching a cluster.

| Layer | What is in it |
|---|---|
| Continuous Integration | GitHub, GitHub Actions, checkout → build → Trivy scan → push, GHCR — annotations; CI has no cluster-side resource |
| AWS network (ACK) | `VPC`, 4 `Subnet`s, `InternetGateway`, `NATGateway`, `ElasticIPAddress`, 2 `RouteTable`s, `SecurityGroup`, bastion `Instance` |
| Cluster | `Cluster` with the public endpoint disabled, plus `Nodegroup` in the private subnets |
| Continuous Delivery | `ArgoCD`, an `Application` carrying the Image Updater annotations, and the `argocd-image-updater` Deployment |
| Ingress | `GatewayClass` → `Gateway` → `HTTPRoute`, AWS Load Balancer Controller, `external-dns`, ACM-terminated listener |
| Application | 4 service Deployments, `redis-cart` / `postgres-orders` StatefulSets, Services, load generator, `HorizontalPodAutoscaler` |
| Logging | ECK — `Elasticsearch`, `Kibana`, `Beat`, operator StatefulSet |
| Monitoring | `Prometheus`, `Alertmanager`, an `AlertmanagerConfig` routing to Slack, `ServiceMonitor`, `PrometheusRule`, Grafana |
| Identity | IAM `Role` for IRSA, `PodIdentityAssociation`, `eks-pod-identity-agent` DaemonSet, IRSA-annotated ServiceAccounts |

**Two provisioning paths, deliberately.** The source architecture provisions AWS with Terraform and keeps state in S3; both stay annotations, because Terraform state is not a cluster resource. The AWS layer is *also* modelled as ACK resources so the design can provision it from a management cluster instead. The README says to pick one, and that the in-cluster half deploys standalone if the VPC and cluster already exist.

**How it was verified**

- Every `(model, kind, apiVersion)` triple resolves against the vendored registry in `models/`, and every `model.version` matches a registry version exactly.
- The file decodes cleanly into the typed `pattern.PatternFile`, with all 57 deployable components carrying a non-empty apiVersion and a namespace.
- Positions were rendered to SVG and checked for overlap against the source layout.

Two things this surfaced, both documented in the README:

- `stages.Validator` resolves *every* component and rejects an empty apiVersion, while annotations are only set aside later in `processAnnotations` during provisioning. A single `meshery-dev-icons` component (those are registered with an empty apiVersion) would therefore abort the whole deploy — fine for a diagram-only design, not for this one. The diagram furniture uses `meshery-shapes` / `meshery-flowchart` instead, which carry `core.meshery.io/v1alpha1`.
- Gateway API components use the `gko` model, the only one in the registry carrying the full `gateway.networking.k8s.io/v1` set.

**Review findings addressed**

- `eafdb16` — the `external-dns-irsa` role granted `AmazonRoute53FullAccess`, applicable as-is straight from the design. Replaced with a scoped inline policy: `route53:ChangeResourceRecordSets` limited to one hosted zone, the three list actions left at `Resource: "*"` because Route 53 cannot resource-scope them.
- `546160a` — the README documented three Secrets but the Argo CD Application also references `pullsecret:argocd/ghcr-creds`. Without it Image Updater cannot read tags from GHCR and the CD half quietly does nothing, so `ghcr-creds` is now documented as a `dockerconfigjson` secret. The other three moved from `--from-literal` to `--from-file` so values stay out of shell history and `ps`.

No secrets are included. Every ARN is a `111122223333` dummy, and the four referenced Secrets are left for the operator to create — the README gives the commands and lists every placeholder to replace.

`relationships` is intentionally empty; Kanvas's relationship evaluation engine derives the edges on load.

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the ACM certificate ARN must be configured in two Gateway locations.
  * Distinguished `shop.example.com` from the parent `example.com` zone and explained their respective uses.
  * Improved GHCR credential setup instructions, including safer temporary directory validation and cleanup.
  * Retained guidance for imports, provisioning options, deployment prerequisites, placeholders, Kubernetes Secrets, and expected modelling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->