### PR TITLE
Tag the workspace BATS suite for the qa dashboard traceability contract

### DIFF
--- a/mesheryctl/tests/e2e/008-workspace/00-workspace.bats
+++ b/mesheryctl/tests/e2e/008-workspace/00-workspace.bats
@@ -6,7 +6,7 @@ setup() {
     _load_bats_libraries
 }
 
-@test "given --help flag provided when running mesheryctl workspace --help displays command usage" {
+@test "[cut=Workspace][tg=Workspace Management] given --help flag provided when running mesheryctl workspace --help displays command usage" {
     run $MESHERYCTL_BIN workspace --help
 
     assert_success

--- a/mesheryctl/tests/e2e/008-workspace/01-workspace-create.bats
+++ b/mesheryctl/tests/e2e/008-workspace/01-workspace-create.bats
@@ -6,7 +6,7 @@ setup() {
 	_load_bats_libraries
 }
 
-@test "given an invalid orgId provided as an argument when running mesheryctl workspace create --orgId invalid-org-id then an error message is displayed" {
+@test "[cut=Workspace][tg=Workspace Management] given an invalid orgId provided as an argument when running mesheryctl workspace create --orgId invalid-org-id then an error message is displayed" {
     run $MESHERYCTL_BIN workspace create --orgId foo
 
     assert_failure 

--- a/mesheryctl/tests/e2e/008-workspace/02-workspace-list.bats
+++ b/mesheryctl/tests/e2e/008-workspace/02-workspace-list.bats
@@ -7,7 +7,7 @@ setup() {
 }
 
 
-@test "given missing --orgId flag when running mesheryctl workspace list then an error message is displayed" {
+@test "[cut=Workspace][tg=Workspace Management] given missing --orgId flag when running mesheryctl workspace list then an error message is displayed" {
     run $MESHERYCTL_BIN workspace list
 
     assert_failure
@@ -15,7 +15,7 @@ setup() {
     assert_output --partial "Invalid value for --orgId ''"
 }
 
-@test "given an invalid orgId is provided as an argument when running mesheryctl workspace list --orgId invalid-orgid then the error message is displayed" {
+@test "[cut=Workspace][tg=Workspace Management] given an invalid orgId is provided as an argument when running mesheryctl workspace list --orgId invalid-orgid then the error message is displayed" {
     ORGANIZATION_ID="foo"
 
     run $MESHERYCTL_BIN workspace list --orgId "$ORGANIZATION_ID"
@@ -25,7 +25,7 @@ setup() {
     assert_output --partial "Invalid value for --orgid 'foo': must be a valid UUID"
 }
 
-@test "given non-existent orgId provided when running mesheryctl workspace list --orgId non-existent-orgId then an error message is displayed" {
+@test "[cut=Workspace][tg=Workspace Management] given non-existent orgId provided when running mesheryctl workspace list --orgId non-existent-orgId then an error message is displayed" {
     NON_EXISTENT_ORGANIZATION_ID="00000000-0000-0000-0000-000000000000"
 
     run $MESHERYCTL_BIN workspace list --orgId "$NON_EXISTENT_ORGANIZATION_ID"


### PR DESCRIPTION
Small starting slice for #21845.

Lee mentioned in Slack that mesheryctl's BATS e2e suite has no dedicated quality report, unlike the UI Playwright suite. Checked this against the actual `meshery/qa` dashboard config and `bats-to-allure.js`: mesheryctl results do reach the dashboard (`project: "mesheryctl"` is always stamped), but the converter's Test Plan traceability tagging (`[TC-n]`, `[cut=...]`, `[tg=...]` title tokens) is opt-in per test, and only 45 of 185 mesheryctl BATS tests (24%) use it. `007-connection` is fully tagged, clearly the origin of the convention. The other nine suite directories are effectively untagged, full breakdown in #21845.

That's too large to fix in one PR (assigning real `[TC-n]` IDs needs coordination against the shared Test Plan spreadsheet I don't have visibility into). This tags the smallest fully-untagged suite, `008-workspace` (5 tests), as a small, concrete, verified demonstration: `[cut=Workspace][tg=Workspace Management]` on each test.

Deliberately no `[TC-n]`: that token claims a specific spreadsheet row, and fabricating one would be worse than leaving it out. `cut`/`tg` alone are enough to give this suite its own component/Test-Group breakdown in the dashboard without that claim.

## Test plan
- [x] Ran `parseTitleTokens()` (bats-to-allure.js) directly against each new title, confirmed correct `componentUnderTest`/`testGroup` labels with tokens cleanly stripped from the display name
- [x] Existing converter regression suite (`node --test bats-to-allure.test.js`, 27 tests) still passes
- [x] Installed bats-core and confirmed all 5 tests in the suite still parse correctly (`bats --count` reports 5, unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated workspace end-to-end test names with standardized Workspace Management tags.
  - Test behavior, assertions, and coverage remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->