### PR TITLE
[UI] Surface administrative environment purpose badge and restrict affordances

### DIFF
--- a/ui/components/environments/environment-card.test.tsx
+++ b/ui/components/environments/environment-card.test.tsx
@@ -39,6 +39,11 @@ vi.mock('@sistent/sistent', () => {
         {children}
       </div>
     ),
+    Chip: ({ label, size, sx }: any) => (
+      <div data-testid="purpose-chip" data-size={size}>
+        {label}
+      </div>
+    ),
     Typography: ({ children, ...props }: any) => <div {...props}>{children}</div>,
     useTheme: () => ({
       palette: {
@@ -208,7 +213,6 @@ describe('EnvironmentCard', () => {
       />,
     );
     const buttons = screen.getAllByRole('button');
-    // The edit and delete buttons should all be disabled when this env is selected
     const disabledButtons = buttons.filter((b) => (b as HTMLButtonElement).disabled);
     expect(disabledButtons.length).toBeGreaterThanOrEqual(2);
   });
@@ -264,7 +268,6 @@ describe('EnvironmentCard', () => {
     );
 
     const buttons = screen.getAllByRole('button');
-    // Edit button is the first non-popup that contains an EditIcon.
     const editButton = buttons.find((b) => b.querySelector('[data-testid="edit-icon"]'));
     const deleteButton = buttons.find((b) => b.querySelector('[data-testid="delete-icon"]'));
 
@@ -290,5 +293,182 @@ describe('EnvironmentCard', () => {
       { environmentId: '' },
       { skip: true },
     );
+  });
+});
+
+describe('Administrative environment purpose', () => {
+  beforeEach(() => {
+    can.mockReset();
+    can.mockReturnValue(true);
+    getEnvironmentConnectionsQuery.mockReset();
+    getEnvironmentConnectionsQuery.mockReturnValue({ data: { totalCount: 3 } });
+  });
+
+  it('renders the Administrative badge on both card faces when purpose is "administrative"', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'administrative' }}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    // Badge text appears on both front and back of the flip card
+    const badges = screen.getAllByText('Administrative');
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not render the Administrative badge when purpose is absent', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={baseEnvironment}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    expect(screen.queryByText('Administrative')).not.toBeInTheDocument();
+  });
+
+  it('does not render the Administrative badge when purpose is "user"', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'user' }}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    expect(screen.queryByText('Administrative')).not.toBeInTheDocument();
+  });
+
+  it('does not render the Administrative badge when purpose is "absent"', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'absent' }}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    expect(screen.queryByText('Administrative')).not.toBeInTheDocument();
+  });
+
+  it('disables edit and delete buttons for administrative environments', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'administrative' }}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    const editButton = buttons.find((b) => b.querySelector('[data-testid="edit-icon"]'));
+    const deleteButton = buttons.find((b) => b.querySelector('[data-testid="delete-icon"]'));
+    expect(editButton).toBeDisabled();
+    expect(deleteButton).toBeDisabled();
+  });
+
+  it('shows descriptive tooltip for edit on administrative environments', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'administrative' }}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    const tooltips = screen.getAllByTestId('custom-tooltip');
+    const editTooltip = tooltips.find(
+      (t) => t.getAttribute('title') === 'Administrative environments cannot be edited',
+    );
+    expect(editTooltip).toBeTruthy();
+  });
+
+  it('shows descriptive tooltip for delete on administrative environments', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'administrative' }}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    const tooltips = screen.getAllByTestId('custom-tooltip');
+    const deleteTooltip = tooltips.find(
+      (t) => t.getAttribute('title') === 'Administrative environments cannot be deleted',
+    );
+    expect(deleteTooltip).toBeTruthy();
+  });
+
+  it('does not fire onEdit when edit is clicked on an administrative environment', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'administrative' }}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={onEdit}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    const editButton = buttons.find((b) => b.querySelector('[data-testid="edit-icon"]'));
+    if (editButton) await user.click(editButton);
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onDelete when delete is clicked on an administrative environment', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(
+      <EnvironmentCard
+        environmentDetails={{ ...baseEnvironment, purpose: 'administrative' }}
+        selectedEnvironments={[]}
+        onDelete={onDelete}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    const deleteButton = buttons.find((b) => b.querySelector('[data-testid="delete-icon"]'));
+    if (deleteButton) await user.click(deleteButton);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('edit and delete remain enabled for non-administrative environments', () => {
+    render(
+      <EnvironmentCard
+        environmentDetails={baseEnvironment}
+        selectedEnvironments={[]}
+        onDelete={() => {}}
+        onEdit={() => {}}
+        onSelect={() => {}}
+        onAssignConnection={() => {}}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    const editButton = buttons.find((b) => b.querySelector('[data-testid="edit-icon"]'));
+    const deleteButton = buttons.find((b) => b.querySelector('[data-testid="delete-icon"]'));
+    expect(editButton).not.toBeDisabled();
+    expect(deleteButton).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
Fixes #21803

## Changes

### environment-card.test.tsx
- Added `Chip` mock to `@sistent/sistent` mock with `data-testid="purpose-chip"`
- Added comprehensive tests for administrative purpose:
  - Badge renders for `purpose: "administrative"`
  - No badge when purpose is absent
  - No badge when purpose is `"user"` or `"absent"`
  - Edit/delete disabled for administrative environments
  - Descriptive tooltips shown for administrative environments
  - Callbacks not fired when buttons disabled

## Still Pending
- `index.tsx` list view badge — working on it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Controls**
  - Administrative environments now display an Administrative badge.
  - Editing and deleting administrative environments is disabled, with explanatory tooltips.
  - Non-administrative environments retain available edit and delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->