### PR TITLE
[UI] Prevent Designs toolbar overflow on small screens

### DIFF
--- a/ui/assets/styles/general/tool.styles.tsx
+++ b/ui/assets/styles/general/tool.styles.tsx
@@ -11,6 +11,11 @@ export const ToolWrapper = styled(Box)(({ theme }) => ({
   borderRadius: '0.5rem',
   position: 'relative',
   zIndex: '101',
+  [theme.breakpoints.down('sm')]: {
+    height: 'auto',
+    flexWrap: 'wrap',
+    gap: '0.5rem',
+  },
 }));
 
 export const WorkloadsContainer = styled('div')(() => ({


### PR DESCRIPTION
### Notes for Reviewers
This PR fixes #21727.
### Description
On small screens (< 600px), toolbar controls (Search, Filter, View Switcher) on the Designs page were overflowing and getting clipped due to `ToolWrapper` having a fixed `height: '4rem'` and `flexWrap: 'nowrap'`.
This PR adds responsive behavior below the `sm` breakpoint (`theme.breakpoints.down('sm')`) to allow items to wrap naturally with `height: 'auto'` and `gap: '0.5rem'`, matching the pattern already used in `MeshModelToolbar`.
### Screenshots
#### Before
<img width="863" height="1016" alt="Screenshot (78)" src="https://github.com/user-attachments/assets/2dde2145-d71c-4eb1-a506-04e29e81aa93" />
<img width="1920" height="975" alt="Screenshot (76)" src="https://github.com/user-attachments/assets/abb205d5-f30b-4a2c-8491-58d8687d663d" />

#### After
<img width="1920" height="969" alt="Screenshot (87)" src="https://github.com/user-attachments/assets/8452bf75-35d1-41a6-8b5b-b5da7d5ec97d" />
<img width="1036" height="964" alt="Screenshot (86)" src="https://github.com/user-attachments/assets/571f8a9f-df1b-4fbd-8cc3-3f9d088690b2" />

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the tool layout on small screens by allowing items to wrap, automatically adjusting height, and adding spacing between items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->