### PR TITLE
[Server] Guard MesheryControllersHelper state with an RWMutex

### DIFF
--- a/server/models/meshery_controllers.go
+++ b/server/models/meshery_controllers.go
@@ -70,6 +70,10 @@ type MesheryControllersHelper struct {
 	// needs a context identifier takes one from its caller (the K8sContext is
 	// available at every call site) rather than reading this field.
 	contextID string
+	// mu protects ctxControllerHandlers, ctxOperatorStatus, and ctxMeshsyncDataHandler from concurrent reads and writes
+	// across the connection lifecycle side-effects and background polling HTTP handlers.
+	mu sync.RWMutex
+
 	//  controller handlers for a particular context
 	// this will be used as the source of truth
 	ctxControllerHandlers map[MesheryController]controllers.IMesheryController
@@ -79,7 +83,6 @@ type MesheryControllersHelper struct {
 
 	// meshsync data handler for a particular context
 	ctxMeshsyncDataHandler *MeshsyncDataHandler
-
 	// meshsyncConnectedEventEmitted tracks whether we already published the
 	// "MeshSync connected in <mode> mode" event for the current data-handler
 	// session. AddMeshsyncDataHandlers can be invoked concurrently while the
@@ -204,14 +207,20 @@ func (mch *MesheryControllersHelper) GetOperatorChartError() error {
 }
 
 func (mch *MesheryControllersHelper) GetControllerHandlersForEachContext() map[MesheryController]controllers.IMesheryController {
+	mch.mu.RLock()
+	defer mch.mu.RUnlock()
 	return mch.ctxControllerHandlers
 }
 
 func (mch *MesheryControllersHelper) GetMeshSyncDataHandlersForEachContext() *MeshsyncDataHandler {
+	mch.mu.RLock()
+	defer mch.mu.RUnlock()
 	return mch.ctxMeshsyncDataHandler
 }
 
 func (mch *MesheryControllersHelper) GetOperatorsStatusMap() controllers.MesheryControllerStatus {
+	mch.mu.RLock()
+	defer mch.mu.RUnlock()
 	return mch.ctxOperatorStatus
 }
 
@@ -319,7 +328,10 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 	// go func(mch *MesheryControllersHelper) {
 
 	ctxID := k8scontext.ID
-	if mch.ctxMeshsyncDataHandler == nil {
+	mch.mu.RLock()
+	handlerIsNil := mch.ctxMeshsyncDataHandler == nil
+	mch.mu.RUnlock()
+	if handlerIsNil {
 		var brokerHandler broker.Handler
 		var stopFunc func()
 
@@ -367,6 +379,10 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 			return mch
 		}
 		token, _ := ctx.Value(TokenCtxKey).(string)
+		if mch.dbHandler == nil {
+			mch.log.Warnf("MesheryControllersHelper::AddMeshsyncDataHandlers dbHandler is nil")
+			return mch
+		}
 		msDataHandler := NewMeshsyncDataHandler(brokerHandler, *mch.dbHandler, mch.log, provider, userID, uuid.FromStringOrNil(k8scontext.ConnectionID), mesheryInstanceID, token, stopFunc)
 		err := msDataHandler.Run()
 		if err != nil {
@@ -379,7 +395,9 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 			}, userID)
 			return mch
 		}
+		mch.mu.Lock()
 		mch.ctxMeshsyncDataHandler = msDataHandler
+		mch.mu.Unlock()
 		mch.log.Info(fmt.Sprintf("MeshSync connected for Kubernetes context (%s)", ctxID))
 	}
 
@@ -392,8 +410,10 @@ func (mch *MesheryControllersHelper) AddMeshsyncDataHandlers(ctx context.Context
 	// later AddMeshsyncDataHandlers call (once IsConnected) emits the event once.
 	// Deduplicate so repeated reconcile calls do not spam the same snackbar.
 	// CompareAndSwap so concurrent AddMeshsyncDataHandlers callers emit once.
-	if mch.ctxMeshsyncDataHandler != nil &&
-		mch.ctxMeshsyncDataHandler.IsConnected() &&
+	mch.mu.RLock()
+	connected := mch.ctxMeshsyncDataHandler != nil && mch.ctxMeshsyncDataHandler.IsConnected()
+	mch.mu.RUnlock()
+	if connected &&
 		mch.meshsyncConnectedEventEmitted.CompareAndSwap(false, true) {
 		description := "MeshSync connected"
 		if mch.meshsyncDeploymentMode != "" {
@@ -454,14 +474,17 @@ func (mch *MesheryControllersHelper) meshsyncDataHandlersNatsBroker(
 	userID core.Uuid,
 ) broker.Handler {
 	ctxID := k8scontext.ID
+
+	mch.mu.RLock()
 	controllerHandlers := mch.ctxControllerHandlers
+	brokerController := controllerHandlers[MesheryBroker]
+	mch.mu.RUnlock()
 
 	// The broker controller handler is only populated by AddCtxControllerHandlers,
 	// which bails early (leaving ctxControllerHandlers empty) when it can't read
 	// the kubeconfig or build a Kubernetes client for this context. Guard against a
 	// nil handler here so that failure surfaces as an actionable diagnostic instead
 	// of a nil-pointer panic when we go to read the broker's endpoint below.
-	brokerController := controllerHandlers[MesheryBroker]
 	if brokerController == nil {
 		opErr := mch.GetOperatorError()
 		mch.log.Warnf("Meshery Broker controller unavailable for Kubernetes context (%v); operator setup likely failed", ctxID)
@@ -725,10 +748,14 @@ func (mch *MesheryControllersHelper) meshsyncDataHandlersStartLibMeshsyncRun(
 }
 
 func (mch *MesheryControllersHelper) RemoveMeshSyncDataHandler(ctx context.Context, contextID string) {
-	if mch.ctxMeshsyncDataHandler != nil {
+	mch.mu.Lock()
+	handler := mch.ctxMeshsyncDataHandler
+	mch.ctxMeshsyncDataHandler = nil
+	mch.mu.Unlock()
+
+	if handler != nil {
 		mch.log.Infof("MesheryControllersHelper::RemoveMeshSyncDataHandler for contextID = %s", contextID)
-		mch.ctxMeshsyncDataHandler.Stop()
-		mch.ctxMeshsyncDataHandler = nil
+		handler.Stop()
 	}
 	// Allow a fresh "MeshSync connected" event when a new handler is attached.
 	mch.meshsyncConnectedEventEmitted.Store(false)
@@ -740,6 +767,8 @@ func (mch *MesheryControllersHelper) RemoveMeshSyncDataHandler(ctx context.Conte
 }
 
 func (mch *MesheryControllersHelper) ResyncMeshsync(ctx context.Context) error {
+	mch.mu.RLock()
+	defer mch.mu.RUnlock()
 	if mch.ctxMeshsyncDataHandler != nil {
 		return mch.ctxMeshsyncDataHandler.Resync()
 	}
@@ -827,7 +856,10 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 			"requestedOperatorChartVersion": mch.operatorDeploymentConfig().MesheryReleaseVersion,
 		}, uuid.Nil)
 		ctxHandlers[MesheryOperator] = controllers.NewMesheryOperatorHandler(client, mch.operatorDeploymentConfig())
+
+		mch.mu.Lock()
 		mch.ctxControllerHandlers = ctxHandlers
+		mch.mu.Unlock()
 		// The attached handler carries no installable version, so the next
 		// reconcile must not mistake a stale value for "already at the desired
 		// version".
@@ -845,7 +877,10 @@ func (mch *MesheryControllersHelper) AddCtxControllerHandlers(ctx K8sContext) *M
 	}
 
 	ctxHandlers[MesheryOperator] = controllers.NewMesheryOperatorHandler(client, depConfig)
+
+	mch.mu.Lock()
 	mch.ctxControllerHandlers = ctxHandlers
+	mch.mu.Unlock()
 	mch.attachedOperatorChartVersion = depConfig.MesheryReleaseVersion
 	mch.setOperatorChartError(nil)
 
@@ -1005,7 +1040,9 @@ func (mch *MesheryControllersHelper) ReconcileOperatorChartVersion(k8sctx K8sCon
 }
 
 func (mch *MesheryControllersHelper) RemoveCtxControllerHandler(ctx context.Context, contextID string) {
+	mch.mu.Lock()
 	mch.ctxControllerHandlers = nil
+	mch.mu.Unlock()
 }
 
 // update the status of MesheryOperator in all the contexts
@@ -1019,13 +1056,22 @@ func (mch *MesheryControllersHelper) UpdateOperatorsStatusMap(ot *OperatorTracke
 
 	if ot.IsUndeployed(mch.contextID) {
 		// this code is probably never reached as mch.contextID is never set
+		mch.mu.Lock()
 		mch.ctxOperatorStatus = controllers.Undeployed
+		mch.mu.Unlock()
 	} else {
+		mch.mu.RLock()
+		var operatorHandler controllers.IMesheryController
 		if mch.ctxControllerHandlers != nil {
-			operatorHandler, ok := mch.ctxControllerHandlers[MesheryOperator]
-			if ok {
-				mch.ctxOperatorStatus = operatorHandler.GetStatus()
-			}
+			operatorHandler = mch.ctxControllerHandlers[MesheryOperator]
+		}
+		mch.mu.RUnlock()
+
+		if operatorHandler != nil {
+			status := operatorHandler.GetStatus()
+			mch.mu.Lock()
+			mch.ctxOperatorStatus = status
+			mch.mu.Unlock()
 		}
 	}
 
@@ -1075,6 +1121,8 @@ func (ot *OperatorTracker) IsUndeployed(ctxID string) bool {
 // AddCtxControllerHandlers could not read the kubeconfig or build a Kubernetes
 // client, so nothing was done to the cluster.
 func (mch *MesheryControllersHelper) attachedOperatorHandler() controllers.IMesheryController {
+	mch.mu.RLock()
+	defer mch.mu.RUnlock()
 	if mch.ctxControllerHandlers == nil {
 		return nil
 	}
@@ -1118,7 +1166,7 @@ func (mch *MesheryControllersHelper) reportMissingOperatorHandler(action, contex
 	mch.emitErrorEvent(action, err, map[string]any{
 		"k8sContextID":           contextID,
 		"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
-		"operatorStatus":         mch.ctxOperatorStatus,
+		"operatorStatus":         mch.GetOperatorsStatusMap(),
 	}, uuid.Nil)
 }
 
@@ -1127,7 +1175,7 @@ func (mch *MesheryControllersHelper) reportMissingOperatorHandler(action, contex
 // NewMesheryControllersHelper seeds. It distinguishes "we saw an operator and
 // can no longer act on it" from "we never reached this cluster at all".
 func (mch *MesheryControllersHelper) operatorStatusObserved() bool {
-	return mch.ctxOperatorStatus != controllers.Unknown
+	return mch.GetOperatorsStatusMap() != controllers.Unknown
 }
 
 // SetOperatorDeployment applies a user-initiated Meshery Operator lifecycle
@@ -1196,7 +1244,7 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 	if mch.meshsyncDeploymentMode != connections.MeshsyncDeploymentModeOperator {
 		return mch
 	}
-	if mch.ctxOperatorStatus != controllers.NotDeployed {
+	if mch.GetOperatorsStatusMap() != controllers.NotDeployed {
 		return mch
 	}
 
@@ -1220,7 +1268,7 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 		mch.emitErrorEvent("Failed to deploy Meshery Operator", err, map[string]any{
 			"k8sContextID":           contextID,
 			"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
-			"operatorStatus":         mch.ctxOperatorStatus,
+			"operatorStatus":         mch.GetOperatorsStatusMap(),
 		}, uuid.Nil)
 	}
 
@@ -1228,7 +1276,7 @@ func (mch *MesheryControllersHelper) DeployUndeployedOperators(ot *OperatorTrack
 }
 
 func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTracker, contextID string) *MesheryControllersHelper {
-	if mch.ctxOperatorStatus == controllers.Undeployed {
+	if mch.GetOperatorsStatusMap() == controllers.Undeployed {
 		return mch
 	}
 
@@ -1262,7 +1310,7 @@ func (mch *MesheryControllersHelper) UndeployDeployedOperators(ot *OperatorTrack
 		mch.emitErrorEvent("Failed to undeploy Meshery Operator", err, map[string]any{
 			"k8sContextID":           contextID,
 			"meshsyncDeploymentMode": mch.meshsyncDeploymentMode,
-			"operatorStatus":         mch.ctxOperatorStatus,
+			"operatorStatus":         mch.GetOperatorsStatusMap(),
 		}, uuid.Nil)
 	}
 

--- a/server/models/meshery_controllers_test.go
+++ b/server/models/meshery_controllers_test.go
@@ -1,9 +1,12 @@
 package models
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/meshery/meshery/server/models/connections"
 	"github.com/meshery/meshkit/logger"
 	"github.com/meshery/meshkit/models/controllers"
 )
@@ -78,7 +81,7 @@ func TestAddCtxControllerHandlersReturnsEarlyOnInvalidConfig(t *testing.T) {
 		nil,
 		nil,
 	)
-	
+
 	// A successful execution of this function without panicking indicates the fix is working.
 	// We wrap in a defer-recover just to explicitly fail the test if a panic occurs.
 	defer func() {
@@ -93,4 +96,108 @@ func TestAddCtxControllerHandlersReturnsEarlyOnInvalidConfig(t *testing.T) {
 	if len(mch.ctxControllerHandlers) != 0 {
 		t.Fatalf("expected ctxControllerHandlers to be empty, got %d", len(mch.ctxControllerHandlers))
 	}
+}
+
+// TestMesheryControllersHelperConcurrency verifies safe R/W to map under RWMutex.
+// Added as part of #21265 lifecycle serialization.
+func TestMesheryControllersHelperConcurrency(t *testing.T) {
+	mch := &MesheryControllersHelper{
+		ctxControllerHandlers: make(map[MesheryController]controllers.IMesheryController),
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			mch.GetControllerHandlersForEachContext()
+			mch.GetMeshSyncDataHandlersForEachContext()
+		}()
+		go func() {
+			defer wg.Done()
+			mch.mu.Lock()
+			mch.ctxControllerHandlers = make(map[MesheryController]controllers.IMesheryController)
+			mch.mu.Unlock()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestMesheryControllersHelperOperatorStatusConcurrency verifies concurrent calls to
+// UpdateOperatorsStatusMap, GetOperatorsStatusMap, and operatorStatusObserved
+// are safe under the race detector.
+func TestMesheryControllersHelperOperatorStatusConcurrency(t *testing.T) {
+	stub := &stubController{status: controllers.Deployed}
+	mch := &MesheryControllersHelper{
+		ctxControllerHandlers: map[MesheryController]controllers.IMesheryController{
+			MesheryOperator: stub,
+		},
+		meshsyncDeploymentMode: connections.MeshsyncDeploymentModeOperator,
+	}
+	ot := NewOperatorTracker(false)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			mch.UpdateOperatorsStatusMap(ot)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = mch.GetOperatorsStatusMap()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = mch.operatorStatusObserved()
+		}()
+		go func() {
+			defer wg.Done()
+			mch.mu.Lock()
+			mch.ctxOperatorStatus = controllers.Undeployed
+			mch.mu.Unlock()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestMesheryControllersHelper_TeardownReleasesSharedLockBeforeStop verifies that
+// RemoveMeshSyncDataHandler releases mch.mu before calling handler.Stop(), allowing
+// concurrent readers to acquire mch.mu while Stop() runs.
+func TestMesheryControllersHelper_TeardownReleasesSharedLockBeforeStop(t *testing.T) {
+	log, _ := logger.New("test", logger.Options{})
+	mch := &MesheryControllersHelper{
+		ctxControllerHandlers: make(map[MesheryController]controllers.IMesheryController),
+		log:                   log,
+	}
+
+	stopCalled := make(chan struct{})
+	stopUnblock := make(chan struct{})
+
+	handler := &MeshsyncDataHandler{
+		StopFunc: func() {
+			close(stopCalled)
+			<-stopUnblock
+		},
+	}
+	mch.ctxMeshsyncDataHandler = handler
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		mch.RemoveMeshSyncDataHandler(ctx, "test-ctx")
+		close(done)
+	}()
+
+	// Wait until handler.Stop() is executing
+	<-stopCalled
+
+	// Verify mch.mu is NOT held: GetMeshSyncDataHandlersForEachContext can acquire RLock and returns nil immediately.
+	got := mch.GetMeshSyncDataHandlersForEachContext()
+	if got != nil {
+		t.Fatalf("expected ctxMeshsyncDataHandler to be nil while Stop() runs, got: %v", got)
+	}
+
+	// Unblock Stop() and wait for RemoveMeshSyncDataHandler to finish.
+	close(stopUnblock)
+	<-done
 }


### PR DESCRIPTION
ctxControllerHandlers, ctxOperatorStatus and ctxMeshsyncDataHandler are written by connection lifecycle side effects (connect, disconnect, delete, MeshSync mode changes) and read concurrently by HTTP handlers and the background status polling. Protect them with an RWMutex, take the handler out of the helper under the lock before stopping it so readers are not blocked behind Stop(), and return early from AddMeshsyncDataHandlers when no database handler is configured instead of dereferencing nil.

This does not change the check-then-act in AddMeshsyncDataHandlers, which remains a separate follow-up.

Part of #21265.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
