### PR TITLE
[UI] Surface administrative environment purpose in list and card

### DIFF
--- a/ui/components/environments/index.tsx
+++ b/ui/components/environments/index.tsx
@@ -8,6 +8,7 @@ import {
   PaginationItem,
   useHasPermission,
   useTheme,
+  Chip,
 } from '@sistent/sistent';
 import { withRouter } from 'next/router';
 import { debounce } from 'lodash';
@@ -521,14 +522,32 @@ const Environments = () => {
               <Grid2 container spacing={2} sx={{ marginTop: '10px' }} size="grow">
                 {environments.map((environment) => (
                   <Grid2 key={environment.id} size={{ xs: 12, md: 6 }}>
+                    {environment.purpose === 'administrative' && (
+                      <Chip
+                        label="Administrative"
+                        size="small"
+                        sx={{
+                          mb: 1,
+                          backgroundColor: 'rgba(0, 179, 159, 0.12)',
+                          color: '#00B39F',
+                          border: '1px solid #00B39F',
+                          fontWeight: 600,
+                          fontSize: '0.7rem',
+                        }}
+                      />
+                    )}
                     <EnvironmentCard
                       // classes={classes}
                       environmentDetails={environment}
                       selectedEnvironments={selectedEnvironments}
-                      onEdit={(e) => handleEnvironmentModalOpen(e, ACTION_TYPES.EDIT, environment)}
+                      onEdit={(e) =>
+                        handleEnvironmentModalOpen(e, ACTION_TYPES.EDIT, environment)
+                      }
                       onDelete={(e) => handleDeleteEnvironmentConfirm(e, environment)}
                       onSelect={(e) => handleBulkSelect(e, environment.id)}
-                      onAssignConnection={(e) => handleonAssignConnectionModalOpen(e, environment)}
+                      onAssignConnection={(e) =>
+                        handleonAssignConnectionModalOpen(e, environment)
+                      }
                     />
                   </Grid2>
                 ))}
@@ -566,7 +585,7 @@ const Environments = () => {
                 />
               }
               message="No environment available"
-              pointerLabel="Click “Create” to establish your first environment."
+              pointerLabel='Click "Create" to establish your first environment.'
             />
           )}
           {(canCreateEnv || canEditEnv) && environmentModal.open && (


### PR DESCRIPTION
Fixes #21803

## Summary
Surfaces the `administrative` purpose designation for environments
across both the list view and the environment card.

## Changes

### index.tsx
- Added `Chip` import from `@sistent/sistent`
- Administrative environments now show a teal "Administrative" badge
  above the card in the list view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administrative environments are now clearly labeled with an “Administrative” chip on their environment cards.

- **Bug Fixes**
  - Improved empty-state labeling by standardizing quotation marks for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->