### PR TITLE
refactor(ui): standardize table toolbars using Sistent DataTableToolbar

### DIFF
--- a/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
+++ b/ui/components/designs/patterns/MesheryPatternsToolbar.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { CustomColumnVisibilityControl, SearchBar, UniversalFilter } from '@sistent/sistent';
+import { CustomColumnVisibilityControl, SearchBar, UniversalFilter, DataTableToolbar } from '@sistent/sistent';
 import { Publish as PublishIcon } from '@/assets/icons';
 import ViewSwitch from '../../general/ViewSwitch';
 import { Keys } from '@meshery/schemas/permissions';
 import TooltipButton from '@/utils/TooltipButton';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
 import {
   ViewSwitchButton,
   CreateButton,
   AddIconStyled,
-  SearchWrapper,
   BtnText,
 } from './MesheryPatterns.styled';
 
@@ -42,68 +40,63 @@ function MesheryPatternsToolbar({
   setColumnVisibility,
 }) {
   return (
-    <ToolWrapper>
-      {width < 600 && isSearchExpanded ? null : (
-        <CreateButton style={{ display: 'flex' }}>
-          {!selectedPattern.show && (patterns.length >= 0 || viewType === 'table') && (
-            <div>
-              {disableCreateImportDesignButton ? null : (
-                <div style={{ display: 'flex', order: '1' }}>
-                  <div style={{ display: 'flex', marginRight: '2rem' }}>
-                    <TooltipButton
-                      title="Create Design"
-                      data-testid="meshery-patterns-create-design-btn"
-                      aria-label="Add Pattern"
-                      variant="contained"
-                      color="primary"
-                      size="large"
-                      // @ts-ignore
-                      onClick={() => router.push('designs/configurator')}
-                      style={{ display: 'flex' }}
-                      permissionKey={Keys.CatalogManagementCreateNewDesign}
-                    >
-                      <AddIconStyled />
-                      <BtnText> Create Design </BtnText>
-                    </TooltipButton>
-                  </div>
-                  <div style={{ display: 'flex', marginRight: '2rem', marginLeft: '-0.6rem' }}>
-                    <TooltipButton
-                      title="Import Design"
-                      data-testid="meshery-patterns-import-design-btn"
-                      aria-label="Add Pattern"
-                      variant="contained"
-                      color="primary"
-                      size="large"
-                      // @ts-ignore
-                      onClick={handleUploadImport}
-                      style={{ display: 'flex' }}
-                      permissionKey={Keys.CatalogManagementImportDesign}
-                    >
-                      <AddIconStyled>
-                        <PublishIcon />
-                      </AddIconStyled>
-                      <BtnText> Import Design </BtnText>
-                    </TooltipButton>
-                  </div>
+    <>
+      <DataTableToolbar
+        primaryActions={
+          width < 600 && isSearchExpanded ? null : (
+            <CreateButton style={{ display: 'flex' }}>
+              {!selectedPattern.show && (patterns.length >= 0 || viewType === 'table') && (
+                <div>
+                  {disableCreateImportDesignButton ? null : (
+                    <div style={{ display: 'flex', order: '1' }}>
+                      <div style={{ display: 'flex', marginRight: '2rem' }}>
+                        <TooltipButton
+                          title="Create Design"
+                          data-testid="meshery-patterns-create-design-btn"
+                          aria-label="Add Pattern"
+                          variant="contained"
+                          color="primary"
+                          size="large"
+                          // @ts-ignore
+                          onClick={() => router.push('designs/configurator')}
+                          style={{ display: 'flex' }}
+                          permissionKey={Keys.CatalogManagementCreateNewDesign}
+                        >
+                          <AddIconStyled />
+                          <BtnText> Create Design </BtnText>
+                        </TooltipButton>
+                      </div>
+                      <div style={{ display: 'flex', marginRight: '2rem', marginLeft: '-0.6rem' }}>
+                        <TooltipButton
+                          title="Import Design"
+                          data-testid="meshery-patterns-import-design-btn"
+                          aria-label="Add Pattern"
+                          variant="contained"
+                          color="primary"
+                          size="large"
+                          // @ts-ignore
+                          onClick={handleUploadImport}
+                          style={{ display: 'flex' }}
+                          permissionKey={Keys.CatalogManagementImportDesign}
+                        >
+                          <AddIconStyled>
+                            <PublishIcon />
+                          </AddIconStyled>
+                          <BtnText> Import Design </BtnText>
+                        </TooltipButton>
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
-            </div>
-          )}
-          {!selectedPattern.show && (
-            <div style={{ display: 'flex' }}>
-              {/* <StyledCatalogFilter>
-              <CatalogFilter
-                catalogVisibility={catalogVisibility}
-                handleCatalogVisibility={handleCatalogVisibility}
-                classes={classes}
-              />
-              </StyledCatalogFilter>*/}
-            </div>
-          )}
-        </CreateButton>
-      )}
-      <SearchWrapper style={{ display: 'flex' }}>
-        <>
+              {!selectedPattern.show && (
+                <div style={{ display: 'flex' }}>
+                </div>
+              )}
+            </CreateButton>
+          )
+        }
+        search={
           <SearchBar
             onSearch={(value) => {
               setSearch(value);
@@ -113,7 +106,9 @@ function MesheryPatternsToolbar({
             placeholder={`Search ${pageTitle.toLowerCase()}...`}
             data-testid="meshery-patterns-search-bar"
           />
-          {disableUniversalFilter ? null : (
+        }
+        filter={
+          disableUniversalFilter ? undefined : (
             <UniversalFilter
               id="ref"
               filters={filter}
@@ -122,24 +117,25 @@ function MesheryPatternsToolbar({
               handleApplyFilter={handleApplyFilter}
               data-testid="meshery-patterns-universal-filter"
             />
-          )}
-          {viewType === 'table' && (
+          )
+        }
+        columnVisibility={
+          viewType === 'table' ? (
             <CustomColumnVisibilityControl
               data-testid="meshery-patterns-column-visibility-control"
               id="ref"
               columns={columns}
               customToolsProps={{ columnVisibility, setColumnVisibility }}
             />
-          )}
-        </>
-
-        {!selectedPattern.show && (
-          <ViewSwitchButton>
-            <ViewSwitch view={viewType} changeView={setViewType} />
-          </ViewSwitchButton>
-        )}
-      </SearchWrapper>
-    </ToolWrapper>
+          ) : undefined
+        }
+      />
+      {!selectedPattern.show && (
+        <ViewSwitchButton>
+          <ViewSwitch view={viewType} changeView={setViewType} />
+        </ViewSwitchButton>
+      )}
+    </>
   );
 }
 

--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -8,11 +8,11 @@ import {
   PaginationItem,
   useHasPermission,
   useTheme,
+  DataTableToolbar,
 } from '@sistent/sistent';
 import { withRouter } from 'next/router';
 import { debounce } from 'lodash';
 import { CreateButtonWrapper, BulkActionWrapper } from './styles';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
 import AddIconCircleBorder from '../../assets/icons/AddIconCircleBorder';
 import EnvironmentCard from './environment-card';
 import EnvironmentIcon from '../../assets/icons/Environment';
@@ -466,41 +466,45 @@ const Environments = () => {
     <NoSsr>
       {canViewEnv ? (
         <>
-          <ToolWrapper>
-            <CreateButtonWrapper style={{ marginRight: '2rem' }}>
-              <Button
-                type="submit"
-                variant="contained"
-                color="primary"
-                size="large"
-                onClick={(e) => handleEnvironmentModalOpen(e, ACTION_TYPES.CREATE)}
-                sx={{
-                  padding: '8px',
-                  borderRadius: '5px',
-                }}
-                permissionKey={Keys.WorkspaceManagementCreateEnvironment}
-                data-cy="btnResetDatabase"
-              >
-                <AddIconCircleBorder sx={{ width: '20px', height: '20px' }} />
-                <Typography
+          <DataTableToolbar
+            primaryActions={
+              <CreateButtonWrapper style={{ marginRight: '2rem' }}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  color="primary"
+                  size="large"
+                  onClick={(e) => handleEnvironmentModalOpen(e, ACTION_TYPES.CREATE)}
                   sx={{
-                    paddingLeft: '4px',
-                    marginRight: '4px',
+                    padding: '8px',
+                    borderRadius: '5px',
                   }}
+                  permissionKey={Keys.WorkspaceManagementCreateEnvironment}
+                  data-cy="btnResetDatabase"
                 >
-                  Create
-                </Typography>
-              </Button>
-            </CreateButtonWrapper>
-            <SearchBar
-              onSearch={(value) => {
-                setSearch(value);
-              }}
-              placeholder="Search Environments..."
-              expanded={isSearchExpanded}
-              setExpanded={setIsSearchExpanded}
-            />
-          </ToolWrapper>
+                  <AddIconCircleBorder sx={{ width: '20px', height: '20px' }} />
+                  <Typography
+                    sx={{
+                      paddingLeft: '4px',
+                      marginRight: '4px',
+                    }}
+                  >
+                    Create
+                  </Typography>
+                </Button>
+              </CreateButtonWrapper>
+            }
+            search={
+              <SearchBar
+                onSearch={(value) => {
+                  setSearch(value);
+                }}
+                placeholder="Search Environments..."
+                expanded={isSearchExpanded}
+                setExpanded={setIsSearchExpanded}
+              />
+            }
+          />
           {selectedEnvironments.length > 0 && (
             <BulkActionWrapper>
               <Typography>

--- a/ui/components/performance/PerformanceProfiles.tsx
+++ b/ui/components/performance/PerformanceProfiles.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import Moment from 'react-moment';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
+
 import {
   AddCircleIcon as AddIcon,
   Button,
@@ -19,6 +19,7 @@ import {
   Typography,
   useTheme,
   useHasPermission,
+  DataTableToolbar,
 } from '@sistent/sistent';
 import MesheryPerformanceComponent from './index';
 import PerformanceProfileGrid from './PerformanceProfileGrid';
@@ -445,27 +446,29 @@ function PerformanceProfile({ handleDelete }) {
   return (
     <>
       <div style={{ padding: '0.5rem' }}>
-        <ToolWrapper>
-          {width < 550 && isSearchExpanded ? null : (
-            <>
-              {(testProfiles.length > 0 || viewType == 'table') && (
-                <div style={{ width: 'fit-content', alignSelf: 'flex-start' }}>
-                  <Button
-                    aria-label="Add Performance Profile"
-                    variant="contained"
-                    color="primary"
-                    size="large"
-                    onClick={() => setProfileForModal({})}
-                    permissionKey={Keys.PerformanceManagementAddPerformaceProfile}
-                  >
-                    <AddIcon style={{ paddingRight: '0.5', ...iconMedium }} />
-                    <ButtonTextWrapper> Add Performance Profile </ButtonTextWrapper>
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-          <ViewSwitchBUtton>
+        <DataTableToolbar
+          primaryActions={
+            width < 550 && isSearchExpanded ? null : (
+              <>
+                {(testProfiles.length > 0 || viewType == 'table') && (
+                  <div style={{ width: 'fit-content', alignSelf: 'flex-start' }}>
+                    <Button
+                      aria-label="Add Performance Profile"
+                      variant="contained"
+                      color="primary"
+                      size="large"
+                      onClick={() => setProfileForModal({})}
+                      permissionKey={Keys.PerformanceManagementAddPerformaceProfile}
+                    >
+                      <AddIcon style={{ paddingRight: '0.5', ...iconMedium }} />
+                      <ButtonTextWrapper> Add Performance Profile </ButtonTextWrapper>
+                    </Button>
+                  </div>
+                )}
+              </>
+            )
+          }
+          search={
             <SearchBar
               onSearch={(value) => {
                 setSearch(value);
@@ -474,16 +477,20 @@ function PerformanceProfile({ handleDelete }) {
               setExpanded={setIsSearchExpanded}
               placeholder="Search Profiles..."
             />
-            {viewType === 'table' && (
+          }
+          columnVisibility={
+            viewType === 'table' ? (
               <CustomColumnVisibilityControl
                 id="ref"
                 columns={columns}
                 customToolsProps={{ columnVisibility, setColumnVisibility }}
               />
-            )}
-            <ViewSwitch view={viewType} changeView={setViewType} />
-          </ViewSwitchBUtton>
-        </ToolWrapper>
+            ) : undefined
+          }
+        />
+        <ViewSwitchBUtton style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '0.5rem', marginBottom: '0.5rem' }}>
+          <ViewSwitch view={viewType} changeView={setViewType} />
+        </ViewSwitchBUtton>
 
         {viewType === 'grid' ? (
           <PerformanceProfileGrid

--- a/ui/components/workspaces/index.tsx
+++ b/ui/components/workspaces/index.tsx
@@ -21,6 +21,7 @@ import {
   useTheme,
   PROMPT_VARIANTS,
   ModalFooter,
+  DataTableToolbar,
 } from '@sistent/sistent';
 import { EmptyState } from '@/components/lifecycle/general';
 import AddIconCircleBorder from '@/assets/icons/AddIconCircleBorder';
@@ -42,7 +43,6 @@ import _PromptComponent from '../general/PromptComponent';
 import { EVENT_TYPES } from '../../lib/event-types';
 import { Keys } from '@meshery/schemas/permissions';
 import DefaultError from '../general/error-404/index';
-import { ToolWrapper } from '@/assets/styles/general/tool.styles';
 import ViewSwitch from '@/components/general/ViewSwitch';
 import { CreateButtonWrapper } from './styles';
 import WorkspaceGridView from './WorkspaceGridView';
@@ -439,62 +439,68 @@ const Workspaces = ({ onSelectWorkspace }) => {
           </Breadcrumbs>
         </div>
         {!selectedWorkspace.id && (
-          <ToolWrapper>
-            <CreateButtonWrapper style={{ marginRight: '2rem' }}>
-              <Button
-                type="submit"
-                variant="contained"
-                color="primary"
-                size="large"
-                onClick={(e) =>
-                  handleWorkspaceModalOpen(e, WORKSPACE_ACTION_TYPES.CREATE, selectedWorkspace)
-                }
-                sx={{
-                  backgroundColor: '#607d8b',
-                  padding: '8px',
-                  borderRadius: '5px',
-                }}
-                permissionKey={Keys.WorkspaceManagementCreateWorkspace}
-                data-cy="btnResetDatabase"
-              >
-                <AddIconCircleBorder sx={{ width: '20px', height: '20px' }} />
-                <Typography
+          <DataTableToolbar
+            primaryActions={
+              <CreateButtonWrapper style={{ marginRight: '2rem' }}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  color="primary"
+                  size="large"
+                  onClick={(e) =>
+                    handleWorkspaceModalOpen(e, WORKSPACE_ACTION_TYPES.CREATE, selectedWorkspace)
+                  }
                   sx={{
-                    paddingLeft: '4px',
-                    marginRight: '4px',
-                    textTransform: 'none',
+                    backgroundColor: '#607d8b',
+                    padding: '8px',
+                    borderRadius: '5px',
                   }}
+                  permissionKey={Keys.WorkspaceManagementCreateWorkspace}
+                  data-cy="btnResetDatabase"
                 >
-                  Create
-                </Typography>
-              </Button>
-            </CreateButtonWrapper>
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              {!selectedWorkspace?.id && (
-                <>
-                  <SearchBar
-                    onSearch={(value) => {
-                      setSearch(value);
+                  <AddIconCircleBorder sx={{ width: '20px', height: '20px' }} />
+                  <Typography
+                    sx={{
+                      paddingLeft: '4px',
+                      marginRight: '4px',
+                      textTransform: 'none',
                     }}
-                    placeholder="Search Workspaces..."
-                    expanded={isSearchExpanded}
-                    setExpanded={setIsSearchExpanded}
-                  />
-                  {viewType !== 'grid' && (
-                    <CustomColumnVisibilityControl
-                      columns={columnList}
-                      customToolsProps={{ columnVisibility, setColumnVisibility }}
-                    />
-                  )}
-                </>
-              )}
-              <ViewSwitch
-                view={viewType}
-                changeView={handleViewChange}
-                key={`view-switch-${viewType}`} // Add key to force re-render when viewType changes
-              />
-            </Box>
-          </ToolWrapper>
+                  >
+                    Create
+                  </Typography>
+                </Button>
+              </CreateButtonWrapper>
+            }
+            search={
+              !selectedWorkspace?.id ? (
+                <SearchBar
+                  onSearch={(value) => {
+                    setSearch(value);
+                  }}
+                  placeholder="Search Workspaces..."
+                  expanded={isSearchExpanded}
+                  setExpanded={setIsSearchExpanded}
+                />
+              ) : undefined
+            }
+            columnVisibility={
+              !selectedWorkspace?.id && viewType !== 'grid' ? (
+                <CustomColumnVisibilityControl
+                  columns={columnList}
+                  customToolsProps={{ columnVisibility, setColumnVisibility }}
+                />
+              ) : undefined
+            }
+          />
+        )}
+        {!selectedWorkspace.id && (
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', marginTop: '-0.5rem', marginBottom: '0.5rem' }}>
+            <ViewSwitch
+              view={viewType}
+              changeView={handleViewChange}
+              key={`view-switch-${viewType}`}
+            />
+          </Box>
         )}
         <>
           {workspaces.length === 0 ? (


### PR DESCRIPTION
## Description
Fixes #20654, #20656, #20657, #20658, #20659, #20660

Replaced legacy ad-hoc `<ToolWrapper>` styled containers across Meshery UI tables with `@sistent/sistent`'s standardized `<DataTableToolbar>`.

### Migrated Tables:
- **Environments Table** (#20656) — `ui/components/environments/index.tsx`
- **Workspaces Table** (#20657) — `ui/components/workspaces/index.tsx`
- **Designs & Catalog Tables** (#20658 & #20659) — `ui/components/designs/patterns/MesheryPatternsToolbar.tsx`
- **Performance Profiles Table** (#20660) — `ui/components/performance/PerformanceProfiles.tsx`

### Changes:
- Mapped actions into standard `primaryActions`, `search`, `filter`, and `columnVisibility` slots.
- Preserved all existing permission key guards, search handlers, column visibility options, and view switches.
**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized toolbar layouts across patterns, environments, performance profiles, and workspaces.
  * Create actions and search are presented consistently, with filtering and column visibility available where applicable.
  * View switching is displayed separately in performance profiles and workspaces for a clearer browsing experience.
  * Toolbar controls now follow a more consistent arrangement across these pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->