### PR TITLE
Revise Consul adapter documentation for clarity

### DIFF
--- a/docs/content/en/extensions/adapters/consul/index.md
+++ b/docs/content/en/extensions/adapters/consul/index.md
@@ -15,14 +15,28 @@ aliases:
 - /extensibility/adapters/consul
 ---
 
+{{< alert title="How adapters install and configure infrastructure" >}}
+Adapters share a common Day 1 / Day 2 model: they install infrastructure with the project's own Helm charts, Kubernetes manifests, and/or CLI (with fallback), and they apply ongoing configuration by deploying Meshery Designs through Meshery Server's registry of registrants. That behavior, and related FAQs, is documented on the [Adapters]({{< ref "concepts/architecture/adapters.md" >}}) page. This page covers only what is specific to Consul.
+{{< /alert >}}
+
 ### Features
 
 1. Lifecycle management of Consul
 1. Lifecycle management of sample applications
-1. Performance management of Consul and it workloads
+1. Performance management of Consul and its workloads
    - Prometheus and Grafana integration
 1. Configuration management and best practices of Consul
 1. Custom configuration
+
+### Lifecycle management of Consul
+
+The Meshery Adapter for Consul can install **v1.8.4** and later of Consul on a connected Kubernetes cluster.
+
+This adapter installs the Consul control plane with the official HashiCorp Consul Helm chart (`hashicorp/consul`). Sample applications and custom configuration are applied as Kubernetes manifests. A Helm-rendered Consul demo snapshot is also available as manifests under the adapter's config templates.
+
+To install Consul from Meshery's UI, choose the Meshery Adapter for Consul, click **(+)**, and select a supported Consul version.
+
+See [Adapters]({{< ref "concepts/architecture/adapters.md" >}}) for the shared installation methods, fallback order, and how subsequent configuration is applied through Designs.
 
 ### Sample Applications
 
@@ -35,11 +49,15 @@ Meshery supports the deployment of a variety of sample applications on Meshery A
 - Image Hub
   - Image Hub is a sample application written to run on Consul for exploring WebAssembly modules used as Envoy filters.
 
-### Performance management of Consul and it workloads
+### Performance management of Consul and its workloads
 
 #### Prometheus and Grafana integration
 
-The Meshery Adapter for Consul will connect to Meshery Adapter for Consul's Prometheus and Grafana instances running in the control plane (typically found in a separate namespace) or other instances to which Meshery has network reachability.
+The Meshery Adapter for Consul will connect to Prometheus and Grafana instances running in the control plane (typically found in a separate namespace) or other instances to which Meshery has network reachability.
+
+### Custom configuration
+
+You can paste (or type in) any Kubernetes manifest and have this adapter apply or delete it in the requested namespace. Use this for Consul-related resources, sample-app changes, or other cluster configuration Meshery can reach.
 
 ### Architecture
 
@@ -48,4 +66,4 @@ The Meshery Adapter for Consul will connect to Meshery Adapter for Consul's Prom
 ### Suggested Topics
 
 - Examine [Meshery's architecture]({{< ref "concepts/architecture/_index.md" >}}) and how adapters fit in as a component.
-- Learn more about [Meshery Adapters]({{< ref "concepts/architecture/adapters.md" >}}).
+- Learn more about [Meshery Adapters]({{< ref "concepts/architecture/adapters.md" >}}), including [Day 1 installation]({{< ref "concepts/architecture/adapters.md" >}}#day-1-installing-infrastructure), [Day 2 configuration through Designs]({{< ref "concepts/architecture/adapters.md" >}}#day-2-ongoing-configuration-through-designs), and [adapter FAQs]({{< ref "concepts/architecture/adapters.md" >}}#adapter-faqs).


### PR DESCRIPTION
Updated the Consul adapter documentation to clarify installation and configuration processes, corrected typos, and enhanced the features section.

**Notes for Reviewers**

- This PR fixes #

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Linked Consul adapter guidance to shared installation and configuration instructions.
  - Added details on Consul lifecycle installation and custom Kubernetes manifest management.
  - Clarified workload terminology and expanded performance-management guidance.
  - Updated Prometheus and Grafana integration references to use externally reachable instances.
  - Improved links to Day 1, Day 2, and FAQ resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->