### PR TITLE
fix: DefaultLocalProvider.GetK8sContexts ignores withStatus filter

### DIFF
--- a/server/models/default_local_provider.go
+++ b/server/models/default_local_provider.go
@@ -584,7 +584,7 @@ func (l *DefaultLocalProvider) GetK8sContexts(_, page, pageSize, search, order s
 		return nil, ErrPageSize(err)
 	}
 
-	return l.MesheryK8sContextPersister.GetMesheryK8sContexts(search, order, pg, pgs)
+	return l.MesheryK8sContextPersister.GetMesheryK8sContexts(search, order, withStatus, pg, pgs)
 }
 
 func (l *DefaultLocalProvider) GetK8sContext(_, id string) (K8sContext, error) {

--- a/server/models/meshery_k8scontext_persister.go
+++ b/server/models/meshery_k8scontext_persister.go
@@ -24,7 +24,8 @@ type MesheryK8sContextPage struct {
 }
 
 // GetMesheryK8sContexts returns all of the contexts
-func (mkcp *MesheryK8sContextPersister) GetMesheryK8sContexts(search, order string, page, pageSize uint64) ([]byte, error) {
+// GetMesheryK8sContexts returns all of the contexts
+func (mkcp *MesheryK8sContextPersister) GetMesheryK8sContexts(search, order, withStatus string, page, pageSize uint64) ([]byte, error) {
 	order = SanitizeOrderInput(order, []string{"created_at", "updated_at", "name"})
 
 	if order == "" {
@@ -34,14 +35,19 @@ func (mkcp *MesheryK8sContextPersister) GetMesheryK8sContexts(search, order stri
 	count := int64(0)
 	contexts := []*K8sContext{}
 
-	query := mkcp.DB.Order(order)
+	query := mkcp.DB.Order(order).Model(&K8sContext{})
 
 	if search != "" {
 		like := "%" + strings.ToLower(search) + "%"
 		query = query.Where("(lower(name) like ?)", like)
 	}
 
-	query.Model(K8sContext{}).Count(&count)
+	if withStatus != "" {
+		query = query.Joins("JOIN connections ON connections.id = k8s_contexts.connection_id").
+			Where("connections.status = ?", withStatus)
+	}
+
+	query.Count(&count)
 
 	Paginate(uint(page), uint(pageSize))(query).Find(&contexts)
 


### PR DESCRIPTION
Relates to #21809

## What this does
`DefaultLocalProvider.GetK8sContexts` accepts a `withStatus` argument but never used it, unlike `RemoteProvider.GetK8sContexts`. This meant callers requesting only `CONNECTED` Kubernetes contexts could still get back contexts whose connection was actually `DISCONNECTED`.

This PR:
- Passes `withStatus` from `DefaultLocalProvider.GetK8sContexts` through to `MesheryK8sContextPersister.GetMesheryK8sContexts`
- Updates `GetMesheryK8sContexts` to join against the `connections` table and filter by `connections.status` when `withStatus` is non-empty
- Leaves behavior unchanged when `withStatus` is empty

## Status: Draft / work in progress
- Regression tests (CONNECTED filtering, empty withStatus, local vs remote parity) are not added yet
- I haven't been able to verify the build compiles locally yet due to a cgo/gcc toolchain issue on my machine (unrelated to this change) — opening as draft so CI can help verify in the meantime
- Marking ready for review once tests are added and the build is confirmed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Kubernetes context listings now correctly filter results by connection status.
  - Result counts and pagination now reflect the selected status filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->