### PR TITLE
[Docs] Add mesheryctl-axi to the extensions catalog

### DIFF
--- a/docs/assets/scss/_elements.scss
+++ b/docs/assets/scss/_elements.scss
@@ -132,7 +132,13 @@ li:has(> a[href*="/installation/quick-start"]) {
   
 }
 
-li:has(> a[href*="/extensions"]) {
+// Flattens the entries of a section listing (`ul.section-title`), which renders
+// each child page as "<link> - <description>" and supplies its own indent.
+// Keep it scoped to that list: unscoped, `li:has(> a[href*="/extensions"])` also
+// matched ordinary prose linking to /extensions, so the "About Meshery
+// Extensions" block carried by every extension page silently lost its
+// "Integrations" bullet.
+ul.section-title li:has(> a[href*="/extensions"]) {
   list-style-type: none;
   margin-left: -2rem;
 }

--- a/docs/content/en/extensions/extensions/mesheryctl-axi/index.md
+++ b/docs/content/en/extensions/extensions/mesheryctl-axi/index.md
@@ -1,0 +1,75 @@
+---
+title: mesheryctl-axi
+description: An agent-ergonomic AXI wrapper around mesheryctl - token-efficient TOON output, always non-interactive, with help[] next-step suggestions.
+display_title: false
+aliases:
+- /extensions/mesheryctl-axi
+---
+
+# 🤖 mesheryctl-axi
+
+`mesheryctl-axi` is an [AXI](https://axi.md/)-compliant wrapper around [`mesheryctl`]({{< ref "reference/references/mesheryctl/_index.md" >}}), built for AI coding agents. Where `mesheryctl` is optimized for a human at a terminal, `mesheryctl-axi` is optimized for an agent consuming the output as context: it wraps the human CLI rather than replacing it, so the two stay in step.
+
+## Features
+
+1. **Token-efficient TOON reporting:** `list` and `view` results are rendered in [TOON](https://toonformat.dev/) rather than verbose tables or JSON, reducing the context an agent spends reading them.
+2. **Always non-interactive:** no TTY prompts, so a command never wedges an unattended agent session.
+3. **Structured errors:** unknown flags and failures exit non-zero with a structured TOON error rather than free-form text.
+4. **`help[]` next-step suggestions:** successful commands append the commands an agent is most likely to want next.
+5. **Definitive empty states:** an empty result is reported explicitly (for example, `connections: 0`) instead of as silence.
+6. **Schema-faithful content:** design and model *content* is returned as raw YAML or JSON - never re-encoded as TOON.
+
+## Installation and Use
+
+### Prerequisites
+
+- **Node.js** v22 or newer.
+- **`mesheryctl` installed and authenticated.** `mesheryctl-axi` spawns `mesheryctl`; it does not embed Meshery. See [Installing mesheryctl]({{< ref "installation/mesheryctl/_index.md" >}}). Point at a specific binary with `MESHERYCTL_BIN=/path/to/mesheryctl`.
+
+### Usage
+
+Run it directly with `npx` - no global install required:
+
+<pre class="codeblock-pre">
+  <div class="codeblock">
+     <div class="clipboardjs">npx -y mesheryctl-axi</div>
+   </div>
+</pre>
+
+With no arguments, `mesheryctl-axi` prints a content-first home: what it is, the resolved `mesheryctl` path, and a best-effort system status and context.
+
+Resource listings and views are reported in TOON:
+
+<pre class="codeblock-pre">
+  <div class="codeblock">
+     <div class="clipboardjs">npx -y mesheryctl-axi connection list</div>
+   </div>
+</pre>
+
+<pre class="codeblock-pre">
+  <div class="codeblock">
+     <div class="clipboardjs">npx -y mesheryctl-axi system status</div>
+   </div>
+</pre>
+
+Design and model *content* is returned verbatim as YAML or JSON:
+
+<pre class="codeblock-pre">
+  <div class="codeblock">
+     <div class="clipboardjs">npx -y mesheryctl-axi design content &lt;name&gt; --format yaml</div>
+   </div>
+</pre>
+
+Source, issues, and the full command reference: [github.com/meshery-extensions/mesheryctl-axi](https://github.com/meshery-extensions/mesheryctl-axi).
+
+<hr />
+
+## About Meshery Extensions
+
+[Meshery Extensions](https://meshery.io/extensions) are plugins or add-ons that enhance the functionality of the Meshery platform beyond its core capabilities. Meshery supports different types of extensions ([docs]({{< ref "extensions/_index.md" >}})):
+
+- [Adapters]({{< ref "concepts/architecture/adapters.md" >}}): Adapters allow Meshery to interface with the different cloud native infrastructure.
+- [Load Generators]({{< ref "reference/extensibility/load-generators.md" >}}): for performance characterization and benchmarking
+- [Integrations]({{< ref "extensions/models/_index.md" >}}): model-based support for a broad variety of design and orchestration of cloud and cloud native platforms, tools, and technologies.
+- [Providers]({{< ref "reference/extensibility/providers/index.md" >}}): for connecting to different cloud providers and infrastructure platforms
+- [UI Plugins]({{< ref "reference/extensibility/ui.md" >}}): Meshery UI has a number of extension points that allow users to customize their experience with third-party plugins.


### PR DESCRIPTION
## Description

Adds a Meshery Extensions catalog entry for **mesheryctl-axi**, published at `/extensions/extensions/mesheryctl-axi/`.

`mesheryctl-axi` is an [AXI](https://axi.md/)-compliant wrapper around `mesheryctl` built for AI coding agents: token-efficient TOON list/view reporting, always non-interactive execution, structured errors, definitive empty states, and `help[]` next-step suggestions. It spawns `mesheryctl` rather than embedding Meshery, and runs via `npx -y mesheryctl-axi`.

The page is modeled on the existing CLI-plugin entry `kubectl-meshsync-snapshot/index.md` and carries the standard "About Meshery Extensions" block. Hugo auto-lists it in the extensions section and the left sidebar, so no index or data file needed changing.

Repository: <https://github.com/meshery-extensions/mesheryctl-axi> · design and scope: #20979

## Out-of-scope fix included

While verifying the rendered page I found a pre-existing CSS defect on **every** extensions page, and fixed it here rather than stepping over it.

- **Symptom** - in the shared "About Meshery Extensions" block, the *Integrations* bullet rendered with no marker and dedented out of its list, while the four bullets around it rendered normally.
- **Root cause** - `li:has(> a[href*="/extensions"])` in `docs/assets/scss/_elements.scss` was unscoped. It was written for the section listing (`ul.section-title`), which supplies its own indent, but it matched *any* list item in body prose whose direct-child link URL contains `/extensions` - which the Integrations bullet does.
- **Fix** - scope the rule to `ul.section-title`. Confirmed against a full `hugo` build that the section listings on `/`, `/extensions/` and `/extensions/extensions/` are unchanged, the sidebar nav is unchanged, and the prose bullet is restored.
- **Watch for** - the sibling rule directly above it, keyed on `/installation/quick-start`, is unscoped in exactly the same way. It is left alone here because the docs home page relies on its current effect, but it carries the same latent risk for any future page that links to quick-start from a list.

## Testing

- Full `hugo` build of `docs/` completes with no errors; all `{{< ref >}}` targets resolve.
- Rendered page reviewed in a browser (light path via the built site) - heading, feature list, copyable code blocks, "About Meshery Extensions" block, breadcrumb, sidebar entry, and prev/next navigation all correct.
- Verified computed styles before and after the SCSS change on `/`, `/extensions/`, `/extensions/extensions/`, `/extensions/extensions/mesheryctl-axi/` and `/extensions/extensions/kubectl-meshsync-snapshot/`.

Closes #21940


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for the `mesheryctl-axi` extension, including setup requirements, usage instructions, example commands, and supported capabilities.

- **Bug Fixes**
  - Fixed extension-page navigation styling so the “Integrations” item remains visible in the “About Meshery Extensions” section.
  - Limited extension-link styling to the intended section-title lists, preventing unintended changes to links in regular page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->