### PR TITLE
[Docs/API] Fix duplicate response schema rendering

### DIFF
--- a/docs/layouts/_default/rest-apis.html
+++ b/docs/layouts/_default/rest-apis.html
@@ -511,8 +511,6 @@
 
                     {{ with index $schema "description" }}
                       <div class="rest-api-prose">{{ . | markdownify }}</div>
-                    {{ else }}
-                      <p class="rest-api-media-block__summary">Schema: <code>{{ $schemaType }}</code></p>
                     {{ end }}
 
                     {{ if gt (len (index $fields "rows")) 0 }}
@@ -664,8 +662,6 @@
 
                           {{ with index $schema "description" }}
                             <div class="rest-api-prose">{{ . | markdownify }}</div>
-                          {{ else }}
-                            <p class="rest-api-media-block__summary">Schema: <code>{{ $schemaType }}</code></p>
                           {{ end }}
 
                           {{ if gt (len (index $fields "rows")) 0 }}


### PR DESCRIPTION
#21931 


# Fix Duplicate Response Schema Rendering — #21931 


## Summary

This PR fixes an issue in the Meshery REST API documentation where response schemas for certain API responses are rendered more than once.

In particular, simple error responses such as **401 Unauthorized** and **500 Internal Server Error** were displaying duplicate schema entries.

## Problem

For some API responses, especially schemas without fields, descriptions, or `oneOf` definitions, the documentation could render the schema type twice.

For example:

```text
401 Expired JWT token used or insufficient privilege

Schema: string
Schema: string
```

This behavior was not limited to a single endpoint and could also occur with other responses using simple schemas.

## Root Cause

The duplication was caused by the REST API documentation template:

```text
docs/layouts/rest-apis/single.html
```

The template had two separate fallback paths capable of rendering the schema type.

When a schema did not contain a description, structured fields, or `oneOf` variants, both fallback paths could be reached, causing the same schema type to be rendered twice.

## Changes Made

This PR updates the shared REST API documentation template to remove the redundant fallback rendering.

The updated rendering flow:

* Shows the schema description when available.
* Shows schema fields when structured fields are present.
* Shows `oneOf` variants when applicable.
* Falls back to the schema type only when no other schema information is available.
* Ensures simple schemas such as `string` are rendered only once.

## Scope

This is a **documentation rendering fix only**.

* No API endpoints were changed.
* No backend behavior was modified.
* No OpenAPI schema definitions were changed.
* No API response behavior is affected.
* The fix is applied at the shared documentation-template level rather than through endpoint-specific workarounds.

## Expected Result

After this change, a response such as:

```text
401 Expired JWT token used or insufficient privilege

Schema: string
```

will be rendered correctly with a single schema entry instead of:

```text
401 Expired JWT token used or insufficient privilege

Schema: string
Schema: string
```

The existing rendering behavior for more complex response schemas remains unchanged.

## Validation

The change should be verified against:

* [ ] `401 Unauthorized` responses.
* [ ] `500 Internal Server Error` responses.
* [ ] Other Registry API endpoints.
* [ ] Simple schemas such as `string`, `boolean`, and other primitive types.
* [ ] Structured schemas containing fields.
* [ ] Schemas using descriptions.
* [ ] Schemas using `oneOf` variants.
* [ ] Existing documentation and CI checks.

## Related Issue

Closes #21931


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated API documentation rendering so media blocks no longer display schema-type summary lines when schema descriptions are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Final Fix - 
 
<img width="1764" height="892" alt="After implementation" src="https://github.com/user-attachments/assets/1b86c571-f04a-4f9e-a5c4-2a4a7ac36637" />
