### PR TITLE
[Models] Add DeliverLogsPermission reference relationship for FlowLog

### DIFF
--- a/models/aws-ec2-controller/v1.21.0/v1.0.0/relationships/edge-non-binding-reference-deliverlogspermission.json
+++ b/models/aws-ec2-controller/v1.21.0/v1.0.0/relationships/edge-non-binding-reference-deliverlogspermission.json
@@ -1,0 +1,101 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "evaluationQuery": "",
+  "kind": "edge",
+  "metadata": {
+    "description": "An IAM Role provides its name to an EC2 FlowLog's deliverLogsPermissionRef.",
+    "isAnnotation": false,
+    "styles": {
+      "primaryColor": "",
+      "svgColor": "",
+      "svgWhite": ""
+    }
+  },
+  "model": {
+    "displayName": "",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "model": {
+      "version": "v1.21.0"
+    },
+    "name": "aws-ec2-controller",
+    "registrant": {
+      "kind": ""
+    },
+    "version": ""
+  },
+  "schemaVersion": "relationships.meshery.io/v1beta2",
+  "selectors": [
+    {
+      "allow": {
+        "from": [
+          {
+            "id": null,
+            "kind": "Role",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-iam-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatorRef": [
+                [
+                  "displayName"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ],
+        "to": [
+          {
+            "id": null,
+            "kind": "FlowLog",
+            "match": {},
+            "match_strategy_matrix": null,
+            "model": {
+              "displayName": "",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "model": {
+                "version": ""
+              },
+              "name": "aws-ec2-controller",
+              "registrant": {
+                "kind": "github"
+              },
+              "version": ""
+            },
+            "patch": {
+              "mutatedRef": [
+                [
+                  "configuration",
+                  "spec",
+                  "deliverLogsPermissionRef",
+                  "from",
+                  "name"
+                ]
+              ],
+              "patchStrategy": "replace"
+            }
+          }
+        ]
+      },
+      "deny": {
+        "from": [],
+        "to": []
+      }
+    }
+  ],
+  "subType": "reference",
+  "status": "enabled",
+  "type": "non-binding",
+  "version": "v1.0.0"
+}


### PR DESCRIPTION
## Notes for Reviewers

Add `edge-non-binding-reference-deliverlogspermission.json` under the latest `aws-ec2-controller` version (`v1.21.0`), wiring an IAM `Role` to an EC2 `FlowLog` through the consumer's `spec.deliverLogsPermissionRef.from.name` reference field.

- This PR fixes #21285

## Validation

- `git diff --check` — passed
- `mesheryctl model build aws-ec2-controller --path ./models` — passed
- Reimported the generated OCI model into a running Meshery Server.
- Verified that the relationship was registered successfully.
- Evaluated a design containing an IAM `Role` and EC2 `FlowLog`.
- Confirmed that evaluation:
  - Added the `edge-reference-non-binding` relationship from `Role` to `FlowLog`.
  - Marked the relationship as `approved`.
  - Patched `configuration.spec.deliverLogsPermissionRef.from.name` on the `FlowLog` with the connected Role component's name.
- Verified that the relationship JSON inside the generated OCI archive exactly matches the source definition.

### Orientation note

Although the issue describes `FlowLog` referencing `DeliverLogsPermission`, the ACK EC2 generator defines `DeliverLogsPermissionARN` as a reference to the IAM `Role` resource. Therefore, the relationship uses:

- `Role` as the provider/source in `from`, with `mutatorRef: [["displayName"]]`
- `FlowLog` as the consumer in `to`, with `mutatedRef: [["configuration", "spec", "deliverLogsPermissionRef", "from", "name"]]`

This orientation also matches Meshery's relationship evaluation and patching behavior.

## Screenshots
<img width="1067" height="580" alt="Screenshot 2026-09-04 at 12 35 50 AM" src="https://github.com/user-attachments/assets/58c42e98-211a-45f6-819b-adf968f39bd4" />
<img width="1060" height="687" alt="Screenshot 2026-09-04 at 12 40 42 AM" src="https://github.com/user-attachments/assets/7d49bca5-043f-40df-b781-faa257dc5d0a" />
<img width="718" height="500" alt="Screenshot 2026-09-05 at 1 32 29 PM" src="https://github.com/user-attachments/assets/a40f5138-9cfe-4659-89c9-d07e6d511660" />



- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for representing non-binding references between AWS IAM roles and EC2 flow logs.
  * IAM role names can now be associated with the flow log configuration used for log delivery permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->