### PR TITLE
fix(server): safely handle missing kid and exp in JWT validation

### DIFF
--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -127,6 +127,13 @@ func (h *Handler) NoCacheMiddleware(next http.Handler) http.Handler {
 // AuthMiddleware is a middleware to validate if a user is authenticated
 func (h *Handler) AuthMiddleware(next http.Handler, auth models.AuthenticationMechanism) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
+		defer func() {
+			if r := recover(); r != nil {
+				h.log.Error(fmt.Errorf("recovered from panic in AuthMiddleware: %v", r))
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+
 		refURLB64 := GetRefURL(req)
 
 		providerH := h.Provider

--- a/server/handlers/middlewares.go
+++ b/server/handlers/middlewares.go
@@ -130,7 +130,7 @@ func (h *Handler) AuthMiddleware(next http.Handler, auth models.AuthenticationMe
 		defer func() {
 			if r := recover(); r != nil {
 				h.log.Error(fmt.Errorf("recovered from panic in AuthMiddleware: %v", r))
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				writeJSONError(w, "Internal Server Error", http.StatusInternalServerError)
 			}
 		}()
 

--- a/server/models/remote_auth.go
+++ b/server/models/remote_auth.go
@@ -309,19 +309,45 @@ func (l *RemoteProvider) VerifyToken(tokenString string) (*jwt.MapClaims, error)
 	if err != nil {
 		return nil, ErrPraseUnverified(err)
 	}
-	kid := tokenUP.Header["kid"].(string)
+	kid, ok := tokenUP.Header["kid"].(string)
+	if !ok || kid == "" {
+		return nil, ErrPraseUnverified(fmt.Errorf("token header missing or invalid 'kid'"))
+	}
+
+	if len(x) < 2 {
+		return nil, ErrPraseUnverified(fmt.Errorf("malformed token: missing payload segment"))
+	}
 
 	var jtk map[string]interface{}
-	t, _ := base64.RawStdEncoding.DecodeString(x[1])
+	t, decodeErr := base64.RawStdEncoding.DecodeString(x[1])
+	if decodeErr != nil {
+		t, decodeErr = base64.RawURLEncoding.DecodeString(x[1])
+		if decodeErr != nil {
+			return nil, ErrPraseUnverified(decodeErr)
+		}
+	}
 	if err := json.Unmarshal(t, &jtk); err != nil {
 		return nil, ErrPraseUnverified(err)
 	}
 
 	// TODO: Once hydra fixes https://github.com/ory/hydra/issues/1542
 	// we should rather configure hydra auth server to remove nbf field in the token
-	_, ok := jtk["exp"]
-	if ok {
-		exp := int64(jtk["exp"].(float64))
+	if expRaw, ok := jtk["exp"]; ok {
+		var exp int64
+		switch v := expRaw.(type) {
+		case float64:
+			exp = int64(v)
+		case int64:
+			exp = v
+		case json.Number:
+			parsed, err := v.Int64()
+			if err != nil {
+				return nil, ErrPraseUnverified(fmt.Errorf("token claim 'exp' is not a valid number: %w", err))
+			}
+			exp = parsed
+		default:
+			return nil, ErrPraseUnverified(fmt.Errorf("token claim 'exp' is not a valid number"))
+		}
 		if time.Now().Unix() > exp {
 			return nil, ErrTokenExpired
 		}

--- a/server/models/remote_auth_test.go
+++ b/server/models/remote_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -468,3 +469,76 @@ func TestRemoteProviderDoRequest_XAPIKeyAnonymousOnly(t *testing.T) {
 		t.Fatalf("authenticated request with inbound X-API-Key must strip it, got %q", got)
 	}
 }
+
+func TestRemoteProvider_VerifyToken_Safeguards(t *testing.T) {
+	provider := newTestRemoteProvider(t, "http://localhost:9876")
+
+	makeToken := func(headerJSON, payloadJSON string) string {
+		hB64 := base64.RawURLEncoding.EncodeToString([]byte(headerJSON))
+		pB64 := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+		sigB64 := base64.RawURLEncoding.EncodeToString([]byte("signature"))
+		rawJWT := strings.Join([]string{hB64, pB64, sigB64}, ".")
+		return encodeTestToken(t, oauth2.Token{AccessToken: rawJWT})
+	}
+
+	tests := []struct {
+		name        string
+		header      string
+		payload     string
+		expectError bool
+		errTarget   error
+	}{
+		{
+			name:        "missing kid in header",
+			header:      `{"alg":"RS256"}`,
+			payload:     `{"sub":"user123","exp":4102444800}`,
+			expectError: true,
+		},
+		{
+			name:        "non-string kid (integer) in header",
+			header:      `{"alg":"RS256","kid":12345}`,
+			payload:     `{"sub":"user123","exp":4102444800}`,
+			expectError: true,
+		},
+		{
+			name:        "empty string kid in header",
+			header:      `{"alg":"RS256","kid":""}`,
+			payload:     `{"sub":"user123","exp":4102444800}`,
+			expectError: true,
+		},
+		{
+			name:        "non-numeric exp claim in payload",
+			header:      `{"alg":"RS256","kid":"valid-key-id"}`,
+			payload:     `{"sub":"user123","exp":"not-a-number"}`,
+			expectError: true,
+		},
+		{
+			name:        "expired token",
+			header:      `{"alg":"RS256","kid":"valid-key-id"}`,
+			payload:     `{"sub":"user123","exp":1000}`,
+			expectError: true,
+			errTarget:   ErrTokenExpired,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			token := makeToken(tc.header, tc.payload)
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("VerifyToken panicked unexpectedly on %s: %v", tc.name, r)
+				}
+			}()
+
+			claims, err := provider.VerifyToken(token)
+			if tc.expectError && err == nil {
+				t.Fatalf("expected error for %s, got nil (claims: %v)", tc.name, claims)
+			}
+			if tc.errTarget != nil && !errors.Is(err, tc.errTarget) {
+				t.Fatalf("expected error %v, got %v", tc.errTarget, err)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
**Notes for Reviewers**

Fixes #21816. Safely handles unchecked type assertions in JWT verification (`remote_auth.go`) to prevent runtime panics on missing/invalid `kid` and `exp`.

| **Missing/invalid `kid`** | `curl: (52) Empty reply`<br>*(Panic crashes request connection)* | `HTTP 302 / Error`<br>*(Graceful redirection / rejection)* |
| **`kid` assertion** | `tokenUP.Header["kid"].(string)` | Comma-ok check `kid, ok := ...` |
| **`exp` assertion** | `int64(jtk["exp"].(float64))` | Type switch supporting `float64`, `int64`, `json.Number` |

### Changes
- `server/models/remote_auth.go`: Comma-ok guards for `kid` and safe type parsing for `exp`.
- `server/handlers/middlewares.go`: Added `recover()` safeguard in `AuthMiddleware`.
- `server/models/remote_auth_test.go`: Added unit tests verifying zero panics on malformed tokens.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token validation for malformed, incomplete, or invalid tokens.
  - Expired tokens are now rejected consistently, while invalid expiration values fail safely.
  - Prevented authentication-related errors from causing unhandled server crashes; affected requests now receive an HTTP 500 response.
  - Added safeguards to ensure invalid authentication inputs are handled without unexpected failures.
  - Authentication error responses now use a consistent JSON format when unexpected failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->