### PR TITLE
[UI] Align Technology multi-select checkbox and label horizontally

### DIFF
--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
@@ -5,9 +5,17 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('@sistent/sistent', () => ({
   IconButton: ({ children }: any) => <button>{children}</button>,
   InputAdornment: ({ children }: any) => <div data-testid="adornment">{children}</div>,
-  ListItemText: ({ primary }: any) => <span>{primary}</span>,
-  MenuItem: ({ children, value, disabled }: any) => (
-    <li data-testid="menu-item" data-value={value} data-disabled={String(!!disabled)}>
+  ListItemText: ({ primary, primaryTypographyProps, style }: any) => (
+    <span
+      data-testid="list-item-text"
+      data-nowrap={String(primaryTypographyProps?.noWrap)}
+      style={style}
+    >
+      {primary}
+    </span>
+  ),
+  MenuItem: ({ children, value, disabled, sx }: any) => (
+    <li data-testid="menu-item" data-value={value} data-disabled={String(!!disabled)} style={sx}>
       {children}
     </li>
   ),
@@ -20,28 +28,39 @@ vi.mock('@sistent/sistent', () => ({
     error,
     InputProps,
     SelectProps,
+    slotProps,
     children,
-  }: any) => (
-    <div data-testid="textfield-wrapper" data-id={id}>
-      <input
-        data-testid="textfield"
-        data-error={String(!!error)}
-        data-label={String(label)}
-        value={value ?? ''}
-        disabled={!!disabled}
-        onChange={(e) => onChange(e)}
-      />
-      {InputProps?.endAdornment}
-      <div data-testid="select-children">{children}</div>
-    </div>
-  ),
+  }: any) => {
+    const endAdornment = slotProps?.input?.endAdornment || InputProps?.endAdornment;
+    const selectConfig = slotProps?.select || SelectProps;
+    const renderedDisplay = selectConfig?.renderValue ? selectConfig.renderValue(value) : null;
+    return (
+      <div
+        data-testid="textfield-wrapper"
+        data-id={id}
+        data-multiple={String(selectConfig?.multiple)}
+        data-rendered-value={String(renderedDisplay)}
+      >
+        <input
+          data-testid="textfield"
+          data-error={String(!!error)}
+          data-label={String(label)}
+          value={value ?? ''}
+          disabled={!!disabled}
+          onChange={(e) => onChange(e)}
+        />
+        {endAdornment}
+        <div data-testid="select-children">{children}</div>
+      </div>
+    );
+  },
   InputLabel: ({ children, htmlFor, required }: any) => (
     <label htmlFor={htmlFor} data-required={String(!!required)}>
       {children}
     </label>
   ),
-  Checkbox: ({ checked }: any) => (
-    <input type="checkbox" checked={!!checked} readOnly data-testid="checkbox" />
+  Checkbox: ({ checked, style }: any) => (
+    <input type="checkbox" checked={!!checked} readOnly data-testid="checkbox" style={style} />
   ),
   useTheme: () => ({ palette: { error: { main: '#f00' }, mode: 'light' } }),
 }));
@@ -66,7 +85,16 @@ vi.mock('../CustomTextTooltip', () => ({
 
 vi.mock('@rjsf/utils', () => ({
   ariaDescribedByIds: (id: string) => `desc-${id}`,
-  enumOptionsIndexForValue: (val: any, enumOpts: any[]) => {
+  enumOptionsIndexForValue: (val: any, enumOpts: any[], multiple?: boolean) => {
+    if (multiple) {
+      if (!Array.isArray(val)) return [];
+      return val
+        .map((v) => {
+          const idx = enumOpts.findIndex((o) => o.value === v);
+          return idx === -1 ? null : String(idx);
+        })
+        .filter((i): i is string => i !== null);
+    }
     const idx = enumOpts.findIndex((o) => o.value === val);
     return idx === -1 ? null : String(idx);
   },
@@ -170,5 +198,59 @@ describe('CustomSelectWidget', () => {
     );
     const label = document.querySelector('label[for="s1"]');
     expect(label).not.toBeNull();
+  });
+
+  it('renders checkboxes and tooltips when multiple is true', () => {
+    render(
+      <CustomSelectWidget
+        id="s1"
+        label="Technology"
+        options={{ enumOptions, multiple: true }}
+        schema={{ type: 'array' }}
+        value={['a']}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />,
+    );
+    const checkboxes = screen.getAllByTestId('checkbox');
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+
+    const tooltips = screen.getAllByTestId('tooltip');
+    expect(tooltips).toHaveLength(2);
+    expect(tooltips[0]).toHaveAttribute('data-title', 'Alpha');
+    expect(tooltips[1]).toHaveAttribute('data-title', 'Beta');
+
+    const textItems = screen.getAllByTestId('list-item-text');
+    expect(textItems).toHaveLength(2);
+    expect(textItems[0]).toHaveAttribute('data-nowrap', 'true');
+
+    const wrapper = screen.getByTestId('textfield-wrapper');
+    expect(wrapper).toHaveAttribute('data-multiple', 'true');
+    expect(wrapper).toHaveAttribute('data-rendered-value', 'Alpha');
+  });
+
+  it('renders without checkboxes for single-select fields', () => {
+    render(
+      <CustomSelectWidget
+        id="s1"
+        label="Type"
+        options={{ enumOptions, multiple: false }}
+        schema={{ type: 'string' }}
+        value="a"
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('checkbox')).toBeNull();
+    const tooltips = screen.getAllByTestId('tooltip');
+    expect(tooltips).toHaveLength(2);
+
+    const wrapper = screen.getByTestId('textfield-wrapper');
+    expect(wrapper).toHaveAttribute('data-multiple', 'false');
+    expect(wrapper).toHaveAttribute('data-rendered-value', 'Alpha');
   });
 });

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
@@ -49,6 +49,10 @@ vi.mock('@sistent/sistent', () => ({
         data-multiple={String(selectConfig?.multiple)}
         data-rendered-value={typeof renderedDisplay === 'string' ? renderedDisplay : undefined}
         data-menu-anchor={selectConfig?.MenuProps?.anchorOrigin?.vertical}
+        data-menu-max-height={
+          selectConfig?.MenuProps?.slotProps?.paper?.style?.maxHeight ||
+          selectConfig?.MenuProps?.PaperProps?.style?.maxHeight
+        }
         data-custom-input={inputConfig?.['data-custom-input']}
       >
         <div data-testid="rendered-display">{renderedDisplay}</div>
@@ -318,7 +322,7 @@ describe('CustomSelectWidget', () => {
     expect(wrapper).toHaveAttribute('data-menu-anchor', 'bottom');
   });
 
-  it('deep merges custom MenuProps and retains anchor defaults', () => {
+  it('deep merges custom MenuProps and retains anchor defaults and maxHeight', () => {
     render(
       <CustomSelectWidget
         id="s1"
@@ -330,6 +334,18 @@ describe('CustomSelectWidget', () => {
           select: {
             MenuProps: {
               className: 'custom-menu',
+              PaperProps: {
+                style: {
+                  backgroundColor: 'blue',
+                },
+              },
+              slotProps: {
+                paper: {
+                  style: {
+                    color: 'white',
+                  },
+                },
+              },
             },
           },
         }}
@@ -340,6 +356,7 @@ describe('CustomSelectWidget', () => {
     );
     const wrapper = screen.getByTestId('textfield-wrapper');
     expect(wrapper).toHaveAttribute('data-menu-anchor', 'bottom');
+    expect(wrapper).toHaveAttribute('data-menu-max-height', '400px');
   });
 
   it('preserves and composes caller-provided endAdornment', () => {

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
@@ -31,8 +31,16 @@ vi.mock('@sistent/sistent', () => ({
     slotProps,
     children,
   }: any) => {
-    const endAdornment = slotProps?.input?.endAdornment || InputProps?.endAdornment;
-    const selectConfig = slotProps?.select || SelectProps;
+    const ownerState = { disabled, error, value };
+    const inputConfig =
+      typeof slotProps?.input === 'function'
+        ? slotProps.input(ownerState)
+        : slotProps?.input || InputProps;
+    const selectConfig =
+      typeof slotProps?.select === 'function'
+        ? slotProps.select(ownerState)
+        : slotProps?.select || SelectProps;
+    const endAdornment = inputConfig?.endAdornment;
     const renderedDisplay = selectConfig?.renderValue ? selectConfig.renderValue(value) : null;
     return (
       <div
@@ -40,6 +48,8 @@ vi.mock('@sistent/sistent', () => ({
         data-id={id}
         data-multiple={String(selectConfig?.multiple)}
         data-rendered-value={typeof renderedDisplay === 'string' ? renderedDisplay : undefined}
+        data-menu-anchor={selectConfig?.MenuProps?.anchorOrigin?.vertical}
+        data-custom-input={inputConfig?.['data-custom-input']}
       >
         <div data-testid="rendered-display">{renderedDisplay}</div>
         <input
@@ -282,5 +292,75 @@ describe('CustomSelectWidget', () => {
     expect(within(display).getByTestId('k8s-badge')).toBeInTheDocument();
     expect(within(display).getByTestId('istio-badge')).toBeInTheDocument();
     expect(display).toHaveTextContent('Kubernetes, Istio');
+  });
+
+  it('supports callback-based slotProps functions', () => {
+    render(
+      <CustomSelectWidget
+        id="s1"
+        label="Pick"
+        options={{ enumOptions }}
+        schema={{}}
+        value="a"
+        slotProps={{
+          input: () => ({ 'data-custom-input': 'callback-applied' }),
+          select: () => ({
+            MenuProps: { anchorOrigin: { vertical: 'bottom', horizontal: 'left' } },
+          }),
+        }}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />,
+    );
+    const wrapper = screen.getByTestId('textfield-wrapper');
+    expect(wrapper).toHaveAttribute('data-custom-input', 'callback-applied');
+    expect(wrapper).toHaveAttribute('data-menu-anchor', 'bottom');
+  });
+
+  it('deep merges custom MenuProps and retains anchor defaults', () => {
+    render(
+      <CustomSelectWidget
+        id="s1"
+        label="Pick"
+        options={{ enumOptions }}
+        schema={{}}
+        value="a"
+        slotProps={{
+          select: {
+            MenuProps: {
+              className: 'custom-menu',
+            },
+          },
+        }}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />,
+    );
+    const wrapper = screen.getByTestId('textfield-wrapper');
+    expect(wrapper).toHaveAttribute('data-menu-anchor', 'bottom');
+  });
+
+  it('preserves and composes caller-provided endAdornment', () => {
+    render(
+      <CustomSelectWidget
+        id="s1"
+        label="Pick"
+        options={{ enumOptions }}
+        schema={{ description: 'Some description' }}
+        value="a"
+        slotProps={{
+          input: {
+            endAdornment: <span data-testid="caller-adornment">CUSTOM_ADORNMENT</span>,
+          },
+        }}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('caller-adornment')).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toBeInTheDocument();
   });
 });

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
@@ -60,8 +60,14 @@ vi.mock('@sistent/sistent', () => ({
       {children}
     </label>
   ),
-  Checkbox: ({ checked, style }: any) => (
-    <input type="checkbox" checked={!!checked} readOnly data-testid="checkbox" style={style} />
+  Checkbox: ({ checked, sx, style }: any) => (
+    <input
+      type="checkbox"
+      checked={!!checked}
+      readOnly
+      data-testid="checkbox"
+      style={sx ?? style}
+    />
   ),
   useTheme: () => ({ palette: { error: { main: '#f00' }, mode: 'light' } }),
 }));

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@sistent/sistent', () => ({
@@ -39,8 +39,9 @@ vi.mock('@sistent/sistent', () => ({
         data-testid="textfield-wrapper"
         data-id={id}
         data-multiple={String(selectConfig?.multiple)}
-        data-rendered-value={String(renderedDisplay)}
+        data-rendered-value={typeof renderedDisplay === 'string' ? renderedDisplay : undefined}
       >
+        <div data-testid="rendered-display">{renderedDisplay}</div>
         <input
           data-testid="textfield"
           data-error={String(!!error)}
@@ -229,7 +230,7 @@ describe('CustomSelectWidget', () => {
 
     const wrapper = screen.getByTestId('textfield-wrapper');
     expect(wrapper).toHaveAttribute('data-multiple', 'true');
-    expect(wrapper).toHaveAttribute('data-rendered-value', 'Alpha');
+    expect(screen.getByTestId('rendered-display')).toHaveTextContent('Alpha');
   });
 
   it('renders without checkboxes for single-select fields', () => {
@@ -251,6 +252,29 @@ describe('CustomSelectWidget', () => {
 
     const wrapper = screen.getByTestId('textfield-wrapper');
     expect(wrapper).toHaveAttribute('data-multiple', 'false');
-    expect(wrapper).toHaveAttribute('data-rendered-value', 'Alpha');
+    expect(screen.getByTestId('rendered-display')).toHaveTextContent('Alpha');
+  });
+
+  it('preserves React-element labels when rendering multiple selected options', () => {
+    const customEnumOptions = [
+      { value: 'k8s', label: <span data-testid="k8s-badge">Kubernetes</span> },
+      { value: 'istio', label: <span data-testid="istio-badge">Istio</span> },
+    ];
+    render(
+      <CustomSelectWidget
+        id="s1"
+        label="Technology"
+        options={{ enumOptions: customEnumOptions, multiple: true }}
+        schema={{ type: 'array' }}
+        value={['k8s', 'istio']}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />,
+    );
+    const display = screen.getByTestId('rendered-display');
+    expect(within(display).getByTestId('k8s-badge')).toBeInTheDocument();
+    expect(within(display).getByTestId('istio-badge')).toBeInTheDocument();
+    expect(display).toHaveTextContent('Kubernetes, Istio');
   });
 });

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -107,14 +107,21 @@ export default function CustomSelectWidget({
         size="small"
         slotProps={{
           ...incomingSlotProps,
-          input: {
-            ...legacyInputProps,
-            ...incomingSlotProps.input,
-            style: {
-              paddingRight: '0px',
-              ...(incomingSlotProps.input?.style || legacyInputProps?.style),
-            },
-            endAdornment: (
+          input: (ownerState: any) => {
+            const resolvedIncoming =
+              typeof incomingSlotProps.input === 'function'
+                ? incomingSlotProps.input(ownerState)
+                : incomingSlotProps.input || {};
+            const resolvedLegacy =
+              typeof legacyInputProps === 'function'
+                ? legacyInputProps(ownerState)
+                : legacyInputProps || {};
+            const callerEndAdornment = resolvedIncoming.endAdornment || resolvedLegacy.endAdornment;
+            const hasWidgetAdornment =
+              rawErrors?.length > 0 ||
+              (typeof schema?.description === 'string' && !!schema.description);
+
+            const widgetAdornment = hasWidgetAdornment ? (
               <InputAdornment position="start" style={{ position: 'absolute', right: '1rem' }}>
                 {rawErrors?.length > 0 && (
                   <CustomTextTooltip
@@ -150,51 +157,110 @@ export default function CustomSelectWidget({
                   </CustomTextTooltip>
                 )}
               </InputAdornment>
-            ),
-          },
-          inputLabel: {
-            ...legacyInputLabelProps,
-            ...incomingSlotProps.inputLabel,
-            shrink: !isEmpty,
-          },
-          select: {
-            MenuProps: {
-              anchorOrigin: {
-                vertical: 'bottom',
-                horizontal: 'left',
+            ) : null;
+
+            const finalEndAdornment =
+              callerEndAdornment && widgetAdornment ? (
+                <>
+                  {callerEndAdornment}
+                  {widgetAdornment}
+                </>
+              ) : (
+                callerEndAdornment || widgetAdornment
+              );
+
+            return {
+              ...resolvedLegacy,
+              ...resolvedIncoming,
+              style: {
+                ...resolvedLegacy?.style,
+                ...resolvedIncoming?.style,
+                paddingRight: '0px',
               },
-              transformOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
+              endAdornment: finalEndAdornment,
+            };
+          },
+          inputLabel: (ownerState: any) => {
+            const resolvedIncoming =
+              typeof incomingSlotProps.inputLabel === 'function'
+                ? incomingSlotProps.inputLabel(ownerState)
+                : incomingSlotProps.inputLabel || {};
+            const resolvedLegacy =
+              typeof legacyInputLabelProps === 'function'
+                ? legacyInputLabelProps(ownerState)
+                : legacyInputLabelProps || {};
+            return {
+              ...resolvedLegacy,
+              ...resolvedIncoming,
+              shrink: !isEmpty,
+            };
+          },
+          select: (ownerState: any) => {
+            const resolvedIncoming =
+              typeof incomingSlotProps.select === 'function'
+                ? incomingSlotProps.select(ownerState)
+                : incomingSlotProps.select || {};
+            const resolvedLegacy =
+              typeof legacySelectProps === 'function'
+                ? legacySelectProps(ownerState)
+                : legacySelectProps || {};
+            const incomingMenuProps = resolvedIncoming.MenuProps || resolvedLegacy.MenuProps || {};
+            const incomingPaperSlot = incomingMenuProps.slotProps?.paper || {};
+            const incomingPaperProps = incomingMenuProps.PaperProps || {};
+
+            return {
+              ...resolvedLegacy,
+              ...resolvedIncoming,
+              multiple: isMultiple,
+              renderValue: (selected: any) => {
+                if (isMultiple && Array.isArray(selected)) {
+                  return selected.map((i: any, index: number) => {
+                    const rawLabel = enumOptions?.[i]?.label;
+                    const labelNode = React.isValidElement(rawLabel)
+                      ? rawLabel
+                      : safeDisplayValue(rawLabel);
+                    return (
+                      <React.Fragment key={i}>
+                        {labelNode}
+                        {index < selected.length - 1 ? ', ' : ''}
+                      </React.Fragment>
+                    );
+                  });
+                }
+                const idx = selected as number;
+                const rawLabel = enumOptions?.[idx]?.label;
+                return React.isValidElement(rawLabel) ? rawLabel : safeDisplayValue(rawLabel);
               },
-              PaperProps: {
-                style: {
-                  maxHeight: '400px',
+              MenuProps: {
+                anchorOrigin: {
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                },
+                transformOrigin: {
+                  vertical: 'top',
+                  horizontal: 'left',
+                },
+                ...incomingMenuProps,
+                PaperProps: {
+                  style: {
+                    maxHeight: '400px',
+                    ...incomingPaperProps.style,
+                  },
+                  ...incomingPaperProps,
+                },
+                slotProps: {
+                  ...incomingMenuProps.slotProps,
+                  paper: {
+                    style: {
+                      maxHeight: '400px',
+                      ...incomingPaperSlot.style,
+                      ...incomingPaperProps.style,
+                    },
+                    ...incomingPaperSlot,
+                  },
                 },
               },
-            },
-            ...legacySelectProps,
-            ...incomingSlotProps.select,
-            multiple: isMultiple,
-            renderValue: (selected) => {
-              if (isMultiple && Array.isArray(selected)) {
-                return selected.map((i, index) => {
-                  const rawLabel = enumOptions?.[i]?.label;
-                  const labelNode = React.isValidElement(rawLabel)
-                    ? rawLabel
-                    : safeDisplayValue(rawLabel);
-                  return (
-                    <React.Fragment key={i}>
-                      {labelNode}
-                      {index < selected.length - 1 ? ', ' : ''}
-                    </React.Fragment>
-                  );
-                });
-              }
-              const idx = selected as number;
-              const rawLabel = enumOptions?.[idx]?.label;
-              return React.isValidElement(rawLabel) ? rawLabel : safeDisplayValue(rawLabel);
-            },
+            };
           },
         }}
         {...cleanTextFieldProps}

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -242,21 +242,21 @@ export default function CustomSelectWidget({
                 },
                 ...incomingMenuProps,
                 PaperProps: {
-                  style: {
-                    maxHeight: '400px',
-                    ...incomingPaperProps.style,
-                  },
                   ...incomingPaperProps,
+                  style: {
+                    ...incomingPaperProps.style,
+                    maxHeight: '400px',
+                  },
                 },
                 slotProps: {
                   ...incomingMenuProps.slotProps,
                   paper: {
-                    style: {
-                      maxHeight: '400px',
-                      ...incomingPaperSlot.style,
-                      ...incomingPaperProps.style,
-                    },
                     ...incomingPaperSlot,
+                    style: {
+                      ...incomingPaperProps.style,
+                      ...incomingPaperSlot.style,
+                      maxHeight: '400px',
+                    },
                   },
                 },
               },

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -158,10 +158,22 @@ export default function CustomSelectWidget({
             multiple: isMultiple,
             renderValue: (selected) => {
               if (isMultiple && Array.isArray(selected)) {
-                return selected.map((i) => safeDisplayValue(enumOptions?.[i]?.label)).join(', ');
+                return selected.map((i, index) => {
+                  const rawLabel = enumOptions?.[i]?.label;
+                  const labelNode = React.isValidElement(rawLabel)
+                    ? rawLabel
+                    : safeDisplayValue(rawLabel);
+                  return (
+                    <React.Fragment key={i}>
+                      {labelNode}
+                      {index < selected.length - 1 ? ', ' : ''}
+                    </React.Fragment>
+                  );
+                });
               }
               const idx = selected as number;
-              return safeDisplayValue(enumOptions?.[idx]?.label);
+              const rawLabel = enumOptions?.[idx]?.label;
+              return React.isValidElement(rawLabel) ? rawLabel : safeDisplayValue(rawLabel);
             },
             MenuProps: {
               anchorOrigin: {
@@ -189,7 +201,7 @@ export default function CustomSelectWidget({
         {Array.isArray(enumOptions) &&
           enumOptions.map(({ value, label }, i) => {
             const disabled = Array.isArray(enumDisabled) && enumDisabled?.indexOf(value) !== -1;
-            const optionLabel = safeDisplayValue(label);
+            const optionLabel = React.isValidElement(label) ? label : safeDisplayValue(label);
             return (
               <MenuItem
                 key={i}

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -150,11 +150,28 @@ export default function CustomSelectWidget({
             ...incomingSlotProps.input,
           },
           inputLabel: {
-            shrink: !isEmpty,
             ...legacyInputLabelProps,
             ...incomingSlotProps.inputLabel,
+            shrink: !isEmpty,
           },
           select: {
+            MenuProps: {
+              anchorOrigin: {
+                vertical: 'bottom',
+                horizontal: 'left',
+              },
+              transformOrigin: {
+                vertical: 'top',
+                horizontal: 'left',
+              },
+              PaperProps: {
+                style: {
+                  maxHeight: '400px',
+                },
+              },
+            },
+            ...legacySelectProps,
+            ...incomingSlotProps.select,
             multiple: isMultiple,
             renderValue: (selected) => {
               if (isMultiple && Array.isArray(selected)) {
@@ -175,23 +192,6 @@ export default function CustomSelectWidget({
               const rawLabel = enumOptions?.[idx]?.label;
               return React.isValidElement(rawLabel) ? rawLabel : safeDisplayValue(rawLabel);
             },
-            MenuProps: {
-              anchorOrigin: {
-                vertical: 'bottom',
-                horizontal: 'left',
-              },
-              transformOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
-              },
-              PaperProps: {
-                style: {
-                  maxHeight: '400px',
-                },
-              },
-            },
-            ...legacySelectProps,
-            ...incomingSlotProps.select,
           },
         }}
         {...cleanTextFieldProps}
@@ -207,7 +207,7 @@ export default function CustomSelectWidget({
                 key={i}
                 value={String(i)}
                 disabled={disabled}
-                style={{
+                sx={{
                   display: 'flex',
                   flexDirection: 'row',
                   alignItems: 'center',
@@ -215,25 +215,16 @@ export default function CustomSelectWidget({
                   gap: '0.5rem',
                   paddingRight: '2rem',
                 }}
-                sx={{
-                  display: 'flex !important',
-                  flexDirection: 'row !important',
-                  alignItems: 'center !important',
-                  flexWrap: 'nowrap !important',
-                  gap: '0.5rem !important',
-                  paddingRight: '2rem !important',
-                }}
               >
                 {isMultiple && (
                   <Checkbox
                     checked={
                       Array.isArray(selectedIndexes) ? selectedIndexes.includes(String(i)) : false
                     }
-                    style={{ padding: 0, flexShrink: 0, marginRight: '0.25rem' }}
                     sx={{
-                      padding: '0 !important',
-                      flexShrink: '0 !important',
-                      marginRight: '0.25rem !important',
+                      padding: 0,
+                      flexShrink: 0,
+                      marginRight: '0.25rem',
                     }}
                   />
                 )}

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -44,6 +44,14 @@ export default function CustomSelectWidget({
   formContext,
   ...textFieldProps
 }) {
+  const {
+    InputProps: legacyInputProps,
+    InputLabelProps: legacyInputLabelProps,
+    SelectProps: legacySelectProps,
+    slotProps: incomingSlotProps = {},
+    ...cleanTextFieldProps
+  } = textFieldProps;
+
   const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;
   const xRjsfGridArea = schema?.['x-rjsf-grid-area']; // check if the field is used in different modal (e.g. publish)
 
@@ -97,88 +105,149 @@ export default function CustomSelectWidget({
         onBlur={_onBlur}
         onFocus={_onFocus}
         size="small"
-        InputProps={{
-          style: { paddingRight: '0px' },
-          endAdornment: (
-            <InputAdornment position="start" style={{ position: 'absolute', right: '1rem' }}>
-              {rawErrors?.length > 0 && (
-                <CustomTextTooltip
-                  bgColor={theme.palette.error.main}
-                  flag={formContext?.overrideFlag}
-                  title={rawErrors?.join('  ')}
-                  interactive={true}
-                >
-                  <IconButton component="span" size="small">
-                    <ErrorOutlineIcon
-                      width="14px"
-                      height="14px"
-                      fill={theme.palette.error.main}
-                      style={{ verticalAlign: 'middle', ...iconSmall }}
-                    />
-                  </IconButton>
-                </CustomTextTooltip>
-              )}
-              {typeof schema?.description === 'string' && schema.description && (
-                <CustomTextTooltip
-                  flag={formContext?.overrideFlag}
-                  title={schema.description}
-                  interactive={true}
-                >
-                  <IconButton component="span" size="small" style={{ marginRight: '4px' }}>
-                    <HelpOutlineIcon
-                      width="14px"
-                      height="14px"
-                      fill={theme.palette.mode === 'dark' ? 'white' : 'gray'}
-                      style={{ verticalAlign: 'middle', ...iconSmall }}
-                    />
-                  </IconButton>
-                </CustomTextTooltip>
-              )}
-            </InputAdornment>
-          ),
-        }}
-        {...textFieldProps}
-        select
-        InputLabelProps={{
-          ...textFieldProps.InputLabelProps,
-          shrink: !isEmpty,
-        }}
-        SelectProps={{
-          ...textFieldProps.SelectProps,
-          renderValue: (selected) => {
-            if (isMultiple && Array.isArray(selected)) {
-              return selected.map((i) => safeDisplayValue(enumOptions?.[i]?.label)).join(', ');
-            }
-            const idx = selected as number;
-            return safeDisplayValue(enumOptions?.[idx]?.label);
+        slotProps={{
+          ...incomingSlotProps,
+          input: {
+            style: { paddingRight: '0px' },
+            endAdornment: (
+              <InputAdornment position="start" style={{ position: 'absolute', right: '1rem' }}>
+                {rawErrors?.length > 0 && (
+                  <CustomTextTooltip
+                    bgColor={theme.palette.error.main}
+                    flag={formContext?.overrideFlag}
+                    title={rawErrors?.join('  ')}
+                    interactive={true}
+                  >
+                    <IconButton component="span" size="small">
+                      <ErrorOutlineIcon
+                        width="14px"
+                        height="14px"
+                        fill={theme.palette.error.main}
+                        style={{ verticalAlign: 'middle', ...iconSmall }}
+                      />
+                    </IconButton>
+                  </CustomTextTooltip>
+                )}
+                {typeof schema?.description === 'string' && schema.description && (
+                  <CustomTextTooltip
+                    flag={formContext?.overrideFlag}
+                    title={schema.description}
+                    interactive={true}
+                  >
+                    <IconButton component="span" size="small" style={{ marginRight: '4px' }}>
+                      <HelpOutlineIcon
+                        width="14px"
+                        height="14px"
+                        fill={theme.palette.mode === 'dark' ? 'white' : 'gray'}
+                        style={{ verticalAlign: 'middle', ...iconSmall }}
+                      />
+                    </IconButton>
+                  </CustomTextTooltip>
+                )}
+              </InputAdornment>
+            ),
+            ...legacyInputProps,
+            ...incomingSlotProps.input,
           },
-          multiple: isMultiple,
-          MenuProps: {
-            anchorOrigin: {
-              vertical: 'bottom',
-              horizontal: 'left',
+          inputLabel: {
+            shrink: !isEmpty,
+            ...legacyInputLabelProps,
+            ...incomingSlotProps.inputLabel,
+          },
+          select: {
+            multiple: isMultiple,
+            renderValue: (selected) => {
+              if (isMultiple && Array.isArray(selected)) {
+                return selected.map((i) => safeDisplayValue(enumOptions?.[i]?.label)).join(', ');
+              }
+              const idx = selected as number;
+              return safeDisplayValue(enumOptions?.[idx]?.label);
             },
-            transformOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            getContentAnchorEl: null,
-            PaperProps: {
-              style: {
-                maxHeight: '400px',
+            MenuProps: {
+              anchorOrigin: {
+                vertical: 'bottom',
+                horizontal: 'left',
+              },
+              transformOrigin: {
+                vertical: 'top',
+                horizontal: 'left',
+              },
+              PaperProps: {
+                style: {
+                  maxHeight: '400px',
+                },
               },
             },
+            ...legacySelectProps,
+            ...incomingSlotProps.select,
           },
         }}
+        {...cleanTextFieldProps}
+        select
         aria-describedby={ariaDescribedByIds(id)}
       >
         {Array.isArray(enumOptions) &&
           enumOptions.map(({ value, label }, i) => {
             const disabled = Array.isArray(enumDisabled) && enumDisabled?.indexOf(value) !== -1;
+            const optionLabel = safeDisplayValue(label);
             return (
-              <MenuItem key={i} value={String(i)} disabled={disabled}>
-                {isMultiple && <Checkbox checked={selectedIndexes?.indexOf(String(i)) !== -1} />}
-                <ListItemText primary={safeDisplayValue(label)} />
+              <MenuItem
+                key={i}
+                value={String(i)}
+                disabled={disabled}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  flexWrap: 'nowrap',
+                  gap: '0.5rem',
+                  paddingRight: '2rem',
+                }}
+                sx={{
+                  display: 'flex !important',
+                  flexDirection: 'row !important',
+                  alignItems: 'center !important',
+                  flexWrap: 'nowrap !important',
+                  gap: '0.5rem !important',
+                  paddingRight: '2rem !important',
+                }}
+              >
+                {isMultiple && (
+                  <Checkbox
+                    checked={
+                      Array.isArray(selectedIndexes) ? selectedIndexes.includes(String(i)) : false
+                    }
+                    style={{ padding: 0, flexShrink: 0, marginRight: '0.25rem' }}
+                    sx={{
+                      padding: '0 !important',
+                      flexShrink: '0 !important',
+                      marginRight: '0.25rem !important',
+                    }}
+                  />
+                )}
+                <CustomTextTooltip
+                  flag={formContext?.overrideFlag}
+                  title={optionLabel}
+                  interactive={true}
+                >
+                  <ListItemText
+                    primary={optionLabel}
+                    primaryTypographyProps={{
+                      noWrap: true,
+                      style: {
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      },
+                    }}
+                    style={{
+                      margin: 0,
+                      minWidth: 0,
+                      flex: '1 1 auto',
+                      overflow: 'hidden',
+                    }}
+                  />
+                </CustomTextTooltip>
               </MenuItem>
             );
           })}

--- a/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
+++ b/ui/components/meshery-mesh-interface/PatternService/RJSFCustomComponents/CustomSelectWidget.tsx
@@ -108,7 +108,12 @@ export default function CustomSelectWidget({
         slotProps={{
           ...incomingSlotProps,
           input: {
-            style: { paddingRight: '0px' },
+            ...legacyInputProps,
+            ...incomingSlotProps.input,
+            style: {
+              paddingRight: '0px',
+              ...(incomingSlotProps.input?.style || legacyInputProps?.style),
+            },
             endAdornment: (
               <InputAdornment position="start" style={{ position: 'absolute', right: '1rem' }}>
                 {rawErrors?.length > 0 && (
@@ -146,8 +151,6 @@ export default function CustomSelectWidget({
                 )}
               </InputAdornment>
             ),
-            ...legacyInputProps,
-            ...incomingSlotProps.input,
           },
           inputLabel: {
             ...legacyInputLabelProps,


### PR DESCRIPTION
**Description**

This PR resolves #21042 by properly aligning the multi-select checkbox and label horizontally in the Technology dropdown and fixing closed-field rendering.

- Migrated `CustomSelectWidget`'s `TextField` to use `slotProps` (`slotProps.select`, `slotProps.input`, `slotProps.inputLabel`) for full compatibility with `@mui/material` v6.
- Fixed the issue where `renderValue` was ignored, which previously caused the checkbox and label to leak into and stack vertically within the closed select input box.
- Aligned `MenuItem` elements horizontally (`flex-direction: row`, `gap: 0.5rem`).
- Added ellipsis text truncation and hover tooltip (`CustomTextTooltip`) for long technology labels.
- Added and updated unit tests in `CustomSelectWidget.test.tsx`.

---

### **Visual Changes**

#### **Before**
<img width="1512" height="982" alt="Before - Vertically stacked checkbox and text" src="https://github.com/user-attachments/assets/f1ad8fc9-a26f-433b-aa67-3b5b5e0eaf43" />

#### **After**
<img width="1512" height="982" alt="After - Horizontally aligned and clean input" src="https://github.com/user-attachments/assets/b950c6d0-60c7-4b0b-9dc7-d5e700bcde6e" />

---

**Fixes**
Fixes #21042


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved custom select rendering for single- and multiple-selection fields.
  - Preserved input adornments, label behavior, select settings, and rich option labels.
  - Added clearer option labels, tooltips, responsive layouts, and consistent checkbox styling.
  - Improved compatibility with existing select and input configurations.
  - Removed outdated select configuration.

- **Tests**
  - Added coverage for multiple-select checkboxes, tooltips, compact labels, and rendered values.
  - Confirmed single-select fields render without checkboxes.
  - Verified custom menu settings, callback-based configuration, and adornment composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->