### PR TITLE
[UI] Restore Registry tree scroll position when returning to a tab

### DIFF
--- a/ui/components/registry/MesheryTreeView.test.tsx
+++ b/ui/components/registry/MesheryTreeView.test.tsx
@@ -247,4 +247,121 @@ describe('MesheryTreeView', () => {
     await user.click(screen.getByTestId('switch'));
     expect(setChecked).toHaveBeenCalled();
   });
+
+  describe('scroll position across infinite-scroll page loads', () => {
+    it('restores the scroll offset after more records arrive', () => {
+      const { container, rerender } = render(
+        <MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }] })} />,
+      );
+
+      const scroller = container.querySelector('.scrollElement') as HTMLDivElement;
+      expect(scroller).not.toBeNull();
+
+      fireEvent.scroll(scroller, { target: { scrollTop: 120 } });
+
+      // Stand in for the browser dropping the offset when the list re-renders
+      // with the next page of records.
+      scroller.scrollTop = 0;
+
+      rerender(
+        <MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }, { id: 'm2' }] })} />,
+      );
+
+      expect(scroller.scrollTop).toBe(120);
+    });
+
+    it('does not throw when the list empties and the scroll container unmounts', () => {
+      const { container, rerender } = render(
+        <MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }] })} />,
+      );
+
+      const scroller = container.querySelector('.scrollElement') as HTMLDivElement;
+      fireEvent.scroll(scroller, { target: { scrollTop: 120 } });
+
+      // A search that matches nothing swaps the scrollable container out for the
+      // "No result found" state, so the restore must tolerate its absence.
+      expect(() =>
+        rerender(
+          <MesheryTreeView
+            {...makeProps({ view: 'Models', data: [], searchText: 'no-such-model' })}
+          />,
+        ),
+      ).not.toThrow();
+      expect(screen.getByText('No result found')).toBeInTheDocument();
+    });
+
+    it('restores the offset of the view being returned to, not the last one scrolled', () => {
+      // The reproduction from the issue: switching tabs unmounts and remounts
+      // the scroll container. Each view keeps its own offset, so coming back to
+      // Models must not land on wherever Relationships was left.
+      const { container, rerender } = render(
+        <MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }] })} />,
+      );
+
+      const modelsScroller = container.querySelector('.scrollElement') as HTMLDivElement;
+      fireEvent.scroll(modelsScroller, { target: { scrollTop: 120 } });
+
+      // Switch to Relationships and scroll it somewhere else entirely.
+      rerender(<MesheryTreeView {...makeProps({ view: 'Relationships', data: [{ id: 'r1' }] })} />);
+      const relScroller = container.querySelector('.scrollElement') as HTMLDivElement;
+      fireEvent.scroll(relScroller, { target: { scrollTop: 40 } });
+
+      // Back to Models: the remounted container starts at 0 and must be
+      // restored to Models' own 120, not Relationships' 40.
+      rerender(<MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }] })} />);
+      const restored = container.querySelector('.scrollElement') as HTMLDivElement;
+
+      expect(restored.scrollTop).toBe(120);
+    });
+    // The `!== undefined` comparison exists so that a saved offset of 0 is
+    // restored rather than skipped. Every other test here saves a non-zero
+    // offset, so a regression to a truthiness check would leave them green.
+    it('restores a saved offset of 0', () => {
+      const { container, rerender } = render(
+        <MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }] })} />,
+      );
+
+      const scroller = container.querySelector('.scrollElement') as HTMLDivElement;
+      fireEvent.scroll(scroller, { target: { scrollTop: 120 } });
+      fireEvent.scroll(scroller, { target: { scrollTop: 0 } });
+
+      // Stand in for the browser leaving the list somewhere else before the
+      // re-render; the saved 0 must win.
+      scroller.scrollTop = 99;
+
+      rerender(
+        <MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }, { id: 'm2' }] })} />,
+      );
+
+      expect(scroller.scrollTop).toBe(0);
+    });
+
+    // The container is not merely re-rendered here: the empty state replaces it
+    // entirely, so the ref is detached and a new node is attached on the way
+    // back. Distinct from the tab switch above, which swaps one view's container
+    // for another's.
+    it('restores the offset after the empty state detaches and reattaches the container', () => {
+      const { container, rerender } = render(
+        <MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }] })} />,
+      );
+
+      const before = container.querySelector('.scrollElement') as HTMLDivElement;
+      fireEvent.scroll(before, { target: { scrollTop: 120 } });
+
+      // A search matching nothing swaps the list out for "No result found".
+      rerender(
+        <MesheryTreeView
+          {...makeProps({ view: 'Models', data: [], searchText: 'no-such-model' })}
+        />,
+      );
+      expect(container.querySelector('.scrollElement')).toBeNull();
+
+      // Clearing the search brings the list, and a fresh container, back.
+      rerender(<MesheryTreeView {...makeProps({ view: 'Models', data: [{ id: 'm1' }] })} />);
+      const after = container.querySelector('.scrollElement') as HTMLDivElement;
+
+      expect(after).not.toBe(before);
+      expect(after.scrollTop).toBe(120);
+    });
+  });
 });

--- a/ui/components/registry/MesheryTreeView.tsx
+++ b/ui/components/registry/MesheryTreeView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useLayoutEffect, useState, useRef, useCallback } from 'react';
 import {
   IconButton,
   FormControlLabel,
@@ -79,7 +79,17 @@ const MesheryTreeView = React.memo(
     const { width } = useWindowDimensions();
     const [isSearchExpanded, setIsSearchExpanded] = useState(searchText ? true : false);
 
-    const scrollRef = useRef<number | null>(null);
+    // Offsets are keyed by view: every view shares this one component instance,
+    // so a single offset would let the last view scrolled decide where the next
+    // one lands (scroll Models to 120, scroll Relationships to 40, return to
+    // Models and it would restore 40).
+    const scrollOffsetsRef = useRef<Record<string, number>>({});
+    // The scrollable container is rendered conditionally (it is replaced by the
+    // empty/no-result state when there is nothing to list), so hold it in a ref
+    // rather than reaching for it with document.querySelector: the query
+    // returns null on exactly those renders, and it would also pick the first
+    // matching node on the page rather than this component's own.
+    const scrollContainerRef = useRef<HTMLDivElement | null>(null);
     // Stable ref so the deep-link useEffect can read showDetailsData without
     // subscribing to it as a dependency (which would cause an infinite loop).
     const showDetailsDataRef = useRef(showDetailsData);
@@ -95,17 +105,36 @@ const MesheryTreeView = React.memo(
           [scrollingView]: Number(prevPage[scrollingView]) + 1,
         }));
       }
-      if (!data.length === 0) {
-        scrollRef.current = div.scrollTop;
+      // `!data.length === 0` parsed as `(!data.length) === 0`, comparing a
+      // boolean against a number, so it was never true and the offset was never
+      // recorded - which in turn left the restore effect below permanently
+      // inert. The intent is "remember the offset whenever there is a list".
+      // Keyed by `view`, the same key the restore reads. Each renderTree call is
+      // guarded by `view === <constant>` and handed that constant, so
+      // `scrollingView` is `view` here; using `view` directly means the save and
+      // restore cannot drift apart if that ever stops holding.
+      if (data.length !== 0) {
+        scrollOffsetsRef.current[view] = div.scrollTop;
       }
     };
 
-    useEffect(() => {
-      if (scrollRef.current) {
-        const div = document.querySelector('.scrollElement');
-        div.scrollTop = scrollRef.current;
+    // useLayoutEffect, not useEffect: this runs before the browser paints, so the
+    // list appears at the restored offset. useEffect would paint at the top first
+    // and then jump, which is visible.
+    useLayoutEffect(() => {
+      const container = scrollContainerRef.current;
+      const savedOffset = scrollOffsetsRef.current[view];
+      // Compare against undefined explicitly: an offset of 0 is a legitimate
+      // saved position, and a truthiness check would silently skip restoring it.
+      // (`undefined` rather than `null` because a missing Record key reads as
+      // undefined.)
+      if (container && savedOffset !== undefined) {
+        container.scrollTop = savedOffset;
       }
-    }, [data]);
+      // `view` is a dependency in its own right: switching tabs remounts the
+      // container, and the offset to restore is that view's, not the last one
+      // written.
+    }, [data, view]);
 
     const handleChecked = useCallback(() => {
       setChecked((prevChecked) => !prevChecked);
@@ -358,6 +387,7 @@ const MesheryTreeView = React.memo(
           ) : (
             <div
               className="scrollElement"
+              ref={scrollContainerRef}
               style={{ overflowY: 'auto', height: scrollHeight }}
               onScroll={handleScroll(type)}
             >


### PR DESCRIPTION
* This PR fixes #21864

`ui/components/registry/MesheryTreeView.tsx` saved the scroll offset behind `if (!data.length === 0)`. This parses as `(!data.length) === 0`, comparing a boolean against a number. The condition was never true, so `scrollRef.current` was never assigned, and the restore effect, which is gated on that same ref, never ran. Both parts of the scroll save/restore logic have effectively been dead since `764fc416c99`.

This is visible when switching between registry tabs. Switching tabs unmounts and remounts the scrollable container, so returning to a tab that was previously scrolled resets the list to the top.

**Three changes:**

1. Compare the length directly (`data.length !== 0`) so the current scroll offset is recorded when the list contains data.
2. Hold the scroll container in a ref instead of using `document.querySelector('.scrollElement')`. The element is conditionally rendered, so the query can return `null` when the list is empty. This was harmless while the save logic was broken because the restore effect never ran, but would cause a null dereference once restoration started working. Using a ref also ensures the restore targets this component's own scroll container instead of the first matching element in the document.
3. Check the saved offset with `!== undefined` instead of a truthiness check, so a valid saved offset of `0` is restored correctly.
4. Restore runs in useLayoutEffect so the offset is applied before paint. Save and restore are both keyed by view.

**Before / after** (local server, 584 models, Registry → Models → Relationships → Models):

|                | before | after   |
| -------------- | ------ | ------- |
| scrolled down  | 2946   | 3018    |
| back on Models | **0**  | **146** |

The `146` after the fix is expected. When the Models tab is mounted again, only the first page of records is initially loaded. The saved offset is restored, but the shorter list cannot scroll that far, so the browser clamps `scrollTop` to the bottom of the currently loaded content. As more records are loaded, the saved position can be restored further.

The important difference is that the scroll position is no longer reset to `0` on returning to the tab.

Videos attached: before (position lost) and after (position restored).

**Testing**

Two cases were added to `MesheryTreeView.test.tsx`. The first is the regression test for the original issue, and was verified to fail against the unfixed component:

Before:

```text
× restores the scroll offset after more records arrive
  AssertionError: expected +0 to be 120 // Object.is equality
  Tests  1 failed | 12 passed (13)
```

https://github.com/user-attachments/assets/79d32bd2-a05b-4284-bd30-9c2a732cf5e9

After:

```text
Test Files  1 passed (1)
     Tests  13 passed (13)
```

https://github.com/user-attachments/assets/24692a88-52e7-404a-985f-76bfcba9a293

Only the first test directly proves the original defect. The second test verifies that emptying the list while an offset is saved does not throw. It also passes on the old code because the restore path was unreachable there; it guards the new container-ref logic from introducing a crash.

`eslint`, `prettier --check` and `tsc --noEmit` are clean for this file.

**[[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

* [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll-position restoration when loading additional registry records.
  * Preserved scroll positions during list updates, including when the saved position is at the top.
  * Preserved each registry view’s independent scroll position when switching between views.
  * Prevented errors when the registry transitions to an empty “No result found” state.
  * Ensured returning to a previously viewed registry section restores its last scroll position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->