### PR TITLE
fix(ui): resolve TypeScript strict mode errors in data-fetch and rela…

### DIFF
--- a/ui/lib/data-fetch.ts
+++ b/ui/lib/data-fetch.ts
@@ -1,6 +1,6 @@
 let sessionExpiredShown = false;
 
-function showSessionExpiredAndRedirect() {
+function showSessionExpiredAndRedirect(): void {
   // Only show once even if multiple requests fail simultaneously
   if (sessionExpiredShown) return;
   sessionExpiredShown = true;
@@ -9,7 +9,7 @@ function showSessionExpiredAndRedirect() {
 
   // If the document isn't interactive yet, redirect immediately
   if (!document.body) {
-    window.location = redirectTo;
+    window.location.href = redirectTo;
     return;
   }
 
@@ -34,7 +34,7 @@ function showSessionExpiredAndRedirect() {
     'background:#477e96;color:#fff;border:none;border-radius:4px;padding:10px 32px;' +
     'font-size:14px;cursor:pointer';
   btn.onclick = () => {
-    window.location = redirectTo;
+    window.location.href = redirectTo;
   };
   box.appendChild(btn);
   overlay.appendChild(box);
@@ -42,15 +42,20 @@ function showSessionExpiredAndRedirect() {
 
   // Auto-redirect after 5 seconds if user doesn't click
   setTimeout(() => {
-    window.location = redirectTo;
+    window.location.href = redirectTo;
   }, 5000);
 }
 
 import { recordActivity } from './sessionTimer';
 
-const dataFetch = (url, options = {}, successFn, errorFn) => {
+const dataFetch = (
+  url: string,
+  options: RequestInit = {},
+  successFn?: (data: unknown) => void,
+  errorFn?: (err: unknown) => void
+): void => {
   if (errorFn === undefined) {
-    errorFn = (err) => {
+    errorFn = (err: unknown) => {
       console.error(`Error fetching ${url} --DataFetch`, err);
     };
   }
@@ -69,7 +74,7 @@ const dataFetch = (url, options = {}, successFn, errorFn) => {
         result = res.text().then((text) => {
           try {
             return JSON.parse(text);
-          } catch (e) {
+          } catch {
             return text;
           }
         });
@@ -81,11 +86,13 @@ const dataFetch = (url, options = {}, successFn, errorFn) => {
     })
     .then(successFn)
     .catch((e) => {
-      if (e.then) {
-        e.then((text) => errorFn(text));
+      if (e && typeof e.then === 'function') {
+        e.then((text: unknown) => {
+          if (errorFn) errorFn(text);
+        });
         return;
       }
-      errorFn(e);
+      if (errorFn) errorFn(e);
     });
 };
 
@@ -93,15 +100,15 @@ const dataFetch = (url, options = {}, successFn, errorFn) => {
  * promisifiedDataFetch adds a promise wrapper to the dataFetch function
  * and ideal for use inside async functions - which is most of the functions
  * @param {string} url url is the endpoint
- * @param {Record<string, any>} options HTTP request options
+ * @param {RequestInit} options HTTP request options
  * @returns
  */
-export function promisifiedDataFetch(url, options = {}) {
+export function promisifiedDataFetch<T = unknown>(url: string, options: RequestInit = {}): Promise<T> {
   return new Promise((resolve, reject) => {
     dataFetch(
       url,
       options,
-      (result) => resolve(result),
+      (result) => resolve(result as T),
       (err) => reject(err),
     );
   });

--- a/ui/lib/relayEnvironment.ts
+++ b/ui/lib/relayEnvironment.ts
@@ -1,12 +1,24 @@
-import { Environment, Network, RecordSource, Store } from 'relay-runtime';
+import {
+  Environment,
+  Network,
+  RecordSource,
+  Store,
+  type FetchFunction,
+  type RequestParameters,
+  type Variables,
+  type GraphQLResponse,
+} from 'relay-runtime';
 import { promisifiedDataFetch } from './data-fetch';
 
 // Meshery Server no longer exposes a `type Subscription`, so this environment is
 // request/response only — there is no graphql-ws client and no subscribe handler.
 // Real-time surfaces use Server-Sent Events (see lib/eventsSubscription.ts and
 // lib/controllersStatusSubscription.ts); everything else is REST.
-function fetchQuery(operation, variables) {
-  return promisifiedDataFetch('/api/system/graphql/query', {
+const fetchQuery: FetchFunction = (
+  operation: RequestParameters,
+  variables: Variables
+): Promise<GraphQLResponse> => {
+  return promisifiedDataFetch<GraphQLResponse>('/api/system/graphql/query', {
     method: 'POST',
     credentials: 'include',
     headers: {
@@ -17,9 +29,9 @@ function fetchQuery(operation, variables) {
       variables,
     }),
   });
-}
+};
 
-export const serializeRelayEnvironment = (environment) => {
+export const serializeRelayEnvironment = (environment: Environment) => {
   return environment.getStore().getSource().toJSON();
 };
 
@@ -28,7 +40,7 @@ export const serializeRelayEnvironment = (environment) => {
 // which defeats Relay's normalized cache.
 let clientEnvironment: Environment | null = null;
 
-export const createRelayEnvironment = (records = {}) => {
+export const createRelayEnvironment = (records: Record<string, unknown> = {}) => {
   // Server-side: always create a fresh environment per request
   if (typeof window === 'undefined') {
     return new Environment({


### PR DESCRIPTION
## Description
Resolves TypeScript strict-mode compiler errors in the GraphQL client and data fetching utilities as part of TypeScript Strict Wave 1.3 (Epic #21694).

### Changes
- **`ui/lib/data-fetch.ts`:**
  - Assigned `window.location.href = redirectTo` instead of direct `window.location` assignment, resolving TS2322 (`Type 'string' is not assignable to type 'Location'`).
  - Added strict typings for `dataFetch` and `promisifiedDataFetch<T>` using `RequestInit` and parameterized generics without introducing any `any`, `@ts-ignore`, or `!` non-null assertions.
- **`ui/lib/relayEnvironment.ts`:**
  - Imported `FetchFunction`, `RequestParameters`, `Variables`, and `GraphQLResponse` from `relay-runtime`.
  - Explicitly typed `fetchQuery: FetchFunction` and environment parameters, resolving TS2345 argument type mismatches.

Fixes #21714

---

### Contributor Checklist
- [x] Commits are signed with `git commit -s` (DCO compliant)
- [x] No new `any` types introduced
- [x] No `@ts-ignore` comments used
- [x] No non-null assertions (`!`) used
- [x] Minimal diff scoped exclusively to the affected files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session-expiration handling by redirecting users to the current page.
  - Improved error handling for rejected requests, ensuring failures are consistently surfaced to the application.
  - Improved reliability when processing responses that contain errors.

- **Refactor**
  - Strengthened internal request and data-handling reliability without changing the expected behavior of Relay-based data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->