### PR TITLE
[UI] Fix badge overlapping with creator's name on mobile

### DIFF
--- a/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
+++ b/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
@@ -408,7 +408,7 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
             </Grid>
             <Grid size={{ xs: 8, lg: 'grow' }}>
               <Grid container spacing={2}>
-                <Grid size={6}>
+                <Grid size={{ xs: 12, sm: 6 }}>
                   <Typography gutterBottom variant="subtitle1">
                     <CustomTooltip
                       title={
@@ -427,8 +427,8 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
                   </Typography>
                 </Grid>
                 <Grid
-                  size={6}
-                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}
+                  size={{ xs: 12, sm: 6 }}
+                  sx={{ display: 'flex', alignItems: 'center', justifyContent: { xs: 'flex-start', sm: 'flex-end' } }}
                 >
                   <Typography
                     gutterBottom

--- a/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
+++ b/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
@@ -428,7 +428,11 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
                 </Grid>
                 <Grid
                   size={{ xs: 12, sm: 6 }}
-                  sx={{ display: 'flex', alignItems: 'center', justifyContent: { xs: 'flex-start', sm: 'flex-end' } }}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: { xs: 'flex-start', sm: 'flex-end' },
+                  }}
                 >
                   <Typography
                     gutterBottom

--- a/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
+++ b/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
@@ -431,7 +431,10 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
-                    justifyContent: { xs: 'flex-start', sm: 'flex-end' },
+                    justifyContent: {
+                      xs: 'flex-start',
+                      sm: 'flex-end',
+                    },
                   }}
                 >
                   <Typography


### PR DESCRIPTION
Fixes #21730

**Notes for Reviewers**

- This PR fixes On small/mobile screens, the PUBLIC/PRIVATE visibility badge/control in Meshery's legacy information modal could overlap or crowd the creator's name.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the legacy information modal’s visibility-control layout for responsive display.
  * Controls now stack on smaller screens and align appropriately on larger screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->