### PR TITLE
Clean up ADOPTERS.md ordering and entry format

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,31 +1,31 @@
+- [Asteria Aerospace](https://asteria.co.in)
+  - "As we are a very modern technology company, we always want to use cutting edge, open source technology to excel. All our microservices are modern in nature and so is their infrastructure. We are cloud agnostic and at the same time, we are fascinated by the cloud native technologies to empower us with secure, reliable, intelligent infrastructure. When we are in an Istio world, the need for managing our cloud native stack was always been a gap. With **Meshery**, we believe we can nurture our infrastructure to perform better and more efficiently."
+- [AYA Innovation Labs](https://ayapay.com/)
+- [BootLabs](https://www.bootlabs.in/)
+  - "We are a true Boutique Tech Consulting partner who understands the pain points of the all-sized company in terms of embracing cloud. Being obsessed about anything “cloud” and automation first, we drive our partner to success. We always strive to provide our customers, the cutting-edge technology and the trend is cloud native now. We enable our clients to make their microservices more secure with cloud-native solutions. When we talk about cloud native technologies, Meshery comes in handy. We have seen the impact Meshery has done for the cloud native infrastructure management and reduced the time to market. "
+- [DigitalOcean](https://www.digitalocean.com)
+  - "Our team at DigitalOcean creates many reference architectures for our users, helping them migrate more easily to our platform by following best practices. We later realized that manually creating such large reference architectures is both challenging and lacks collaboration and reusability. During our exploration, we discovered Meshery. It helps us manage both existing and new reference architectures for our users. With Meshery’s drag-and-drop functionality, it's now much faster to build complex architectures, integrate existing ones, and visualize them effectively as well. Our DevRel team extensively uses Meshery to create and maintain these large-scale reference architectures."
+- [Ericsson](https://www.ericsson.com)
+- [F5](https://www.f5.com/)
 - [HPE Labs- Cloudless](https://www.labs.hpe.com/page/cloudless)
   - "Our complex, dynamic, and intelligent system demands leverage different tools to efficiently manage service exchange and ecosystem at a global scale; for instance, we need to identify the right fit cloud native component to address varying workload scenarios, distributed systems across locations, different security tiers, minimal latency etc. Meshery helps us curate cloud native components for tailored need by helping us running simulations and identifying the right fit cloud native solution that works efficiently across a diverse ecosystem of tools."
 - [HPE Security Engineering](https://www.hpe.com)
   - "As a security-focused organization, HPE Security Engineering continually evaluates, assesses, and conducts performance analysis over cloud-native technologies. Meshery has been an instrumental piece of our daily work, as having a simple yet powerful management plane facilitates our engineers to deploy, manage, experiment, and quickly iterate. Meshery's features can only be overshadowed by its friendly and welcoming community always willing to help."
-- [Intraserve Systems](http://intraservesystems.com)
-  - [Mohsen Houshmand](https://twitter.com/houshym): "Working with cloud native technology, I find one of the most useful tools is Meshery! I use Meshery to run POCs for our customers to help them adopt, and then, ongoing to check our mesh configuration. The most fantastic part about Meshery is its performance management features."
-- [SolarWinds](https://solarwinds.com)
-- Sudeep Batra ([Ericsson](https://www.ericsson.com))
-- [Metabob](https://metabob.com)
-  - [Sako WS](https://twitter.com/sakows): "We find Meshery to be the perfect tool to help us successfully operate our cloud native infrastructure. And with so many new features coming out, it's only getting better and better."
-- [Asteria Aerospace](https://asteria.co.in)
-  - "As we are a very modern technology company, we always want to use cutting edge, open source technology to excel. All our microservices are modern in nature and so is their infrastructure. We are cloud agnostic and at the same time, we are fascinated by the cloud native technologies to empower us with secure, reliable, intelligent infrastructure. When we are in an Istio world, the need for managing our cloud native stack was always been a gap. With **Meshery**, we believe we can nurture our infrastructure to perform better and more efficiently."
-- [BootLabs](https://www.bootlabs.in/)
-  - "We are a true Boutique Tech Consulting partner who understands the pain points of the all-sized company in terms of embracing cloud. Being obsessed about anything “cloud” and automation first, we drive our partner to success. We always strive to provide our customers, the cutting-edge technology and the trend is cloud native now. We enable our clients to make their microservices more secure with cloud-native solutions. When we talk about cloud native technologies, Meshery comes in handy. We have seen the impact Meshery has done for the cloud native infrastructure management and reduced the time to market. "
-- [Intel](https://www.intel.com)
-  - "We are working on the acceleration and security of open source cloud native projects. Meshery is the best tool for managing and operating different cloud native projects, it greatly helped us compare the functions and performance of them, and demonstrate the results of our efforts. We also love Meshery's community where we can connect with talents and enthusiasts from all over the world!"
-- [DigitalOcean](https://www.digitalocean.com)
-  - "Our team at DigitalOcean creates many reference architectures for our users, helping them migrate more easily to our platform by following best practices. We later realized that manually creating such large reference architectures is both challenging and lacks collaboration and reusability. During our exploration, we discovered Meshery. It helps us manage both existing and new reference architectures for our users. With Meshery’s drag-and-drop functionality, it's now much faster to build complex architectures, integrate existing ones, and visualize them effectively as well. Our DevRel team extensively uses Meshery to create and maintain these large-scale reference architectures."
-- [Red Hat](https://www.redhat.com)
-- [Metabit Trading](https://www.metabit-trading.com/)
-- [PITS Global Data Recovery Services](https://www.pitsdatarecovery.net/)
-- [AYA Innovation Labs](https://ayapay.com/)
-- [TCS Labs](https://tata-consulting.co.uk)
-- [OD10 Ventures](https://od10.in/)
-  - "I stumbled upon **Meshery** while looking for tools that can help visualize Kubernetes and its components. This helps me during PoCs and solution design demonstrations. What surprised me is that the visual design was not just a bunch of icons but could be deployed and managed collaboratively. And these are just a few of the many features of **Meshery**. It was just the product of my area of interest, so I decided to be a contributor, too." [Sangram Rath](https://linkedin.com/in/sangramrath)
-- [F5](https://www.f5.com/) Mario Arriaga
 - [Infor](https://www.infor.com/)
   - "At Infor, we deliver industry-specific cloud enterprise software for manufacturing, distribution, healthcare, and more—built on a modern, AWS-native platform that powers complex, multi-tenant environments for tens of thousands of customers worldwide. Managing the underlying Kubernetes and cloud native infrastructure at this scale demands precision, visibility, and collaboration. Meshery has become an essential part of how we design, operate, and continuously improve that foundation. The open, welcoming community around the project only strengthens the value we get from it every day."
+- [Intel](https://www.intel.com)
+  - "We are working on the acceleration and security of open source cloud native projects. Meshery is the best tool for managing and operating different cloud native projects, it greatly helped us compare the functions and performance of them, and demonstrate the results of our efforts. We also love Meshery's community where we can connect with talents and enthusiasts from all over the world!"
+- [Intraserve Systems](http://intraservesystems.com)
+  - [Mohsen Houshmand](https://twitter.com/houshym): "Working with cloud native technology, I find one of the most useful tools is Meshery! I use Meshery to run POCs for our customers to help them adopt, and then, ongoing to check our mesh configuration. The most fantastic part about Meshery is its performance management features."
+- [Metabit Trading](https://www.metabit-trading.com/)
+- [Metabob](https://metabob.com)
+  - [Sako WS](https://twitter.com/sakows): "We find Meshery to be the perfect tool to help us successfully operate our cloud native infrastructure. And with so many new features coming out, it's only getting better and better."
+- [OD10 Ventures](https://od10.in/)
+  - "I stumbled upon **Meshery** while looking for tools that can help visualize Kubernetes and its components. This helps me during PoCs and solution design demonstrations. What surprised me is that the visual design was not just a bunch of icons but could be deployed and managed collaboratively. And these are just a few of the many features of **Meshery**. It was just the product of my area of interest, so I decided to be a contributor, too." [Sangram Rath](https://linkedin.com/in/sangramrath)
+- [PITS Global Data Recovery Services](https://www.pitsdatarecovery.net/)
+- [Red Hat](https://www.redhat.com)
+- [SolarWinds](https://solarwinds.com)
+- [TCS Labs](https://tata-consulting.co.uk)
 ---
 
 If you're using Meshery and aren't on this list, please [submit a pull request](https://github.com/meshery/meshery/pulls)!


### PR DESCRIPTION
Reorders the adopters list alphabetically and normalizes every entry to `- [Name](url)`, per the list Lee posted in Slack. Testimonials stay under their companies. The two bare contributor names on the Ericsson and F5 lines are dropped to match the format; say the word if they should stay.

Two links worth a look, left as-is since they're on the list: `bootlabs.in` no longer resolves (NXDOMAIN on both hostnames), and the HPE Labs Cloudless page now redirects to the general HPE Labs page.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Meshery adopters list alphabetically by company name.
  * Updated F5 and Ericsson entries to display company links without individual names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->