### PR TITLE
[ui] Fix design actions dropdown placement

### DIFF
--- a/ui/components/designs/patterns/ActionButton.tsx
+++ b/ui/components/designs/patterns/ActionButton.tsx
@@ -75,14 +75,7 @@ export default function ActionButton({
         }}
         open={open}
         anchorEl={anchorRef.current}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
+        placement="bottom-start"
       >
         <Paper>
           <ClickAwayListener onClickAway={handleClose}>


### PR DESCRIPTION
## Summary

- Fix the Actions dropdown placement in Designs on smaller screens.
- Use Popper's `bottom-start` placement so the dropdown is positioned relative to the Actions button instead of being obscured by the toolbar.

## Issue

Fixes #21728

## Testing

- Manually reproduced the issue using a small responsive viewport.
- Verified the Actions dropdown is visible and correctly positioned after the fix.
- `ActionButton.test.tsx`: 6/6 tests passed.
- ESLint: passed with 0 errors and 0 warnings.
- `git diff --check`: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action menu positioning by anchoring it consistently below and to the start of the action button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->