### PR TITLE
fix(ui): raise design action dropdown above the sticky toolbar

### DIFF
--- a/ui/components/designs/patterns/ActionButton.tsx
+++ b/ui/components/designs/patterns/ActionButton.tsx
@@ -71,7 +71,7 @@ export default function ActionButton({
       </ButtonGroup>
       <Popper
         sx={{
-          zIndex: 1,
+          zIndex: (theme) => theme.zIndex.modal,
         }}
         open={open}
         anchorEl={anchorRef.current}

--- a/ui/components/designs/patterns/ActionPopover.tsx
+++ b/ui/components/designs/patterns/ActionPopover.tsx
@@ -44,7 +44,7 @@ const ActionPopover = ({ actions = [] }) => {
 
       <ClickAwayListener mouseEvent="onMouseDown" onClickAway={handleClose}>
         <Popper
-          sx={{ zIndex: 1 }}
+          sx={{ zIndex: (theme) => theme.zIndex.modal }}
           open={open}
           anchorEl={anchorRef.current}
           placement="bottom-start"


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21728

### Root cause

Both `ActionButton.tsx` and `ActionPopover.tsx` render their `<Popper>` with `sx={{ zIndex: 1 }}` — the same defect duplicated in two files.

Measured in production with the dropdown open:

| Element | z-index |
|---|---|
| Action dropdown Popper | **1** |
| `header` AppBar (sticky toolbar) | **1100** |
| Drawer | 1200 |
| Floating button | 1400 |

The Popper sits below the entire layout chrome. It also flips upward when there is no room below (measured: button at top=553, menu drawn from 325 to 553), which is what puts it behind the toolbar on short viewports.

### Change

`zIndex: 1` → `zIndex: (theme) => theme.zIndex.modal` (= 1300)

This is the value MUI's own `Menu` uses for its popup: above the app bar and drawer, below snackbars and tooltips — where a floating menu belongs. Using the theme token instead of a magic number keeps it in sync if the layout stacking changes later.

One line per file. `prettier --check` passes with the repo config.

### Note

I did not manage to capture a screenshot of the overlap itself — I could not shrink the browser window enough for the menu to actually reach the toolbar. The z-index measurements above are from the live playground and identify the cause; happy to produce a capture on a proper mobile viewport if a reviewer wants one.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed action menus and popovers appearing behind modal overlays.
  * Updated their display layering to ensure they remain visible above dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->