### PR TITLE
[Models] Add OpenAI model-provider connection definition

### DIFF
--- a/models/meshery-core/0.7.2/v1.0.0/connections/OpenAIConnection.json
+++ b/models/meshery-core/0.7.2/v1.0.0/connections/OpenAIConnection.json
@@ -1,0 +1,98 @@
+{
+    "schemaVersion": "connections.meshery.io/v1beta3",
+    "name": "OpenAI",
+    "description": "An OpenAI account used as a model-provider connection for Meshery's AI Adapter, enabling natural-language-to-Design generation with a user-supplied API key.",
+    "kind": "openai",
+    "type": "model-provider",
+    "subType": "inference",
+    "status": "registered",
+    "transitionMap": {
+        "registered": [
+            {
+                "nextState": "connected",
+                "description": "Validates the API key against OpenAI and makes it available for Design generation in Meshery."
+            },
+            {
+                "nextState": "ignored",
+                "description": "Keeps the OpenAI registration but stops Meshery from using it for generation. You can connect it again whenever you choose."
+            }
+        ],
+        "connected": [
+            {
+                "nextState": "disconnected",
+                "description": "Disconnects OpenAI: it stops being available for Design generation. The registration is kept, so you can connect it again later."
+            },
+            {
+                "nextState": "ignored",
+                "description": "Stops Meshery from using this provider for generation without deleting it. You can connect it again whenever you choose."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes the OpenAI connection and its credential from Meshery's database entirely."
+            }
+        ],
+        "disconnected": [
+            {
+                "nextState": "connected",
+                "description": "Re-validates the API key and makes OpenAI available for Design generation again."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes the OpenAI connection and its credential from Meshery's database entirely."
+            }
+        ],
+        "ignored": [
+            {
+                "nextState": "connected",
+                "description": "Resumes using this provider for Design generation."
+            },
+            {
+                "nextState": "deleted",
+                "description": "Removes the OpenAI connection and its credential from Meshery's database entirely."
+            }
+        ]
+    },
+    "connectionSchema": {
+        "type": "object",
+        "title": "OpenAI Connection",
+        "required": [
+            "defaultModel"
+        ],
+        "properties": {
+            "baseUrl": {
+                "type": "string",
+                "format": "uri",
+                "title": "API Base URL",
+                "description": "Base URL of the OpenAI API (e.g. https://api.openai.com/v1). Override only for an OpenAI-compatible proxy or gateway you control."
+            },
+            "organizationId": {
+                "type": "string",
+                "title": "Organization ID",
+                "description": "Optional OpenAI organization identifier, used to scope usage and billing."
+            },
+            "defaultModel": {
+                "type": "string",
+                "title": "Default Model",
+                "description": "Model used for Design generation unless overridden per request, e.g. gpt-4o."
+            }
+        }
+    },
+    "credentialSchema": {
+        "type": "object",
+        "title": "OpenAI Credential",
+        "required": [
+            "apiKey"
+        ],
+        "properties": {
+            "apiKey": {
+                "type": "string",
+                "title": "API Key",
+                "description": "OpenAI secret key used to authenticate requests. Stored only in Meshery's Credential store."
+            }
+        }
+    },
+    "styles": {
+        "svgColor": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" width=\"24\" height=\"24\"><circle cx=\"12\" cy=\"12\" r=\"11\" fill=\"#10A37F\"/><text x=\"12\" y=\"16\" font-size=\"10\" text-anchor=\"middle\" fill=\"#fff\" font-family=\"sans-serif\">AI</text></svg>",
+        "svgWhite": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" width=\"24\" height=\"24\"><circle cx=\"12\" cy=\"12\" r=\"11\" fill=\"none\" stroke=\"#fff\" stroke-width=\"1.5\"/><text x=\"12\" y=\"16\" font-size=\"10\" text-anchor=\"middle\" fill=\"#fff\" font-family=\"sans-serif\">AI</text></svg>"
+    }
+}


### PR DESCRIPTION
Part of #20994 (Meshery: BYOM — Adapter for AI and LLMs).

Adds OpenAI as a model-provider Connection/Credential kind, following the field contract from #19877 (type=model-provider, subType=inference) and the definition shape used by the existing Prometheus/Grafana connections (models/meshery-core/0.7.2/v1.0.0/connections/).

Files changed:
- models/meshery-core/0.7.2/v1.0.0/connections/OpenAIConnection.json - connection/credential schemas and full transitionMap

Open note for reviewers:
`baseUrl` is user-overridable to support OpenAI-compatible proxies. Per the SSRF concern raised on #21240's `baseUrl` field, whoever implements the health-check/RegisterAction for this definition should validate the host against a trusted allowlist before making outbound requests with the stored API key. Left unresolved here since no request-sending code exists yet in this PR.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI connection support for Meshery’s AI Adapter.
  * Added configuration for selecting a default model, optional endpoint and organization settings, and API key authentication.
  * Added connection status handling and OpenAI branding for the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->