### PR TITLE
[CI] Trigger Go tests on go.mod and go.sum path updates

### DIFF
--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "**.go"
       - "**.golden"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/go-testing-ci.yml"
       - ".github/.golangci.yml"
   pull_request:
@@ -14,6 +18,10 @@ on:
     paths:
       - "**.go"
       - "**.golden"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/go-testing-ci.yml"
       - ".github/.golangci.yml"
   workflow_dispatch:

--- a/.github/workflows/server-integration-tests.yml
+++ b/.github/workflows/server-integration-tests.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "server/**"
       - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/server-integration-tests.yml"
       - "install/kubernetes/helm/meshery-operator/**"
   pull_request:
@@ -14,6 +18,10 @@ on:
     paths:
       - "server/**"
       - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - ".github/workflows/server-integration-tests.yml"
       - "install/kubernetes/helm/meshery-operator/**"
 


### PR DESCRIPTION
## Summary
- Add `go.mod`, `go.sum`, `**/go.mod`, and `**/go.sum` to path filters in `go-testing-ci.yml` and `server-integration-tests.yml` so dependency-only bumps run Go unit/lint/integration jobs.
- Fixes #21834

## Test plan
- [ ] Confirm workflow YAML is valid and path filters include the new entries for both `push` and `pull_request`
- [ ] Open or identify a deps-only PR (only `go.mod`/`go.sum`) and verify `Golang Unit and Integration Tests` and `Meshery Server Integration Tests` are triggered (not skipped)
- [ ] Confirm a normal `.go`-only change still triggers the same workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Go testing and server integration test workflows now run when root or nested Go module files (`go.mod` and `go.sum`) change.
  - Existing triggers for server, build, workflow, and Helm chart changes remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->