### PR TITLE
[UI] Fix inconsistent tab heights on small screens

### DIFF
--- a/ui/components/layout/Header/Header.styles.tsx
+++ b/ui/components/layout/Header/Header.styles.tsx
@@ -36,10 +36,10 @@ export const UserContainer = styled('div')(({ theme }) => ({
   paddingLeft: 1,
   display: 'flex',
   alignItems: 'center',
+  marginBlock: '0.5rem',
   [theme.breakpoints.down('sm')]: {
     width: '100%',
     justifyContent: 'flex-end',
-    marginBlock: '0.5rem',
   },
 }));
 


### PR DESCRIPTION
Fixes #21722.

## Summary

`UserContainer` only applied its vertical margin below the `sm` breakpoint, while `PageTitleWrapper` applied the same margin unconditionally. This caused inconsistent vertical spacing between the two header sections at responsive widths.

This change applies `marginBlock: '0.5rem'` unconditionally to `UserContainer` so both header sections remain consistent across breakpoints.

## Testing

- `npx vitest run components/layout/Header/Header.styles.test.tsx` → 5/5 passed
- ESLint → passed
- `git diff --check` → passed
- Manually verified the rendered UI at multiple responsive widths, including mobile, tablet, and desktop.

## Notes for Reviewers

The change is limited to `ui/components/layout/Header/Header.styles.tsx`.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted header user area spacing so the margin is applied consistently across all screen sizes.
  * Preserved full-width, right-aligned behavior on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->