### PR TITLE
Improve search bar UI with enhanced styling and functionality

### DIFF
--- a/ui/components/layout/Header/Header.styles.tsx
+++ b/ui/components/layout/Header/Header.styles.tsx
@@ -97,11 +97,17 @@ export const CBadgeContainer = styled('div')({
 
 export const CMenuContainer = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.background.card,
-  borderRadius: '3px',
-  padding: '1rem',
-  boxShadow: '20px #979797',
+  borderRadius: '0px',
+  padding: '1.25rem',
+  minWidth: '520px',
+  maxWidth: 'calc(100vw - 32px)',
+  boxShadow: theme.shadows?.[8] || '0px 4px 20px rgba(0, 0, 0, 0.15)',
   transition: 'linear .2s',
   transitionProperty: 'height',
+  [theme.breakpoints.down('sm')]: {
+    minWidth: 'min(340px, calc(100vw - 32px))',
+    padding: '1rem',
+  },
 }));
 
 export const IconButtonAvatar = styled(IconButton)(({ theme }) => ({

--- a/ui/components/layout/Header/Header.test.tsx
+++ b/ui/components/layout/Header/Header.test.tsx
@@ -194,6 +194,7 @@ vi.mock('@sistent/sistent', () => ({
   Toolbar: ({ children }: any) => <div>{children}</div>,
   Paper: ({ children }: any) => <div>{children}</div>,
   MenuIcon: () => <svg data-testid="menu-icon" />,
+  InputAdornment: ({ children }: any) => <div data-testid="input-adornment">{children}</div>,
 }));
 
 vi.mock('@/utils/can', () => ({

--- a/ui/components/layout/Header/Header.tsx
+++ b/ui/components/layout/Header/Header.tsx
@@ -35,6 +35,7 @@ import {
   SettingsIcon,
   FilterAllIcon,
   useHasPermission,
+  InputAdornment,
 } from '@sistent/sistent';
 import { Keys } from '@meshery/schemas/permissions';
 import OrganizationAndWorkSpaceSwitcher from '../../workspaces/SpacesSwitcher/SpaceSwitcher';
@@ -177,7 +178,7 @@ function K8sContextMenu({
 
   const styleSlider = {
     position: 'absolute',
-    left: '-7rem',
+    right: '-0.5rem',
     zIndex: '-1',
     top: '60px',
   };
@@ -289,10 +290,10 @@ function K8sContextMenu({
                 }}
               >
                 <CMenuContainer id="menu-list-grow">
-                  <div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                     <TextField
                       id="search-ctx"
-                      label="Search"
+                      placeholder="Search by cluster name..."
                       size="small"
                       variant="outlined"
                       onChange={(ev) => searchContexts(ev.target.value)}
@@ -301,10 +302,24 @@ function K8sContextMenu({
                         backgroundColor: 'rgba(102, 102, 102, 0.12)',
                         margin: '1px 0px',
                       }}
-                      InputProps={{
-                        endAdornment: <SearchIcon style={iconMedium} width={24} />,
+                      slotProps={{
+                        htmlInput: {
+                          'aria-label': 'Search clusters',
+                        },
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <SearchIcon
+                                style={iconMedium}
+                                width={20}
+                                fill={theme?.palette?.text?.secondary || 'currentColor'}
+                              />
+                            </InputAdornment>
+                          ),
+                        },
                       }}
                     />
+                    <MesherySettingsEnvButtons onOpened={() => setShowFullContextMenu(false)} />
                   </div>
                   <div>
                     {contexts?.totalCount > 0 && (
@@ -362,9 +377,6 @@ function K8sContextMenu({
                         />
                       );
                     })}
-                    <Box sx={{ marginTop: '1rem' }}>
-                      <MesherySettingsEnvButtons onOpened={() => setShowFullContextMenu(false)} />
-                    </Box>
                   </div>
                 </CMenuContainer>
               </ClickAwayListener>


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21775

### Description
This PR improves the user interface of the Kubernetes cluster switcher dropdown in the header:

- **Row Alignment**: Placed the search box and the "Add Cluster" button side-by-side in the same row to save space and look cleaner.
- **Search Bar**: Added a search icon on the left inside the search box and replaced the label with clean placeholder text (`Search by cluster name...`).
- **Responsive Design**: Improved the dropdown width and padding so that it looks good on both desktop and mobile/smaller screens.
- **Better Alignment**: Fixed the position of the dropdown so it aligns properly with the Kubernetes icon in the header.

### Screenshots

**Before** 
<img width="1920" height="907" alt="Screenshot (1012)" src="https://github.com/user-attachments/assets/2f66e85b-2e56-4969-9068-b525b42d8e5c" />



 **After**
<img width="1909" height="970" alt="Screenshot (1031)" src="https://github.com/user-attachments/assets/fc1783a9-f4d9-41ca-a057-a239f1ba7abc" />
 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refined the Kubernetes context switcher with responsive sizing, spacing, and theme-aware shadows.
  * Updated the context search field with clearer placeholder text and a leading search icon.
  * Positioned environment settings controls alongside the search field.
  * Adjusted dropdown alignment and styling for improved usability across screen sizes.
  * Updated the menu container with square corners and increased default padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->