### PR TITLE
[CI] Trigger Go testing and integration workflows on go.mod and go.sum updates

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "**.go"
       - "**.golden"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/go-testing-ci.yml"
       - ".github/.golangci.yml"
   pull_request:
@@ -14,6 +18,10 @@ on:
     paths:
       - "**.go"
       - "**.golden"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/go-testing-ci.yml"
       - ".github/.golangci.yml"
   workflow_dispatch:

--- a/.github/workflows/server-integration-tests.yml
+++ b/.github/workflows/server-integration-tests.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "server/**"
       - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/server-integration-tests.yml"
       - "install/kubernetes/helm/meshery-operator/**"
   pull_request:
@@ -14,6 +18,10 @@ on:
     paths:
       - "server/**"
       - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/server-integration-tests.yml"
       - "install/kubernetes/helm/meshery-operator/**"
 


### PR DESCRIPTION
**Notes for Reviewers**

Fixes #21834

### Summary
In `.github/workflows/go-testing-ci.yml` and `.github/workflows/server-integration-tests.yml`, the `paths:` trigger filter previously only included `**.go` and `**.golden`. Because GitHub Actions glob matching for `**.go` does not match `.mod` or `.sum` files, dependency bump PRs (such as Dependabot updates or manual security updates to `go.mod` / `go.sum`) completely bypassed Go unit tests, race detection tests, AST linters, and integration tests.

This PR adds:
- `go.mod`
- `go.sum`
- `**/go.mod`
- `**/go.sum`

to the `push` and `pull_request` path filters in both workflows, ensuring dependency updates are properly verified by CI prior to merging.

### Contribution Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md).
- [x] All commits are signed off (`git commit -s`).
- [x] Workflows syntax validated with YAML parser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Continuous integration checks now run when root or nested Go dependency files (`go.mod` and `go.sum`) change.
  - Server integration tests now also run for updates to root or nested Go dependency files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->