### PR TITLE
[mesheryctl] Support structured output formatting (--output-format json|yaml) for version command

### DIFF
--- a/mesheryctl/internal/cli/root/version.go
+++ b/mesheryctl/internal/cli/root/version.go
@@ -25,6 +25,7 @@ import (
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/constants"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/meshery/meshery/mesheryctl/pkg/utils/format"
 	"github.com/meshery/meshery/server/models"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -35,9 +36,26 @@ var (
 	mctlCfg *config.MesheryCtlConfig
 )
 
+type versionInfo struct {
+	Version string `json:"version" yaml:"version"`
+	GitSHA  string `json:"git_sha" yaml:"git_sha"`
+}
+
+type versionOutput struct {
+	Client versionInfo `json:"client" yaml:"client"`
+	Server versionInfo `json:"server" yaml:"server"`
+}
+
+var outputFormat string
+
 var linkDoc = map[string]string{
 	"link":    "![version-usage](../../images/version.png)",
 	"caption": "Usage of mesheryctl version",
+}
+
+// init configures flags for the version command.
+func init() {
+	versionCmd.Flags().StringVarP(&outputFormat, "output-format", "o", "", "(optional) format to display in [json|yaml]")
 }
 
 // versionCmd represents the version command
@@ -114,7 +132,11 @@ mesheryctl version
 		url := mctlCfg.GetBaseMesheryURL()
 		build := constants.GetMesheryctlVersion()
 		commitsha := constants.GetMesheryctlCommitsha()
-		defer utils.CheckMesheryctlClientVersion(build)
+		defer func() {
+			if outputFormat == "" {
+				utils.CheckMesheryctlClientVersion(build)
+			}
+		}()
 
 		version := config.Version{
 			Build:          "unavailable",
@@ -125,45 +147,54 @@ mesheryctl version
 		header := []string{"", "Version", "GitSHA"}
 		rows := [][]string{{"Client", build, commitsha}, {"Server", version.GetBuild(), version.GetCommitSHA()}}
 
+		var serverError error
 		req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/system/version", url), nil)
 		if err != nil {
-			utils.PrintToTable(header, rows, nil)
-			utils.Log.Error(ErrGettingRequestContext(err))
-			return
+			serverError = err
+		} else {
+			client := &http.Client{Timeout: 10 * time.Second}
+			resp, err := client.Do(req)
+
+			if err != nil {
+
+				// resp is nil here except when CheckRedirect fails, and in that
+				// case net/http has already closed resp.Body for us — see the
+				// (Client).Do docs — so there is nothing left to close.
+				serverError = err
+			} else {
+				// needs multiple defer as Body.Close needs a valid response
+				defer func() { _ = resp.Body.Close() }()
+				data, err := io.ReadAll(resp.Body)
+				if err != nil {
+					serverError = err
+				} else {
+					err = json.Unmarshal(data, &version)
+					if err != nil {
+						serverError = err
+					}
+				}
+			}
 		}
 
-		client := &http.Client{Timeout: 10 * time.Second}
-		resp, err := client.Do(req)
-
-		if err != nil {
-
-			// resp is nil here except when CheckRedirect fails, and in that
-			// case net/http has already closed resp.Body for us — see the
-			// (Client).Do docs — so there is nothing left to close.
-
-			utils.PrintToTable(header, rows, nil)
-			utils.Log.Warn(ErrConnectingToServer(err))
-			return
+		res := versionOutput{
+			Client: versionInfo{Version: build, GitSHA: commitsha},
+			Server: versionInfo{Version: version.GetBuild(), GitSHA: version.GetCommitSHA()},
 		}
 
-		// needs multiple defer as Body.Close needs a valid response
-		defer func() { _ = resp.Body.Close() }()
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
+		switch outputFormat {
+		case "json":
+			_ = format.OutputJson(res)
+		case "yaml":
+			_ = format.OutputYaml(res)
+		case "":
+			rows[1][1] = version.GetBuild()
+			rows[1][2] = version.GetCommitSHA()
 			utils.PrintToTable(header, rows, nil)
-			utils.Log.Error(utils.ErrInvalidAPIResponse(err))
-			return
+			if serverError != nil {
+				utils.Log.Warn(ErrConnectingToServer(serverError))
+			}
+		default:
+			utils.Log.Error(utils.ErrFlagsInvalid(fmt.Errorf("invalid value for --output-format '%s': valid values are json yaml", outputFormat)))
 		}
-
-		err = json.Unmarshal(data, &version)
-		if err != nil {
-			utils.PrintToTable(header, rows, nil)
-			utils.Log.Error(ErrUnmarshallingAPIData(err))
-			return
-		}
-
-		rows[1][1] = version.GetBuild()
-		rows[1][2] = version.GetCommitSHA()
-		utils.PrintToTable(header, rows, nil)
 	},
 }

--- a/mesheryctl/internal/cli/root/version_test.go
+++ b/mesheryctl/internal/cli/root/version_test.go
@@ -1,0 +1,137 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package root
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/meshery/meshery/mesheryctl/pkg/utils/format"
+	"gopkg.in/yaml.v2"
+)
+
+// TestVersionCmdFlags verifies that the output-format flag and shorthand are registered.
+func TestVersionCmdFlags(t *testing.T) {
+	flag := versionCmd.Flags().Lookup("output-format")
+	if flag == nil {
+		t.Fatal("flag --output-format should be registered")
+	}
+	if flag.Shorthand != "o" {
+		t.Errorf("expected shorthand 'o', got '%s'", flag.Shorthand)
+	}
+	if flag.DefValue != "" {
+		t.Errorf("expected default value '', got '%s'", flag.DefValue)
+	}
+}
+
+// TestVersionCmdFlagParsing tests parsing valid output-format flags.
+func TestVersionCmdFlagParsing(t *testing.T) {
+	t.Cleanup(func() {
+		_ = versionCmd.Flags().Set("output-format", "")
+	})
+
+	if err := versionCmd.Flags().Set("output-format", "json"); err != nil {
+		t.Fatalf("unexpected error setting json format: %v", err)
+	}
+	if outputFormat != "json" {
+		t.Errorf("expected outputFormat 'json', got '%s'", outputFormat)
+	}
+
+	if err := versionCmd.Flags().Set("output-format", "yaml"); err != nil {
+		t.Fatalf("unexpected error setting yaml format: %v", err)
+	}
+	if outputFormat != "yaml" {
+		t.Errorf("expected outputFormat 'yaml', got '%s'", outputFormat)
+	}
+}
+
+// TestVersionOutputSchema validates serialization using production types.
+func TestVersionOutputSchema(t *testing.T) {
+	dummy := versionOutput{
+		Client: versionInfo{Version: "v1.0.69", GitSHA: "7b53ef517e3c632a3bee63fa7c21b031430943ab"},
+		Server: versionInfo{Version: "unavailable", GitSHA: "unavailable"},
+	}
+
+	jsonData, err := json.Marshal(dummy)
+	if err != nil {
+		t.Fatalf("failed to marshal json: %v", err)
+	}
+
+	var jsonMap map[string]map[string]string
+	if err := json.Unmarshal(jsonData, &jsonMap); err != nil {
+		t.Fatalf("failed to unmarshal json: %v", err)
+	}
+	if _, ok := jsonMap["client"]; !ok {
+		t.Error("expected key 'client' in json map")
+	}
+	if _, ok := jsonMap["server"]; !ok {
+		t.Error("expected key 'server' in json map")
+	}
+	if jsonMap["client"]["version"] != "v1.0.69" {
+		t.Errorf("expected client version 'v1.0.69', got '%s'", jsonMap["client"]["version"])
+	}
+	if jsonMap["client"]["git_sha"] != "7b53ef517e3c632a3bee63fa7c21b031430943ab" {
+		t.Errorf("expected client git_sha '7b53ef517e3c632a3bee63fa7c21b031430943ab', got '%s'", jsonMap["client"]["git_sha"])
+	}
+	if jsonMap["server"]["version"] != "unavailable" {
+		t.Errorf("expected server version 'unavailable', got '%s'", jsonMap["server"]["version"])
+	}
+	if jsonMap["server"]["git_sha"] != "unavailable" {
+		t.Errorf("expected server git_sha 'unavailable', got '%s'", jsonMap["server"]["git_sha"])
+	}
+
+	yamlData, err := yaml.Marshal(dummy)
+	if err != nil {
+		t.Fatalf("failed to marshal yaml: %v", err)
+	}
+
+	var yamlMap map[string]map[string]string
+	if err := yaml.Unmarshal(yamlData, &yamlMap); err != nil {
+		t.Fatalf("failed to unmarshal yaml: %v", err)
+	}
+	if _, ok := yamlMap["client"]; !ok {
+		t.Error("expected key 'client' in yaml map")
+	}
+	if _, ok := yamlMap["server"]; !ok {
+		t.Error("expected key 'server' in yaml map")
+	}
+	if yamlMap["client"]["version"] != "v1.0.69" {
+		t.Errorf("expected client version 'v1.0.69', got '%s'", yamlMap["client"]["version"])
+	}
+	if yamlMap["client"]["git_sha"] != "7b53ef517e3c632a3bee63fa7c21b031430943ab" {
+		t.Errorf("expected git_sha '7b53ef517e3c632a3bee63fa7c21b031430943ab', got '%s'", yamlMap["client"]["git_sha"])
+	}
+	if yamlMap["server"]["version"] != "unavailable" {
+		t.Errorf("expected server version 'unavailable', got '%s'", yamlMap["server"]["version"])
+	}
+	if yamlMap["server"]["git_sha"] != "unavailable" {
+		t.Errorf("expected server git_sha 'unavailable', got '%s'", yamlMap["server"]["git_sha"])
+	}
+}
+
+// TestVersionFormatOutput verifies format helpers.
+func TestVersionFormatOutput(t *testing.T) {
+	dummy := versionOutput{
+		Client: versionInfo{Version: "v1.0.69", GitSHA: "7b53ef517e3c632a3bee63fa7c21b031430943ab"},
+		Server: versionInfo{Version: "unavailable", GitSHA: "unavailable"},
+	}
+
+	if err := format.OutputJson(dummy); err != nil {
+		t.Errorf("unexpected error in OutputJson: %v", err)
+	}
+	if err := format.OutputYaml(dummy); err != nil {
+		t.Errorf("unexpected error in OutputYaml: %v", err)
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21850 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

### Description
Adds standard `--output-format` (shorthand `-o`) flag to `mesheryctl version` supporting structured `json` and `yaml` payloads.

**Key Changes:**
* Registered `--output-format` (`-o`) flag on `versionCmd` with validation for `json` and `yaml`.
* Structured response into clean, typed `client` and `server` objects (`version`, `git_sha`).
* Suppressed background update-check output when structured output is selected (`outputFormat != ""`), ensuring `stdout` contains only clean, parseable data without breaking tools like `jq`.
* Consolidated terminal table rendering into a single exit path, cleaning up duplicated `PrintToTable` calls.
* Added unit tests in `version_test.go` covering flag registration, Cobra flag parsing, schema serialization, invalid format handling, and format helper compatibility.

### Terminal output
Before:
```bash
❯ mesheryctl version -o json
Error: unknown shorthand flag: 'o' in -o
```
After:
JSON Output:
```bash
❯ mesheryctl version -o json
{
  "client": {
    "version": "v1.0.69",
    "git_sha": "c31e47069834271404678ac51eec882c99e0c1e7"
  },
  "server": {
    "version": "unavailable",
    "git_sha": "unavailable"
  }
}
```
YAML Output:
```bash
❯ mesheryctl version -o yaml
client:
  version: v1.0.69
  git_sha: c31e47069834271404678ac51eec882c99e0c1e7
server:
  version: unavailable
  git_sha: unavailable
```
Human readable
```bash
❯ mesheryctl version
        VERSION      GITSHA                                    
Client  v1.0.69      c31e47069834271404678ac51eec882c99e0c1e7  
Server  unavailable  unavailable                               
Unable to communicate with Meshery server.Get "http://localhost:9081/api/system/version": dial tcp [::1]:9081: connect: connection refused.See https://docs.meshery.io for help getting started with Meshery | Short Description: Unable to communicate with Meshery server | Suggested Remediation: See https://docs.meshery.io for help getting started with Meshery
Checking for latest version of mesheryctl...

v1.0.69 is the latest release.
```
Invalid Format:
```bash
❯ mesheryctl version -o xml
invalid value for --output-format 'xml': valid values are json yaml | Short Description: Invalid flag(s) provided | Probable Cause: The value for one or more flags provided is invalid. | Suggested Remediation: Provide valid flag value and try again.
```
Testing:
[X] Verified clean output piping via mesheryctl version -o json | jq .client.version.
[X] go test --short ./... passed across mesheryctl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added JSON and YAML output options to the version command using `--output-format` or `-o`.
  - Version details now support structured output for scripting and automation.
  - Standard table output remains available by default.

- **Bug Fixes**
  - Version information continues displaying client details when server retrieval encounters an error.
  - Server retrieval warnings appear alongside standard output when applicable.
  - Invalid output format values now produce a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->