### PR TITLE
[CI] Trigger Go tests on dependency manifest changes

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "**.go"
       - "**.golden"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/go-testing-ci.yml"
       - ".github/.golangci.yml"
   pull_request:
@@ -14,6 +18,10 @@ on:
     paths:
       - "**.go"
       - "**.golden"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/go-testing-ci.yml"
       - ".github/.golangci.yml"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Trigger Go CI when `go.mod` or `go.sum` changes at the root or in subprojects.
- Apply the dependency-manifest path filters to both `push` and `pull_request` events.

## Related Issue

Fixes #21834

## Validation

- `git diff --check` passes.
- Verified the staged diff contains only the intended workflow path-filter changes.
- YAML lint was checked; reported formatting issues are pre-existing in the workflow and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Go testing checks now run when dependency manifest files change, including manifests in nested directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->