### PR TITLE
fix(machines): treat Exit as loop-terminal in state machine transition loop

### DIFF
--- a/server/machines/models.go
+++ b/server/machines/models.go
@@ -195,7 +195,7 @@ func (sm *StateMachine) SendEvent(ctx context.Context, eventType EventType, payl
 	// so the repeated background failure is suppressed.
 	haltedWithoutTransition := false
 
-	for eventType != NoOp {
+	for eventType != NoOp && eventType != Exit {
 		nextState, err := sm.getNextState(eventType)
 		if err != nil {
 			sm.Log.Error(err)

--- a/server/machines/models_test.go
+++ b/server/machines/models_test.go
@@ -582,3 +582,46 @@ func TestSendEvent_ExitActionFailureHaltsWithoutTransition(t *testing.T) {
 		t.Fatalf("expected persisted status to remain CONNECTED, got %q", provider.status)
 	}
 }
+
+// TestSendEvent_ExitEventHaltsWithoutInvalidTransition covers the bug fixed by
+// treating Exit as loop-terminal: an action (like the real Prometheus/Grafana
+// RegisterAction.Execute) that reports success by emitting Exit must not be
+// treated as an ordinary event needing its own transition. Before the fix,
+// Exit was passed into getNextState() and, since REGISTERED (like the real
+// state machines) registers no Exit transition, this failed with an
+// "unsupported transition event" error even though the action itself
+// succeeded.
+func TestSendEvent_ExitEventHaltsWithoutInvalidTransition(t *testing.T) {
+	provider := &fakeProvider{status: connections.DISCOVERED}
+	sm := newTestMachine(t, provider, &stubAction{execNext: NoOp})
+	// REGISTERED's action reports success via Exit, exactly like the real
+	// Prometheus/Grafana RegisterAction.Execute on a successful health check.
+	// Like the real machines, no Exit transition is registered anywhere.
+	sm.States[REGISTERED] = State{
+		Events: Events{Connect: CONNECTED, Ignore: IGNORED},
+		Action: &stubAction{execNext: Exit},
+	}
+	ctx := newTestContext(t)
+
+	// Reach DISCOVERED first (Register is only valid from there).
+	if _, err := sm.SendEvent(ctx, Discovery, nil); err != nil {
+		t.Fatalf("setup: unexpected error reaching DISCOVERED: %v", err)
+	}
+
+	event, err := sm.SendEvent(ctx, Register, nil)
+	if err != nil {
+		t.Fatalf("expected Exit to halt the loop without an invalid-transition error, got %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected a confirmation event when the machine settles in REGISTERED, got nil")
+	}
+	if event.Severity != events.Informational {
+		t.Fatalf("expected Informational severity on success, got %q", event.Severity)
+	}
+	if sm.CurrentState != REGISTERED {
+		t.Fatalf("expected machine to settle in %q after Exit, got %q", REGISTERED, sm.CurrentState)
+	}
+	if provider.lastUpdateTo != connections.ConnectionStatus(REGISTERED) {
+		t.Fatalf("expected connection status persisted as %q, got %q", REGISTERED, provider.lastUpdateTo)
+	}
+}


### PR DESCRIPTION
## Description
Fixes #21811

The Prometheus and Grafana `RegisterAction.Execute()` implementations both
return `machines.Exit` as their follow-up event on success. However, no
state's `Events` map registers a transition for `Exit` it appears `Exit`
was intended to behave like `NoOp` (a terminal "stop, don't transition
further" signal), which is already implied by the existing
`originalEventType != Exit` special case used later in `SendEvent` when
deciding whether to persist connection status.

The `SendEvent` transition loop's condition (`for eventType != NoOp`) didn't
account for this, so `Exit` was passed into `getNextState()`, which found no
matching transition and errored out. This caused every Prometheus and
Grafana connection registration to fail with a misleading "record not
found" error in the UI.

## Changes
- `server/machines/models.go`: change the transition loop condition from
  `for eventType != NoOp` to `for eventType != NoOp && eventType != Exit`,
  treating `Exit` as loop-terminal, consistent with how it's already treated
  elsewhere in the same function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Exit events now stop state-machine processing immediately, preventing invalid transitions and related actions from running.
  - Successful registration now completes cleanly and preserves the registered connection status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->