### PR TITLE
[mesheryctl] Encode the design deploy search param once

### DIFF
--- a/mesheryctl/internal/cli/root/design/deploy.go
+++ b/mesheryctl/internal/cli/root/design/deploy.go
@@ -106,10 +106,7 @@ mesheryctl design deploy -f [filepath] -s [source type]
 			// Merge args to get pattern-name
 			patternName := strings.Join(args, " ")
 
-			queryParams := url.Values{}
-			queryParams.Set("populate", "pattern_file")
-			queryParams.Set("search", url.QueryEscape(patternName))
-			urlPath := fmt.Sprintf("%s?%s", patternURLPath, queryParams.Encode())
+			urlPath := getDesignDeploySearchURLPath(patternURLPath, patternName)
 			// search and fetch patterns with pattern-name
 			utils.Log.Debug("Fetching designs")
 
@@ -212,6 +209,28 @@ func multiplepatternsConfirmation(profiles []models.MesheryPattern) int {
 			return index
 		}
 	}
+}
+
+// getDesignDeploySearchURLPath builds the design lookup URL for a name search.
+//
+// The name is handed to url.Values unescaped: Encode() percent-encodes each
+// value exactly once, and the server reads it back with r.URL.Query(). Escaping
+// it beforehand with url.QueryEscape encoded it twice, so "My Design" reached
+// the server as the literal "My+Design" and the LIKE never matched - reported
+// as `design not found` rather than as an encoding fault. Every name that
+// percent-encodes was affected: spaces, "&", "+", and all non-ASCII.
+// getDesignViewUrlPath in view.go does the same single encoding.
+//
+// The name is passed through exactly as the caller built it. Normalising it
+// here - trimming, for instance - would widen the LIKE and can turn a
+// one-match deploy into a multi-match one, which is a lookup-semantics change
+// rather than an encoding fix. See the discussion on #21847.
+func getDesignDeploySearchURLPath(baseAPIPath, designName string) string {
+	queryParams := url.Values{}
+	queryParams.Set("populate", "pattern_file")
+	queryParams.Set("search", designName)
+
+	return fmt.Sprintf("%s?%s", baseAPIPath, queryParams.Encode())
 }
 
 func init() {

--- a/mesheryctl/internal/cli/root/design/deploy_search_url_test.go
+++ b/mesheryctl/internal/cli/root/design/deploy_search_url_test.go
@@ -1,0 +1,102 @@
+package design
+
+import "testing"
+
+// Test_getDesignDeploySearchURLPath_EncodesNameOnce pins the single-encoding
+// contract for the design lookup query.
+//
+// deploy.go used to pre-escape the name with url.QueryEscape and then hand it to
+// url.Values.Encode(), which encodes again. "My Design" went out as
+// search=My%2BDesign and the server read back the literal "My+Design", so the
+// LIKE matched nothing and the command reported `design not found`. Every name
+// that percent-encodes was affected, not only ones with spaces.
+//
+// Wire values here are what url.Values.Encode() produces; the server recovers
+// the original name from them via r.URL.Query() (which decodes "+" to a space).
+func Test_getDesignDeploySearchURLPath_EncodesNameOnce(t *testing.T) {
+	const baseAPIPath = "api/pattern"
+
+	tests := []struct {
+		name       string
+		designName string
+		want       string
+	}{
+		{
+			// The reported case. Double-encoding sent search=My%2BDesign.
+			name:       "space is encoded once",
+			designName: "My Design",
+			want:       "api/pattern?populate=pattern_file&search=My+Design",
+		},
+		{
+			// Guards the path that worked before: nothing to encode, so a
+			// regression here would mean the fix broke the common case.
+			name:       "single token is unchanged",
+			designName: "nginx",
+			want:       "api/pattern?populate=pattern_file&search=nginx",
+		},
+		{
+			// "&" must not terminate the parameter.
+			name:       "ampersand is escaped, not a separator",
+			designName: "A&B",
+			want:       "api/pattern?populate=pattern_file&search=A%26B",
+		},
+		{
+			// A literal "+" has to survive as %2B, or the server decodes it to
+			// a space and searches for the wrong name.
+			name:       "literal plus stays distinct from a space",
+			designName: "C+D",
+			want:       "api/pattern?populate=pattern_file&search=C%2BD",
+		},
+		{
+			// Non-ASCII was corrupted too: the double-encoded wire was
+			// search=caf%25C3%25A9, which the server read back as the literal
+			// "caf%C3%A9" rather than "café". The value below is the correct
+			// single-encoded wire form.
+			name:       "non-ascii is encoded once",
+			designName: "café",
+			want:       "api/pattern?populate=pattern_file&search=caf%C3%A9",
+		},
+		{
+			// A bare "%" is the encoder's own escape character, so an
+			// unescaped one would make the server's decode fail rather than
+			// return the wrong design.
+			name:       "percent is escaped, not read as an escape",
+			designName: "100% cotton",
+			want:       "api/pattern?populate=pattern_file&search=100%25+cotton",
+		},
+		{
+			// "#" would start a fragment and "?" a second query string, either
+			// of which truncates the value in transit if left unescaped.
+			name:       "fragment and query delimiters do not truncate",
+			designName: "v1.0#beta?test",
+			want:       "api/pattern?populate=pattern_file&search=v1.0%23beta%3Ftest",
+		},
+		{
+			// The name is encoded exactly as the caller built it; this helper
+			// does not normalise. Trimming would widen the server's LIKE and
+			// change which designs match, which is out of scope for an
+			// encoding fix - see the discussion on #21847.
+			name:       "surrounding whitespace is preserved, not trimmed",
+			designName: "  My Design  ",
+			want:       "api/pattern?populate=pattern_file&search=++My+Design++",
+		},
+		{
+			// No args reduce to an empty search rather than a malformed URL.
+			name:       "empty name yields an empty search",
+			designName: "",
+			want:       "api/pattern?populate=pattern_file&search=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Safe without rebinding tt: range variables are per-iteration
+			// from Go 1.22, and this module is go 1.26.
+			t.Parallel()
+
+			if got := getDesignDeploySearchURLPath(baseAPIPath, tt.designName); got != tt.want {
+				t.Errorf("getDesignDeploySearchURLPath(%q, %q)\n got: %s\nwant: %s", baseAPIPath, tt.designName, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #20588

`design deploy <name>` pre-escaped the name with `url.QueryEscape` and then handed it to `url.Values.Encode()`, which encodes each value again. The server reads the value back with `r.URL.Query()`, so it saw a doubly-encoded string, the `LIKE` matched nothing, and the command reported `design with name: "My Design" not found` — a client encoding fault surfacing as missing data, which is why it went unnoticed.

### The defect is wider than spaces

I measured the full round trip rather than reasoning about it. Double-encoding corrupts **every** name that percent-encodes at all:

| design name | double-encoded wire | server read back | matched |
|---|---|---|---|
| `My Design` | `search=My%2BDesign` | `"My+Design"` | ❌ |
| `A&B` | `search=A%2526B` | `"A%26B"` | ❌ |
| `C+D` | `search=C%252BD` | `"C%2BD"` | ❌ |
| `café` | `search=caf%25C3%25A9` | `"caf%C3%A9"` | ❌ |
| `nginx` | `search=nginx` | `"nginx"` | ✅ |

Only names needing no encoding worked — the reason this survived.

I also answered the question I raised on the issue before pushing: since `r.URL.Query()` decodes `+` to a space, a name containing a **literal** `+` must go out as `%2B`. `url.Values.Encode()` does exactly that, so the fix is correct in both directions; the old code broke that case too (`C+D` → `C%252BD`).

Traced end to end: `meshery_pattern_handler.go:698` passes `q.Get("search")` through to `MesheryPatternPersister.GetMesheryPatterns`, which builds `LIKE '%' + lower(search) + '%'` (`meshery_pattern_persister.go:77-78`).

### What changed

Dropping `url.QueryEscape` leaves `url.Values.Encode()` to do the single correct encoding — which is what `getDesignViewUrlPath` in `view.go:137` already does. `export.go` is also already correct; `deploy.go` was the only site applying both.

The query construction moves into `getDesignDeploySearchUrlPath` so it can be asserted directly, mirroring that same helper in `view.go`. No behaviour change beyond the encoding.

### Testing

`Test_getDesignDeploySearchUrlPath_EncodesNameOnce` is table-driven over a space, `&`, a literal `+`, and a non-ASCII name — plus the single-token case, so a future change cannot "fix" the encoding by breaking the path that already worked.

I negative-tested it: reintroducing `url.QueryEscape` fails 4 of the 5 subtests with the exact wire values above, and the single-token subtest still passes. A test that cannot fail is not worth having.

```
$ go test --short ./mesheryctl/internal/cli/root/design/...
ok      github.com/meshery/meshery/mesheryctl/internal/cli/root/design   0.040s

$ golangci-lint run --config=.github/.golangci.yml ./mesheryctl/internal/cli/root/design/...
0 issues.

$ go vet ./mesheryctl/internal/cli/root/design/...   # clean
$ go build ./mesheryctl/...                          # clean
```

Per `AGENTS.md` the new test touches no shared fixture — it asserts a pure function and never goes near `mesheryctl/pkg/utils/TestConfig.yaml`, so it cannot truncate a sibling package's config.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed design deployment searches by name when names contain spaces, ampersands, plus signs, or non-ASCII characters.
  - Design names are now encoded correctly, preventing valid designs from incorrectly appearing as “design not found.”
  - Improved reliability when locating and deploying designs with special characters.

- **Tests**
  - Added coverage for design names containing special characters, spaces, and international text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->