### PR TITLE
fix: deduplicate embedded design style properties

### DIFF
--- a/server/models/pattern/core/pattern.go
+++ b/server/models/pattern/core/pattern.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/gofrs/uuid"
 	"github.com/meshery/meshery/server/models/pattern/utils"
@@ -189,13 +190,25 @@ func ToCytoscapeJS(patternFile *pattern.PatternFile, log logger.Handler) (cytosc
 			return cy, err
 		}
 
+		var data interface{} = *cmp
+		cmpByt, err := json.Marshal(cmp)
+		if err == nil {
+			var cmpMap map[string]interface{}
+			if err := json.Unmarshal(cmpByt, &cmpMap); err == nil {
+				if styles, ok := cmpMap["styles"].(map[string]interface{}); ok {
+					resolveDuplicateStyles(styles)
+				}
+				data = cmpMap
+			}
+		}
+
 		elem := cytoscapejs.Element{
 			Data:       elemData,
 			Position:   &elemPosition,
 			Selectable: true,
 			Grabbable:  true,
-			Scratch: map[string]component.ComponentDefinition{
-				"_data": *cmp,
+			Scratch: map[string]interface{}{
+				"_data": data,
 			},
 		}
 
@@ -540,4 +553,30 @@ func getCytoscapeJSPosition(component *component.ComponentDefinition, log logger
 	}
 
 	return pos, nil
+}
+
+func resolveDuplicateStyles(styles map[string]interface{}) {
+	for k := range styles {
+		kebab := toKebabCase(k)
+		if kebab != k {
+			if _, exists := styles[kebab]; exists {
+				delete(styles, k)
+			}
+		}
+	}
+}
+
+func toKebabCase(s string) string {
+	var res string
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				res += "-"
+			}
+			res += string(unicode.ToLower(r))
+		} else {
+			res += string(r)
+		}
+	}
+	return res
 }

--- a/server/models/pattern/core/pattern_test.go
+++ b/server/models/pattern/core/pattern_test.go
@@ -2,6 +2,12 @@ package core
 
 import (
 	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models/pattern/pattern"
+	"github.com/meshery/meshkit/logger"
+	"github.com/meshery/schemas/models/core"
+	"github.com/meshery/schemas/models/v1beta2/component"
 )
 
 func TestDesignNameFromFileName(t *testing.T) {
@@ -89,5 +95,88 @@ func TestDesignNameFromFileName(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expectedName, result)
 			}
 		})
+	}
+}
+
+func TestToCytoscapeJSDuplicateStyles(t *testing.T) {
+	log, _ := logger.New("test", logger.Options{Format: logger.SyslogLogFormat})
+
+	// Setup component definition with overlapping styles
+	cmpId, _ := uuid.NewV4()
+	bgColor := "blue"
+	textOpacity := float32(1.0)
+	cmp := component.ComponentDefinition{
+		ID: cmpId,
+		Styles: &core.ComponentStyles{
+			BackgroundColor: &bgColor,
+			TextOpacity:     &textOpacity,
+			AdditionalProperties: map[string]interface{}{
+				"backgroundColor": "red",
+				"textOpacity":     0.5,
+				"borderWidth":     "2px",
+				"border-width":    "2px",
+				"transparent":     "true", // ordinary CSS value
+				"inherit":         "true",
+			},
+		},
+	}
+
+	pf := &pattern.PatternFile{
+		Components: []*component.ComponentDefinition{&cmp},
+	}
+
+	cy, err := ToCytoscapeJS(pf, log)
+	if err != nil {
+		t.Fatalf("ToCytoscapeJS failed: %v", err)
+	}
+
+	if len(cy.Elements) != 1 {
+		t.Fatalf("Expected 1 element, got %d", len(cy.Elements))
+	}
+
+	elem := cy.Elements[0]
+	scratch, ok := elem.Scratch.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Scratch is not map[string]interface{}")
+	}
+
+	data, ok := scratch["_data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("_data is not map[string]interface{}")
+	}
+
+	styles, ok := data["styles"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("styles is not map[string]interface{}")
+	}
+
+	// Verify duplicate camelCase/kebab-case resolution
+	if _, exists := styles["backgroundColor"]; exists {
+		t.Errorf("Expected camelCase 'backgroundColor' to be deleted")
+	}
+	if _, exists := styles["textOpacity"]; exists {
+		t.Errorf("Expected camelCase 'textOpacity' to be deleted")
+	}
+	if _, exists := styles["borderWidth"]; exists {
+		t.Errorf("Expected camelCase 'borderWidth' to be deleted")
+	}
+
+	// Verify legitimate kebab-case properties exist
+	if _, exists := styles["background-color"]; !exists {
+		t.Errorf("Expected kebab-case 'background-color' to be preserved")
+	}
+	if _, exists := styles["text-opacity"]; !exists {
+		t.Errorf("Expected kebab-case 'text-opacity' to be preserved")
+	}
+	if _, exists := styles["border-width"]; !exists {
+		t.Errorf("Expected kebab-case 'border-width' to be preserved")
+	}
+
+	// Verify other unrelated values
+	if _, exists := styles["transparent"]; !exists {
+		t.Errorf("Expected 'transparent' to be preserved")
+	}
+	if _, exists := styles["inherit"]; !exists {
+		t.Errorf("Expected 'inherit' to be preserved")
 	}
 }


### PR DESCRIPTION
#21744 

## Summary

This PR fixes duplicate style properties in Meshery's embedded design export.

While investigating issue #21744, I found that some component styles could be serialized in both `kebab-case` and `camelCase`, resulting in duplicate properties in the generated CytoscapeJS `elementStyles` payload.

### What changed

* Updated `ToCytoscapeJS` to remove duplicate `camelCase` style properties when their canonical `kebab-case` equivalents already exist.
* Legitimate standalone `kebab-case` properties are preserved.
* Added a regression test covering properties such as `backgroundColor`, `borderWidth`, and `textOpacity`.
* Kept the change limited to the backend serialization logic.
* No generated JavaScript files were modified.

### Upstream note

The `inheirt` typo and quoted `transparent` CSS values were traced to the upstream `@layer5/meshery-design-embed` package. They are intentionally not patched in this PR, since modifying generated artifacts would only mask the upstream issue.

### Testing

* `git diff --check` ✅
* Regression test added
* Go tests/build: not run locally because the Go toolchain is unavailable in the current environment; these should be validated by CI.

Closes #21744


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cytoscape component data handling for Unicode content.
  * Resolved duplicate style properties by consistently retaining kebab-case keys when equivalent camelCase keys are present.
  * Preserved legitimate style properties and unrelated component values during data conversion.

* **Tests**
  * Added coverage for duplicate style-key resolution and component data conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->