### PR TITLE
[UI] Normalize Artifact Hub registrant in model creation

### DIFF
--- a/ui/components/registry/Stepper/UrlStepper.test.tsx
+++ b/ui/components/registry/Stepper/UrlStepper.test.tsx
@@ -31,11 +31,13 @@ vi.mock('@sistent/sistent', () => {
     ),
     ModalBody: ({ children }: any) => <div data-testid="modal-body">{children}</div>,
     Box: ({ children }: any) => <div>{children}</div>,
-    TextField: ({ label, value, onChange, id }: any) => (
+    TextField: ({ label, value, onChange, id, placeholder, disabled }: any) => (
       <label>
         {label}
         <input
           data-testid={`textfield-${id || label}`}
+          placeholder={placeholder}
+          disabled={disabled}
           value={value || ''}
           onChange={(e) => onChange?.(e)}
         />
@@ -57,9 +59,9 @@ vi.mock('@sistent/sistent', () => {
       </select>
     ),
     InputLabel: ({ children }: any) => <label>{children}</label>,
-    FormControlLabel: ({ label, control }: any) => (
+    FormControlLabel: ({ label, control, value }: any) => (
       <label>
-        {control}
+        {React.cloneElement(control, { value })}
         {label}
       </label>
     ),
@@ -68,9 +70,9 @@ vi.mock('@sistent/sistent', () => {
     ),
     Typography: ({ children }: any) => <span>{children}</span>,
     FormControl: ({ children }: any) => <div>{children}</div>,
-    RadioGroup: ({ children }: any) => <div>{children}</div>,
+    RadioGroup: ({ children, onChange }: any) => <div onChange={onChange}>{children}</div>,
     MenuItem: ({ children, value }: any) => <option value={value}>{children}</option>,
-    Radio: () => <input type="radio" />,
+    Radio: (props: any) => <input type="radio" {...props} />,
     Grid2: ({ children }: any) => <div>{children}</div>,
     AppRegistrationIcon: () => <svg />,
     BrushIcon: () => <svg />,
@@ -183,6 +185,43 @@ describe('UrlStepper', () => {
     };
   });
 
+  it.each([
+    ['Artifact Hub', 'artifacthub', 'https://artifacthub.io/packages/helm/meshery/meshery'],
+    ['GitHub', 'github', 'git://github.com/cert-manager/cert-manager/master/deploy/crds'],
+  ])(
+    'uses the canonical registrant for %s and keeps its display label',
+    (label, registrant, url) => {
+      stepperState.activeStep = 3;
+      const { rerender } = render(<UrlStepper handleClose={vi.fn()} />);
+      fireEvent.click(screen.getByLabelText(label));
+      expect(screen.getByLabelText('Model URL')).not.toHaveAttribute(
+        'placeholder',
+        'Select a source first',
+      );
+      fireEvent.change(screen.getByLabelText('Model URL'), { target: { value: url } });
+      expect(screen.getByTestId('UrlStepper-Button-Next')).toBeEnabled();
+      expect(stepperState.steps[6].component.props.requestBody.importBody.model.registrant).toBe(
+        registrant,
+      );
+      stepperState.activeStep = 5;
+      rerender(<UrlStepper handleClose={vi.fn()} />);
+      expect(screen.getByText(label)).toBeInTheDocument();
+    },
+  );
+
+  it('rejects invalid Artifact Hub URLs and accepts supported search URLs', () => {
+    stepperState.activeStep = 3;
+    render(<UrlStepper handleClose={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText('Artifact Hub'));
+    fireEvent.change(screen.getByLabelText('Model URL'), {
+      target: { value: 'https://example.com/not-artifacthub' },
+    });
+    expect(screen.getByTestId('UrlStepper-Button-Next')).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Model URL'), {
+      target: { value: 'https://artifacthub.io/packages/search?ts_query_web=meshery-operator' },
+    });
+    expect(screen.getByTestId('UrlStepper-Button-Next')).toBeEnabled();
+  });
   it('renders modal body and footer', () => {
     render(<UrlStepper handleClose={vi.fn()} />);
     expect(screen.getByTestId('modal-body')).toBeInTheDocument();

--- a/ui/components/registry/Stepper/UrlStepper.tsx
+++ b/ui/components/registry/Stepper/UrlStepper.tsx
@@ -33,7 +33,6 @@ import {
 } from './style';
 import SourceIcon from '@/assets/icons/SourceIcon';
 import FinishFlagIcon from '@/assets/icons/FinishFlagIcon';
-import { capitalize } from 'lodash';
 import { DeploymentSelectorIcon } from '@/assets/icons/DeploymentSelectorIcon';
 import {
   CategoryDefinitionV1Beta1OpenApiSchema,
@@ -41,6 +40,11 @@ import {
   SubCategoryDefinitionV1Beta1OpenApiSchema,
 } from '@meshery/schemas';
 import FinishModelGenerateStep from './FinishModelGenerateStep';
+
+const modelSources = [
+  { label: 'Artifact Hub', value: 'artifacthub' },
+  { label: 'GitHub', value: 'github' },
+];
 
 type UrlStepperProps = { handleClose: () => void };
 
@@ -493,16 +497,16 @@ const UrlStepper = React.memo(({ handleClose }: UrlStepperProps) => {
                 aria-label="source"
                 name="source"
                 value={modelSource}
-                onChange={(e) => setModelSource(e.target.value.toLowerCase())}
+                onChange={(e) => setModelSource(e.target.value)}
                 style={{ gap: '2rem' }}
               >
-                {['Artifact Hub', 'GitHub'].map((source, idx) => (
+                {modelSources.map((source) => (
                   <FormControlLabel
-                    key={idx}
-                    value={source.toLowerCase()}
+                    key={source.value}
+                    value={source.value}
                     control={<Radio />}
-                    label={<>{source}</>}
-                    data-testid={`UrlStepper-Select-Source-${source}`}
+                    label={<>{source.label}</>}
+                    data-testid={`UrlStepper-Select-Source-${source.label}`}
                   />
                 ))}
               </RadioGroup>
@@ -521,7 +525,7 @@ const UrlStepper = React.memo(({ handleClose }: UrlStepperProps) => {
                 placeholder={
                   modelSource === 'github'
                     ? 'git://github.com/cert-manager/cert-manager/master/deploy/crds'
-                    : modelSource === 'artifact hub'
+                    : modelSource === 'artifacthub'
                       ? 'https://artifacthub.io/packages/search?ts_query_web={model-name}'
                       : 'Select a source first'
                 }
@@ -669,7 +673,10 @@ const UrlStepper = React.memo(({ handleClose }: UrlStepperProps) => {
               <SectionHeading variant="subtitle1">Source</SectionHeading>
               <Grid2 container spacing={2} size="grow">
                 <Grid2 size={{ xs: 12, sm: 6 }}>
-                  <SummaryField label="Source Type" value={capitalize(modelSource || '')} />
+                  <SummaryField
+                    label="Source Type"
+                    value={modelSources.find((source) => source.value === modelSource)?.label || ''}
+                  />
                 </Grid2>
                 <Grid2 size={{ xs: 12, sm: 6 }}>
                   <SummaryField label="URL" value={modelUrl} />


### PR DESCRIPTION
Fixes #21888

## Description

The Create Model wizard derived source values directly from their display labels. This caused Artifact Hub to be stored as `artifact hub`, while the backend and MeshKit expect the canonical registrant value `artifacthub`.

This change separates source labels from their canonical values. The UI continues to display “Artifact Hub”, while the import request now submits `artifacthub`.

The change also aligns Artifact Hub URL validation with the canonical source value, ensuring invalid URLs are rejected before model generation.

## Changes

- Added explicit labels and canonical values for supported model sources.
- Normalized the Artifact Hub registrant to `artifacthub`.
- Preserved user-facing source labels in the wizard summary.
- Corrected the Artifact Hub URL validation and placeholder conditions.
- Added regression tests for Artifact Hub and GitHub source selection.
- Added coverage for valid and invalid Artifact Hub URLs.

## Validation

- [x] Registry stepper and model-generation tests pass.
- [x] ESLint passes for the changed files.
- [x] Prettier validation passes.
- [x] Meshery UI production build passes.
- [x] All commits are signed off.