### PR TITLE
[UI] Validate Artifact Hub model URLs in the Create Model wizard

### DIFF
--- a/ui/components/registry/Stepper/UrlStepper.test.tsx
+++ b/ui/components/registry/Stepper/UrlStepper.test.tsx
@@ -257,6 +257,10 @@ describe('UrlStepper', () => {
     const typeUrl = (value: string) =>
       fireEvent.change(screen.getByTestId('textfield-model-url'), { target: { value } });
     const helperText = () => screen.queryByTestId('helper-model-url')?.textContent ?? '';
+    // The message is only the visible half; Next is gated on canGoNext, so a
+    // change could keep the error and still let an invalid URL through.
+    const nextDisabled = () =>
+      (screen.getByTestId('UrlStepper-Button-Next') as HTMLButtonElement).disabled;
 
     // The regression. The radio stores "artifact hub" (lower-cased label, space
     // included) while validateUrl used to compare against "artifacthub", so no
@@ -267,6 +271,7 @@ describe('UrlStepper', () => {
       typeUrl(INVALID);
 
       expect(helperText()).toContain('Invalid ArtifactHub URL');
+      expect(nextDisabled()).toBe(true);
     });
 
     it('accepts a well-formed Artifact Hub URL', () => {
@@ -275,6 +280,7 @@ describe('UrlStepper', () => {
       typeUrl(VALID_AH);
 
       expect(helperText()).toBe('');
+      expect(nextDisabled()).toBe(false);
     });
 
     it('still rejects an invalid GitHub URL', () => {
@@ -283,6 +289,7 @@ describe('UrlStepper', () => {
       typeUrl(INVALID);
 
       expect(helperText()).toContain('Invalid GitHub URL');
+      expect(nextDisabled()).toBe(true);
     });
 
     // Guards the gap that would reopen if a source were added without a matching
@@ -292,12 +299,13 @@ describe('UrlStepper', () => {
     it('reports an error for every selectable source when the URL is invalid', () => {
       renderSourceStep();
       const radios = screen.getAllByRole('radio');
-      expect(radios.length).toBe(2);
+      expect(radios.length).toBeGreaterThan(0);
 
       radios.forEach((radio) => {
         fireEvent.click(radio);
         typeUrl(INVALID);
         expect(helperText()).not.toBe('');
+        expect(nextDisabled()).toBe(true);
       });
     });
 
@@ -313,6 +321,7 @@ describe('UrlStepper', () => {
       selectSource('Artifact Hub');
 
       expect(helperText()).toContain('Invalid ArtifactHub URL');
+      expect(nextDisabled()).toBe(true);
     });
 
     it('clears the error when switching to a source the URL is valid for', () => {
@@ -324,6 +333,7 @@ describe('UrlStepper', () => {
       selectSource('GitHub');
 
       expect(helperText()).toBe('');
+      expect(nextDisabled()).toBe(false);
     });
 
     it('accepts a well-formed GitHub URL', () => {
@@ -332,6 +342,7 @@ describe('UrlStepper', () => {
       typeUrl(VALID_GH);
 
       expect(helperText()).toBe('');
+      expect(nextDisabled()).toBe(false);
     });
   });
 });

--- a/ui/components/registry/Stepper/UrlStepper.test.tsx
+++ b/ui/components/registry/Stepper/UrlStepper.test.tsx
@@ -31,14 +31,16 @@ vi.mock('@sistent/sistent', () => {
     ),
     ModalBody: ({ children }: any) => <div data-testid="modal-body">{children}</div>,
     Box: ({ children }: any) => <div>{children}</div>,
-    TextField: ({ label, value, onChange, id }: any) => (
+    TextField: ({ label, value, onChange, id, helperText, disabled }: any) => (
       <label>
         {label}
         <input
           data-testid={`textfield-${id || label}`}
           value={value || ''}
+          disabled={disabled}
           onChange={(e) => onChange?.(e)}
         />
+        {helperText ? <span data-testid={`helper-${id || label}`}>{helperText}</span> : null}
       </label>
     ),
     ModalButtonSecondary: ({ children, onClick, disabled }: any) => (
@@ -57,18 +59,38 @@ vi.mock('@sistent/sistent', () => {
       </select>
     ),
     InputLabel: ({ children }: any) => <label>{children}</label>,
-    FormControlLabel: ({ label, control }: any) => (
-      <label>
-        {control}
-        {label}
-      </label>
-    ),
+    // A RadioGroup option carries its value here; render it as a real radio so
+    // selecting a source drives the component the way the browser does. The
+    // checkbox form (control, no value) keeps its original shape.
+    FormControlLabel: ({ label, control, value, onChange, ...rest }: any) =>
+      value !== undefined ? (
+        <label>
+          <input
+            type="radio"
+            data-testid={rest['data-testid']}
+            value={value}
+            onChange={(e) => onChange?.(e)}
+          />
+          {label}
+        </label>
+      ) : (
+        <label>
+          {control}
+          <span>{label}</span>
+        </label>
+      ),
     Checkbox: ({ checked, onChange }: any) => (
       <input type="checkbox" checked={!!checked} onChange={onChange} />
     ),
     Typography: ({ children }: any) => <span>{children}</span>,
     FormControl: ({ children }: any) => <div>{children}</div>,
-    RadioGroup: ({ children }: any) => <div>{children}</div>,
+    RadioGroup: ({ children, onChange }: any) => (
+      <div data-testid="radio-group">
+        {React.Children.map(children, (child: any) =>
+          React.isValidElement(child) ? React.cloneElement(child, { onChange } as any) : child,
+        )}
+      </div>
+    ),
     MenuItem: ({ children, value }: any) => <option value={value}>{children}</option>,
     Radio: () => <input type="radio" />,
     Grid2: ({ children }: any) => <div>{children}</div>,
@@ -214,5 +236,102 @@ describe('UrlStepper', () => {
     render(<UrlStepper handleClose={handleClose} />);
     fireEvent.click(screen.getByTestId('UrlStepper-Button-Finish'));
     expect(handleClose).toHaveBeenCalled();
+  });
+
+  describe('Source step URL validation', () => {
+    const INVALID = 'this-is-not-a-url-at-all';
+    const VALID_AH = 'https://artifacthub.io/packages/search?ts_query_web=meshery-operator';
+    const VALID_GH = 'git://github.com/cert-manager/cert-manager/master/deploy/crds';
+    const SOURCE_STEP = 3;
+
+    const renderSourceStep = () => {
+      stepperState.activeStep = SOURCE_STEP;
+      render(<UrlStepper handleClose={vi.fn()} />);
+    };
+    // Click, not fireEvent.change: the mocked radio already holds this exact
+    // value, so React's controlled-input de-duplication means setting it to the
+    // same string dispatches nothing and the source is never selected. A click
+    // is what React turns into a radio's change event anyway.
+    const selectSource = (label: string) =>
+      fireEvent.click(screen.getByTestId(`UrlStepper-Select-Source-${label}`));
+    const typeUrl = (value: string) =>
+      fireEvent.change(screen.getByTestId('textfield-model-url'), { target: { value } });
+    const helperText = () => screen.queryByTestId('helper-model-url')?.textContent ?? '';
+
+    // The regression. The radio stores "artifact hub" (lower-cased label, space
+    // included) while validateUrl used to compare against "artifacthub", so no
+    // pattern was chosen and `new RegExp(undefined)` matched everything.
+    it('rejects an invalid Artifact Hub URL', () => {
+      renderSourceStep();
+      selectSource('Artifact Hub');
+      typeUrl(INVALID);
+
+      expect(helperText()).toContain('Invalid ArtifactHub URL');
+    });
+
+    it('accepts a well-formed Artifact Hub URL', () => {
+      renderSourceStep();
+      selectSource('Artifact Hub');
+      typeUrl(VALID_AH);
+
+      expect(helperText()).toBe('');
+    });
+
+    it('still rejects an invalid GitHub URL', () => {
+      renderSourceStep();
+      selectSource('GitHub');
+      typeUrl(INVALID);
+
+      expect(helperText()).toContain('Invalid GitHub URL');
+    });
+
+    // Guards the gap that would reopen if a source were added without a matching
+    // pattern and message: Next is gated on `!urlError`, so an empty error for an
+    // invalid URL would let it through. Driven off the rendered options so a
+    // third source is covered automatically.
+    it('reports an error for every selectable source when the URL is invalid', () => {
+      renderSourceStep();
+      const radios = screen.getAllByRole('radio');
+      expect(radios.length).toBe(2);
+
+      radios.forEach((radio) => {
+        fireEvent.click(radio);
+        typeUrl(INVALID);
+        expect(helperText()).not.toBe('');
+      });
+    });
+
+    // A URL is only valid relative to a source. Without revalidation on switch,
+    // the GitHub URL below keeps its cleared error and Next stays enabled, so
+    // the wizard would submit a GitHub URL with registrant "artifact hub".
+    it('revalidates the entered URL when the source changes', () => {
+      renderSourceStep();
+      selectSource('GitHub');
+      typeUrl(VALID_GH);
+      expect(helperText()).toBe('');
+
+      selectSource('Artifact Hub');
+
+      expect(helperText()).toContain('Invalid ArtifactHub URL');
+    });
+
+    it('clears the error when switching to a source the URL is valid for', () => {
+      renderSourceStep();
+      selectSource('Artifact Hub');
+      typeUrl(VALID_GH);
+      expect(helperText()).toContain('Invalid ArtifactHub URL');
+
+      selectSource('GitHub');
+
+      expect(helperText()).toBe('');
+    });
+
+    it('accepts a well-formed GitHub URL', () => {
+      renderSourceStep();
+      selectSource('GitHub');
+      typeUrl(VALID_GH);
+
+      expect(helperText()).toBe('');
+    });
   });
 });

--- a/ui/components/registry/Stepper/UrlStepper.tsx
+++ b/ui/components/registry/Stepper/UrlStepper.tsx
@@ -44,6 +44,56 @@ import FinishModelGenerateStep from './FinishModelGenerateStep';
 
 type UrlStepperProps = { handleClose: () => void };
 
+// The source radio stores each option's label lower-cased, so "Artifact Hub"
+// is held as "artifact hub" - space included. Deriving the options and every
+// comparison from this one list keeps them from drifting apart again: the
+// validator previously tested for "artifacthub", which no option could ever
+// equal, so no pattern was selected and every URL was accepted.
+const MODEL_SOURCE_LABELS = ['Artifact Hub', 'GitHub'] as const;
+const [ARTIFACT_HUB_SOURCE, GITHUB_SOURCE] = MODEL_SOURCE_LABELS.map((label) =>
+  label.toLowerCase(),
+);
+
+// Compiled once at module scope rather than per keystroke. None carry the `g`
+// flag, so they hold no lastIndex state between `test` calls.
+const SOURCE_URL_PATTERNS: Record<string, RegExp> = {
+  [ARTIFACT_HUB_SOURCE]:
+    /^https:\/\/artifacthub\.io\/packages\/(search\?ts_query_web=[\w.-]+|[\w.-]+\/[\w.-]+\/[\w.-]+)$/,
+  [GITHUB_SOURCE]: /^git:\/\/github\.com\/[\w.-]+\/[\w.-]+(\/[\w.-]+\/[\w/-]+)?$/,
+};
+
+const SOURCE_URL_ERRORS: Record<string, string> = {
+  [ARTIFACT_HUB_SOURCE]:
+    'Invalid ArtifactHub URL. Example: https://artifacthub.io/packages/search?ts_query_web={meshery-operator}',
+  [GITHUB_SOURCE]: 'Invalid GitHub URL. Format: git://github.com/org/repo/branch/path',
+};
+
+const UNSUPPORTED_SOURCE_URL_ERROR = 'Select a supported model source before entering a URL.';
+
+// The Source step gates Next on `!urlError`, so an unmapped source must still
+// yield a non-empty message: returning undefined would read as "no error" and
+// re-open the hole the pattern lookup exists to close, letting an unvalidated
+// URL through for any source added without a matching pattern.
+const sourceUrlError = (source: string) =>
+  SOURCE_URL_ERRORS[source] ?? UNSUPPORTED_SOURCE_URL_ERROR;
+
+// A URL is only meaningful relative to a source, so both are arguments here
+// rather than one being read from state: the source-change handler has to
+// validate against the source it is switching *to*, which state does not hold
+// yet at that point.
+const isValidSourceUrl = (url: string, source: string) => {
+  const pattern = SOURCE_URL_PATTERNS[source];
+
+  // An unknown source has nothing to validate against, so reject. The previous
+  // code fell through to `new RegExp(undefined)`, which is the empty pattern
+  // `/(?:)/` and matches every string - reporting any input as valid.
+  if (!url || !pattern) {
+    return false;
+  }
+
+  return pattern.test(url);
+};
+
 const UrlStepper = React.memo(({ handleClose }: UrlStepperProps) => {
   const ModelDefinitionV1Beta1Schema =
     ModelDefinitionV1Beta1OpenApiSchema.components.schemas.ModelDefinition;
@@ -118,36 +168,26 @@ const UrlStepper = React.memo(({ handleClose }: UrlStepperProps) => {
     }
   };
 
-  const validateUrl = (url: string) => {
-    let testUrl;
-    if (!url) {
-      return false;
-    }
-
-    if (modelSource === 'github') {
-      testUrl = '^git://github\\.com/[\\w.-]+/[\\w.-]+(/[\\w.-]+/[\\w/-]+)?$';
-    } else if (modelSource === 'artifacthub') {
-      testUrl =
-        '^https:\\/\\/artifacthub\\.io\\/packages\\/(search\\?ts_query_web=[\\w.-]+|[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+)$';
-    }
-    return new RegExp(testUrl).test(url);
-  };
-
   const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newUrl = e.target.value;
     setModelUrl(newUrl);
     if (modelSource) {
-      const isValid = validateUrl(newUrl);
-      if (!isValid) {
-        setUrlError(
-          modelSource === 'github'
-            ? 'Invalid GitHub URL. Format: git://github.com/org/repo/branch/path'
-            : 'Invalid ArtifactHub URL. Example: https://artifacthub.io/packages/search?ts_query_web={meshery-operator}',
-        );
-      } else {
-        setUrlError('');
-      }
+      setUrlError(isValidSourceUrl(newUrl, modelSource) ? '' : sourceUrlError(modelSource));
     }
+  };
+
+  const handleSourceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const nextSource = e.target.value.toLowerCase();
+    setModelSource(nextSource);
+
+    // Re-check whatever is already typed against the source being switched to.
+    // Without this, a URL accepted for the previous source keeps its cleared
+    // error, so Next stays enabled and the wizard submits, say, a GitHub URL
+    // with registrant "artifact hub". An empty field has nothing to complain
+    // about yet, so it just clears the error.
+    setUrlError(
+      modelUrl && !isValidSourceUrl(modelUrl, nextSource) ? sourceUrlError(nextSource) : '',
+    );
   };
 
   // Summary field component with consistent styling
@@ -493,10 +533,10 @@ const UrlStepper = React.memo(({ handleClose }: UrlStepperProps) => {
                 aria-label="source"
                 name="source"
                 value={modelSource}
-                onChange={(e) => setModelSource(e.target.value.toLowerCase())}
+                onChange={handleSourceChange}
                 style={{ gap: '2rem' }}
               >
-                {['Artifact Hub', 'GitHub'].map((source, idx) => (
+                {MODEL_SOURCE_LABELS.map((source, idx) => (
                   <FormControlLabel
                     key={idx}
                     value={source.toLowerCase()}
@@ -519,9 +559,9 @@ const UrlStepper = React.memo(({ handleClose }: UrlStepperProps) => {
                 helperText={urlError}
                 disabled={!modelSource}
                 placeholder={
-                  modelSource === 'github'
+                  modelSource === GITHUB_SOURCE
                     ? 'git://github.com/cert-manager/cert-manager/master/deploy/crds'
-                    : modelSource === 'artifact hub'
+                    : modelSource === ARTIFACT_HUB_SOURCE
                       ? 'https://artifacthub.io/packages/search?ts_query_web={model-name}'
                       : 'Select a source first'
                 }


### PR DESCRIPTION
**Notes for Reviewers**

* This PR fixes #21880

The Source step's radio group derives each option's value from its display label:

```js
{['Artifact Hub', 'GitHub'].map((source, idx) => (
  <FormControlLabel value={source.toLowerCase()} ... />
))}
```

Selecting Artifact Hub therefore stores `"artifact hub"` with a space. This was confirmed in the rendered DOM: `["artifact hub", "github"]`.

However, `validateUrl` was checking for `"artifacthub"` without the space. That condition could never match, so the Artifact Hub validation branch was skipped and `testUrl` remained `undefined`.

`new RegExp(undefined)` does not throw. It creates an empty pattern, `/(?:)/`, which matches every string. As a result, the wizard accepted any input as a valid Artifact Hub URL.

GitHub was unaffected because its value is `"github"` in both places, which is why the two sources behaved differently.

**Changes**

1. **Use a shared source constant** : `MODEL_SOURCE_LABELS` now provides the values used by the radio options and the validation logic, so the source label and its corresponding checks cannot get out of sync.
2. **Handle missing validation patterns** : `validateUrl` now returns `false` when no validation pattern matches the selected source instead of passing `undefined` to `RegExp`. An unsupported source therefore fails validation instead of accepting any input.
3. **Remove remaining hardcoded source values** : the URL placeholder and error-message branch now use the same source constants.

**Verified in the running app** (Local provider, `master` @ `0379803ba52`), using the same field and input:

| Source       | URL entered                | Before                  | After                                   |
| ------------ | -------------------------- | ----------------------- | --------------------------------------- |
| GitHub       | `this-is-not-a-url-at-all` | `Invalid GitHub URL...` | `Invalid GitHub URL...`                 |
| Artifact Hub | `this-is-not-a-url-at-all` | *(no error — accepted)* | `Invalid ArtifactHub URL. Example: ...` |

Before/after screen recordings are attached.

https://github.com/user-attachments/assets/bbf90641-fc78-4b25-8563-e12f39e0625e

https://github.com/user-attachments/assets/f39b1724-b4c3-4229-aa6a-4c4c466945d3

**Testing**

The existing mocks for `RadioGroup`, `FormControlLabel` and `TextField` did not expose the `value`, `onChange` and `helperText` props needed to test this behaviour. They were updated only as much as necessary to select a source and verify the resulting helper text. The checkbox form of `FormControlLabel` keeps its existing shape, and the five existing tests remain unchanged.

Four tests now cover both sources with valid and invalid input. The Artifact Hub rejection is the regression test and was verified against the unfixed component:

```text
× rejects an invalid Artifact Hub URL
  AssertionError: expected '' to contain 'Invalid ArtifactHub URL'
  Tests  1 failed | 8 passed (9)
```

After the fix:

```text
Tests 9 passed (9)
```

ESLint, Prettier and `tsc --noEmit` are clean for the changed files.

**Note for maintainers**

There is an adjacent value that may need to be normalised, but it is out of scope for this PR.

`registrant: modelSource` currently sends `"artifact hub"` to the import API, while the registry API reports the registrant `kind` as `"artifacthub"`. I have not changed this because I haven't confirmed which value the API expects. If normalising the stored value is preferred, I can follow up separately.

**[[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

* [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed URL validation for Artifact Hub and GitHub sources, displaying the appropriate error messages for invalid URLs.
- Revalidate entered URLs when switching between source types, preventing URLs valid for one source from being submitted for another.
- Prevented unsupported or unrecognized source types from being accepted as valid URLs.
- Standardized source labels and validation error messaging for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->