### PR TITLE
[mesheryctl][PoC] Standardize structured output via printer package and add -o json/yaml to version cmd

### DIFF
--- a/docs/content/en/reference/references/mesheryctl/version.md
+++ b/docs/content/en/reference/references/mesheryctl/version.md
@@ -33,11 +33,22 @@ mesheryctl version
 </div>
 </pre> 
 
+To view the version in JSON or YAML format
+<pre class='codeblock-pre'>
+<div class='codeblock'>
+<div class='clipboardjs'>
+mesheryctl version -o json
+
+</div>
+</div>
+</pre>
+
 ## Options
 
 <pre class='codeblock-pre'>
 <div class='codeblock'>
   -h, --help   help for version
+  -o, --output-format string   (optional) format to display in [json|yaml|table|string]
 
 </div>
 </pre>

--- a/mesheryctl/internal/cli/pkg/printer/printer.go
+++ b/mesheryctl/internal/cli/pkg/printer/printer.go
@@ -1,0 +1,72 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/meshery/meshery/mesheryctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type Printer struct {
+	format string
+	out    io.Writer
+}
+
+// AddFormatFlag helper-func that helps to add flag in command
+func AddFormatFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVarP(target, "output-format", "o", "", "(optional) format to display in [json|yaml|table|string]")
+}
+
+// New returns a new Printer. It returns an error only if out is nil.
+func New(format string, out io.Writer) (*Printer, error) {
+	if out == nil {
+		return nil, errors.New("writer is not provided")
+	}
+
+	return &Printer{format: strings.ToLower(strings.TrimSpace(format)), out: out}, nil
+}
+
+// Print writes data to p.out according to the configured format.
+// For "json"/"yaml" it marshals data directly; for "", "table", "string"
+// it delegates rendering to humanRender.
+func (p *Printer) Print(data any, humanRender func(w io.Writer) error) error {
+	switch p.format {
+	case "json":
+		enc := json.NewEncoder(p.out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
+	case "yaml":
+		enc := yaml.NewEncoder(p.out)
+		enc.SetIndent(2)
+		defer func() {
+			_ = enc.Close()
+		}()
+		return enc.Encode(data)
+	case "", "table", "string":
+		if humanRender != nil {
+			return humanRender(p.out)
+		}
+		return nil
+	default:
+		return utils.ErrFlagsInvalid(fmt.Errorf("invalid value for --output-format '%s': valid values are json, yaml, table, string", p.format))
+	}
+}

--- a/mesheryctl/internal/cli/pkg/printer/printer_test.go
+++ b/mesheryctl/internal/cli/pkg/printer/printer_test.go
@@ -1,0 +1,180 @@
+// Copyright Meshery Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type sampleData struct {
+	Name  string `json:"name" yaml:"name"`
+	Count int    `json:"count" yaml:"count"`
+}
+
+func TestAddFormatFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var format string
+
+	AddFormatFlag(cmd, &format)
+
+	flag := cmd.Flags().Lookup("output-format")
+	if flag == nil {
+		t.Fatal("expected 'output-format' flag to be added")
+	}
+	if flag.Shorthand != "o" {
+		t.Errorf("expected shorthand 'o', got '%s'", flag.Shorthand)
+	}
+}
+
+func TestNewPrinter(t *testing.T) {
+	tests := []struct {
+		name        string
+		format      string
+		writer      io.Writer
+		expectErr   bool
+		expectedFmt string
+	}{
+		{
+			name:      "nil writer returns error",
+			format:    "json",
+			writer:    nil,
+			expectErr: true,
+		},
+		{
+			name:        "valid format json",
+			format:      "json",
+			writer:      &bytes.Buffer{},
+			expectErr:   false,
+			expectedFmt: "json",
+		},
+		{
+			name:        "valid format yaml uppercase trimmed",
+			format:      "  YAML ",
+			writer:      &bytes.Buffer{},
+			expectErr:   false,
+			expectedFmt: "yaml",
+		},
+		{
+			name:        "empty format defaults to empty/table",
+			format:      "",
+			writer:      &bytes.Buffer{},
+			expectErr:   false,
+			expectedFmt: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New(tc.format, tc.writer)
+			if tc.expectErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p != nil && p.format != tc.expectedFmt {
+				t.Errorf("expected format %q, got %q", tc.expectedFmt, p.format)
+			}
+		})
+	}
+}
+
+func TestPrinter_Print(t *testing.T) {
+	data := sampleData{Name: "test-model", Count: 42}
+
+	t.Run("renders JSON with indentation", func(t *testing.T) {
+		var buf bytes.Buffer
+		p, _ := New("json", &buf)
+
+		if err := p.Print(data, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expected := "{\n  \"name\": \"test-model\",\n  \"count\": 42\n}\n"
+		if buf.String() != expected {
+			t.Errorf("got %q, want %q", buf.String(), expected)
+		}
+	})
+
+	t.Run("renders YAML with indent", func(t *testing.T) {
+		var buf bytes.Buffer
+		p, _ := New("yaml", &buf)
+
+		if err := p.Print(data, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expected := "name: test-model\ncount: 42\n"
+		if buf.String() != expected {
+			t.Errorf("got %q, want %q", buf.String(), expected)
+		}
+	})
+
+	t.Run("delegates to humanRender for table/empty format", func(t *testing.T) {
+		var buf bytes.Buffer
+		p, _ := New("table", &buf)
+
+		called := false
+		err := p.Print(data, func(w io.Writer) error {
+			called = true
+			_, err := fmt.Fprint(w, "rendered table")
+			return err
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Errorf("expected humanRender to be called")
+		}
+		if buf.String() != "rendered table" {
+			t.Errorf("got %q, want %q", buf.String(), "rendered table")
+		}
+	})
+
+	t.Run("returns error on invalid format", func(t *testing.T) {
+		var buf bytes.Buffer
+		p, _ := New("unsupported_format", &buf)
+
+		err := p.Print(data, nil)
+		if err == nil {
+			t.Fatalf("expected error for invalid format, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid value for --output-format") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("passes through humanRender error", func(t *testing.T) {
+		var buf bytes.Buffer
+		p, _ := New("", &buf)
+
+		customErr := errors.New("render failed")
+		err := p.Print(data, func(w io.Writer) error {
+			return customErr
+		})
+
+		if !errors.Is(err, customErr) {
+			t.Errorf("got error %v, want %v", err, customErr)
+		}
+	})
+}

--- a/mesheryctl/internal/cli/root/root.go
+++ b/mesheryctl/internal/cli/root/root.go
@@ -74,6 +74,7 @@ mesheryctl -v [or] --verbose
 		// Initialize a validator and add it to the command context
 		// This allows us to use the same validator instance across all subcommands and avoid initializing multiple instances of the validator
 		mesheryctlflags.InitValidators(cmd)
+
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/mesheryctl/internal/cli/root/version.go
+++ b/mesheryctl/internal/cli/root/version.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/meshery/meshery/mesheryctl/internal/cli/pkg/printer"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/config"
 	"github.com/meshery/meshery/mesheryctl/internal/cli/root/constants"
 	"github.com/meshery/meshery/mesheryctl/pkg/utils"
@@ -30,14 +31,60 @@ import (
 	"github.com/spf13/viper"
 )
 
+type versionInfo struct {
+	Version string `json:"version" yaml:"version"`
+	GitSHA  string `json:"gitSha" yaml:"gitSha"`
+}
+
+type versionOutput struct {
+	Client versionInfo `json:"client" yaml:"client"`
+	Server versionInfo `json:"server" yaml:"server"`
+}
+
+// stringOutput make human string output for version command
+func (v versionOutput) stringOutput() string {
+	clientSHA := formatShortSHA(v.Client.GitSHA)
+
+	serverSHA := v.Server.GitSHA
+	if serverSHA != "unavailable" {
+		serverSHA = formatShortSHA(serverSHA)
+	}
+
+	out := fmt.Sprintf("Client Version: %s", v.Client.Version)
+	if clientSHA != "" && clientSHA != "unavailable" {
+		out += fmt.Sprintf(" (%s)", clientSHA)
+	}
+
+	out += fmt.Sprintf("\nServer Version: %s", v.Server.Version)
+	if serverSHA != "" && serverSHA != "unavailable" {
+		out += fmt.Sprintf(" (%s)", serverSHA)
+	}
+
+	return out + "\n"
+}
+
+// formatShortSHA make commitSHA shorter for human output
+func formatShortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}
+
 var (
 	// Mesheryctl config - holds config handler
 	mctlCfg *config.MesheryCtlConfig
+
+	outputFormat string
 )
 
 var linkDoc = map[string]string{
 	"link":    "![version-usage](../../images/version.png)",
 	"caption": "Usage of mesheryctl version",
+}
+
+func init() {
+	printer.AddFormatFlag(versionCmd, &outputFormat)
 }
 
 // versionCmd represents the version command
@@ -109,61 +156,69 @@ mesheryctl version
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		activePrinter, err := printer.New(outputFormat, cmd.OutOrStdout())
 
-		url := mctlCfg.GetBaseMesheryURL()
+		if err != nil {
+			return err
+		}
+
 		build := constants.GetMesheryctlVersion()
 		commitsha := constants.GetMesheryctlCommitsha()
-		defer utils.CheckMesheryctlClientVersion(build)
 
-		version := config.Version{
-			Build:          "unavailable",
-			CommitSHA:      "unavailable",
-			ReleaseChannel: "unavailable",
+		isHumanOutput := outputFormat == "" || outputFormat == "table" || outputFormat == "string"
+
+		if isHumanOutput {
+			defer utils.CheckMesheryctlClientVersion(build)
 		}
 
-		header := []string{"", "Version", "GitSHA"}
-		rows := [][]string{{"Client", build, commitsha}, {"Server", version.GetBuild(), version.GetCommitSHA()}}
-
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/system/version", url), nil)
-		if err != nil {
-			utils.PrintToTable(header, rows, nil)
-			utils.Log.Error(ErrGettingRequestContext(err))
-			return
+		out := versionOutput{
+			Client: versionInfo{Version: build, GitSHA: commitsha},
+			Server: versionInfo{Version: "unavailable", GitSHA: "unavailable"},
 		}
 
-		client := &http.Client{Timeout: 10 * time.Second}
-		resp, err := client.Do(req)
-
-		if err != nil {
-
-			// resp is nil here except when CheckRedirect fails, and in that
-			// case net/http has already closed resp.Body for us — see the
-			// (Client).Do docs — so there is nothing left to close.
-
-			utils.PrintToTable(header, rows, nil)
-			utils.Log.Warn(ErrConnectingToServer(err))
-			return
+		if mctlCfg != nil {
+			if srv, err := fetchServerVersion(mctlCfg.GetBaseMesheryURL()); err == nil {
+				out.Server = srv
+			} else if isHumanOutput {
+				utils.Log.Warn(ErrConnectingToServer(err))
+			}
 		}
 
-		// needs multiple defer as Body.Close needs a valid response
-		defer func() { _ = resp.Body.Close() }()
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
-			utils.PrintToTable(header, rows, nil)
-			utils.Log.Error(utils.ErrInvalidAPIResponse(err))
-			return
-		}
-
-		err = json.Unmarshal(data, &version)
-		if err != nil {
-			utils.PrintToTable(header, rows, nil)
-			utils.Log.Error(ErrUnmarshallingAPIData(err))
-			return
-		}
-
-		rows[1][1] = version.GetBuild()
-		rows[1][2] = version.GetCommitSHA()
-		utils.PrintToTable(header, rows, nil)
+		return activePrinter.Print(out, func(w io.Writer) error {
+			_, err := fmt.Fprint(w, out.stringOutput())
+			return err
+		})
 	},
+}
+
+// fetchServerVersion helper function to fetch version info from api
+func fetchServerVersion(baseURL string) (versionInfo, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("%s/api/system/version", baseURL))
+	if err != nil {
+		return versionInfo{}, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return versionInfo{}, fmt.Errorf("server returned status: %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return versionInfo{}, err
+	}
+
+	var raw config.Version
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return versionInfo{}, err
+	}
+
+	return versionInfo{
+		Version: raw.GetBuild(),
+		GitSHA:  raw.GetCommitSHA(),
+	}, nil
 }


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #21893 

> **PoC Scope:** This PR serves as an isolated Proof of Concept demonstrating a centralized printer pattern for machine-readable output. It refactors only `mesheryctl version` to validate the architecture without causing regressions in existing commands.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.

**Summary of Changes:**
1. **Introduced `printer` package (`internal/cli/pkg/printer`):**
   - Streamlines JSON/YAML serialization directly to `io.Writer`.
   - Delegates human-readable output (tables/strings) to command closures.
   - Comprehensive unit tests added (`printer_test.go`).
2. **Provided Command-Level Flag Helper (printer.AddFormatFlag):**
   - Added printer.AddFormatFlag(cmd, &target) helper to bind -o, --output-format (json, yaml, table, string) without boilerplate.
   - Kept localized to individual commands (no persistent flag on RootCmd) to eliminate collisions with existing flags
3. **Refactored mesheryctl version:**
   - Bound -o, --output-format locally using printer.AddFormatFlag.
   - Structured version output as versionOutput model.
   - Isolated stdout to prevent update checks or network errors from corrupting JSON/YAML piping.
---

**Terminal Output / Verification**

- **Clean JSON output for automation (`jq`):**
```bash
$ mesheryctl version -o json | jq .client.version
"v1.0.69"
```
- **Clean YAML output for automation (`yq`):**
```bash
$ mesheryctl version -o yaml | yq .client.version
v1.0.69
```
- **Fail on invalid format**:
```bash
$ mesheryctl version -o invalid
Error: invalid value for --output-format 'invalid': valid values are json, yaml, table, string | Short Description: Invalid flag(s) provided | Probable Cause: The value for one or more flags provided is invalid. | Suggested Remediation: Provide valid flag value and try again.
```
- **Default output**:
```bash
$ mesheryctl version
Unable to communicate with Meshery server.Get "http://localhost:9081/api/system/version": dial tcp [::1]:9081: connect: connection refused.See https://docs.meshery.io for help getting started with Meshery | Short Description: Unable to communicate with Meshery server | Suggested Remediation: See https://docs.meshery.io for help getting started with Meshery
Client Version: v1.0.69 (890b8a5)
Server Version: unavailable
Checking for latest version of mesheryctl...

v1.0.69 is the latest release.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global `--output-format` (`-o`) option for CLI commands, supporting JSON and YAML output.
  - Version information can now be displayed in structured JSON or YAML formats.
  - Improved version output formatting, including concise commit identifiers and server version details when available.

- **Bug Fixes**
  - Version command failures are now reported consistently when server version information cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->