### PR TITLE
fix(mesheryctl): prevent TruncateID panic on short IDs

### DIFF
--- a/mesheryctl/pkg/utils/helpers.go
+++ b/mesheryctl/pkg/utils/helpers.go
@@ -611,10 +611,13 @@ func ValidateURL(URL string) error {
 	return nil
 }
 
-// TruncateID shortens an id to 8 characters
+// TruncateID shortens an id to 8 characters. If the input is shorter than 8
+// characters it is returned unchanged — slicing [:8] would panic.
 func TruncateID(id string) string {
-	ShortenedID := id[0:8]
-	return ShortenedID
+	if len(id) < 8 {
+		return id
+	}
+	return id[0:8]
 }
 
 func BoldString(s string) string {

--- a/mesheryctl/pkg/utils/helpers_test.go
+++ b/mesheryctl/pkg/utils/helpers_test.go
@@ -273,11 +273,25 @@ func TestValidateURL(t *testing.T) {
 // }
 
 func TestTruncateID(t *testing.T) {
-	id := "1234567890"
-	want := "12345678"
-	got := TruncateID(id)
-	if got != want {
-		t.Errorf("TruncateID got = %v want = %v", got, want)
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "longer than 8", id: "1234567890", want: "12345678"},
+		{name: "exactly 8", id: "12345678", want: "12345678"},
+		{name: "shorter than 8", id: "abc", want: "abc"},
+		{name: "empty", id: "", want: ""},
+		{name: "uuid prefix", id: "0195b0ab-1f4d-7a3c-9c1e-3a5f8d2b6c40", want: "0195b0ab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TruncateID(tt.id)
+			if got != tt.want {
+				t.Errorf("TruncateID(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- `TruncateID` in `mesheryctl/pkg/utils/helpers.go` sliced `id[0:8]` with no length check, so any caller passing a string shorter than 8 characters panicked (`slice bounds out of range`).
- Guard the slice: return the input unchanged when `len(id) < 8`; otherwise return the first 8 characters.
- Expand `TestTruncateID` for empty, short, exact-8, longer, and UUID-prefix inputs.

Fixes #21909

## Test plan
- [x] `CGO_ENABLED=0 go test ./mesheryctl/pkg/utils/ -run TestTruncateID -count=1`
- [ ] Confirm `mesheryctl filter list` / `design list` still show truncated IDs for normal UUID-length values
- [ ] Confirm short/empty owner strings no longer crash the process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when displaying identifiers shorter than eight characters.
  * Preserved existing truncation behavior for identifiers that are eight or more characters long.

* **Tests**
  * Expanded coverage for long, exact-length, short, empty, and UUID-style identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->