### PR TITLE
[mesheryctl] Add traceability tags to Half B BATS tests

### DIFF
--- a/mesheryctl/tests/e2e/000-prerequisites/00-cli.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-cli.bats
@@ -7,7 +7,7 @@ setup() {
 
 # Basic tests to validate cli has been build and behave properly at root
 
-@test "cli is available" {
+@test "[cut=mesheryctl CLI][tg=CLI Prerequisites] cli is available" {
     if [[ -z "$MESHERYCTL_BIN" ]]; then
         echo "Error: MESHERYCTL_BIN is not defined. Set it before running tests."
         exit 1
@@ -17,7 +17,7 @@ setup() {
     assert_success
 }
 
-@test "mesheryctl version return Client and Server" {
+@test "[cut=mesheryctl CLI][tg=CLI Prerequisites] mesheryctl version return Client and Server" {
     run $MESHERYCTL_BIN version
     assert_success
     

--- a/mesheryctl/tests/e2e/000-prerequisites/00-config.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-config.bats
@@ -7,22 +7,22 @@ setup() {
 
 # tests config file and authenticatin file set properly
 
-@test "meshery config.yaml file as been created" {
+@test "[cut=Meshery Configuration][tg=Configuration Prerequisites] meshery config.yaml file as been created" {
     assert_exists "$MESHERY_CONFIG_FILE_PATH"
 }
 
-@test "meshery config.yaml provider is Meshery" {
+@test "[cut=Meshery Configuration][tg=Configuration Prerequisites] meshery config.yaml provider is Meshery" {
     run yq '.contexts.local.provider' "$MESHERY_CONFIG_FILE_PATH"
     assert_success
 
     assert_output  --partial "Meshery"
 }
 
-@test "meshery auth.json file as been created" {
+@test "[cut=Meshery Configuration][tg=Configuration Prerequisites] meshery auth.json file as been created" {
     assert_exists "$MESHERY_AUTH_FILE"
 }
 
-@test "meshery auth.json file meshery provider is Meshery" {
+@test "[cut=Meshery Configuration][tg=Configuration Prerequisites] meshery auth.json file meshery provider is Meshery" {
     run jq '."meshery-provider"' "$MESHERY_AUTH_FILE"
     assert_success
 

--- a/mesheryctl/tests/e2e/000-prerequisites/00-servert.bats
+++ b/mesheryctl/tests/e2e/000-prerequisites/00-servert.bats
@@ -10,7 +10,7 @@ setup() {
     DETIK_CLIENT_NAME="kubectl"
 }
 
-@test "meshery pod is deployed" {
+@test "[cut=Meshery Server][tg=Server Prerequisites] meshery pod is deployed" {
 	run verify "there are more than 0 pod named '^meshery-[a-z0-9]+-[a-z0-9]+$'"
 	assert_success
 }
@@ -20,23 +20,23 @@ setup() {
 # meshery-broker. Accept either, because the operator version is a property of
 # the cluster under test, not of this suite. Only the workload was renamed - the
 # Broker custom resource is still meshery-broker.
-@test "meshery-broker pod is deployed" {
+@test "[cut=Meshery Server][tg=Server Prerequisites] meshery-broker pod is deployed" {
 	run verify "there are more than 0 pod named '^meshery-(nats|broker)-[0-9]+$'"
 	assert_success
 }
 
-@test "meshery-meshsync pod is deployed" {
+@test "[cut=Meshery Server][tg=Server Prerequisites] meshery-meshsync pod is deployed" {
     run verify "there are more than 0 pod named '^meshery-meshsync-[a-z0-9]+-[a-z0-9]+$'"
 	assert_success
 }
 
-@test "meshery-operator pod is deployed" {
+@test "[cut=Meshery Server][tg=Server Prerequisites] meshery-operator pod is deployed" {
 	run verify "there are more than 0 pod named '^meshery-operator-[a-z0-9]+-[a-z0-9]+$'"
 	assert_success
 }
 
 
-@test "meshery service is deployed" {
+@test "[cut=Meshery Server][tg=Server Prerequisites] meshery service is deployed" {
 	run verify "there is 1 service named '^meshery$'"
 	assert_success
 }
@@ -44,12 +44,12 @@ setup() {
 # See the pod test above for why both names are accepted. The NATS chart also
 # publishes a meshery-nats-headless service; the anchored pattern matches only
 # the addressable one, so the count stays 1.
-@test "meshery-broker service is deployed" {
+@test "[cut=Meshery Server][tg=Server Prerequisites] meshery-broker service is deployed" {
 	run verify "there is 1 service named '^meshery-(nats|broker)$'"
 	assert_success
 }
 
-@test "meshery-operator service is deployed" {
+@test "[cut=Meshery Server][tg=Server Prerequisites] meshery-operator service is deployed" {
 	run verify "there is 1 service named '^meshery-operator$'"
 	assert_success
 }

--- a/mesheryctl/tests/e2e/003-design/01-design-import.bats
+++ b/mesheryctl/tests/e2e/003-design/01-design-import.bats
@@ -10,7 +10,7 @@ setup() {
   export FIXTURES_DIR="$BATS_TEST_DIRNAME/fixtures"
 }
 
-@test "mesheryctl design import -f nginx.yaml displays imported and output the design Id" {
+@test "[cut=Design][tg=Design Import] mesheryctl design import -f nginx.yaml displays imported and output the design Id" {
   # Import the design directly from the testdata directory
   run $MESHERYCTL_BIN design import -f "$FIXTURES_DIR/design-import/nginx.yaml" --source-type "Kubernetes Manifest"
   assert_success
@@ -21,7 +21,7 @@ setup() {
   echo "$DESIGN_ID" > "$TESTDATA_DIR/id"
 }
 
-@test "mesheryctl design import with an invalid path displays an error message" {
+@test "[cut=Design][tg=Design Import] mesheryctl design import with an invalid path displays an error message" {
   # Use a non-existent file path
   run $MESHERYCTL_BIN design import -f "$TESTDATA_DIR/design-import/nonexistent.yaml" --source-type "Kubernetes Manifest"
   # TODO: Update command to assert is failing

--- a/mesheryctl/tests/e2e/003-design/02-design-view.bats
+++ b/mesheryctl/tests/e2e/003-design/02-design-view.bats
@@ -7,7 +7,7 @@ setup() {
   export TESTDATA_DIR="$TEMP_DATA_DIR/testdata/design"
 }
 
-@test "mesheryctl design view using ID displays the design content" {
+@test "[cut=Design][tg=Design View] mesheryctl design view using ID displays the design content" {
   if [[ ! -f "$TESTDATA_DIR/id" ]]; then
     skip "Design ID file not found (import test may have failed)"
   fi
@@ -20,19 +20,19 @@ setup() {
   assert_output --partial "nginx-deployment"
 }
 
-@test "mesheryctl design view using name displays the design content" {
+@test "[cut=Design][tg=Design View] mesheryctl design view using name displays the design content" {
   run $MESHERYCTL_BIN design view "nginx-deployment"
   assert_success
   assert_output --partial "nginx-deployment"
 }
 
-@test "mesheryctl design view with no argument throws an error" {
+@test "[cut=Design][tg=Design View] mesheryctl design view with no argument throws an error" {
   run $MESHERYCTL_BIN design view
   assert_failure
   assert_output --partial "Provide a design name or ID"
 }
 
-@test "mesheryctl design view with nonexistent design throws an error" {
+@test "[cut=Design][tg=Design View] mesheryctl design view with nonexistent design throws an error" {
   run $MESHERYCTL_BIN design view "nonexistent-design"
   assert_failure
   assert_output --partial "not found"

--- a/mesheryctl/tests/e2e/003-design/03-design-list.bats
+++ b/mesheryctl/tests/e2e/003-design/03-design-list.bats
@@ -10,7 +10,7 @@ setup() {
   export DESIGN_LIST_OUTPUT__HEADER_REGEX_PATTERN="^DESIGN[[:space:]]ID[[:space:]]+(USER[[:space:]]ID)?[[:space:]]+NAME[[:space:]]+CREATED[[:space:]]+UPDATED[[:space:]]+$"
 }
 
-@test "given all requirements met when running mesheryctl design list --page 1 then the total numbers of designs and a list of designs are displayed" {
+@test "[cut=Design][tg=Design List] given all requirements met when running mesheryctl design list --page 1 then the total numbers of designs and a list of designs are displayed" {
   run $MESHERYCTL_BIN design list --page 1
   assert_success
 
@@ -18,7 +18,7 @@ setup() {
   assert_line --regexp "$LIST_COMMAND_OUTPUT_REGEX_PATTERN"
 }
 
-@test "given all requirements met when running mesheryctl design list --count then the total numbers of designs is displayed" {
+@test "[cut=Design][tg=Design List] given all requirements met when running mesheryctl design list --count then the total numbers of designs is displayed" {
   run $MESHERYCTL_BIN design list --count
   assert_success
   

--- a/mesheryctl/tests/e2e/003-design/04-design-apply.bats
+++ b/mesheryctl/tests/e2e/003-design/04-design-apply.bats
@@ -10,13 +10,13 @@ setup() {
   export TESTDATA_PATH="$FIXTURES_DIR/design-import/nginx.yaml"
 }
 
-@test "mesheryctl design apply applies design file" {
+@test "[cut=Design][tg=Design Apply] mesheryctl design apply applies design file" {
   run $MESHERYCTL_BIN design apply -f "$TESTDATA_PATH"
 
   assert_success
 }
 
-@test "mesheryctl design apply -f invalid path shows error" {
+@test "[cut=Design][tg=Design Apply] mesheryctl design apply -f invalid path shows error" {
   INVALID_PATH="./test/invalid/path/nginx.yaml"
   run $MESHERYCTL_BIN design apply -f "$INVALID_PATH"
 

--- a/mesheryctl/tests/e2e/003-design/05-design-deploy.bats
+++ b/mesheryctl/tests/e2e/003-design/05-design-deploy.bats
@@ -11,21 +11,21 @@ setup() {
   export SHARED_FIXTURES_DIR="$BATS_TEST_DIRNAME/fixtures/design-import"
 }
 
-@test "given --file and --source flags provided when mesheryctl design deploy --file file-path --source source-type then design is deployed" {
+@test "[cut=Design][tg=Design Deploy] given --file and --source flags provided when mesheryctl design deploy --file file-path --source source-type then design is deployed" {
   run $MESHERYCTL_BIN design deploy -f "$SHARED_FIXTURES_DIR/nginx.yaml" -s "Kubernetes Manifest"
 
   assert_success
   assert_output --partial "design deployed"
 }
 
-@test "given an invalid file path when mesheryctl design deploy --file invalid-file-path --source source-type then an error message is displayed" {
+@test "[cut=Design][tg=Design Deploy] given an invalid file path when mesheryctl design deploy --file invalid-file-path --source source-type then an error message is displayed" {
   run $MESHERYCTL_BIN design deploy -f "$TESTDATA_DIR/nonexistent.yaml" -s "Kubernetes Manifest"
 
   assert_failure
   assert_output --partial "Invalid value for --file '$TESTDATA_DIR/nonexistent.yaml'"
 }
 
-@test "given an invalid source type when mesheryctl design deploy --file file-path --source invalid-source-type then an error message is displayed" {
+@test "[cut=Design][tg=Design Deploy] given an invalid source type when mesheryctl design deploy --file file-path --source invalid-source-type then an error message is displayed" {
   run $MESHERYCTL_BIN design deploy -f "$SHARED_FIXTURES_DIR/nginx.yaml" -s "InvalidSourceType"
 
   assert_failure
@@ -34,7 +34,7 @@ setup() {
   assert_output --partial "Provide valid flag value and try again"
 }
 
-@test "given no required flags when mesheryctl design deploy then an appropriate error is displayed" {
+@test "[cut=Design][tg=Design Deploy] given no required flags when mesheryctl design deploy then an appropriate error is displayed" {
   run $MESHERYCTL_BIN design deploy
 
   assert_failure

--- a/mesheryctl/tests/e2e/003-design/06-design-delete.bats
+++ b/mesheryctl/tests/e2e/003-design/06-design-delete.bats
@@ -10,7 +10,7 @@ setup() {
   export TESTDATA_DIR="$TEMP_DATA_DIR/testdata/design"
 }
 
-@test "mesheryctl design delete removes the associate design" {
+@test "[cut=Design][tg=Design Delete] mesheryctl design delete removes the associate design" {
   # Check if the design ID file exists (created by previous import test)
   if [[ ! -f "$TESTDATA_DIR/id" ]]; then
     skip "Design ID file not found (import test may have failed)"
@@ -26,7 +26,7 @@ setup() {
 }
 
 
-@test "mesheryctl design delete for non-existent ID gives appropriate response" {
+@test "[cut=Design][tg=Design Delete] mesheryctl design delete for non-existent ID gives appropriate response" {
   # Use a non-existent design ID
   NONEXISTENT_ID="00000000-0000-0000-0000-000000000000"
 

--- a/mesheryctl/tests/e2e/006-registry/01-generate.bats
+++ b/mesheryctl/tests/e2e/006-registry/01-generate.bats
@@ -24,7 +24,7 @@ require_spreadsheet_credentials() {
     fi
 }
 
-@test "given no arguments when running mesheryctl registry generate then usage instructions are displayed" {
+@test "[cut=Registry][tg=Registry Generate] given no arguments when running mesheryctl registry generate then usage instructions are displayed" {
     run $MESHERYCTL_BIN registry generate 
     assert_failure
     assert_output --partial "[ Spreadsheet ID | Registrant Connection Definition Path | Local Directory | Individual CSV files ] isn't specified"
@@ -32,39 +32,39 @@ require_spreadsheet_credentials() {
     assert_output --partial "mesheryctl registry generate --spreadsheet-id [Spreadsheet ID] --spreadsheet-cred \$CRED"
 }
 
-@test "given spreadsheet-id without spreadsheet-cred when running mesheryctl registry generate then an error message is displayed" {
+@test "[cut=Registry][tg=Registry Generate] given spreadsheet-id without spreadsheet-cred when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --spreadsheet-id "test-id"
     assert_failure
     assert_output --partial "Spreadsheet Credentials is required"
 }
 
-@test "given registrant-def without registrant-cred when running mesheryctl registry generate then an error message is displayed" {
+@test "[cut=Registry][tg=Registry Generate] given registrant-def without registrant-cred when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --registrant-def "$FIXTURES_DIR/connection-def.json"
     assert_failure
     assert_output --partial "Registrant Credentials is required"
 }
 
-@test "given an invalid directory when running mesheryctl registry generate then an error message is displayed" {
+@test "[cut=Registry][tg=Registry Generate] given an invalid directory when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --directory "invalid-directory"
     assert_failure
     assert_output --partial "error reading the directory"
 }
 
-@test "given a directory missing required csv files when running mesheryctl registry generate then an error message is displayed" {
+@test "[cut=Registry][tg=Registry Generate] given a directory missing required csv files when running mesheryctl registry generate then an error message is displayed" {
     run $MESHERYCTL_BIN registry generate --directory "$FIXTURES_DIR/incomplete-csv-dir"
     assert_failure
     assert_output --partial "error reading the directory"
     assert_output --partial "either the model csv or component csv is missing"
 }
 
-@test "given valid spreadsheet credentials and a model name when running mesheryctl registry generate then only that model is generated" {
+@test "[cut=Registry][tg=Registry Generate] given valid spreadsheet credentials and a model name when running mesheryctl registry generate then only that model is generated" {
     require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry generate --spreadsheet-id "$TEST_SPREADSHEET_ID" --spreadsheet-cred "$TEST_SPREADSHEET_CRED" --model "flyte"
     assert_success
     common_outputs_on_success
 }
 
-@test "given valid spreadsheet credentials when running mesheryctl registry generate then models are generated successfully" {
+@test "[cut=Registry][tg=Registry Generate] given valid spreadsheet credentials when running mesheryctl registry generate then models are generated successfully" {
     require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry generate --spreadsheet-id "$TEST_SPREADSHEET_ID" --spreadsheet-cred "$TEST_SPREADSHEET_CRED"
     assert_success

--- a/mesheryctl/tests/e2e/006-registry/02-update.bats
+++ b/mesheryctl/tests/e2e/006-registry/02-update.bats
@@ -15,47 +15,47 @@ require_spreadsheet_credentials() {
     fi
 }
 
-@test "given no arguments when running mesheryctl registry update then an error is displayed" {
+@test "[cut=Registry][tg=Registry Update] given no arguments when running mesheryctl registry update then an error is displayed" {
     run $MESHERYCTL_BIN registry update
     assert_failure
     assert_output --partial "error updating registry"
 }
 
-@test "given spreadsheet-id without spreadsheet-cred when running mesheryctl registry update then an error about missing flag is displayed" {
+@test "[cut=Registry][tg=Registry Update] given spreadsheet-id without spreadsheet-cred when running mesheryctl registry update then an error about missing flag is displayed" {
     run $MESHERYCTL_BIN registry update --spreadsheet-id "test-id"
     assert_failure
     assert_output --partial "if any flags in the group [spreadsheet-id spreadsheet-cred] are set they must all be set"
     assert_output --partial "spreadsheet-cred"
 }
 
-@test "given spreadsheet-cred without spreadsheet-id when running mesheryctl registry update then an error about missing flag is displayed" {
+@test "[cut=Registry][tg=Registry Update] given spreadsheet-cred without spreadsheet-id when running mesheryctl registry update then an error about missing flag is displayed" {
     run $MESHERYCTL_BIN registry update --spreadsheet-cred "test-cred"
     assert_failure
     assert_output --partial "if any flags in the group [spreadsheet-id spreadsheet-cred] are set they must all be set"
     assert_output --partial "spreadsheet-id"
 }
 
-@test "given invalid spreadsheet credentials when running mesheryctl registry update then an error is displayed" {
+@test "[cut=Registry][tg=Registry Update] given invalid spreadsheet credentials when running mesheryctl registry update then an error is displayed" {
     run $MESHERYCTL_BIN registry update --spreadsheet-id "invalid-id" --spreadsheet-cred "invalid-cred"
     assert_failure
     assert_output --partial "Invalid JWT credentials"
 }
 
-@test "given an invalid model name when running mesheryctl registry update then zero models are updated" {
+@test "[cut=Registry][tg=Registry Update] given an invalid model name when running mesheryctl registry update then zero models are updated" {
     require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry update --spreadsheet-id "$TEST_SPREADSHEET_ID" --spreadsheet-cred "$TEST_SPREADSHEET_CRED" --model "nonexistent-model"
     assert_success
     assert_output --partial "Updated 0 models and 0 components"
 }
 
-@test "given valid spreadsheet credentials and a model name when running mesheryctl registry update then that model is updated" {
+@test "[cut=Registry][tg=Registry Update] given valid spreadsheet credentials and a model name when running mesheryctl registry update then that model is updated" {
     require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry update --spreadsheet-id "$TEST_SPREADSHEET_ID" --spreadsheet-cred "$TEST_SPREADSHEET_CRED" --model "kubernetes"
     assert_success
     assert_output --regexp "Updated [1-9][0-9]* models? and [0-9]+ components?"
 }
 
-@test "given valid spreadsheet credentials when running mesheryctl registry update then models are updated successfully" {
+@test "[cut=Registry][tg=Registry Update] given valid spreadsheet credentials when running mesheryctl registry update then models are updated successfully" {
     require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry update --spreadsheet-id "$TEST_SPREADSHEET_ID" --spreadsheet-cred "$TEST_SPREADSHEET_CRED"
     assert_success

--- a/mesheryctl/tests/e2e/006-registry/03-publish.bats
+++ b/mesheryctl/tests/e2e/006-registry/03-publish.bats
@@ -17,41 +17,41 @@ require_spreadsheet_credentials() {
     fi
 }
 
-@test "given no arguments when running mesheryctl registry publish then an error about required args is displayed" {
+@test "[cut=Registry][tg=Registry Publish] given no arguments when running mesheryctl registry publish then an error about required args is displayed" {
     run $MESHERYCTL_BIN registry publish
     assert_failure
     assert_output --partial "system, google sheet credential, sheet-id, models output path, imgs output path"
     assert_output --partial "are required"
 }
 
-@test "given fewer than five arguments when running mesheryctl registry publish then an error about required args is displayed" {
+@test "[cut=Registry][tg=Registry Publish] given fewer than five arguments when running mesheryctl registry publish then an error about required args is displayed" {
     run $MESHERYCTL_BIN registry publish website
     assert_failure
     assert_output --partial "system, google sheet credential, sheet-id, models output path, imgs output path"
     assert_output --partial "are required"
 }
 
-@test "given invalid spreadsheet credentials when running mesheryctl registry publish then an error is displayed" {
+@test "[cut=Registry][tg=Registry Publish] given invalid spreadsheet credentials when running mesheryctl registry publish then an error is displayed" {
     run $MESHERYCTL_BIN registry publish website "invalid-cred" "invalid-id" "$TESTDATA_DIR/models" "$TESTDATA_DIR/imgs"
     assert_failure
     assert_output --partial "Invalid JWT Token"
 }
 
-@test "given an invalid output format when running mesheryctl registry publish website then an error is displayed" {
+@test "[cut=Registry][tg=Registry Publish] given an invalid output format when running mesheryctl registry publish website then an error is displayed" {
     require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry publish website "$TEST_SPREADSHEET_CRED" "$TEST_SPREADSHEET_ID" "$TESTDATA_DIR/models" "$TESTDATA_DIR/imgs" -o "invalid"
     assert_failure
     assert_output --partial "invalid output format"
 }
 
-@test "given an invalid system when running mesheryctl registry publish then an error is displayed" {
+@test "[cut=Registry][tg=Registry Publish] given an invalid system when running mesheryctl registry publish then an error is displayed" {
     require_spreadsheet_credentials
     run $MESHERYCTL_BIN registry publish invalid-system "$TEST_SPREADSHEET_CRED" "$TEST_SPREADSHEET_ID" "$TESTDATA_DIR/models" "$TESTDATA_DIR/imgs"
     assert_failure
     assert_output --partial "invalid system"
 }
 
-@test "given valid credentials when running mesheryctl registry publish to website with md format then models are published" {
+@test "[cut=Registry][tg=Registry Publish] given valid credentials when running mesheryctl registry publish to website with md format then models are published" {
     require_spreadsheet_credentials
     mkdir -p "$TESTDATA_DIR/models-out" "$TESTDATA_DIR/imgs-out"
     run $MESHERYCTL_BIN registry publish website "$TEST_SPREADSHEET_CRED" "$TEST_SPREADSHEET_ID" "$TESTDATA_DIR/models-out" "$TESTDATA_DIR/imgs-out" -o md

--- a/mesheryctl/tests/e2e/999-system/01-system-context.bats
+++ b/mesheryctl/tests/e2e/999-system/01-system-context.bats
@@ -10,14 +10,14 @@ setup() {
    CONTEXT_NAME_2="example-context2"
 }
 
-@test "given a valid context-name is provided as an argument when running mesheryctl system context create then the context is created" {
+@test "[cut=System Context][tg=Context Management] given a valid context-name is provided as an argument when running mesheryctl system context create then the context is created" {
    run $MESHERYCTL_BIN system context create "$CONTEXT_NAME"
 
    assert_success
    assert_output --partial "Added"
 }
 
-@test "given an already existing context-name is provided as an argument when running mesheryctl system context create then an error message is displayed" {
+@test "[cut=System Context][tg=Context Management] given an already existing context-name is provided as an argument when running mesheryctl system context create then an error message is displayed" {
    run $MESHERYCTL_BIN system context create "$CONTEXT_NAME"
 
    assert_failure
@@ -25,7 +25,7 @@ setup() {
    assert_output --partial "name already exists"
 }
 
-@test "given no context-name as an argument when running mesheryctl system context create then the error message displays" {
+@test "[cut=System Context][tg=Context Management] given no context-name as an argument when running mesheryctl system context create then the error message displays" {
    run $MESHERYCTL_BIN system context create
 
    assert_failure
@@ -33,7 +33,7 @@ setup() {
    assert_output --partial "provide a context name"
 }
 
-@test "given a valid url as an argument when running mesheryctl system context create --url invalid-url then an the context is displayed" {
+@test "[cut=System Context][tg=Context Management] given a valid url as an argument when running mesheryctl system context create --url invalid-url then an the context is displayed" {
    run $MESHERYCTL_BIN system context delete "$CONTEXT_NAME"
    run $MESHERYCTL_BIN system context create "$CONTEXT_NAME" --url "$CONTEXT_URL"
 
@@ -41,7 +41,7 @@ setup() {
    assert_output --partial "Added"
 }
 
-@test "given an invalid url as an argument when running mesheryctl system context create --url invalid-url then an error message is displayed" {
+@test "[cut=System Context][tg=Context Management] given an invalid url as an argument when running mesheryctl system context create --url invalid-url then an error message is displayed" {
    run $MESHERYCTL_BIN system context create "$CONTEXT_NAME" --url invalid
 
    assert_failure
@@ -49,7 +49,7 @@ setup() {
    assert_output --partial "invalid URI"
 }
 
-@test "given all requirements met with --set flag when running mesheryctl system context create context-name --url valid-url --set then the new context is created and set it as current context" {
+@test "[cut=System Context][tg=Context Management] given all requirements met with --set flag when running mesheryctl system context create context-name --url valid-url --set then the new context is created and set it as current context" {
    skip "Temporarily skipping"
    run $MESHERYCTL_BIN system context create "$CONTEXT_NAME_2" --url "$CONTEXT_URL" --set
 
@@ -61,7 +61,7 @@ setup() {
    assert_line --regexp "Current Context:[[:space:]]+$CONTEXT_NAME_2"
 }
 
-@test "given --all flag provided when running mesheryctl system context view --all then all contexts details are displayed" {
+@test "[cut=System Context][tg=Context Management] given --all flag provided when running mesheryctl system context view --all then all contexts details are displayed" {
    run $MESHERYCTL_BIN system context view --all
    assert_success
 
@@ -69,7 +69,7 @@ setup() {
    assert_output --partial "token"
 }
 
-@test "given all requirements met when running mesheryctl system context view then the details of current context is displayed" {
+@test "[cut=System Context][tg=Context Management] given all requirements met when running mesheryctl system context view then the details of current context is displayed" {
    run $MESHERYCTL_BIN system context view
    assert_success
    
@@ -77,14 +77,14 @@ setup() {
    assert_output --partial "token"
 }
 
-@test "given an invalid context-name as an argument when running mesheryctl system context view --context then the error message displays" {
+@test "[cut=System Context][tg=Context Management] given an invalid context-name as an argument when running mesheryctl system context view --context then the error message displays" {
    run $MESHERYCTL_BIN system context view --context invalid
 
    assert_failure
    assert_output --partial "does not exist"
 }
 
-@test "given a valid context-name as an argument when running mesheryctl system context view --context then it displays the detailed context" {
+@test "[cut=System Context][tg=Context Management] given a valid context-name as an argument when running mesheryctl system context view --context then it displays the detailed context" {
    run $MESHERYCTL_BIN system context view --context "$CONTEXT_NAME"
 
    assert_success
@@ -92,14 +92,14 @@ setup() {
    assert_output --partial "token"
 }
 
-@test "given all requirements met when running mesheryctl system context list then the available contexts are displayed" {
+@test "[cut=System Context][tg=Context Management] given all requirements met when running mesheryctl system context list then the available contexts are displayed" {
    run $MESHERYCTL_BIN system context list
 
    assert_success
    assert_output --partial "Available contexts"
 }
 
-@test "given an invalid context-name provided when running mesheryctl system context switch then an error message is displayed" {
+@test "[cut=System Context][tg=Context Management] given an invalid context-name provided when running mesheryctl system context switch then an error message is displayed" {
    run $MESHERYCTL_BIN system context switch invalid
 
    assert_failure
@@ -107,7 +107,7 @@ setup() {
    assert_output --partial "context does not exist"
 }
 
-@test "given no context-name provided when running mesheryctl system context switch then an error message is displayed" {
+@test "[cut=System Context][tg=Context Management] given no context-name provided when running mesheryctl system context switch then an error message is displayed" {
    run $MESHERYCTL_BIN system context switch
 
    assert_failure
@@ -115,7 +115,7 @@ setup() {
    assert_output --partial "provide exactly one context name"
 }
 
-@test "given a valid context-name provided when running mesheryctl system context switch context-name then the current context is switched to specified context" {
+@test "[cut=System Context][tg=Context Management] given a valid context-name provided when running mesheryctl system context switch context-name then the current context is switched to specified context" {
    skip "Temporarily skipping"
    run $MESHERYCTL_BIN system context switch "$CONTEXT_NAME_2"
 
@@ -127,7 +127,7 @@ setup() {
    assert_line --regexp "Current Context:[[:space:]]+$CONTEXT_NAME_2"
 }
 
-@test "given no context-name provided when running mesheryctl system context delete then an error message is displayed" {
+@test "[cut=System Context][tg=Context Management] given no context-name provided when running mesheryctl system context delete then an error message is displayed" {
    run $MESHERYCTL_BIN system context delete
 
    assert_failure
@@ -135,7 +135,7 @@ setup() {
    assert_output --partial "provide a context name to delete"
 }
 
-@test "given an invalid context-name provided when running mesheryctl system context delete invalid-context-name then an error message is displayed" {
+@test "[cut=System Context][tg=Context Management] given an invalid context-name provided when running mesheryctl system context delete invalid-context-name then an error message is displayed" {
    run $MESHERYCTL_BIN system context delete invalid
 
    assert_failure
@@ -143,7 +143,7 @@ setup() {
    assert_output --partial "no context name found"
 }
 
-@test "given a valid context-name provided when running mesheryctl system context delete context-name then the specified context is deleted" {
+@test "[cut=System Context][tg=Context Management] given a valid context-name provided when running mesheryctl system context delete context-name then the specified context is deleted" {
    run $MESHERYCTL_BIN system context delete "$CONTEXT_NAME"
 
    assert_success


### PR DESCRIPTION
## Notes for Reviewers

- This PR addresses Half B of [Docs/QA] mesheryctl BATS e2e issue: 140 of 185 tests untagged for the qa dashboard traceability contract #21845.
- It covers tests under `000-prerequisites`, `003-design`, `006-registry`, and `999-system/01-system-context`.

## Changes

- Added `[cut=...]` and `[tg=...]` traceability tokens to the BATS E2E test titles.
- Added traceability metadata to Prerequisites tests.
- Added traceability metadata to Design tests.
- Added traceability metadata to Registry tests.
- Added traceability metadata to System Context tests.

## Validation

- `git diff --check` passed.
- Verified the modified BATS test titles contain the required traceability tags.

Closes #21845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added categorization metadata to end-to-end test names across CLI, configuration, server prerequisites, design workflows, registry operations, and system context.
  * Improved test organization and reporting without changing test behavior, assertions, or coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->