### PR TITLE
[CI] Document reusable-workflow traps for external callers, and fix three live instances

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'push' }}
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: "[Meshery] Sync Go Unit Test Results - ${GITHUB_SHA}"
+          commit_message: "[Meshery] Sync Go Unit Test Results - ${{ github.sha }}"
           commit_options: "--signoff"
           repository: qa
           commit_user_name: meshery-ci
@@ -192,7 +192,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'push' }}
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: "[Mesheryctl] Sync Go Unit Test Results - ${GITHUB_SHA}"
+          commit_message: "[Mesheryctl] Sync Go Unit Test Results - ${{ github.sha }}"
           commit_options: "--signoff"
           repository: qa
           commit_user_name: meshery-ci

--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -244,7 +244,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'push' && matrix.publish_to_qa == true }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "[mesheryctl] Sync mesheryctl E2E Test Results - ${GITHUB_SHA}"
+          commit_message: "[mesheryctl] Sync mesheryctl E2E Test Results - ${{ github.sha }}"
           commit_options: "--signoff"
           repository: qa
           commit_user_name: meshery-ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,7 +488,7 @@ both of which have shipped as silent no-ops:
   decision, not a repair.
 
 Before editing a shared workflow, find its callers:
-`gh-axi api -X GET search/code -f q='<workflow-file> path:.github/workflows'`. A caller having
+`gh-axi api -X GET search/code --field q='<workflow-file> path:.github/workflows'`. A caller having
 zero runs (no matching tags/releases) means changes there are untested by CI - verify by
 reading, not by waiting for a green check.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,7 +488,7 @@ both of which have shipped as silent no-ops:
   decision, not a repair.
 
 Before editing a shared workflow, find its callers:
-`gh api -X GET search/code -f q='<workflow-file> path:.github/workflows'`. A caller having
+`gh-axi api -X GET search/code -f q='<workflow-file> path:.github/workflows'`. A caller having
 zero runs (no matching tags/releases) means changes there are untested by CI - verify by
 reading, not by waiting for a green check.
 
@@ -506,6 +506,7 @@ worked detail behind them — open the one that matches what you are working on.
 | MeshKit error codes | [How to write MeshKit compatible errors](./docs/content/en/project/contributing/contributing-error.md) |
 | A Go lint rule firing, or adding one | [Go Lint Rules](./docs/content/en/project/contributing/contributing-lint.md) |
 | Releases, CI secrets, the QA dashboard | [Build & Release (CI)](./docs/content/en/project/contributing/build-and-release.md) |
+| A reusable workflow called from another repo | [Build & Release (CI)](./docs/content/en/project/contributing/build-and-release.md) |
 | Connections and credential secrets | [Connections](./docs/content/en/project/contributing/models/connections.md) |
 | A permission-gated page, control or key | [Extensibility: Authorization](./docs/content/en/reference/extensibility/authorization/index.md) |
 | Providers, `PROVIDER` enforcement, boot-time seeding | [Extensibility: Providers](./docs/content/en/reference/extensibility/providers/index.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,7 +475,7 @@ touching any of them.
 `meshery-extensions` via `uses: meshery/meshery/.github/workflows/<file>@master`. Two traps,
 both of which have shipped as silent no-ops:
 
-- **`with:` values are Actions expressions, not shell.** `${GITHUB_REF/refs\/tags\//}` or a
+- **`with:` values are not evaluated by a shell.** Only `${{ ... }}` expressions are evaluated; `${GITHUB_REF/refs\/tags\//}` or a
   bare `${GITHUB_SHA}` in a `with:` value is forwarded verbatim - GitHub never evaluates it.
   Use `${{ github.ref_name }}` / `${{ github.sha }}`. The same substitution inside a `run:`
   step is correct, because a shell evaluates it there; don't "fix" those.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,6 +469,27 @@ touching any of them.
 - Hooks in `.agents/hooks/`: `format-frontend.sh` (post-edit Prettier) and
   `block-lockfiles.sh` (pre-edit lock-file guard).
 
+## Reusable Workflows Consumed by Other Repos
+
+`.github/workflows/*.yaml` here are called by repos across `meshery` and `meshery-extensions`
+via `uses: meshery/meshery/.github/workflows/<file>@master`. Two traps, both of which have
+shipped as silent no-ops:
+
+- **`with:` values are Actions expressions, not shell.** `${GITHUB_REF/refs\/tags\//}` in a
+  `with:` value is forwarded verbatim - GitHub never evaluates it. Use `${{ github.ref_name }}`.
+  The same substitution inside a `run:` step is correct, because a shell evaluates it there;
+  don't "fix" those. `build-and-release-stable.yml` contains both forms.
+- **`if: github.repository == 'meshery/meshery'` disables the job for every external caller.**
+  In a reusable workflow the `github` context is the *caller's*, so this guard is false from
+  any other repo. Jobs in caller files carry it too, and a job whose `needs:` dependency is
+  skipped is itself skipped. Changing such a guard activates dormant deploys - a product
+  decision, not a repair.
+
+Before editing a shared workflow, find its callers:
+`gh api -X GET search/code -f q='<workflow-file> path:.github/workflows'`. A caller having
+zero runs (no matching tags/releases) means changes there are untested by CI - verify by
+reading, not by waiting for a green check.
+
 ## Further Reading
 
 The rules above are complete on their own. These files hold the reasoning, evidence and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,14 +471,16 @@ touching any of them.
 
 ## Reusable Workflows Consumed by Other Repos
 
-`.github/workflows/*.yaml` here are called by repos across `meshery` and `meshery-extensions`
-via `uses: meshery/meshery/.github/workflows/<file>@master`. Two traps, both of which have
-shipped as silent no-ops:
+`.github/workflows/*.{yml,yaml}` here are called by repos across `meshery` and
+`meshery-extensions` via `uses: meshery/meshery/.github/workflows/<file>@master`. Two traps,
+both of which have shipped as silent no-ops:
 
-- **`with:` values are Actions expressions, not shell.** `${GITHUB_REF/refs\/tags\//}` in a
-  `with:` value is forwarded verbatim - GitHub never evaluates it. Use `${{ github.ref_name }}`.
-  The same substitution inside a `run:` step is correct, because a shell evaluates it there;
-  don't "fix" those. `build-and-release-stable.yml` contains both forms.
+- **`with:` values are Actions expressions, not shell.** `${GITHUB_REF/refs\/tags\//}` or a
+  bare `${GITHUB_SHA}` in a `with:` value is forwarded verbatim - GitHub never evaluates it.
+  Use `${{ github.ref_name }}` / `${{ github.sha }}`. The same substitution inside a `run:`
+  step is correct, because a shell evaluates it there; don't "fix" those.
+  `build-and-release-stable.yml` shows the correct `run:` form; the `with:` form it once
+  carried was fixed in `7eac7cd01a7a`.
 - **`if: github.repository == 'meshery/meshery'` disables the job for every external caller.**
   In a reusable workflow the `github` context is the *caller's*, so this guard is false from
   any other repo. Jobs in caller files carry it too, and a job whose `needs:` dependency is

--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -150,9 +150,8 @@ tests in adapters are end-to-end tests and use patternfile. The reusable workflo
 Both of these fail silently - the workflow runs and reports success while doing nothing you
 expected - so they are worth checking before you debug anything else:
 
-1. **A `with:` value is a GitHub Actions expression, not a shell command.** A shell parameter
-   expansion such as `${GITHUB_SHA}` or `${GITHUB_REF/refs\/tags\//}` in a `with:` value is
-   forwarded to the workflow verbatim, because nothing ever evaluates it. Use
+1. **A `with:` value is not evaluated by a shell.** Only `${{ ... }}` expressions are evaluated; shell-style expansions such as `${GITHUB_SHA}` or `${GITHUB_REF/refs\/tags\//}` in a `with:` value are
+   forwarded to the workflow verbatim, because nothing ever evaluates them. Use
    `${{ github.sha }}` or `${{ github.ref_name }}` instead. The same expansion inside a `run:`
    step is correct, because a shell evaluates it there.
 2. **A job guarded by `if: github.repository == 'meshery/meshery'` never runs for you.** In a

--- a/docs/content/en/project/contributing/build-and-release.md
+++ b/docs/content/en/project/contributing/build-and-release.md
@@ -145,6 +145,26 @@ tests in adapters are end-to-end tests and use patternfile. The reusable workflo
       secrets:
         token: ${{ secrets.PROVIDER_TOKEN }}
 
+#### Two traps when calling a Meshery reusable workflow
+
+Both of these fail silently - the workflow runs and reports success while doing nothing you
+expected - so they are worth checking before you debug anything else:
+
+1. **A `with:` value is a GitHub Actions expression, not a shell command.** A shell parameter
+   expansion such as `${GITHUB_SHA}` or `${GITHUB_REF/refs\/tags\//}` in a `with:` value is
+   forwarded to the workflow verbatim, because nothing ever evaluates it. Use
+   `${{ github.sha }}` or `${{ github.ref_name }}` instead. The same expansion inside a `run:`
+   step is correct, because a shell evaluates it there.
+2. **A job guarded by `if: github.repository == 'meshery/meshery'` never runs for you.** In a
+   reusable workflow the `github` context belongs to the *caller*, so that condition is false
+   from any other repository. The adapter workflows described above carry no such guard, so
+   this does not affect them; it is a caveat for the other reusable workflows in
+   `meshery/meshery`, notably the CNCF Playground deployments.
+
+Contributors changing a shared workflow should also read the "Reusable Workflows Consumed by
+Other Repos" section of [`AGENTS.md`](https://github.com/meshery/meshery/blob/master/AGENTS.md)
+in the repository root.
+
 ### Functionality of Central Workflow
 
 1. Checks out the code of the repository(on the ref of latest commit of branch which made the PR) in which it is referenced.


### PR DESCRIPTION
## What this delivers

Two things, in three commits plus a follow-up:

1. **Documentation of two traps** that repos calling this repo's reusable workflows keep hitting. Both fail silently - the workflow runs, reports success, and does nothing you expected.
2. **Removal of three live occurrences of the first trap**, which were writing a literal `${GITHUB_SHA}` into `meshery/qa`'s git history.

The lead commit is an existing, previously reviewed commit by @carlosriosilva that was written but never pushed; it is delivered here unmodified, with its original authorship and sign-off intact.

## The traps

- **A `with:` value is an Actions expression, not shell.** `${GITHUB_SHA}` or `${GITHUB_REF/refs\/tags\//}` in a `with:` value is forwarded verbatim, because nothing evaluates it. Use `${{ github.sha }}` / `${{ github.ref_name }}`. The same expansion inside a `run:` step is correct and must not be "fixed".
- **`if: github.repository == 'meshery/meshery'` is false for every external caller.** In a reusable workflow the `github` context is the *caller's*, so that guard disables the job for anyone calling from another repo.

## The three live fixes

Not merely documented - removed:

| File | Line |
|---|---|
| `.github/workflows/go-testing-ci.yml` | 111 |
| `.github/workflows/go-testing-ci.yml` | 195 |
| `.github/workflows/mesheryctl-e2e.yaml` | 247 |

Each passed a bare `${GITHUB_SHA}` to `stefanzweifel/git-auto-commit-action`'s `commit_message` input. This was confirmed against the real consequence rather than assumed: `meshery/qa` commits `6c1ba8f28458` and `600e5b214c6b` carry the literal string `${GITHUB_SHA}` in their commit messages. All three are now `${{ github.sha }}`, and both files were re-parsed as valid YAML.

Every `with:` block across all 56 workflow files and both composite actions was swept; there is no fourth instance. Deliberately left alone, because they are correct as written: the same expansion inside `run:` steps, the JS template literals under `script:` in `codeql-analysis.yml` and `comment-e2e-test.yml`, and the shell expansions in the `appleboy/ssh-action` `script:` block in `cncf-playground-deploy-meshery.yaml` (which passes `envs: MANIFEST_REF`, so it resolves on the remote host).

## Correction to the original commit

The original commit cited `build-and-release-stable.yml` as containing both the broken and the correct form. That had gone stale: the broken `with:` form was removed in `7eac7cd01a7a` (2025-10-29), so only the correct `run:` form remains. Rather than silently amending another contributor's commit, the correction is a separate follow-up commit. The workflow-file glob was also widened, since these files are a mix of `.yml` and `.yaml`.

## Documentation

The traps are documented for contributors in `AGENTS.md`, and for external callers in `docs/content/en/project/contributing/build-and-release.md`, on the page those callers already read. That note is deliberately scoped to a pointer plus a Further Reading row - the page is otherwise unchanged. It also states explicitly that the adapter workflows that section documents (`test_adapters.yaml`, `test_adaptersv2.yaml`) carry no `github.repository` guard, so the second trap is a caveat for the other reusable workflows here rather than a live breakage for those callers.

## Reviewer notes

- **This touches `.github/workflows/`, which `AGENTS.md` lists under "Require Human Review".** The three edits are one-line substitutions in `commit_message` inputs. Both files are gated on `github.event_name == 'push'` and neither is a `workflow_call` workflow, so `${{ github.sha }}` resolves to this repo's own SHA - equivalent to the runner's `GITHUB_SHA`, which is what the original intended. Nothing downstream parses those commit-message strings.
- **No `github.repository` guard was changed.** Changing one activates dormant deploys, which is a product decision rather than a repair.
- **No workflow linter was added.** Stock actionlint would not catch this anyway, since a bare `${VAR}` is a valid input string; catching it would need a repo-specific rule. Recorded as a known gap, not addressed here.
