### PR TITLE
fix(docs): correct REST API curl example

### DIFF
--- a/docs/content/en/reference/references/rest-apis/_index.md
+++ b/docs/content/en/reference/references/rest-apis/_index.md
@@ -78,8 +78,8 @@ Using curl, you can access Meshery's REST API by executing this command:
   <br/>
   <br/>
   <pre class="codeblock-pre">
-  <div class="codeblock"><div class="clipboardjs">curl --location 'localhost:9081/api/&lt;endpoint&gt;' \
---header 'token: &lt;your-token&gt;\
+  <div class="codeblock"><div class="clipboardjs">curl --location 'http://localhost:9081/api/&lt;endpoint&gt;' \
+--header 'token: &lt;your-token&gt;' \
 --header 'Cookie: provider=Meshery; cloud.meshery.io_ref=/;token=&lt;your-token&gt;
 </div>
 </div>


### PR DESCRIPTION
## Description

Fixes the malformed curl example in the Meshery REST API documentation.

### Changes
- Added the missing `http://` scheme to the API URL.
- Fixed the missing closing quote in the `token` header.

### Issue
Fixes #21854

### Verification
- Verified the change with `git diff --check`.
- Confirmed that only the intended curl example was modified.

### DCO
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the REST API documentation’s `curl` example to use a complete URL.
  - Fixed shell command line continuation after the token header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->