### PR TITLE
fix(ui): release the RTK Query subscription in initiateQuery

### DIFF
--- a/ui/rtk-query/__tests__/utils.test.ts
+++ b/ui/rtk-query/__tests__/utils.test.ts
@@ -30,6 +30,33 @@ describe('initiateQuery', () => {
     expect(result).toEqual({ data: { ok: true } });
   });
 
+  it('releases the cache subscription that initiate() opened', async () => {
+    // The real dispatch returns a QueryActionCreatorResult, which is a promise
+    // that also carries unsubscribe(). Leaving it unsubscribed pins the cache
+    // entry for the life of the session.
+    const unsubscribe = vi.fn();
+    const subscription = Object.assign(Promise.resolve({ data: { ok: true } }), { unsubscribe });
+    dispatch.mockReturnValue(subscription);
+    const initiate = vi.fn().mockReturnValue({ type: 'thunk-action' });
+
+    const result = await initiateQuery({ initiate }, { id: 'abc' });
+
+    expect(result).toEqual({ data: { ok: true } });
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the subscription even when the query rejects', async () => {
+    const unsubscribe = vi.fn();
+    const subscription = Object.assign(Promise.reject(new Error('boom')), { unsubscribe });
+    dispatch.mockReturnValue(subscription);
+    const initiate = vi.fn().mockReturnValue({ type: 'thunk-action' });
+
+    const result = await initiateQuery({ initiate }, undefined);
+
+    expect(result.isError).toBe(true);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it('returns the awaited dispatch result on success', async () => {
     const fulfilled = {
       data: { foo: 'bar' },

--- a/ui/rtk-query/__tests__/utils.test.ts
+++ b/ui/rtk-query/__tests__/utils.test.ts
@@ -45,6 +45,27 @@ describe('initiateQuery', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  it('dispatches initiate exactly once and releases that one subscription', async () => {
+    // Guards against a refactor that dispatches twice, or that releases a
+    // different subscription than the one it awaited.
+    const unsubscribe = vi.fn();
+    const fulfilled = { data: { id: 'one' } };
+    const subscription = Object.assign(Promise.resolve(fulfilled), { unsubscribe });
+    dispatch.mockReturnValue(subscription);
+    const thunk = { type: 'thunk-action' };
+    const initiate = vi.fn().mockReturnValue(thunk);
+    const variables = { id: 'one' };
+
+    const result = await initiateQuery({ initiate }, variables);
+
+    expect(initiate).toHaveBeenCalledTimes(1);
+    expect(initiate).toHaveBeenCalledWith(variables);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(thunk);
+    expect(result).toBe(fulfilled);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it('releases the subscription even when the query rejects', async () => {
     const unsubscribe = vi.fn();
     const subscription = Object.assign(Promise.reject(new Error('boom')), { unsubscribe });

--- a/ui/rtk-query/utils.ts
+++ b/ui/rtk-query/utils.ts
@@ -37,8 +37,14 @@ export const appendInvalidatesTags =
  * @returns {Promise<Object>} - A Promise resolving with an object containing query execution results.
  */
 export const initiateQuery = async (query, variables) => {
+  // initiate() opens a cache subscription that is only released by
+  // unsubscribing. Callers here read the result and drop it, so without the
+  // release in `finally` the entry is pinned for the life of the session and
+  // keepUnusedDataFor never applies.
+  let subscription;
   try {
-    return await store.dispatch(query.initiate(variables));
+    subscription = store.dispatch(query.initiate(variables));
+    return await subscription;
   } catch (error) {
     // Return an object with error details if there's an exception
     return {
@@ -49,5 +55,10 @@ export const initiateQuery = async (query, variables) => {
       isLoading: false,
       isError: true,
     };
+  } finally {
+    // `query` is untyped here, so guard the call as well as the value: a
+    // caller passing something that is not an RTK-Query endpoint still gets
+    // the old behaviour rather than a TypeError.
+    subscription?.unsubscribe?.();
   }
 };


### PR DESCRIPTION
## The problem

`initiateQuery` dispatches an RTK Query `initiate()` and awaits the result, but never unsubscribes:

```ts
export const initiateQuery = async (query, variables) => {
  try {
    return await store.dispatch(query.initiate(variables));
  } catch (error) {
    ...
  }
};
```

A manually dispatched `initiate()` returns a `QueryActionCreatorResult`, which holds a cache subscription until `unsubscribe()` is called. Every call here therefore pins its cache entry for the life of the session, and `keepUnusedDataFor` never gets a chance to apply.

There are **13 live call sites** across `rtk-query/user.ts`, `view.ts` and `design.ts`, and several of them run repeatedly rather than once:

```
user.ts:368   getProviderCapabilities
user.ts:373   getAccessToken
user.ts:378   getLoggedInUser
user.ts:383   getSystemVersion
user.ts:388   getAllUsers
view.ts:79    getView
design.ts:190 ...
```

Each caller reads the returned object and drops it, so nothing is relying on the subscription staying open.

## The change

Capture the subscription, await it as before, release it in `finally` so the error path is covered too.

The `unsubscribe` call is optional-chained as well as the value. `query` is untyped in this helper, so a caller passing something that is not an endpoint keeps the current behaviour instead of getting a `TypeError` from the cleanup. The existing tests in `utils.test.ts` mock `dispatch` with `mockResolvedValue`, which returns a plain promise with no `unsubscribe`, so without that guard this change would have broken them.

The repo already uses this pattern in `rtk-query/__tests__/design-import-invalidation.test.ts:143`, which dispatches `initiate()` and then calls `listSub.unsubscribe()` once it is done with the entry.

## Verification

Three tests in `rtk-query/__tests__/utils.test.ts`: the success path, the rejection path, and one pinning that `query.initiate()` is called exactly once, the thunk is dispatched exactly once, the awaited value is returned unchanged, and the single subscription is released.

```
npx vitest run rtk-query/
  Test Files  30 passed (30)
  Tests       301 passed (301)
```

## Not included

`rtk-query/workspace.ts` has six more unreleased `initiate()` dispatches, at lines 105, 114, 121, 128, 174 and 239. I wrote that fix first and then reverted it, because the file's own comment documents those endpoints as dead code under #21175: `injectEndpoints` without `overrideExisting: true` silently discards the colliding names, so the `@meshery/schemas` definitions serve every call and the `expandInfo` and `expandUser` paths never run. Worth fixing whenever #21175 is resolved, but fixing it now would change nothing at runtime.

---

## Addressed review, 2026-09-03

**The `Filters.tsx` reference was wrong and has been removed.** @TheRealVeni is right: `fetchCatalogFilter({...}).subscribe({ next, error })` there is an RxJS-style observable subscription, not a `QueryActionCreatorResult`. `design-import-invalidation.test.ts:143` is the only genuine `initiate()` plus `unsubscribe()` pair in the repo, so that is what the description cites now.

**Coverage added as requested**, in `test(ui): assert initiateQuery dispatches once per call`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query lifecycle handling by releasing cache subscriptions after successful or failed requests.
  - Preserved existing query results and error responses.
  - Non-RTK Query endpoints continue to behave as before.
  - Cache retention settings can now take effect as expected after queries complete.

- **Tests**
  - Added coverage for subscription cleanup following both successful and rejected queries.
  - Added verification that queries are initiated and dispatched correctly, with results returned unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->