### PR TITLE
fix(ui): allow the tool wrapper to wrap on small screens

### DIFF
--- a/ui/assets/styles/general/tool.styles.tsx
+++ b/ui/assets/styles/general/tool.styles.tsx
@@ -11,6 +11,11 @@ export const ToolWrapper = styled(Box)(({ theme }) => ({
   borderRadius: '0.5rem',
   position: 'relative',
   zIndex: '101',
+  [theme.breakpoints.down('sm')]: {
+    height: 'auto',
+    flexWrap: 'wrap',
+    gap: '0.5rem',
+  },
 }));
 
 export const WorkloadsContainer = styled('div')(() => ({


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21727

### Scope — please read

`ToolWrapper` is shared by **8 pages**: Designs, Filters, Environments, Workspaces, Performance, Credentials, Dashboard resources and DatabaseSummary. The overflow affects all of them, so this one change fixes all of them.

The new rules live entirely inside `theme.breakpoints.down('sm')`, so **desktop rendering is unchanged**. If you'd rather keep the fix scoped to the Designs toolbar only, say so and I'll narrow it.

### Root cause

`ui/assets/styles/general/tool.styles.tsx` → `ToolWrapper`:

- fixed `height: '4rem'`
- `display: flex` with `justifyContent: 'space-between'`
- **no `flexWrap`, and no breakpoints at all**

With no way to wrap, the children overflow the container instead of moving to a second row. On the Designs page that pushes the search, filter and view controls outside the toolbar and leaves the blank area described in the issue.

Measured on the playground with the toolbar at 390px:

| | |
|---|---|
| visible width | 390px |
| actual content | 508px |
| **overflow** | **118px** |

The search block ends at x=800 while the toolbar ends at x=682.

### Change

```js
[theme.breakpoints.down('sm')]: {
  height: 'auto',
  flexWrap: 'wrap',
  gap: '0.5rem',
},
```

This is the same treatment `MeshModelToolbar` already uses in this very file — the pattern already exists in the codebase, this just applies it to the toolbar that was missing it.

After: overflow is **0**, the children stack (top 159 and 207) and the toolbar grows from 64px to 110px instead of clipping. I verified `flexWrap` alone is enough — no `minWidth: 0` on the children was needed, keeping the diff at 5 lines.

`prettier --check` passes with the repo config.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the tool layout on small screens by allowing items to wrap naturally with appropriate spacing.
  * Tool containers now adjust their height automatically for better mobile responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->