### PR TITLE
Add Simple Web Application Architecture design

### DIFF
--- a/simple-web-application-architecture.yaml
+++ b/simple-web-application-architecture.yaml
@@ -1,0 +1,135 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-router
+  namespace: default
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-service
+                port:
+                  number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend-service
+                port:
+                  number: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+  namespace: default
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-deployment
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: web
+          image: nginx:alpine
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+  namespace: default
+spec:
+  selector:
+    app: backend-api
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-deployment
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend-api
+  template:
+    metadata:
+      labels:
+        app: backend-api
+    spec:
+      containers:
+        - name: api
+          image: node:18-alpine
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DB_HOST
+              value: postgres-service
+            - name: DB_PORT
+              value: "5432"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  namespace: default
+spec:
+  selector:
+    app: postgresql
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-statefulset
+  namespace: default
+spec:
+  serviceName: postgres-service
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: appdb
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: securepassword

--- a/simple-web-application-architecture.yaml
+++ b/simple-web-application-architecture.yaml
@@ -1,3 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: default
+type: Opaque
+stringData:
+  password: securepassword123!
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -49,9 +58,19 @@ spec:
       labels:
         app: frontend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: web
           image: nginx:alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 80
 ---
@@ -82,9 +101,28 @@ spec:
       labels:
         app: backend-api
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: api
-          image: node:18-alpine
+          image: node:22-alpine
+          command: ["node", "-e"]
+          args:
+            - |
+              const http = require('http');
+              const server = http.createServer((req, res) => {
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify({ status: 'ok', service: 'backend-api', time: new Date() }));
+              });
+              server.listen(8080, () => console.log('API listening on 8080'));
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 8080
           env:
@@ -121,9 +159,21 @@ spec:
       labels:
         app: postgresql
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgresql
           image: postgres:15-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 5432
           env:
@@ -132,4 +182,18 @@ spec:
             - name: POSTGRES_USER
               value: postgres
             - name: POSTGRES_PASSWORD
-              value: securepassword
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi

--- a/simple-web-application-architecture.yaml
+++ b/simple-web-application-architecture.yaml
@@ -1,12 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres-credentials
-  namespace: default
-type: Opaque
-stringData:
-  password: securepassword123!
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -41,7 +32,7 @@ spec:
     app: frontend
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,14 +56,14 @@ spec:
           type: RuntimeDefault
       containers:
         - name: web
-          image: nginx:alpine
+          image: nginxinc/nginx-unprivileged:alpine
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL
           ports:
-            - containerPort: 80
+            - containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -177,6 +168,8 @@ spec:
           ports:
             - containerPort: 5432
           env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
             - name: POSTGRES_DB
               value: appdb
             - name: POSTGRES_USER


### PR DESCRIPTION
This PR adds the **Simple Web Application Architecture** design pattern for catalog publication.

### Summary of Changes:
- Added `simple-web-application-architecture.yaml` representing a 4-tier cloud-native application topology.
- Components:
  - **Ingress Router** (`Ingress`)
  - **Frontend UI** (`Deployment` + `Service`)
  - **Backend API** (`Deployment` + `Service`)
  - **PostgreSQL Database** (`StatefulSet` + `Service`)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Kubernetes routing for frontend pages and backend API requests.
  - Added deployable frontend, backend, and PostgreSQL workloads.
  - PostgreSQL data now persists across pod restarts through dedicated storage.
  - Database credentials are supplied through Kubernetes secrets.

- **Security**
  - Frontend, backend, and database workloads run with non-root execution and restricted privileges.

- **Maintenance**
  - The backend uses Node.js 22 and listens on port 8080.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->