### PR TITLE
[UI] Fixing partially clipped Save Button in Design Info on small screens. 

### DIFF
--- a/ui/components/shared/Modal/Information/InfoModal.test.tsx
+++ b/ui/components/shared/Modal/Information/InfoModal.test.tsx
@@ -114,6 +114,7 @@ vi.mock('@/assets/icons', () => ({
   Close: () => <svg data-testid="close-icon" />,
   Lock: () => <svg data-testid="lock-icon" />,
   Public: () => <svg data-testid="public-icon" />,
+  InfoOutlinedIcon: () => <svg data-testid="info-outlined-icon" />,
 }));
 
 vi.mock('@/components/meshery-mesh-interface/PatternService/RJSF_wrapper', () => ({

--- a/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
+++ b/ui/components/shared/Modal/Information/LegacyInfoModal.tsx
@@ -26,7 +26,7 @@ import {
   useHasPermission,
   useTheme,
 } from '@sistent/sistent';
-import { Close, Lock, Public } from '@/assets/icons';
+import { Close, Lock, Public, InfoOutlinedIcon } from '@/assets/icons';
 import * as yaml from 'js-yaml';
 import _ from 'lodash';
 import { useSnackbar } from 'notistack';
@@ -326,6 +326,7 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
   const [imageError, setImageError] = useState(false);
   const version = getDesignVersion(selectedResource);
   const canChangeVisibility = !isPublished && isOwner;
+  const [showModalFooterInfo, setModalFooterInfo] = useState(false);
   const handleError = () => {
     setImageError(true);
   };
@@ -486,13 +487,35 @@ const InfoModal_: FC<InfoModalProps> = React.memo((props) => {
             </Grid>
           </Grid>
         </ModalBody>
-        <ModalFooter
-          helpText={
-            'Upon submitting your catalog item, an approval flow will be initiated. [Learn More](https://docs.meshery.io/concepts/catalog)'
-          }
-          variant="filled"
-        >
-          <ActionContainer>
+        <ModalFooter variant="filled">
+          <Box
+            style={{
+              alignContent: 'center',
+              justifyContent: 'space-between',
+              minWidth: 0,
+            }}
+          >
+            <CustomTooltip
+              title={
+                'Upon submitting your catalog item, an approval flow will be initiated. [Learn More](https://docs.meshery.io/concepts/catalog)'
+              }
+              open={showModalFooterInfo}
+              placement="top"
+              onClose={() => setModalFooterInfo(false)}
+            >
+              <IconButton
+                aria-label="Show catalog approval flow help"
+                onClick={() => setModalFooterInfo(true)}
+              >
+                <InfoOutlinedIcon fill={theme.palette.common.white} style={iconMedium} />
+              </IconButton>
+            </CustomTooltip>
+          </Box>
+          <ActionContainer
+            sx={{
+              gap: { xs: '0.25rem', sm: '0.5rem', md: '1rem' },
+            }}
+          >
             <TooltipButton title={'Copy Design Link'} onClick={handleCopy}>
               <CopyLinkButton>Copy Link</CopyLinkButton>
             </TooltipButton>

--- a/ui/components/shared/Modal/Information/styles.tsx
+++ b/ui/components/shared/Modal/Information/styles.tsx
@@ -9,7 +9,6 @@ export const CreatAtContainer = styled(Typography)(({ isBold }) => ({
 export const ActionContainer = styled(Box)({
   width: '100%',
   display: 'flex',
-  gap: '1rem',
   justifyContent: 'end',
 });
 


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21732

It took me sometime to setup the system, hence a delayed PR. Steps I did before making this PR:-
1. Replicated the problem by inspect and changing the size of the viewport.
2. Found the specific component that is related to the problem. It was the LegacyInfoModal.


Problem:-
1. The Save button was being clipped.
2. Found out that the content was overflowing the modal footer.

Solution:
1. In the LegacyInfoModal, the ActionContainer was not wrapping properly.
2. Changed the property flexWrap to wrap from no-wrap.
3. Decreased the gap as well as changed overflow to auto.

Screenshots:-
Before the fix:-
<img width="472" height="826" alt="save-button-prob" src="https://github.com/user-attachments/assets/e64c1848-5b8f-45a8-8e10-2f0244ad337d" />



Afer the fix:

For small screens
<img width="556" height="884" alt="save-button-fix-sm" src="https://github.com/user-attachments/assets/a5d4bcd0-16b6-4930-bd9b-3377277860dc" />

For screens with extra small width
<img width="473" height="873" alt="save-button-fix-xs" src="https://github.com/user-attachments/assets/75df594c-3c98-4f6c-b7f5-b41470db4ba1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Added an approval-flow help tooltip to the information modal footer, opened by selecting the information icon.
  * Adjusted footer action spacing for improved responsive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->