### PR TITLE
[Docs] Migrate related reading sections to upstream module

### DIFF
--- a/docs/content/en/guides/configuration-management/creating-a-meshery-design.md
+++ b/docs/content/en/guides/configuration-management/creating-a-meshery-design.md
@@ -108,11 +108,3 @@ mesheryctl design list
 
 See the [`mesheryctl design` reference]({{< ref "reference/references/mesheryctl/design/_index.md" >}}) for the full subcommand reference.
 {{< /tabs >}}
-
-## Related
-
-- [Meshery Designs concept]({{< ref "concepts/logical/designs.md" >}})
-- [Importing Designs]({{< ref "guides/configuration-management/importing-models/index.md" >}})
-- [Deploying a Design]({{< ref "guides/configuration-management/working-with-designs/index.md" >}})
-- [`mesheryctl design` reference]({{< ref "reference/references/mesheryctl/design/_index.md" >}})
-- [Meshery Catalog](https://meshery.io/catalog)

--- a/docs/content/en/guides/configuration-management/pattern-management/index.md
+++ b/docs/content/en/guides/configuration-management/pattern-management/index.md
@@ -75,7 +75,3 @@ $ mesheryctl design apply -f book-catalog
 Deploying application “BookCatalog”...
 Deployed. Endpoint(s) available at: http://localhost:8000/catalog
 ```
-
-## Related
-
-- [`mesheryctl design`]({{< ref "reference/references/mesheryctl/design/_index.md" >}})

--- a/docs/content/en/guides/mesheryctl/running-system-checks-using-mesheryctl.md
+++ b/docs/content/en/guides/mesheryctl/running-system-checks-using-mesheryctl.md
@@ -129,13 +129,5 @@ Users can also narrow down the tests to just check the status of the Meshery ope
 
 **Answer**: _Configure Meshery to use on your Kubernetes cluster, then upload the kubeconfig file via Meshery UI to notify Meshery to use that cluster. If that didn't work, feel free to [open up an issue](https://github.com/meshery/meshery/issues) in GitHub._
 
-### Suggested Reading
-
-For an exhaustive list of `mesheryctl` commands and syntax:
-
-- See [`mesheryctl` Command Reference]({{< ref "reference/references/mesheryctl/_index.md" >}}).
-
-Guides to using Meshery's various features and components.
-
 {{< related-discussions tag="mesheryctl" >}}
 

--- a/docs/content/en/guides/troubleshooting/_index.md
+++ b/docs/content/en/guides/troubleshooting/_index.md
@@ -6,8 +6,4 @@ weight: 25
 
 Troubleshooting guides to using Meshery's various features and components.
 
-#### See Also
-
-- [Meshery Error Code Reference]({{< ref "reference/references/error-codes.md" >}})
-
 {{< discuss >}}

--- a/docs/content/en/guides/troubleshooting/_index.md
+++ b/docs/content/en/guides/troubleshooting/_index.md
@@ -6,4 +6,8 @@ weight: 25
 
 Troubleshooting guides to using Meshery's various features and components.
 
+## Additional Resources
+
+- [Meshery Error Code Reference]({{< ref "reference/references/error-codes.md" >}})
+
 {{< discuss >}}

--- a/docs/content/en/guides/troubleshooting/installation/index.md
+++ b/docs/content/en/guides/troubleshooting/installation/index.md
@@ -103,7 +103,3 @@ For more details about Meshery Providers:
 
 - [Extensibility: Providers]({{< ref "reference/extensibility/providers/index.md" >}})
 
-## See Also
-
-- [Meshery Error Code Reference]({{< ref "reference/references/error-codes.md" >}})
-

--- a/docs/content/en/guides/troubleshooting/installation/index.md
+++ b/docs/content/en/guides/troubleshooting/installation/index.md
@@ -103,3 +103,7 @@ For more details about Meshery Providers:
 
 - [Extensibility: Providers]({{< ref "reference/extensibility/providers/index.md" >}})
 
+## Additional Resources
+
+- [Meshery Error Code Reference]({{< ref "reference/references/error-codes.md" >}})
+

--- a/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
+++ b/docs/content/en/guides/troubleshooting/meshery-operator-meshsync.md
@@ -304,11 +304,5 @@ kubectl -n meshery get deploy meshery-meshsync \
 - **Secrets are discovered by default.** MeshSync watches `secrets.v1.`, and the Secret objects it forwards to Meshery Server include their `data` and `stringData` payload. Those Secret contents are therefore transmitted over the Broker and persisted in the Meshery Database. In security-sensitive environments, either blacklist `secrets.v1.` (or use a whitelist that omits it) to keep Secrets out of discovery entirely, or set `MESHSYNC_REDACT_SECRETS=true` on the MeshSync Deployment to keep discovering Secrets while replacing their values with `[REDACTED]` (keys are preserved). See [Redacting Secret contents]({{< ref "guides/infrastructure-management/configuring-operator-meshsync-broker.md#redacting-secret-contents" >}}).
 - **Discovery is watch-driven with no periodic re-list.** MeshSync relies on the Kubernetes watch stream rather than polling. If you suspect the in-memory snapshot has drifted, force a re-list with `kubectl -n meshery rollout restart deploy/meshery-meshsync` or reset the Meshery Database from the UI.
 
-## See Also
-
-- [Kubernetes Connection Lifecycle]({{< ref "guides/infrastructure-management/kubernetes-connection-lifecycle.md" >}})
-- [Troubleshooting Meshery Installations]({{< ref "guides/troubleshooting/installation.md" >}})
-- [Troubleshooting Errors while running Meshery]({{< ref "guides/troubleshooting/meshery-server.md" >}})
-
 {{< related-discussions tag="meshery" >}}
 

--- a/docs/content/en/guides/troubleshooting/meshery-server.md
+++ b/docs/content/en/guides/troubleshooting/meshery-server.md
@@ -45,7 +45,3 @@ make: *** [Makefile:76: server] Error 1
 
 1. Flush the database by deleting the `.meshery/config`
 2. `make server`
-
-#### See Also
-
-- [Error Code Reference]({{< ref "reference/references/error-codes.md" >}})

--- a/docs/content/en/guides/troubleshooting/meshery-server.md
+++ b/docs/content/en/guides/troubleshooting/meshery-server.md
@@ -45,3 +45,7 @@ make: *** [Makefile:76: server] Error 1
 
 1. Flush the database by deleting the `.meshery/config`
 2. `make server`
+
+## Additional Resources
+
+- [Error Code Reference]({{< ref "reference/references/error-codes.md" >}})

--- a/docs/content/en/installation/docker/_index.md
+++ b/docs/content/en/installation/docker/_index.md
@@ -49,5 +49,3 @@ You're ready to use Meshery! Open your browser and navigate to the Meshery UI.
 {{< installation/accessing-meshery-ui >}}
 
 {{< related-discussions tag="meshery" >}}
-
-### See Also

--- a/docs/content/en/installation/kubernetes/_index.md
+++ b/docs/content/en/installation/kubernetes/_index.md
@@ -33,7 +33,6 @@ Manage your Kubernetes clusters with Meshery. Deploy Meshery in Kubernetes [in-c
 - [Out-of-cluster Installation](#out-of-cluster-installation)
   - [Set up Ingress on Minikube with the NGINX Ingress Controller](#set-up-ingress-on-minikube-with-the-nginx-ingress-controller)
   - [Installing cert-manager with kubectl](#installing-cert-manager-with-kubectl)
-    - [See Also](#see-also)
 
 # In-cluster Installation
 
@@ -118,5 +117,3 @@ Install Meshery on Docker (out-of-cluster) and connect it to your Kubernetes clu
 {{< code code="kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml" >}}
 
 {{< related-discussions tag="meshery" >}}
-
-### See Also 

--- a/docs/content/en/installation/mesheryctl/_index.md
+++ b/docs/content/en/installation/mesheryctl/_index.md
@@ -31,10 +31,4 @@ Mesheryctl is configured for Kubernetes by default. To specify a different suppo
 
 Continue deploying Meshery onto one of the [Supported Platforms]({{< ref "installation/_index.md" >}}).
 
-## Meshery CLI Guides
-
-Guides to using Meshery's various features and components.
-
-{{< mesheryctl-guides-list >}}
-
 {{< related-discussions tag="mesheryctl" >}}

--- a/docs/content/en/installation/mesheryctl/linux-mac/_index.md
+++ b/docs/content/en/installation/mesheryctl/linux-mac/_index.md
@@ -20,13 +20,6 @@ To set up and run Meshery on Linux or macOS, you will need to install `mesheryct
 
 {{% mesheryctl/installation-bash %}}
 
-
-## Meshery CLI Guides
-
-Guides to using Meshery's various features and components.
-
-{{< mesheryctl-guides-list >}}
-
 {{< related-discussions tag="mesheryctl" >}}
 
 ### Installation Options

--- a/docs/content/en/installation/mesheryctl/windows/_index.md
+++ b/docs/content/en/installation/mesheryctl/windows/_index.md
@@ -32,12 +32,6 @@ Optionally, move the `mesheryctl` binary to a directory in your `PATH`.
 
 Type `yes` when prompted to choose to configure a file. To get started, choose Docker as your platform to deploy Meshery. -->
 
-## Meshery CLI Guides
-
-Guides to using Meshery's various features and components.
-
-{{< mesheryctl-guides-list >}}
-
 {{< related-discussions tag="mesheryctl" >}}
 
 ### Installation Options

--- a/docs/content/en/installation/mesheryctl/windows/scoop.md
+++ b/docs/content/en/installation/mesheryctl/windows/scoop.md
@@ -10,9 +10,3 @@ description: Install Meshery CLI on Windows with Scoop
 # Install Meshery CLI with Scoop
 
 {{% mesheryctl/installation-scoop %}}
-
-## Mesheryctl Guides
-
-Guides to using Meshery's various features and components.
-
-{{< mesheryctl-guides-list >}}

--- a/docs/content/en/installation/quick-start/index.md
+++ b/docs/content/en/installation/quick-start/index.md
@@ -108,13 +108,3 @@ You may now proceed to manage any cloud native infrastructure supported by Meshe
 🧑‍🔬 Explore these tutorials to learn how to use Meshery for collaboratively managing infrastructure.
 
 {{< tutorials-list >}}
-
-## Additional Guides
-
-<div class="section">
-    <ul>
-        <li><a href="{{< ref "guides/troubleshooting/installation.md" >}}">Troubleshooting Meshery Installations</a></li>
-        <li><a href="{{< ref "reference/references/error-codes.md" >}}">Meshery Error Code Reference</a></li>
-        <li><a href="{{< ref "reference/references/mesheryctl/system/check.md" >}}">mesheryctl system check</a></li> 
-    </ul>
-</div>

--- a/docs/content/en/installation/quick-start/index.md
+++ b/docs/content/en/installation/quick-start/index.md
@@ -108,3 +108,9 @@ You may now proceed to manage any cloud native infrastructure supported by Meshe
 🧑‍🔬 Explore these tutorials to learn how to use Meshery for collaboratively managing infrastructure.
 
 {{< tutorials-list >}}
+
+## Additional Resources
+
+- [Troubleshooting Meshery Installations]({{< ref "guides/troubleshooting/installation.md" >}})
+- [Meshery Error Code Reference]({{< ref "reference/references/error-codes.md" >}})
+- [mesheryctl system check]({{< ref "reference/references/mesheryctl/system/check.md" >}})

--- a/docs/content/en/project/contributing/contributing-docs/shortcode-examples.md
+++ b/docs/content/en/project/contributing/contributing-docs/shortcode-examples.md
@@ -346,7 +346,6 @@ All of them take no body, and all take no parameters except `mesheryctl-command-
 | `error-codes-detail` | `{{</* error-codes-detail */>}}` | [Error Codes Reference]({{< ref "reference/references/error-codes.md" >}}) |
 | `troubleshooting-guides-list` | `{{</* troubleshooting-guides-list */>}}` | [Error Codes Reference]({{< ref "reference/references/error-codes.md" >}}) |
 | `mesheryctl-command-table` | `{{</* mesheryctl-command-table command="adapter" */>}}` | [mesheryctl Reference]({{< ref "reference/references/mesheryctl/_index.md" >}}) |
-| `mesheryctl-guides-list` | `{{</* mesheryctl-guides-list */>}}` | [mesheryctl Installation]({{< ref "installation/mesheryctl/_index.md" >}}) |
 | `network-ports` | `{{</* network-ports */>}}` | [Architecture]({{< ref "concepts/architecture/_index.md" >}}) |
 | `permissions` | `{{</* permissions */>}}` | [Permissions Reference]({{< ref "reference/references/permissions.md" >}}) |
 | `tutorials-list` | `{{</* tutorials-list */>}}` | [Quick Start]({{< ref "installation/quick-start/index.md" >}}) |

--- a/docs/content/en/project/contributing/contributing-docs/shortcode-examples.md
+++ b/docs/content/en/project/contributing/contributing-docs/shortcode-examples.md
@@ -346,6 +346,7 @@ All of them take no body, and all take no parameters except `mesheryctl-command-
 | `error-codes-detail` | `{{</* error-codes-detail */>}}` | [Error Codes Reference]({{< ref "reference/references/error-codes.md" >}}) |
 | `troubleshooting-guides-list` | `{{</* troubleshooting-guides-list */>}}` | [Error Codes Reference]({{< ref "reference/references/error-codes.md" >}}) |
 | `mesheryctl-command-table` | `{{</* mesheryctl-command-table command="adapter" */>}}` | [mesheryctl Reference]({{< ref "reference/references/mesheryctl/_index.md" >}}) |
+| `mesheryctl-guides-list` | `{{</* mesheryctl-guides-list */>}}` | [mesheryctl Installation]({{< ref "installation/mesheryctl/_index.md" >}}) |
 | `network-ports` | `{{</* network-ports */>}}` | [Architecture]({{< ref "concepts/architecture/_index.md" >}}) |
 | `permissions` | `{{</* permissions */>}}` | [Permissions Reference]({{< ref "reference/references/permissions.md" >}}) |
 | `tutorials-list` | `{{</* tutorials-list */>}}` | [Quick Start]({{< ref "installation/quick-start/index.md" >}}) |

--- a/docs/content/en/reference/references/mesheryctl/adapter/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-adapter
 display_title: false
 command: adapter
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl adapter

--- a/docs/content/en/reference/references/mesheryctl/adapter/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-adapter
 display_title: false
 command: adapter
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-adapter]
 ---
 
 # mesheryctl adapter

--- a/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
@@ -3,6 +3,7 @@ title: mesheryctl-adapter-deploy
 display_title: false
 command: adapter
 subcommand: deploy
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl adapter deploy

--- a/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/deploy.md
@@ -3,7 +3,7 @@ title: mesheryctl-adapter-deploy
 display_title: false
 command: adapter
 subcommand: deploy
-categories: [mesheryctl-ref]
+categories: [mesheryctl-adapter]
 ---
 
 # mesheryctl adapter deploy

--- a/docs/content/en/reference/references/mesheryctl/adapter/remove.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/remove.md
@@ -3,6 +3,7 @@ title: mesheryctl-adapter-remove
 display_title: false
 command: adapter
 subcommand: remove
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl adapter remove

--- a/docs/content/en/reference/references/mesheryctl/adapter/remove.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/remove.md
@@ -3,7 +3,7 @@ title: mesheryctl-adapter-remove
 display_title: false
 command: adapter
 subcommand: remove
-categories: [mesheryctl-ref]
+categories: [mesheryctl-adapter]
 ---
 
 # mesheryctl adapter remove

--- a/docs/content/en/reference/references/mesheryctl/adapter/validate.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/validate.md
@@ -3,6 +3,7 @@ title: mesheryctl-adapter-validate
 display_title: false
 command: adapter
 subcommand: validate
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl adapter validate

--- a/docs/content/en/reference/references/mesheryctl/adapter/validate.md
+++ b/docs/content/en/reference/references/mesheryctl/adapter/validate.md
@@ -3,7 +3,7 @@ title: mesheryctl-adapter-validate
 display_title: false
 command: adapter
 subcommand: validate
-categories: [mesheryctl-ref]
+categories: [mesheryctl-adapter]
 ---
 
 # mesheryctl adapter validate

--- a/docs/content/en/reference/references/mesheryctl/completion.md
+++ b/docs/content/en/reference/references/mesheryctl/completion.md
@@ -3,6 +3,7 @@ title: mesheryctl-completion
 display_title: false
 command: completion
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl completion

--- a/docs/content/en/reference/references/mesheryctl/completion.md
+++ b/docs/content/en/reference/references/mesheryctl/completion.md
@@ -3,7 +3,7 @@ title: mesheryctl-completion
 display_title: false
 command: completion
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-completion]
 ---
 
 # mesheryctl completion

--- a/docs/content/en/reference/references/mesheryctl/component/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/component/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-component
 display_title: false
 command: component
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl component

--- a/docs/content/en/reference/references/mesheryctl/component/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/component/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-component
 display_title: false
 command: component
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-component]
 ---
 
 # mesheryctl component

--- a/docs/content/en/reference/references/mesheryctl/component/list.md
+++ b/docs/content/en/reference/references/mesheryctl/component/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-component-list
 display_title: false
 command: component
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl component list

--- a/docs/content/en/reference/references/mesheryctl/component/list.md
+++ b/docs/content/en/reference/references/mesheryctl/component/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-component-list
 display_title: false
 command: component
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-component]
 ---
 
 # mesheryctl component list

--- a/docs/content/en/reference/references/mesheryctl/component/search.md
+++ b/docs/content/en/reference/references/mesheryctl/component/search.md
@@ -3,6 +3,7 @@ title: mesheryctl-component-search
 display_title: false
 command: component
 subcommand: search
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl component search

--- a/docs/content/en/reference/references/mesheryctl/component/search.md
+++ b/docs/content/en/reference/references/mesheryctl/component/search.md
@@ -3,7 +3,7 @@ title: mesheryctl-component-search
 display_title: false
 command: component
 subcommand: search
-categories: [mesheryctl-ref]
+categories: [mesheryctl-component]
 ---
 
 # mesheryctl component search

--- a/docs/content/en/reference/references/mesheryctl/component/view.md
+++ b/docs/content/en/reference/references/mesheryctl/component/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-component-view
 display_title: false
 command: component
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl component view

--- a/docs/content/en/reference/references/mesheryctl/component/view.md
+++ b/docs/content/en/reference/references/mesheryctl/component/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-component-view
 display_title: false
 command: component
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-component]
 ---
 
 # mesheryctl component view

--- a/docs/content/en/reference/references/mesheryctl/connection/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-connection
 display_title: false
 command: connection
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl connection

--- a/docs/content/en/reference/references/mesheryctl/connection/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-connection
 display_title: false
 command: connection
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-connection]
 ---
 
 # mesheryctl connection

--- a/docs/content/en/reference/references/mesheryctl/connection/create.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/create.md
@@ -3,6 +3,7 @@ title: mesheryctl-connection-create
 display_title: false
 command: connection
 subcommand: create
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl connection create

--- a/docs/content/en/reference/references/mesheryctl/connection/create.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/create.md
@@ -3,7 +3,7 @@ title: mesheryctl-connection-create
 display_title: false
 command: connection
 subcommand: create
-categories: [mesheryctl-ref]
+categories: [mesheryctl-connection]
 ---
 
 # mesheryctl connection create

--- a/docs/content/en/reference/references/mesheryctl/connection/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-connection-delete
 display_title: false
 command: connection
 subcommand: delete
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl connection delete

--- a/docs/content/en/reference/references/mesheryctl/connection/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-connection-delete
 display_title: false
 command: connection
 subcommand: delete
-categories: [mesheryctl-ref]
+categories: [mesheryctl-connection]
 ---
 
 # mesheryctl connection delete

--- a/docs/content/en/reference/references/mesheryctl/connection/list.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-connection-list
 display_title: false
 command: connection
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl connection list

--- a/docs/content/en/reference/references/mesheryctl/connection/list.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-connection-list
 display_title: false
 command: connection
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-connection]
 ---
 
 # mesheryctl connection list

--- a/docs/content/en/reference/references/mesheryctl/connection/view.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-connection-view
 display_title: false
 command: connection
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl connection view

--- a/docs/content/en/reference/references/mesheryctl/connection/view.md
+++ b/docs/content/en/reference/references/mesheryctl/connection/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-connection-view
 display_title: false
 command: connection
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-connection]
 ---
 
 # mesheryctl connection view

--- a/docs/content/en/reference/references/mesheryctl/design/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/design/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-design
 display_title: false
 command: design
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design

--- a/docs/content/en/reference/references/mesheryctl/design/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/design/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-design
 display_title: false
 command: design
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design

--- a/docs/content/en/reference/references/mesheryctl/design/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/design/apply.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-apply
 display_title: false
 command: design
 subcommand: apply
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design apply

--- a/docs/content/en/reference/references/mesheryctl/design/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/design/apply.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-apply
 display_title: false
 command: design
 subcommand: apply
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design apply

--- a/docs/content/en/reference/references/mesheryctl/design/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/design/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-delete
 display_title: false
 command: design
 subcommand: delete
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design delete

--- a/docs/content/en/reference/references/mesheryctl/design/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/design/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-delete
 display_title: false
 command: design
 subcommand: delete
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design delete

--- a/docs/content/en/reference/references/mesheryctl/design/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/deploy.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-deploy
 display_title: false
 command: design
 subcommand: deploy
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design deploy

--- a/docs/content/en/reference/references/mesheryctl/design/deploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/deploy.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-deploy
 display_title: false
 command: design
 subcommand: deploy
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design deploy

--- a/docs/content/en/reference/references/mesheryctl/design/evaluate.md
+++ b/docs/content/en/reference/references/mesheryctl/design/evaluate.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-evaluate
 display_title: false
 command: design
 subcommand: evaluate
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design evaluate

--- a/docs/content/en/reference/references/mesheryctl/design/evaluate.md
+++ b/docs/content/en/reference/references/mesheryctl/design/evaluate.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-evaluate
 display_title: false
 command: design
 subcommand: evaluate
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design evaluate

--- a/docs/content/en/reference/references/mesheryctl/design/export.md
+++ b/docs/content/en/reference/references/mesheryctl/design/export.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-export
 display_title: false
 command: design
 subcommand: export
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design export

--- a/docs/content/en/reference/references/mesheryctl/design/export.md
+++ b/docs/content/en/reference/references/mesheryctl/design/export.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-export
 display_title: false
 command: design
 subcommand: export
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design export

--- a/docs/content/en/reference/references/mesheryctl/design/import.md
+++ b/docs/content/en/reference/references/mesheryctl/design/import.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-import
 display_title: false
 command: design
 subcommand: import
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design import

--- a/docs/content/en/reference/references/mesheryctl/design/import.md
+++ b/docs/content/en/reference/references/mesheryctl/design/import.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-import
 display_title: false
 command: design
 subcommand: import
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design import

--- a/docs/content/en/reference/references/mesheryctl/design/list.md
+++ b/docs/content/en/reference/references/mesheryctl/design/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-list
 display_title: false
 command: design
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design list

--- a/docs/content/en/reference/references/mesheryctl/design/list.md
+++ b/docs/content/en/reference/references/mesheryctl/design/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-list
 display_title: false
 command: design
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design list

--- a/docs/content/en/reference/references/mesheryctl/design/undeploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/undeploy.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-undeploy
 display_title: false
 command: design
 subcommand: undeploy
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design undeploy

--- a/docs/content/en/reference/references/mesheryctl/design/undeploy.md
+++ b/docs/content/en/reference/references/mesheryctl/design/undeploy.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-undeploy
 display_title: false
 command: design
 subcommand: undeploy
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design undeploy

--- a/docs/content/en/reference/references/mesheryctl/design/view.md
+++ b/docs/content/en/reference/references/mesheryctl/design/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-design-view
 display_title: false
 command: design
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl design view

--- a/docs/content/en/reference/references/mesheryctl/design/view.md
+++ b/docs/content/en/reference/references/mesheryctl/design/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-design-view
 display_title: false
 command: design
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-design]
 ---
 
 # mesheryctl design view

--- a/docs/content/en/reference/references/mesheryctl/environment/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-environment
 display_title: false
 command: environment
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl environment

--- a/docs/content/en/reference/references/mesheryctl/environment/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-environment
 display_title: false
 command: environment
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-environment]
 ---
 
 # mesheryctl environment

--- a/docs/content/en/reference/references/mesheryctl/environment/create.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/create.md
@@ -3,6 +3,7 @@ title: mesheryctl-environment-create
 display_title: false
 command: environment
 subcommand: create
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl environment create

--- a/docs/content/en/reference/references/mesheryctl/environment/create.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/create.md
@@ -3,7 +3,7 @@ title: mesheryctl-environment-create
 display_title: false
 command: environment
 subcommand: create
-categories: [mesheryctl-ref]
+categories: [mesheryctl-environment]
 ---
 
 # mesheryctl environment create

--- a/docs/content/en/reference/references/mesheryctl/environment/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-environment-delete
 display_title: false
 command: environment
 subcommand: delete
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl environment delete

--- a/docs/content/en/reference/references/mesheryctl/environment/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-environment-delete
 display_title: false
 command: environment
 subcommand: delete
-categories: [mesheryctl-ref]
+categories: [mesheryctl-environment]
 ---
 
 # mesheryctl environment delete

--- a/docs/content/en/reference/references/mesheryctl/environment/list.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-environment-list
 display_title: false
 command: environment
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl environment list

--- a/docs/content/en/reference/references/mesheryctl/environment/list.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-environment-list
 display_title: false
 command: environment
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-environment]
 ---
 
 # mesheryctl environment list

--- a/docs/content/en/reference/references/mesheryctl/environment/view.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-environment-view
 display_title: false
 command: environment
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl environment view

--- a/docs/content/en/reference/references/mesheryctl/environment/view.md
+++ b/docs/content/en/reference/references/mesheryctl/environment/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-environment-view
 display_title: false
 command: environment
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-environment]
 ---
 
 # mesheryctl environment view

--- a/docs/content/en/reference/references/mesheryctl/exp.md
+++ b/docs/content/en/reference/references/mesheryctl/exp.md
@@ -3,6 +3,7 @@ title: mesheryctl-exp
 display_title: false
 command: exp
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl exp

--- a/docs/content/en/reference/references/mesheryctl/exp.md
+++ b/docs/content/en/reference/references/mesheryctl/exp.md
@@ -3,7 +3,7 @@ title: mesheryctl-exp
 display_title: false
 command: exp
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-exp]
 ---
 
 # mesheryctl exp

--- a/docs/content/en/reference/references/mesheryctl/filter/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-filter
 display_title: false
 command: filter
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl filter

--- a/docs/content/en/reference/references/mesheryctl/filter/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-filter
 display_title: false
 command: filter
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-filter]
 ---
 
 # mesheryctl filter

--- a/docs/content/en/reference/references/mesheryctl/filter/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-filter-delete
 display_title: false
 command: filter
 subcommand: delete
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl filter delete

--- a/docs/content/en/reference/references/mesheryctl/filter/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-filter-delete
 display_title: false
 command: filter
 subcommand: delete
-categories: [mesheryctl-ref]
+categories: [mesheryctl-filter]
 ---
 
 # mesheryctl filter delete

--- a/docs/content/en/reference/references/mesheryctl/filter/import.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/import.md
@@ -3,6 +3,7 @@ title: mesheryctl-filter-import
 display_title: false
 command: filter
 subcommand: import
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl filter import

--- a/docs/content/en/reference/references/mesheryctl/filter/import.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/import.md
@@ -3,7 +3,7 @@ title: mesheryctl-filter-import
 display_title: false
 command: filter
 subcommand: import
-categories: [mesheryctl-ref]
+categories: [mesheryctl-filter]
 ---
 
 # mesheryctl filter import

--- a/docs/content/en/reference/references/mesheryctl/filter/list.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-filter-list
 display_title: false
 command: filter
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl filter list

--- a/docs/content/en/reference/references/mesheryctl/filter/list.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-filter-list
 display_title: false
 command: filter
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-filter]
 ---
 
 # mesheryctl filter list

--- a/docs/content/en/reference/references/mesheryctl/filter/view.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-filter-view
 display_title: false
 command: filter
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl filter view

--- a/docs/content/en/reference/references/mesheryctl/filter/view.md
+++ b/docs/content/en/reference/references/mesheryctl/filter/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-filter-view
 display_title: false
 command: filter
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-filter]
 ---
 
 # mesheryctl filter view

--- a/docs/content/en/reference/references/mesheryctl/model/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/model/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-model
 display_title: false
 command: model
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model

--- a/docs/content/en/reference/references/mesheryctl/model/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/model/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-model
 display_title: false
 command: model
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model

--- a/docs/content/en/reference/references/mesheryctl/model/build.md
+++ b/docs/content/en/reference/references/mesheryctl/model/build.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-build
 display_title: false
 command: model
 subcommand: build
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model build

--- a/docs/content/en/reference/references/mesheryctl/model/build.md
+++ b/docs/content/en/reference/references/mesheryctl/model/build.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-build
 display_title: false
 command: model
 subcommand: build
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model build

--- a/docs/content/en/reference/references/mesheryctl/model/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/model/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-delete
 display_title: false
 command: model
 subcommand: delete
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model delete

--- a/docs/content/en/reference/references/mesheryctl/model/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/model/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-delete
 display_title: false
 command: model
 subcommand: delete
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model delete

--- a/docs/content/en/reference/references/mesheryctl/model/export.md
+++ b/docs/content/en/reference/references/mesheryctl/model/export.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-export
 display_title: false
 command: model
 subcommand: export
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model export

--- a/docs/content/en/reference/references/mesheryctl/model/export.md
+++ b/docs/content/en/reference/references/mesheryctl/model/export.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-export
 display_title: false
 command: model
 subcommand: export
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model export

--- a/docs/content/en/reference/references/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/model/generate.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-generate
 display_title: false
 command: model
 subcommand: generate
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model generate

--- a/docs/content/en/reference/references/mesheryctl/model/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/model/generate.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-generate
 display_title: false
 command: model
 subcommand: generate
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model generate

--- a/docs/content/en/reference/references/mesheryctl/model/import.md
+++ b/docs/content/en/reference/references/mesheryctl/model/import.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-import
 display_title: false
 command: model
 subcommand: import
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model import

--- a/docs/content/en/reference/references/mesheryctl/model/import.md
+++ b/docs/content/en/reference/references/mesheryctl/model/import.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-import
 display_title: false
 command: model
 subcommand: import
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model import

--- a/docs/content/en/reference/references/mesheryctl/model/init.md
+++ b/docs/content/en/reference/references/mesheryctl/model/init.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-init
 display_title: false
 command: model
 subcommand: init
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model init

--- a/docs/content/en/reference/references/mesheryctl/model/init.md
+++ b/docs/content/en/reference/references/mesheryctl/model/init.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-init
 display_title: false
 command: model
 subcommand: init
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model init

--- a/docs/content/en/reference/references/mesheryctl/model/list.md
+++ b/docs/content/en/reference/references/mesheryctl/model/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-list
 display_title: false
 command: model
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model list

--- a/docs/content/en/reference/references/mesheryctl/model/list.md
+++ b/docs/content/en/reference/references/mesheryctl/model/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-list
 display_title: false
 command: model
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model list

--- a/docs/content/en/reference/references/mesheryctl/model/search.md
+++ b/docs/content/en/reference/references/mesheryctl/model/search.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-search
 display_title: false
 command: model
 subcommand: search
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model search

--- a/docs/content/en/reference/references/mesheryctl/model/search.md
+++ b/docs/content/en/reference/references/mesheryctl/model/search.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-search
 display_title: false
 command: model
 subcommand: search
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model search

--- a/docs/content/en/reference/references/mesheryctl/model/view.md
+++ b/docs/content/en/reference/references/mesheryctl/model/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-model-view
 display_title: false
 command: model
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl model view

--- a/docs/content/en/reference/references/mesheryctl/model/view.md
+++ b/docs/content/en/reference/references/mesheryctl/model/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-model-view
 display_title: false
 command: model
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-model]
 ---
 
 # mesheryctl model view

--- a/docs/content/en/reference/references/mesheryctl/organization/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-organization
 display_title: false
 command: organization
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl organization

--- a/docs/content/en/reference/references/mesheryctl/organization/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-organization
 display_title: false
 command: organization
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-organization]
 ---
 
 # mesheryctl organization

--- a/docs/content/en/reference/references/mesheryctl/organization/list.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-organization-list
 display_title: false
 command: organization
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl organization list

--- a/docs/content/en/reference/references/mesheryctl/organization/list.md
+++ b/docs/content/en/reference/references/mesheryctl/organization/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-organization-list
 display_title: false
 command: organization
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-organization]
 ---
 
 # mesheryctl organization list

--- a/docs/content/en/reference/references/mesheryctl/perf/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-perf
 display_title: false
 command: perf
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl perf

--- a/docs/content/en/reference/references/mesheryctl/perf/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-perf
 display_title: false
 command: perf
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-perf]
 ---
 
 # mesheryctl perf

--- a/docs/content/en/reference/references/mesheryctl/perf/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/apply.md
@@ -3,6 +3,7 @@ title: mesheryctl-perf-apply
 display_title: false
 command: perf
 subcommand: apply
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl perf apply

--- a/docs/content/en/reference/references/mesheryctl/perf/apply.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/apply.md
@@ -3,7 +3,7 @@ title: mesheryctl-perf-apply
 display_title: false
 command: perf
 subcommand: apply
-categories: [mesheryctl-ref]
+categories: [mesheryctl-perf]
 ---
 
 # mesheryctl perf apply

--- a/docs/content/en/reference/references/mesheryctl/perf/profile.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/profile.md
@@ -3,6 +3,7 @@ title: mesheryctl-perf-profile
 display_title: false
 command: perf
 subcommand: profile
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl perf profile

--- a/docs/content/en/reference/references/mesheryctl/perf/profile.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/profile.md
@@ -3,7 +3,7 @@ title: mesheryctl-perf-profile
 display_title: false
 command: perf
 subcommand: profile
-categories: [mesheryctl-ref]
+categories: [mesheryctl-perf]
 ---
 
 # mesheryctl perf profile

--- a/docs/content/en/reference/references/mesheryctl/perf/result.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/result.md
@@ -3,6 +3,7 @@ title: mesheryctl-perf-result
 display_title: false
 command: perf
 subcommand: result
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl perf result

--- a/docs/content/en/reference/references/mesheryctl/perf/result.md
+++ b/docs/content/en/reference/references/mesheryctl/perf/result.md
@@ -3,7 +3,7 @@ title: mesheryctl-perf-result
 display_title: false
 command: perf
 subcommand: result
-categories: [mesheryctl-ref]
+categories: [mesheryctl-perf]
 ---
 
 # mesheryctl perf result

--- a/docs/content/en/reference/references/mesheryctl/registry/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-registry
 display_title: false
 command: registry
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl registry

--- a/docs/content/en/reference/references/mesheryctl/registry/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-registry
 display_title: false
 command: registry
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-registry]
 ---
 
 # mesheryctl registry

--- a/docs/content/en/reference/references/mesheryctl/registry/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/generate.md
@@ -3,6 +3,7 @@ title: mesheryctl-registry-generate
 display_title: false
 command: registry
 subcommand: generate
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl registry generate

--- a/docs/content/en/reference/references/mesheryctl/registry/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/generate.md
@@ -3,7 +3,7 @@ title: mesheryctl-registry-generate
 display_title: false
 command: registry
 subcommand: generate
-categories: [mesheryctl-ref]
+categories: [mesheryctl-registry]
 ---
 
 # mesheryctl registry generate

--- a/docs/content/en/reference/references/mesheryctl/registry/publish.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/publish.md
@@ -3,6 +3,7 @@ title: mesheryctl-registry-publish
 display_title: false
 command: registry
 subcommand: publish
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl registry publish

--- a/docs/content/en/reference/references/mesheryctl/registry/publish.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/publish.md
@@ -3,7 +3,7 @@ title: mesheryctl-registry-publish
 display_title: false
 command: registry
 subcommand: publish
-categories: [mesheryctl-ref]
+categories: [mesheryctl-registry]
 ---
 
 # mesheryctl registry publish

--- a/docs/content/en/reference/references/mesheryctl/registry/purge.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/purge.md
@@ -3,6 +3,7 @@ title: mesheryctl-registry-purge
 display_title: false
 command: registry
 subcommand: purge
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl registry purge

--- a/docs/content/en/reference/references/mesheryctl/registry/purge.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/purge.md
@@ -3,7 +3,7 @@ title: mesheryctl-registry-purge
 display_title: false
 command: registry
 subcommand: purge
-categories: [mesheryctl-ref]
+categories: [mesheryctl-registry]
 ---
 
 # mesheryctl registry purge

--- a/docs/content/en/reference/references/mesheryctl/registry/update.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/update.md
@@ -3,6 +3,7 @@ title: mesheryctl-registry-update
 display_title: false
 command: registry
 subcommand: update
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl registry update

--- a/docs/content/en/reference/references/mesheryctl/registry/update.md
+++ b/docs/content/en/reference/references/mesheryctl/registry/update.md
@@ -3,7 +3,7 @@ title: mesheryctl-registry-update
 display_title: false
 command: registry
 subcommand: update
-categories: [mesheryctl-ref]
+categories: [mesheryctl-registry]
 ---
 
 # mesheryctl registry update

--- a/docs/content/en/reference/references/mesheryctl/relationship/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-relationship
 display_title: false
 command: relationship
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl relationship

--- a/docs/content/en/reference/references/mesheryctl/relationship/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-relationship
 display_title: false
 command: relationship
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-relationship]
 ---
 
 # mesheryctl relationship

--- a/docs/content/en/reference/references/mesheryctl/relationship/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/generate.md
@@ -3,6 +3,7 @@ title: mesheryctl-relationship-generate
 display_title: false
 command: relationship
 subcommand: generate
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl relationship generate

--- a/docs/content/en/reference/references/mesheryctl/relationship/generate.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/generate.md
@@ -3,7 +3,7 @@ title: mesheryctl-relationship-generate
 display_title: false
 command: relationship
 subcommand: generate
-categories: [mesheryctl-ref]
+categories: [mesheryctl-relationship]
 ---
 
 # mesheryctl relationship generate

--- a/docs/content/en/reference/references/mesheryctl/relationship/list.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-relationship-list
 display_title: false
 command: relationship
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl relationship list

--- a/docs/content/en/reference/references/mesheryctl/relationship/list.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-relationship-list
 display_title: false
 command: relationship
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-relationship]
 ---
 
 # mesheryctl relationship list

--- a/docs/content/en/reference/references/mesheryctl/relationship/search.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/search.md
@@ -3,6 +3,7 @@ title: mesheryctl-relationship-search
 display_title: false
 command: relationship
 subcommand: search
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl relationship search

--- a/docs/content/en/reference/references/mesheryctl/relationship/search.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/search.md
@@ -3,7 +3,7 @@ title: mesheryctl-relationship-search
 display_title: false
 command: relationship
 subcommand: search
-categories: [mesheryctl-ref]
+categories: [mesheryctl-relationship]
 ---
 
 # mesheryctl relationship search

--- a/docs/content/en/reference/references/mesheryctl/relationship/view.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-relationship-view
 display_title: false
 command: relationship
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl relationship view

--- a/docs/content/en/reference/references/mesheryctl/relationship/view.md
+++ b/docs/content/en/reference/references/mesheryctl/relationship/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-relationship-view
 display_title: false
 command: relationship
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-relationship]
 ---
 
 # mesheryctl relationship view

--- a/docs/content/en/reference/references/mesheryctl/system/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-system
 display_title: false
 command: system
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system

--- a/docs/content/en/reference/references/mesheryctl/system/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-system
 display_title: false
 command: system
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system

--- a/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-channel
 display_title: false
 command: system
 subcommand: channel
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system channel

--- a/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-channel
 display_title: false
 command: system
 subcommand: channel
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system channel

--- a/docs/content/en/reference/references/mesheryctl/system/channel/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/set.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-channel-set
 display_title: false
 command: system
 subcommand: channel
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system channel set

--- a/docs/content/en/reference/references/mesheryctl/system/channel/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/set.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-channel-set
 display_title: false
 command: system
 subcommand: channel
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system channel set

--- a/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-channel-switch
 display_title: false
 command: system
 subcommand: channel
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system channel switch

--- a/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/switch.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-channel-switch
 display_title: false
 command: system
 subcommand: channel
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system channel switch

--- a/docs/content/en/reference/references/mesheryctl/system/channel/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-channel-view
 display_title: false
 command: system
 subcommand: channel
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system channel view

--- a/docs/content/en/reference/references/mesheryctl/system/channel/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/channel/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-channel-view
 display_title: false
 command: system
 subcommand: channel
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system channel view

--- a/docs/content/en/reference/references/mesheryctl/system/check.md
+++ b/docs/content/en/reference/references/mesheryctl/system/check.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-check
 display_title: false
 command: system
 subcommand: check
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system check

--- a/docs/content/en/reference/references/mesheryctl/system/check.md
+++ b/docs/content/en/reference/references/mesheryctl/system/check.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-check
 display_title: false
 command: system
 subcommand: check
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system check

--- a/docs/content/en/reference/references/mesheryctl/system/context/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-context
 display_title: false
 command: system
 subcommand: context
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system context

--- a/docs/content/en/reference/references/mesheryctl/system/context/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-context
 display_title: false
 command: system
 subcommand: context
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system context

--- a/docs/content/en/reference/references/mesheryctl/system/context/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/create.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-context-create
 display_title: false
 command: system
 subcommand: context
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system context create

--- a/docs/content/en/reference/references/mesheryctl/system/context/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/create.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-context-create
 display_title: false
 command: system
 subcommand: context
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system context create

--- a/docs/content/en/reference/references/mesheryctl/system/context/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-context-delete
 display_title: false
 command: system
 subcommand: context
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system context delete

--- a/docs/content/en/reference/references/mesheryctl/system/context/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-context-delete
 display_title: false
 command: system
 subcommand: context
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system context delete

--- a/docs/content/en/reference/references/mesheryctl/system/context/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-context-list
 display_title: false
 command: system
 subcommand: context
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system context list

--- a/docs/content/en/reference/references/mesheryctl/system/context/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-context-list
 display_title: false
 command: system
 subcommand: context
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system context list

--- a/docs/content/en/reference/references/mesheryctl/system/context/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/switch.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-context-switch
 display_title: false
 command: system
 subcommand: context
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system context switch

--- a/docs/content/en/reference/references/mesheryctl/system/context/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/switch.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-context-switch
 display_title: false
 command: system
 subcommand: context
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system context switch

--- a/docs/content/en/reference/references/mesheryctl/system/context/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-context-view
 display_title: false
 command: system
 subcommand: context
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system context view

--- a/docs/content/en/reference/references/mesheryctl/system/context/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/context/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-context-view
 display_title: false
 command: system
 subcommand: context
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system context view

--- a/docs/content/en/reference/references/mesheryctl/system/dashboard.md
+++ b/docs/content/en/reference/references/mesheryctl/system/dashboard.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-dashboard
 display_title: false
 command: system
 subcommand: dashboard
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system dashboard

--- a/docs/content/en/reference/references/mesheryctl/system/dashboard.md
+++ b/docs/content/en/reference/references/mesheryctl/system/dashboard.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-dashboard
 display_title: false
 command: system
 subcommand: dashboard
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system dashboard

--- a/docs/content/en/reference/references/mesheryctl/system/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-delete
 display_title: false
 command: system
 subcommand: delete
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system delete

--- a/docs/content/en/reference/references/mesheryctl/system/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-delete
 display_title: false
 command: system
 subcommand: delete
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system delete

--- a/docs/content/en/reference/references/mesheryctl/system/login.md
+++ b/docs/content/en/reference/references/mesheryctl/system/login.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-login
 display_title: false
 command: system
 subcommand: login
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system login

--- a/docs/content/en/reference/references/mesheryctl/system/login.md
+++ b/docs/content/en/reference/references/mesheryctl/system/login.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-login
 display_title: false
 command: system
 subcommand: login
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system login

--- a/docs/content/en/reference/references/mesheryctl/system/logout.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logout.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-logout
 display_title: false
 command: system
 subcommand: logout
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system logout

--- a/docs/content/en/reference/references/mesheryctl/system/logout.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logout.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-logout
 display_title: false
 command: system
 subcommand: logout
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system logout

--- a/docs/content/en/reference/references/mesheryctl/system/logs.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logs.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-logs
 display_title: false
 command: system
 subcommand: logs
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system logs

--- a/docs/content/en/reference/references/mesheryctl/system/logs.md
+++ b/docs/content/en/reference/references/mesheryctl/system/logs.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-logs
 display_title: false
 command: system
 subcommand: logs
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system logs

--- a/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-provider
 display_title: false
 command: system
 subcommand: provider
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system provider

--- a/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-provider
 display_title: false
 command: system
 subcommand: provider
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system provider

--- a/docs/content/en/reference/references/mesheryctl/system/provider/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-provider-list
 display_title: false
 command: system
 subcommand: provider
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system provider list

--- a/docs/content/en/reference/references/mesheryctl/system/provider/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-provider-list
 display_title: false
 command: system
 subcommand: provider
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system provider list

--- a/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-provider-reset
 display_title: false
 command: system
 subcommand: provider
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system provider reset

--- a/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/reset.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-provider-reset
 display_title: false
 command: system
 subcommand: provider
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system provider reset

--- a/docs/content/en/reference/references/mesheryctl/system/provider/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/set.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-provider-set
 display_title: false
 command: system
 subcommand: provider
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system provider set

--- a/docs/content/en/reference/references/mesheryctl/system/provider/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/set.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-provider-set
 display_title: false
 command: system
 subcommand: provider
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system provider set

--- a/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-provider-switch
 display_title: false
 command: system
 subcommand: provider
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system provider switch

--- a/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/switch.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-provider-switch
 display_title: false
 command: system
 subcommand: provider
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system provider switch

--- a/docs/content/en/reference/references/mesheryctl/system/provider/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-provider-view
 display_title: false
 command: system
 subcommand: provider
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system provider view

--- a/docs/content/en/reference/references/mesheryctl/system/provider/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/provider/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-provider-view
 display_title: false
 command: system
 subcommand: provider
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system provider view

--- a/docs/content/en/reference/references/mesheryctl/system/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/reset.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-reset
 display_title: false
 command: system
 subcommand: reset
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system reset

--- a/docs/content/en/reference/references/mesheryctl/system/reset.md
+++ b/docs/content/en/reference/references/mesheryctl/system/reset.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-reset
 display_title: false
 command: system
 subcommand: reset
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system reset

--- a/docs/content/en/reference/references/mesheryctl/system/restart.md
+++ b/docs/content/en/reference/references/mesheryctl/system/restart.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-restart
 display_title: false
 command: system
 subcommand: restart
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system restart

--- a/docs/content/en/reference/references/mesheryctl/system/restart.md
+++ b/docs/content/en/reference/references/mesheryctl/system/restart.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-restart
 display_title: false
 command: system
 subcommand: restart
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system restart

--- a/docs/content/en/reference/references/mesheryctl/system/start.md
+++ b/docs/content/en/reference/references/mesheryctl/system/start.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-start
 display_title: false
 command: system
 subcommand: start
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system start

--- a/docs/content/en/reference/references/mesheryctl/system/start.md
+++ b/docs/content/en/reference/references/mesheryctl/system/start.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-start
 display_title: false
 command: system
 subcommand: start
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system start

--- a/docs/content/en/reference/references/mesheryctl/system/status.md
+++ b/docs/content/en/reference/references/mesheryctl/system/status.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-status
 display_title: false
 command: system
 subcommand: status
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system status

--- a/docs/content/en/reference/references/mesheryctl/system/status.md
+++ b/docs/content/en/reference/references/mesheryctl/system/status.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-status
 display_title: false
 command: system
 subcommand: status
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system status

--- a/docs/content/en/reference/references/mesheryctl/system/stop.md
+++ b/docs/content/en/reference/references/mesheryctl/system/stop.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-stop
 display_title: false
 command: system
 subcommand: stop
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system stop

--- a/docs/content/en/reference/references/mesheryctl/system/stop.md
+++ b/docs/content/en/reference/references/mesheryctl/system/stop.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-stop
 display_title: false
 command: system
 subcommand: stop
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system stop

--- a/docs/content/en/reference/references/mesheryctl/system/token/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-token
 display_title: false
 command: system
 subcommand: token
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system token

--- a/docs/content/en/reference/references/mesheryctl/system/token/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-token
 display_title: false
 command: system
 subcommand: token
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system token

--- a/docs/content/en/reference/references/mesheryctl/system/token/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/create.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-token-create
 display_title: false
 command: system
 subcommand: token
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system token create

--- a/docs/content/en/reference/references/mesheryctl/system/token/create.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/create.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-token-create
 display_title: false
 command: system
 subcommand: token
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system token create

--- a/docs/content/en/reference/references/mesheryctl/system/token/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/delete.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-token-delete
 display_title: false
 command: system
 subcommand: token
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system token delete

--- a/docs/content/en/reference/references/mesheryctl/system/token/delete.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/delete.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-token-delete
 display_title: false
 command: system
 subcommand: token
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system token delete

--- a/docs/content/en/reference/references/mesheryctl/system/token/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-token-list
 display_title: false
 command: system
 subcommand: token
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system token list

--- a/docs/content/en/reference/references/mesheryctl/system/token/list.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-token-list
 display_title: false
 command: system
 subcommand: token
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system token list

--- a/docs/content/en/reference/references/mesheryctl/system/token/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/set.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-token-set
 display_title: false
 command: system
 subcommand: token
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system token set

--- a/docs/content/en/reference/references/mesheryctl/system/token/set.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/set.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-token-set
 display_title: false
 command: system
 subcommand: token
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system token set

--- a/docs/content/en/reference/references/mesheryctl/system/token/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-token-view
 display_title: false
 command: system
 subcommand: token
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system token view

--- a/docs/content/en/reference/references/mesheryctl/system/token/view.md
+++ b/docs/content/en/reference/references/mesheryctl/system/token/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-token-view
 display_title: false
 command: system
 subcommand: token
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system token view

--- a/docs/content/en/reference/references/mesheryctl/system/update.md
+++ b/docs/content/en/reference/references/mesheryctl/system/update.md
@@ -3,6 +3,7 @@ title: mesheryctl-system-update
 display_title: false
 command: system
 subcommand: update
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl system update

--- a/docs/content/en/reference/references/mesheryctl/system/update.md
+++ b/docs/content/en/reference/references/mesheryctl/system/update.md
@@ -3,7 +3,7 @@ title: mesheryctl-system-update
 display_title: false
 command: system
 subcommand: update
-categories: [mesheryctl-ref]
+categories: [mesheryctl-system]
 ---
 
 # mesheryctl system update

--- a/docs/content/en/reference/references/mesheryctl/version.md
+++ b/docs/content/en/reference/references/mesheryctl/version.md
@@ -3,6 +3,7 @@ title: mesheryctl-version
 display_title: false
 command: version
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl version

--- a/docs/content/en/reference/references/mesheryctl/version.md
+++ b/docs/content/en/reference/references/mesheryctl/version.md
@@ -3,7 +3,7 @@ title: mesheryctl-version
 display_title: false
 command: version
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-version]
 ---
 
 # mesheryctl version

--- a/docs/content/en/reference/references/mesheryctl/workspace/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/_index.md
@@ -3,6 +3,7 @@ title: mesheryctl-workspace
 display_title: false
 command: workspace
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl workspace

--- a/docs/content/en/reference/references/mesheryctl/workspace/_index.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/_index.md
@@ -3,7 +3,7 @@ title: mesheryctl-workspace
 display_title: false
 command: workspace
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-workspace]
 ---
 
 # mesheryctl workspace

--- a/docs/content/en/reference/references/mesheryctl/workspace/create.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/create.md
@@ -3,6 +3,7 @@ title: mesheryctl-workspace-create
 display_title: false
 command: workspace
 subcommand: create
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl workspace create

--- a/docs/content/en/reference/references/mesheryctl/workspace/create.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/create.md
@@ -3,7 +3,7 @@ title: mesheryctl-workspace-create
 display_title: false
 command: workspace
 subcommand: create
-categories: [mesheryctl-ref]
+categories: [mesheryctl-workspace]
 ---
 
 # mesheryctl workspace create

--- a/docs/content/en/reference/references/mesheryctl/workspace/list.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/list.md
@@ -3,6 +3,7 @@ title: mesheryctl-workspace-list
 display_title: false
 command: workspace
 subcommand: list
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl workspace list

--- a/docs/content/en/reference/references/mesheryctl/workspace/list.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/list.md
@@ -3,7 +3,7 @@ title: mesheryctl-workspace-list
 display_title: false
 command: workspace
 subcommand: list
-categories: [mesheryctl-ref]
+categories: [mesheryctl-workspace]
 ---
 
 # mesheryctl workspace list

--- a/docs/content/en/reference/references/mesheryctl/workspace/view.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/view.md
@@ -3,6 +3,7 @@ title: mesheryctl-workspace-view
 display_title: false
 command: workspace
 subcommand: view
+categories: [mesheryctl-ref]
 ---
 
 # mesheryctl workspace view

--- a/docs/content/en/reference/references/mesheryctl/workspace/view.md
+++ b/docs/content/en/reference/references/mesheryctl/workspace/view.md
@@ -3,7 +3,7 @@ title: mesheryctl-workspace-view
 display_title: false
 command: workspace
 subcommand: view
-categories: [mesheryctl-ref]
+categories: [mesheryctl-workspace]
 ---
 
 # mesheryctl workspace view

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -38,6 +38,22 @@ taxonomyCloudTitle = ["Tags", "Categories"]
 # set taxonomyPageHeader = [] to hide taxonomies on the page headers
 taxonomyPageHeader = ["tags", "categories"]
 
+[related]
+  threshold = 70
+  includeNewer = true
+  toLower = true
+
+  [[related.indices]]
+    name = "section"
+    weight = 10
+
+  [[related.indices]]
+    name = "tags"
+    weight = 50
+
+  [[related.indices]]
+    name = "categories"
+    weight = 70
 
 staticDir = ['static']
 

--- a/docs/layouts/shortcodes/mesheryctl-guides-list.html
+++ b/docs/layouts/shortcodes/mesheryctl-guides-list.html
@@ -1,8 +1,0 @@
-<ul>
-  {{ range where .Site.AllPages "Section" "guides" }}
-    {{ if and (in .Params.categories "mesheryctl") (not .IsSection) }}
-      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-    {{ end }}
-  {{ end }}
-  <li><a href="{{ relref . "installation/upgrades/index.md#upgrading-meshery-cli" }}">Upgrading Meshery CLI</a></li>
-</ul>

--- a/docs/layouts/shortcodes/mesheryctl-guides-list.html
+++ b/docs/layouts/shortcodes/mesheryctl-guides-list.html
@@ -1,0 +1,8 @@
+<ul>
+  {{ range where .Site.AllPages "Section" "guides" }}
+    {{ if and (in .Params.categories "mesheryctl") (not .IsSection) }}
+      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  {{ end }}
+  <li><a href="{{ relref . "installation/upgrades/index.md#upgrading-meshery-cli" }}">Upgrading Meshery CLI</a></li>
+</ul>

--- a/mesheryctl/doc/doc.go
+++ b/mesheryctl/doc/doc.go
@@ -36,6 +36,7 @@ title: %s
 display_title: false
 command: %s
 subcommand: %s
+categories: [mesheryctl-ref]
 ---
 
 `

--- a/mesheryctl/doc/doc.go
+++ b/mesheryctl/doc/doc.go
@@ -36,7 +36,7 @@ title: %s
 display_title: false
 command: %s
 subcommand: %s
-categories: [mesheryctl-ref]
+categories: [%s]
 ---
 
 `
@@ -46,7 +46,7 @@ func prepender(filename string) string {
 	idx := strings.Index(filename, "mesheryctl")
 	if idx == -1 {
 		base := strings.TrimSuffix(filepath.Base(filename), ".md")
-		return fmt.Sprintf(markdownTemplateCommand, base, base, "nil")
+		return fmt.Sprintf(markdownTemplateCommand, base, base, "nil", "mesheryctl-ref")
 	}
 
 	relPath := strings.TrimSuffix(filename[idx:], ".md")
@@ -73,12 +73,18 @@ func prepender(filename string) string {
 		subcommand = parts[2] // Set the second part as the subcommand
 	}
 
+	category := "mesheryctl-ref"
+	if len(parts) >= 2 {
+		category = fmt.Sprintf("mesheryctl-%s", parts[1])
+	}
+
 	title := strings.Join(parts, "-")
 
 	return fmt.Sprintf(markdownTemplateCommand,
 		title,
 		command,
 		subcommand,
+		category,
 	)
 }
 

--- a/mesheryctl/doc/doc_test.go
+++ b/mesheryctl/doc/doc_test.go
@@ -32,6 +32,7 @@ title: mesheryctl
 display_title: false
 command: mesheryctl
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 `
@@ -45,6 +46,7 @@ title: mesheryctl-adapter
 display_title: false
 command: adapter
 subcommand: nil
+categories: [mesheryctl-ref]
 ---
 
 `
@@ -58,6 +60,7 @@ title: mesheryctl-adapter-deploy
 display_title: false
 command: adapter
 subcommand: deploy
+categories: [mesheryctl-ref]
 ---
 
 `
@@ -71,6 +74,7 @@ title: mesheryctl-exp-relationship-generate
 display_title: false
 command: exp
 subcommand: relationship
+categories: [mesheryctl-ref]
 ---
 
 `

--- a/mesheryctl/doc/doc_test.go
+++ b/mesheryctl/doc/doc_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -46,7 +47,7 @@ title: mesheryctl-adapter
 display_title: false
 command: adapter
 subcommand: nil
-categories: [mesheryctl-ref]
+categories: [mesheryctl-adapter]
 ---
 
 `
@@ -60,7 +61,7 @@ title: mesheryctl-adapter-deploy
 display_title: false
 command: adapter
 subcommand: deploy
-categories: [mesheryctl-ref]
+categories: [mesheryctl-adapter]
 ---
 
 `
@@ -74,11 +75,53 @@ title: mesheryctl-exp-relationship-generate
 display_title: false
 command: exp
 subcommand: relationship
-categories: [mesheryctl-ref]
+categories: [mesheryctl-exp]
 ---
 
 `
 		filename := "docs/content/en/reference/references/mesheryctl/exp/relationship/generate.md"
+		assert.Equal(t, expected, prepender(filename))
+	})
+
+	t.Run("Single command (completion.md)", func(t *testing.T) {
+		expected := `---
+title: mesheryctl-completion
+display_title: false
+command: completion
+subcommand: nil
+categories: [mesheryctl-completion]
+---
+
+`
+		filename := "docs/content/en/reference/references/mesheryctl/completion.md"
+		assert.Equal(t, expected, prepender(filename))
+	})
+
+	t.Run("Single command (version.md)", func(t *testing.T) {
+		expected := `---
+title: mesheryctl-version
+display_title: false
+command: version
+subcommand: nil
+categories: [mesheryctl-version]
+---
+
+`
+		filename := "docs/content/en/reference/references/mesheryctl/version.md"
+		assert.Equal(t, expected, prepender(filename))
+	})
+
+	t.Run("Subcommand (system/start.md)", func(t *testing.T) {
+		expected := `---
+title: mesheryctl-system-start
+display_title: false
+command: system
+subcommand: start
+categories: [mesheryctl-system]
+---
+
+`
+		filename := "docs/content/en/reference/references/mesheryctl/system/start.md"
 		assert.Equal(t, expected, prepender(filename))
 	})
 }
@@ -110,13 +153,21 @@ func TestDoc(t *testing.T) {
 		)
 	})
 
-	t.Run("Test GenMarkdownTreeCustom function", func(t *testing.T) {
+	t.Run("Test GenMarkdownTreeCustom function skips root _index.md", func(t *testing.T) {
 		cmd.AddCommand(&cobra.Command{
 			Use: "sub",
 		})
 		markDownPath := t.TempDir()
-		err := GenMarkdownTreeCustom(cmd, markDownPath, prepender, linkHandler)
+		rootIndex := filepath.Join(markDownPath, "_index.md")
+		err := os.WriteFile(rootIndex, []byte("hand-authored"), 0644)
 		assert.NoError(t, err)
+
+		err = GenMarkdownTreeCustom(cmd, markDownPath, prepender, linkHandler)
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(rootIndex)
+		assert.NoError(t, err)
+		assert.Equal(t, "hand-authored", string(content))
 	})
 
 	t.Run("Test HasSeeAlso function", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes #20149 
migrates Meshery's local static Related / See Also sections to the upstream Layer5 Docs related-reading module.
It adds Hugo's related-content configuration and updates generated `mesheryctl` reference pages so they participate in related-content discovery

### Changes

- Configure Hugo related content using `section`, `tags`, and `categories`.
- Add `categories: [mesheryctl-ref]` to generated `mesheryctl` reference documentation.
- Regenerate the `mesheryctl` reference pages from the generator.
- Remove the obsolete local `mesheryctl-guides-list` shortcode.
- Remove its shortcode documentation example.
- Remove redundant static Related / See Also / Suggested Reading sections from the audited documentation pages.
- Preserve existing troubleshooting content and section navigation.
- Remove the stale Kubernetes See Also TOC anchor.

### Context

This PR follows the direction of #20150, but is implemented as a fresh branch from the current `upstream/master` rather than reviving the stale PR. Only the changes still applicable to the current documentation architecture have been carried forward.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved documentation navigation by organizing Meshery CLI references into command-specific categories.
  * Added related-content matching to surface more relevant pages across the documentation.
  * Renamed selected “See Also” and “Additional Guides” sections for consistency.
  * Converted the Quick Start resource links to a clearer Markdown list.
  * Removed several redundant related-reading sections and Meshery CLI guide listings from installation and troubleshooting pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->