### PR TITLE
[UI] Fix Dry Run content overflow on small screens

### DIFF
--- a/ui/components/designs/lifecycle/styles.tsx
+++ b/ui/components/designs/lifecycle/styles.tsx
@@ -40,6 +40,7 @@ export const DryRunComponentStyled = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.card,
   color: theme.palette.text.default,
   marginBlock: '0.5rem',
+  wordBreak: 'break-word',
 }));
 
 export const DryRunComponentLabel = styled(ListItem)(({ theme }) => ({
@@ -73,10 +74,12 @@ export const DryRunRootListStyled = styled(List)({
   width: '100%',
   position: 'relative',
   marginBottom: '0.5rem',
+  overflowX: 'auto',
 });
 
 export const DryRunSignleError = styled(ListItemText)(({ theme }) => ({
   paddingInline: theme.spacing(1),
   paddingBlock: theme.spacing(1),
   marginInline: theme.spacing(0.5),
+  wordBreak: 'break-word',
 }));


### PR DESCRIPTION
Fixes #21729

**Notes for Reviewers**

- This PR fixes When Meshery shows Dry Run results on a small/mobile screen, the content can be too wide and spill outside the screen.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dry-run result display by enabling horizontal scrolling for wide content.
  * Long error messages and component content now wrap within the available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->