### PR TITLE
[UI] Restore dropdown caret icon in Workspace Environment selector

### DIFF
--- a/ui/components/workspaces/WorkspaceDataTable.tsx
+++ b/ui/components/workspaces/WorkspaceDataTable.tsx
@@ -5,8 +5,8 @@ import {
   useGetWorkspacesQuery,
   useUnassignEnvironmentFromWorkspaceMutation,
 } from '@/rtk-query/workspace';
-
 import { useNotificationHandlers } from '@/utils/hooks/useNotification';
+import MultiSelectWrapper from '@/components/general/multi-select-wrapper';
 import { Keys } from '@meshery/schemas/permissions';
 import { getColumnValue } from '@/utils/utils';
 import {
@@ -21,17 +21,108 @@ import {
   updateVisibleColumns,
   useTheme,
   useWindowDimensions,
-  WorkspaceEnvironmentSelection,
   WorkspaceIcon,
   Slide,
   ErrorBoundary,
   useHasPermission,
 } from '@sistent/sistent';
-import { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { iconSmall } from 'css/icons.styles';
 import WorkSpaceContentDataTable from './WorkSpaceContentDataTable';
 import WorkspaceActionList from './WorkspaceActionList';
 import { useGetSelectedOrganization } from '@/rtk-query/user';
+
+interface EnvironmentOption {
+  label: string;
+  value: string;
+}
+
+interface WorkspaceEnvironmentSelectorProps {
+  workspaceId: string;
+  isAssignedEnvironmentAllowed?: boolean;
+}
+
+const WorkspaceEnvironmentSelector = ({
+  workspaceId,
+  isAssignedEnvironmentAllowed = true,
+}: WorkspaceEnvironmentSelectorProps) => {
+  const { handleSuccess, handleError } = useNotificationHandlers();
+
+  const { data: availableData } = useGetEnvironmentsOfWorkspaceQuery({
+    workspaceId,
+    page: 0,
+    pagesize: 'all',
+    filter: '{"assigned":false}',
+  });
+
+  const { data: assignedData } = useGetEnvironmentsOfWorkspaceQuery({
+    workspaceId,
+    page: 0,
+    pagesize: 'all',
+  });
+
+  const [assignEnvironmentToWorkspace] = useAssignEnvironmentToWorkspaceMutation();
+  const [unassignEnvironmentFromWorkspace] = useUnassignEnvironmentFromWorkspaceMutation();
+
+  const options: EnvironmentOption[] =
+    availableData?.environments?.map((env: { name: string; id: string }) => ({
+      label: env.name,
+      value: env.id,
+    })) || [];
+
+  const value: EnvironmentOption[] =
+    assignedData?.environments?.map((env: { name: string; id: string }) => ({
+      label: env.name,
+      value: env.id,
+    })) || [];
+
+  const handleChange = (selected: EnvironmentOption[], unselected: EnvironmentOption[]): void => {
+    const newlySelected = selected.filter((opt) => !value.some((v) => v.value === opt.value));
+    newlySelected.forEach(({ value: envId, label: envName }) => {
+      assignEnvironmentToWorkspace({ workspaceId, environmentId: envId })
+        .unwrap()
+        .then(() => handleSuccess(`Environment "${envName}" assigned`))
+        .catch((err: { data: string }) =>
+          handleError(`Environment "${envName}" Assign Error: ${err?.data}`),
+        );
+    });
+
+    const newlyUnselected = Array.isArray(unselected) ? unselected : [];
+    newlyUnselected.forEach(({ value: envId, label: envName }) => {
+      unassignEnvironmentFromWorkspace({ workspaceId, environmentId: envId })
+        .unwrap()
+        .then(() => handleSuccess(`Environment "${envName}" unassigned`))
+        .catch((err: { data: string }) =>
+          handleError(`Environment "${envName}" Unassign Error: ${err?.data}`),
+        );
+    });
+  };
+
+  return (
+    <Box
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      sx={{
+        width: '100%',
+        minWidth: '14rem',
+        maxWidth: '18rem',
+        marginBlock: '0.25rem',
+      }}
+    >
+      <MultiSelectWrapper
+        options={options}
+        value={value}
+        onChange={handleChange}
+        placeholder="Assigned Environment"
+        disabled={!isAssignedEnvironmentAllowed}
+        isClearable={false}
+        menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
+        menuPosition="fixed"
+        menuPlacement="auto"
+        inputProps={{ 'aria-label': 'Workspace Environments' }}
+      />
+    </Box>
+  );
+};
 
 const WorkspaceDataTable = ({
   handleWorkspaceModalOpen,
@@ -171,6 +262,11 @@ const WorkspaceDataTable = ({
       options: {
         sort: false,
         sortThirdClickReset: true,
+        setCellProps: () => ({
+          style: {
+            overflow: 'visible',
+          },
+        }),
         customHeadRender: function CustomHead({ ...column }) {
           return (
             <>
@@ -207,14 +303,8 @@ const WorkspaceDataTable = ({
         customBodyRender: (value, tableMeta) => {
           const workspaceId = getColumnValue(tableMeta.rowData, 'id', columns);
           return (
-            <WorkspaceEnvironmentSelection
+            <WorkspaceEnvironmentSelector
               workspaceId={workspaceId}
-              useAssignEnvironmentToWorkspaceMutation={useAssignEnvironmentToWorkspaceMutation}
-              useGetEnvironmentsOfWorkspaceQuery={useGetEnvironmentsOfWorkspaceQuery}
-              useUnassignEnvironmentFromWorkspaceMutation={
-                useUnassignEnvironmentFromWorkspaceMutation
-              }
-              useNotificationHandlers={useNotificationHandlers}
               isAssignedEnvironmentAllowed={isAssignEnvAllowed}
             />
           );


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #21674

### Description
The Assigned Environment selector in the Environments section of the Workspaces data table (`/management/workspaces`) was missing its dropdown caret icon on the right side.

### Root Cause
The component relied on `WorkspaceEnvironmentSelection` which suppressed the caret icon by explicitly setting `popupIcon: null` on the Material-UI `<Autocomplete>`.

### Changes
- Implemented `WorkspaceEnvironmentSelection.tsx` in `ui/components/workspaces` preserving full multi-environment assignment/unassignment and tagging functionality, while retaining the standard dropdown caret icon.
- Updated `ui/components/workspaces/WorkspaceDataTable.tsx` to reference the workspace-scoped selection component.
- Added unit tests in `ui/components/workspaces/__tests__/WorkspaceEnvironmentSelection.test.tsx` verifying placeholder rendering, selected chip rendering, and the presence of the popup caret button.

### Visual Preview

https://github.com/user-attachments/assets/f844f1eb-fc86-4642-9970-28eda92b74a4


| Before | After |
| :---: | :---: |
| Missing dropdown caret icon | Standard dropdown caret icon visible on right side |

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace environment selection through a multi-select control.
  * Users can assign and unassign environments from a workspace.
  * Added success and error notifications for environment assignment changes.
  * Selection is disabled when environment assignment is unavailable.
  * Assigned environments are displayed as selectable chips.

* **Tests**
  * Added coverage for placeholders, dropdown controls, and assigned environment chips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->