### PR TITLE
fix(mesheryctl): auto-page lists when stdout is not a TTY

### DIFF
--- a/mesheryctl/internal/cli/pkg/display/noninteractive_test.go
+++ b/mesheryctl/internal/cli/pkg/display/noninteractive_test.go
@@ -24,17 +24,11 @@ func withTerminal(t *testing.T, interactive bool) {
 	t.Cleanup(func() { utils.IsInteractiveTerminal = original })
 }
 
-// TestListPageHandlerStopsWithoutTerminal pins the behaviour that makes
-// mesheryctl usable in scripts, pipelines and CI: with more results than fit on
-// one page and no terminal to page on, the handler stops after the page it has
-// printed and reports success.
-//
-// It used to fall through to the keyboard library, which reads the controlling
-// terminal directly and fails with "open /dev/tty: no such device or address"
-// where there isn't one - so `mesheryctl connection list` printed a correct
-// first page and then exited non-zero, which is how it failed in CI for an
-// account holding more than one page of connections.
-func TestListPageHandlerStopsWithoutTerminal(t *testing.T) {
+// TestListPageHandlerAutoPagesWithoutTerminal pins the AXI non-interactive
+// path: with more results than fit on one page and no terminal to page on, the
+// handler advances automatically instead of blocking on a keypress (or failing
+// on /dev/tty). Scripts, pipelines and CI get the full list without hanging.
+func TestListPageHandlerAutoPagesWithoutTerminal(t *testing.T) {
 	withTerminal(t, false)
 
 	handler := listPageHandler(
@@ -50,8 +44,8 @@ func TestListPageHandlerStopsWithoutTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error without a terminal, got %v", err)
 	}
-	if shouldContinue {
-		t.Error("expected paging to stop without a terminal, got shouldContinue=true")
+	if !shouldContinue {
+		t.Error("expected paging to continue without a terminal, got shouldContinue=false")
 	}
 }
 

--- a/mesheryctl/internal/cli/pkg/display/pagination.go
+++ b/mesheryctl/internal/cli/pkg/display/pagination.go
@@ -37,8 +37,9 @@ func HandlePaginationAsync[T any](
 	}
 
 	for {
-		// Clear the terminal screen
-		if currentPage > 0 {
+		// Clear only when a human is watching; ClearLine runs `clear`/`cls` and
+		// would wipe or spam redirected/piped output between pages.
+		if currentPage > 0 && utils.IsInteractiveTerminal() {
 			utils.ClearLine()
 		}
 

--- a/mesheryctl/internal/cli/pkg/display/pagination_handlers.go
+++ b/mesheryctl/internal/cli/pkg/display/pagination_handlers.go
@@ -62,14 +62,11 @@ func listPageHandler[T any](displayData DisplayDataAsync, processDataFunc listRo
 		// exits non-zero having already printed a perfectly good first page -
 		// which is how `mesheryctl connection list` came to fail outright in CI
 		// and in any pipeline, as soon as the account held more than one page.
-		// Stop after this page instead, and say so, so the output stays usable
-		// and the exit status stays honest.
+		// Advance pages automatically instead so scripts/CI get the full list
+		// without hanging (AXI non-interactive path; see #20979 / #21334).
 		if !utils.IsInteractiveTerminal() {
-			utils.Log.Infof(
-				"Showing page %d only: paging through results needs an interactive terminal. Use --page and --pagesize to select a page, or --count for the total.",
-				currentPage+1,
-			)
-			return false, nil
+			startIndex += pgSize
+			return true, nil
 		}
 
 		// Wait for user input to navigate pages

--- a/mesheryctl/pkg/utils/helpers.go
+++ b/mesheryctl/pkg/utils/helpers.go
@@ -621,8 +621,13 @@ func BoldString(s string) string {
 	return fmt.Sprintf("\033[1m%s\033[0m", s)
 }
 
-// ClearLine clears the last line from output
+// ClearLine clears the last line from output.
+// No-op when stdout/stdin are not an interactive terminal so redirected and
+// piped runs do not emit clear/cls sequences (AXI / #20979).
 func ClearLine() {
+	if !IsInteractiveTerminal() {
+		return
+	}
 	clearCmd := exec.Command("clear", "-x") // for UNIX-like systems
 	if runtime.GOOS == "windows" {
 		clearCmd = exec.Command("cmd", "/c", "cls") // for Windows
@@ -1290,14 +1295,11 @@ func HandlePagination(pageSize int, component string, data [][]string, header []
 
 		// Same reasoning as display.listPageHandler: without a terminal there is
 		// nobody to press the key, and keyboard.GetKeys fails on /dev/tty rather
-		// than blocking. Stop after this page instead of turning a successful
-		// listing into a non-zero exit.
+		// than blocking. Advance automatically so scripts/CI get the full list.
 		if !IsInteractiveTerminal() {
-			Log.Infof(
-				"Showing page %d only: paging through results needs an interactive terminal. Use --page to select a page.",
-				startIndex/pageSize+1,
-			)
-			break
+			startIndex = endIndex
+			endIndex = min(len(data), startIndex+pageSize)
+			continue
 		}
 
 		keysEvents, err := keyboard.GetKeys(10)


### PR DESCRIPTION
## Summary
- When stdout/stdin are not an interactive terminal, list pagination advances through all pages instead of stopping after page 1 or failing on `/dev/tty`.
- Skip `ClearLine` / clear-screen sequences on non-TTY so pipes and redirects are not wiped between pages.
- Leaves the interactive table path unchanged. Related to #20979 (AXI non-interactive slice).

## Test plan
- [ ] Unit: `go test ./internal/cli/pkg/display/ -run TestListPageHandlerAutoPagesWithoutTerminal`
- [ ] Interactive TTY: `mesheryctl connection list` still pages on keypress as before
- [ ] Non-TTY: `mesheryctl connection list </dev/null | cat` (or pipe) completes without hang and prints beyond page 1 when results exceed one page
- [ ] Redirected output has no clear/cls / ClearLine control noise between pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paginated command output now continues automatically in non-interactive environments, allowing scripts and CI jobs to receive complete lists.
  * Redirected and piped output no longer includes terminal-clearing sequences.
  * Interactive terminal pagination continues to clear the screen between pages as expected.

* **Tests**
  * Updated pagination coverage to verify automatic advancement without a terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->