### PR TITLE
fix(ui): pointer cursor on Environment card Edit/Delete

### DIFF
--- a/ui/components/environments/styles.tsx
+++ b/ui/components/environments/styles.tsx
@@ -239,8 +239,12 @@ export const TextButton = styled('button')({
 
 export const IconButton = styled('button')({
   minWidth: 'fit-content',
+  cursor: 'pointer',
   '&:hover': {
     background: 'transparent',
+  },
+  '&:disabled': {
+    cursor: 'not-allowed',
   },
   padding: 0,
   background: 'none',


### PR DESCRIPTION
## Summary
- Adds `cursor: pointer` to the Environment card `IconButton` styled component used by Edit/Delete actions.
- Adds `cursor: not-allowed` for the disabled state so unavailable actions are clearer.

Fixes #20699

## Test plan
- [ ] Open Environments page and flip/view an environment card back face
- [ ] Hover Edit (pencil) — cursor should be pointer
- [ ] Hover Delete (trash) — cursor should be pointer
- [ ] If an action is disabled, hover should show not-allowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved icon button cursor indicators: enabled buttons show a pointer cursor, while disabled buttons show a not-allowed cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->